### PR TITLE
Update spack resource environments and flags

### DIFF
--- a/community/examples/spack-gromacs.yaml
+++ b/community/examples/spack-gromacs.yaml
@@ -51,23 +51,24 @@ deployment_groups:
     settings:
       install_dir: /sw/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.17.1
+      spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:
       - type: single-config
         scope: defaults
-        value: "config:build_stage:/sw/spack/spack-stage"
+        content: "config:build_stage:/sw/spack/spack-stage"
       - type: file
         scope: defaults
-        value: |
+        content: |
           modules:
-            tcl:
-              hash_length: 0
-              all:
-                conflict:
-                  - '{name}'
-              projections:
-                all: '{name}/{version}-{compiler.name}-{compiler.version}'
+            default:
+              tcl:
+                hash_length: 0
+                all:
+                  conflict:
+                    - '{name}'
+                projections:
+                  all: '{name}/{version}-{compiler.name}-{compiler.version}'
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:

--- a/community/modules/scripts/spack-install/README.md
+++ b/community/modules/scripts/spack-install/README.md
@@ -36,7 +36,7 @@ see this module used in a full blueprint, see the [spack-gromacs.yaml] example.
     settings:
       install_dir: /sw/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.17.0
+      spack_ref: v0.18.0
       spack_cache_url:
       - mirror_name: 'gcs_cache'
         mirror_url: gs://example-buildcache/linux-centos7
@@ -48,13 +48,14 @@ see this module used in a full blueprint, see the [spack-gromacs.yaml] example.
         scope: defaults
         value: |
           modules:
-            tcl:
-              hash_length: 0
-              all:
-                conflict:
-                  - '{name}'
-              projections:
-                all: '{name}/{version}-{compiler.name}-{compiler.version}'
+            default:
+              tcl:
+                hash_length: 0
+                all:
+                  conflict:
+                    - '{name}'
+                projections:
+                  all: '{name}/{version}-{compiler.name}-{compiler.version}'
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:
@@ -65,6 +66,29 @@ see this module used in a full blueprint, see the [spack-gromacs.yaml] example.
         - intel-mkl%gcc@10.3.0 target=skylake
         - intel-mpi@2018.4.274%gcc@10.3.0 target=skylake
         - fftw%intel@18.0.5 target=skylake ^intel-mpi@2018.4.274%intel@18.0.5 target=x86_64
+      - name: explicit-env
+        content: |
+          spack:
+            definitions:
+            - compilers:
+              - gcc@10.3.0
+            - mpis:
+              - intel-mpi@2018.4.274
+            - packages:
+              - intel-mkl
+            - mpi_packages:
+              - fftw
+            specs:
+            - matrix:
+              - - $packages
+              - - $%compilers
+            - matrix:
+              - - $mpis
+              - - $%compilers
+            - matrix:
+              - - $mpi_packages
+              - - $%compilers
+              - - $^mpis
 ```
 
 Following the above description of this module, it can be added to a Slurm
@@ -139,16 +163,18 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_caches_to_populate"></a> [caches\_to\_populate](#input\_caches\_to\_populate) | Defines caches which will be populated with the installed packages.<br>  Each cache must specify a type (either directory, or mirror).<br>  Each cache must also specify a path. For directory caches, this path<br>  must be on a local file system (i.e. file:///path/to/cache). For<br>  mirror paths, this can be any valid URL that spack accepts.<br><br>  NOTE: GPG Keys should be installed before trying to populate a cache<br>  with packages.<br><br>  NOTE: The gpg\_keys variable can be used to install existing GPG keys<br>  and create new GPG keys, both of which are acceptable for populating a<br>  cache. | `list(map(any))` | `[]` | no |
 | <a name="input_compilers"></a> [compilers](#input\_compilers) | Defines compilers for spack to install before installing packages. | `list(string)` | `[]` | no |
-| <a name="input_configs"></a> [configs](#input\_configs) | List of configuration options to set within spack.<br>    Configs can be of type 'single-config' or 'file'.<br>    All configs must specify a value, and a<br>    a scope. | `list(map(any))` | `[]` | no |
-| <a name="input_environments"></a> [environments](#input\_environments) | Defines a spack environment to configure. | <pre>list(object({<br>    name     = string<br>    packages = list(string)<br>  }))</pre> | `null` | no |
+| <a name="input_concretize_flags"></a> [concretize\_flags](#input\_concretize\_flags) | Defines the flags to pass into `spack concretize` | `string` | `""` | no |
+| <a name="input_configs"></a> [configs](#input\_configs) | List of configuration options to set within spack.<br>    Configs can be of type 'single-config' or 'file'.<br>    All configs must specify content, and a<br>    a scope. | `list(map(any))` | `[]` | no |
+| <a name="input_environments"></a> [environments](#input\_environments) | Defines spack environments to configure, given as a list.<br>  Each environment must define a name.<br>  Additional optional attributes are 'content' and 'packages'.<br>  'content' must be a string, defining the content of the Spack Environment YAML file.<br>  'packages' must be a list of strings, defining the spack specs to install.<br>  If both 'content' and 'packages' are defined, 'content' is processed first. | `any` | `[]` | no |
 | <a name="input_gpg_keys"></a> [gpg\_keys](#input\_gpg\_keys) | GPG Keys to trust within spack.<br>  Each key must define a type. Valid types are 'file' and 'new'.<br>  Keys of type 'file' must define a path to the key that<br>  should be trusted.<br>  Keys of type 'new' must define a 'name' and 'email' to create<br>  the key with. | `list(map(any))` | `[]` | no |
 | <a name="input_install_dir"></a> [install\_dir](#input\_install\_dir) | Directory to install spack into. | `string` | `"/sw/spack"` | no |
+| <a name="input_install_flags"></a> [install\_flags](#input\_install\_flags) | Defines the flags to pass into `spack install` | `string` | `""` | no |
 | <a name="input_licenses"></a> [licenses](#input\_licenses) | List of software licenses to install within spack. | <pre>list(object({<br>    source = string<br>    dest   = string<br>  }))</pre> | `null` | no |
 | <a name="input_log_file"></a> [log\_file](#input\_log\_file) | Defines the logfile that script output will be written to | `string` | `"/dev/null"` | no |
 | <a name="input_packages"></a> [packages](#input\_packages) | Defines root packages for spack to install (in order). | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
 | <a name="input_spack_cache_url"></a> [spack\_cache\_url](#input\_spack\_cache\_url) | List of buildcaches for spack. | <pre>list(object({<br>    mirror_name = string<br>    mirror_url  = string<br>  }))</pre> | `null` | no |
-| <a name="input_spack_ref"></a> [spack\_ref](#input\_spack\_ref) | Git ref to checkout for spack. | `string` | `"develop"` | no |
+| <a name="input_spack_ref"></a> [spack\_ref](#input\_spack\_ref) | Git ref to checkout for spack. | `string` | `"v0.18.0"` | no |
 | <a name="input_spack_url"></a> [spack\_url](#input\_spack\_url) | URL to clone the spack repo from. | `string` | `"https://github.com/spack/spack"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone where the instance is running. | `string` | n/a | yes |
 

--- a/community/modules/scripts/spack-install/main.tf
+++ b/community/modules/scripts/spack-install/main.tf
@@ -15,6 +15,13 @@
  */
 
 locals {
+  env = [
+    for e in var.environments : {
+      name     = e.name
+      packages = contains(keys(e), "packages") ? e.packages : null
+      content  = contains(keys(e), "content") ? e.content : null
+    }
+  ]
   script_content = templatefile(
     "${path.module}/templates/install_spack.tpl",
     {
@@ -27,7 +34,9 @@ locals {
       CONFIGS            = var.configs == null ? [] : var.configs
       LICENSES           = var.licenses == null ? [] : var.licenses
       PACKAGES           = var.packages == null ? [] : var.packages
-      ENVIRONMENTS       = var.environments == null ? [] : var.environments
+      INSTALL_FLAGS      = var.install_flags == null ? "" : var.install_flags
+      CONCRETIZE_FLAGS   = var.concretize_flags == null ? "" : var.concretize_flags
+      ENVIRONMENTS       = local.env
       MIRRORS            = var.spack_cache_url == null ? [] : var.spack_cache_url
       GPG_KEYS           = var.gpg_keys == null ? [] : var.gpg_keys
       CACHES_TO_POPULATE = var.caches_to_populate == null ? [] : var.caches_to_populate

--- a/community/modules/scripts/spack-install/templates/.shellcheckrc
+++ b/community/modules/scripts/spack-install/templates/.shellcheckrc
@@ -21,3 +21,8 @@ disable=SC2034
 # Disabled because string is not literal, variable is prefaced with $$ for template
 # https://github.com/koalaman/shellcheck/wiki/SC2157
 disable=SC2157
+
+
+# Disabled because parenthesis are used in terraform code
+# https://github.com/koalaman/shellcheck/wiki/SC1036
+disable=SC1036

--- a/tools/validate_configs/test_configs/spack-environments.yaml
+++ b/tools/validate_configs/test_configs/spack-environments.yaml
@@ -35,7 +35,7 @@ deployment_groups:
     settings:
       install_dir: /apps/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
+      spack_ref: v0.17.1
       log_file: /var/log/spack.log
       configs:
       - type: 'single-config'
@@ -43,9 +43,37 @@ deployment_groups:
         content: 'config:install_tree:padded_length:128'
       compilers:
       - gcc@10.3.0 target=x86_64
-      packages:
-      - intel-mpi@2018.4.274%gcc@10.3.0
-      - gromacs@2021.2 %gcc@10.3.0 ^intel-mpi@2018.4.274
+      environments:
+      - name: 'file-test'
+        content: |
+          spack:
+            definitions:
+            - compilers:
+              - gcc@10.3.0
+            - mpis:
+              - intel-mpi@2018.4.274
+            - mpi_packages:
+              - gromacs@2021.2
+            specs:
+            - matrix:
+              - - $mpis
+              - - $%compilers
+            - matrix:
+              - - $mpi_packages
+              - - $%compilers
+              - - $^mpis
+      - name: 'pkg-test'
+        packages:
+        - intel-mpi@2018.4.274 %gcc@10.3.0
+        - gromacs@2021.2 %gcc@10.3.0 ^intel-mpi@2018.4.274
+      - name: 'mixed-test'
+        content: |
+          spack:
+            specs:
+              intel-mpi@20184.274 %gcc@10.3.0
+        packages:
+        - gromacs@2021.2 %gcc@10.3.0 ^intel-mpi@2018.4.274
+      - name: 'empty-test'
       gpg_keys:
       - type: 'file'
         path: '/tmp/spack_key.gpg'


### PR DESCRIPTION
This merge makes several updates to the spack module:
 - environments can be defined with a provided spack.yaml
 - Files that are written (spack.yaml or configs) will not expand
   environment variables anymore
 - Default version of spack is updated to v0.18.0
 - install_flags and concretize_flags can be passed in with
   a toolkit yaml

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?
