### PR TITLE
Add external IP output to vm-instance module

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -157,6 +157,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_external_ip"></a> [external\_ip](#output\_external\_ip) | External IP of the instances (if enabled) |
 | <a name="output_internal_ip"></a> [internal\_ip](#output\_internal\_ip) | Internal IP of the instances |
 | <a name="output_name"></a> [name](#output\_name) | Name of any instance created |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute/vm-instance/outputs.tf
+++ b/modules/compute/vm-instance/outputs.tf
@@ -19,6 +19,11 @@ output "name" {
   value       = google_compute_instance.compute_vm.*.name
 }
 
+output "external_ip" {
+  description = "External IP of the instances (if enabled)"
+  value       = try(google_compute_instance.compute_vm.*.network_interface.0.access_config.0.nat_ip, [])
+}
+
 output "internal_ip" {
   description = "Internal IP of the instances"
   value       = google_compute_instance.compute_vm.*.network_interface.0.network_ip


### PR DESCRIPTION
- if public IPs are enabled (default), the output is the list of external "NAT" IPs for each VM
- if public IPs are disabled explicitly, the output is the empty list

We already have a task to expand test coverage of this module and I will add public/private IP to its description.

A blueprint that one can use to test this is below. The terraform outputs will yield:

```hcl
external_ip_private = []
external_ip_public = [
  "104.197.82.46",
  "35.223.38.149",
  "34.71.34.33",
  "34.72.25.136",
  "34.123.15.216",
]
internal_ip_private = [
  "10.0.0.9",
  "10.0.0.3",
  "10.0.0.8",
]
internal_ip_public = [
  "10.0.0.2",
  "10.0.0.4",
  "10.0.0.7",
  "10.0.0.5",
  "10.0.0.6",
]
```

```yaml
---
blueprint_name: vm-test

vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: vm-test-001
  region: us-central1
  zone: us-central1-c


deployment_groups:
- group: vm_test
  modules:
  - source: modules/network/vpc
    kind: terraform
    id: network1
  - source: modules/compute/vm-instance
    kind: terraform
    id: private
    use:
    - network1
    settings:
      instance_count: 3
      name_prefix: private
      disable_public_ips: true
    outputs:
    - external_ip
    - internal_ip
  - source: modules/compute/vm-instance
    kind: terraform
    id: public
    use:
    - network1
    settings:
      instance_count: 5
      name_prefix: public
    outputs:
    - external_ip
    - internal_ip
```

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?