### PR TITLE
Default to not disabling services upon destroy

### DIFF
--- a/community/modules/project/service-enablement/README.md
+++ b/community/modules/project/service-enablement/README.md
@@ -61,6 +61,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_disable_on_destroy"></a> [disable\_on\_destroy](#input\_disable\_on\_destroy) | Disable services on destroy if they were enabled (or already enabled) during apply (default: false) | `bool` | `false` | no |
 | <a name="input_gcp_service_list"></a> [gcp\_service\_list](#input\_gcp\_service\_list) | list of APIs to be enabled for the project | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the project | `string` | n/a | yes |
 

--- a/community/modules/project/service-enablement/main.tf
+++ b/community/modules/project/service-enablement/main.tf
@@ -24,5 +24,5 @@ resource "google_project_service" "gcp_services" {
   }
 
   disable_dependent_services = true
-  disable_on_destroy         = true
+  disable_on_destroy         = var.disable_on_destroy
 }

--- a/community/modules/project/service-enablement/variables.tf
+++ b/community/modules/project/service-enablement/variables.tf
@@ -23,3 +23,9 @@ variable "gcp_service_list" {
   description = "list of APIs to be enabled for the project"
   type        = list(string)
 }
+
+variable "disable_on_destroy" {
+  description = "Disable services on destroy if they were enabled (or already enabled) during apply (default: false)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Alters default behavior of the experimental service enablement module to *not* disable services upon destroy because it can fail in the common circumstance that resources exist outside of the Terraform state. Disabling upon destroy makes the implicit assumption that this Terraform module is the sole manager of services within the project. There may be circumstances where it should be true and the user should specifically elect them. This choice retains the behavior of ensuring the activation of requisite APIs.

For an example of why the status quo (hard-coded to true) is undesirable: this module is essentially unusable in our integration tests because `terraform destroy` will nearly always fail due to the presence of many other resources for a popular API such as GCE.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?
