### PR TITLE
Support extra args for ansible playbooks

### DIFF
--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -46,7 +46,12 @@ Each runner receives the following attributes:
   [example blueprint snippet](#example). To reference any other source file, an
   absolute path must be used.
 
-- `args`: (Optional) Arguments to be passed to shell scripts.
+- `args`: (Optional) Arguments to be passed to `shell` or `ansible-local`
+  runners. For `shell` runners, these will be passed as arguments to the script
+  when it is executed. For `ansible-local` runners, they will be appended to
+  a list of default arguments that invoke `ansible-playbook` on the localhost.
+  Therefore`args` should not include any arguments that alter this behavior,
+  such as `--connection`, `--inventory`, or `--limit`.
 
   > **_NOTE:_** `args` will only be applied to runners of `type` `shell`.
 

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -53,8 +53,6 @@ Each runner receives the following attributes:
   Therefore`args` should not include any arguments that alter this behavior,
   such as `--connection`, `--inventory`, or `--limit`.
 
-  > **_NOTE:_** `args` will only be applied to runners of `type` `shell`.
-
 ### Staging the runners
 
 Runners will be uploaded to a

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -6,7 +6,7 @@ stdlib::run_playbook() {
     "Please install ansible before running ansible-local runners."
     exit 1
   fi
-  /usr/bin/ansible-playbook --connection=local --inventory=localhost, --limit localhost $1
+  /usr/bin/ansible-playbook --connection=local --inventory=localhost, --limit localhost $1 $2
 }
 
 stdlib::runner() {
@@ -27,7 +27,7 @@ stdlib::runner() {
   stdlib::get_from_bucket -u "gs://${bucket}/$object" -d "$destpath" -f "$filename"
 
   case "$1" in
-    ansible-local) stdlib::run_playbook "$destpath/$filename";;
+    ansible-local) stdlib::run_playbook "$destpath/$filename" "$args";;
     # shellcheck source=/dev/null
     shell)  sh -c "source '$destpath/$filename' $args";;
   esac


### PR DESCRIPTION
A common pattern in Ansible is to supply the `--extra-vars` argument or other arguments to `ansible-playbook`. See, for example, our [own invocation in integration tests](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/b0a5f6f1ef6298ccda812e9c332be7a195e1f117/tools/cloud-build/daily-tests/integration-group-1.yaml#L61-L62).

We do not presently support this in Runners. This PR adds that support. It will be useful for use cases such as rendering a Terraform value into an Ansible variable:

```hcl
  role_example = {
    "type"        = "ansible-local"
    "content"     = file("${path.module}/files/example_role.yml")
    "destination" = "example_role.yml"
    "args"        = "-e \"password_id=${google_secret_manager_secret.pool_password.secret_id}\""
  }
```

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?