### PR TITLE
Add experimental HTCondor modules to Toolkit

### DIFF
--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -1,0 +1,53 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.0, < 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.0, < 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_access_point_service_account"></a> [access\_point\_service\_account](#module\_access\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
+| <a name="module_central_manager_service_account"></a> [central\_manager\_service\_account](#module\_central\_manager\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_secret_manager_secret.pool_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_iam_member.access_point](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.central_manager](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_version.pool_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [random_password.pool](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_point_roles"></a> [access\_point\_roles](#input\_access\_point\_roles) | Project-wide roles for HTCondor Access Point service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/compute.instanceAdmin",<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name for HTCondor pool | `string` | n/a | yes |
+| <a name="input_pool_password"></a> [pool\_password](#input\_pool\_password) | HTCondor Pool Password | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_access_point_runners"></a> [access\_point\_runners](#output\_access\_point\_runners) | Toolkit Runner to configure an HTCondor Access Point |
+| <a name="output_access_point_service_account"></a> [access\_point\_service\_account](#output\_access\_point\_service\_account) | HTCondor Access Point Service Account (e-mail format) |
+| <a name="output_central_manager_runners"></a> [central\_manager\_runners](#output\_central\_manager\_runners) | Toolkit Runner to configure an HTCondor Central Manager |
+| <a name="output_central_manager_service_account"></a> [central\_manager\_service\_account](#output\_central\_manager\_service\_account) | HTCondor Central Manager Service Account (e-mail format) |
+| <a name="output_pool_password_secret_id"></a> [pool\_password\_secret\_id](#output\_pool\_password\_secret\_id) | Google Cloud Secret Manager ID containing HTCondor Pool Password |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_role.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_role.yml
@@ -1,0 +1,51 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Configure HTCondor Role
+  become: true
+  hosts: localhost
+  tasks:
+  - name: Remove default HTCondor configuration
+    ansible.builtin.file:
+      name: /etc/condor/config.d/00-htcondor-9.0.config
+      state: absent
+  - name: set HTCondor role
+    ansible.builtin.copy:
+      dest: /etc/condor/config.d/01-role
+      content: |
+        use role:{{ htcondor_role }}
+  - name: Configure VM to be HTCondor Central Manager
+    when: htcondor_role == 'get_htcondor_central_manager'
+    block:
+    - name: set HTCondor Central Manager
+      ansible.builtin.copy:
+        dest: /etc/condor/config.d/00-central-manager
+        content: |
+          CONDOR_HOST={{ ansible_default_ipv4.address }}
+  - name: Read HTCondor Central Manager from metadata
+    when: htcondor_role != 'get_htcondor_central_manager'
+    block:
+    - name: Read metadata central-manager
+      uri:
+        url: http://metadata.google.internal/computeMetadata/v1/instance/attributes/central-manager
+        return_content: true
+        headers:
+          Metadata-Flavor: "Google"
+      register: cm
+    - name: set HTCondor Central Manager
+      ansible.builtin.copy:
+        dest: /etc/condor/config.d/00-central-manager
+        content: |
+          CONDOR_HOST={{ cm.content }}

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_secure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_secure.yml
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Secure HTCondor
+  become: yes
+  hosts: localhost
+  tasks:
+  - name: Set HTCondor credentials
+    ansible.builtin.shell: |
+      set -e
+      export CLOUDSDK_PYTHON=/usr/bin/python
+      POOL_PASSWORD=$(gcloud secrets versions access latest --secret={{ password_id }})
+      echo -n "$POOL_PASSWORD" | sh -c "condor_store_cred add -c -i -"
+      umask 0077
+      TRUST_DOMAIN=$(condor_config_val TRUST_DOMAIN)
+      condor_token_create -identity condor@$TRUST_DOMAIN > /etc/condor/tokens.d/condor@$TRUST_DOMAIN
+    args:
+      creates: /etc/condor/passwords.d/POOL

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_start_enable.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_start_enable.yml
@@ -1,0 +1,24 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Start and enable HTCondor
+  become: true
+  hosts: localhost
+  tasks:
+  - name: start HTCondor
+    ansible.builtin.service:
+      name: condor
+      state: started
+      enabled: true

--- a/community/modules/scheduler/htcondor-configure/main.tf
+++ b/community/modules/scheduler/htcondor-configure/main.tf
@@ -1,0 +1,118 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  access_point_display_name    = "HTCondor Access Point (${var.deployment_name})"
+  access_point_roles           = [for role in var.access_point_roles : "${var.project_id}=>${role}"]
+  central_manager_display_name = "HTCondor Central Manager (${var.deployment_name})"
+  central_manager_roles        = [for role in var.central_manager_roles : "${var.project_id}=>${role}"]
+
+  pool_password = var.pool_password == null ? random_password.pool.result : var.pool_password
+
+  start_enable_runner = {
+    "type"        = "ansible-local"
+    "content"     = file("${path.module}/files/htcondor_start_enable.yml")
+    "destination" = "htcondor_start_enable.yml"
+  }
+
+  secure_runner = {
+    "type"        = "ansible-local"
+    "content"     = file("${path.module}/files/htcondor_secure.yml")
+    "destination" = "htcondor_secure.yml"
+    "args"        = "-e \"password_id=${google_secret_manager_secret.pool_password.secret_id}\""
+  }
+
+  role_runner_cm = {
+    "type"        = "ansible-local"
+    "content"     = file("${path.module}/files/htcondor_role.yml")
+    "destination" = "htcondor_role.yml"
+    "args"        = "-e \"htcondor_role=get_htcondor_central_manager\""
+  }
+
+  role_runner_access = {
+    "type"        = "ansible-local"
+    "content"     = file("${path.module}/files/htcondor_role.yml")
+    "destination" = "htcondor_role.yml"
+    "args"        = "-e \"htcondor_role=get_htcondor_submit\""
+  }
+
+  central_manager_runners = [
+    local.role_runner_cm,
+    local.secure_runner,
+    local.start_enable_runner,
+  ]
+
+  access_point_runners = [
+    local.role_runner_access,
+    local.secure_runner,
+    local.start_enable_runner,
+  ]
+}
+
+module "access_point_service_account" {
+  source     = "terraform-google-modules/service-accounts/google"
+  version    = "~> 4.1"
+  project_id = var.project_id
+  prefix     = var.deployment_name
+
+  names         = ["access"]
+  display_name  = local.access_point_display_name
+  project_roles = local.access_point_roles
+}
+
+module "central_manager_service_account" {
+  source     = "terraform-google-modules/service-accounts/google"
+  version    = "~> 4.1"
+  project_id = var.project_id
+  prefix     = var.deployment_name
+
+  names         = ["cm"]
+  display_name  = local.central_manager_display_name
+  project_roles = local.central_manager_roles
+}
+
+resource "random_password" "pool" {
+  length           = 24
+  special          = true
+  override_special = "_-#=."
+}
+
+resource "google_secret_manager_secret" "pool_password" {
+  secret_id = "${var.deployment_name}-pool-password"
+
+  labels = {
+    label = var.deployment_name
+  }
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "pool_password" {
+  secret      = google_secret_manager_secret.pool_password.id
+  secret_data = local.pool_password
+}
+
+resource "google_secret_manager_secret_iam_member" "central_manager" {
+  secret_id = google_secret_manager_secret.pool_password.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = module.central_manager_service_account.iam_email
+}
+
+resource "google_secret_manager_secret_iam_member" "access_point" {
+  secret_id = google_secret_manager_secret.pool_password.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = module.access_point_service_account.iam_email
+}

--- a/community/modules/scheduler/htcondor-configure/outputs.tf
+++ b/community/modules/scheduler/htcondor-configure/outputs.tf
@@ -1,0 +1,45 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "access_point_service_account" {
+  description = "HTCondor Access Point Service Account (e-mail format)"
+  value       = module.access_point_service_account.email
+  depends_on = [
+    google_secret_manager_secret_iam_member.access_point
+  ]
+}
+
+output "central_manager_service_account" {
+  description = "HTCondor Central Manager Service Account (e-mail format)"
+  value       = module.central_manager_service_account.email
+  depends_on = [
+    google_secret_manager_secret_iam_member.central_manager
+  ]
+}
+
+output "pool_password_secret_id" {
+  description = "Google Cloud Secret Manager ID containing HTCondor Pool Password"
+  value       = google_secret_manager_secret.pool_password.secret_id
+  sensitive   = true
+}
+
+output "central_manager_runners" {
+  description = "Toolkit Runner to configure an HTCondor Central Manager"
+  value       = local.central_manager_runners
+}
+
+output "access_point_runners" {
+  description = "Toolkit Runner to configure an HTCondor Access Point"
+  value       = local.access_point_runners
+}

--- a/community/modules/scheduler/htcondor-configure/variables.tf
+++ b/community/modules/scheduler/htcondor-configure/variables.tf
@@ -1,0 +1,51 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "Project in which HTCondor pool will be created"
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "Name for HTCondor pool"
+  type        = string
+}
+
+variable "access_point_roles" {
+  description = "Project-wide roles for HTCondor Access Point service account"
+  type        = list(string)
+  default = [
+    "roles/monitoring.metricWriter",
+    "roles/logging.logWriter",
+    "roles/storage.objectViewer",
+  ]
+}
+
+variable "central_manager_roles" {
+  description = "Project-wide roles for HTCondor Central Manager service account"
+  type        = list(string)
+  default = [
+    "roles/compute.instanceAdmin",
+    "roles/monitoring.metricWriter",
+    "roles/logging.logWriter",
+    "roles/storage.objectViewer",
+  ]
+}
+
+variable "pool_password" {
+  description = "HTCondor Pool Password"
+  type        = string
+  sensitive   = true
+  default     = null
+}

--- a/community/modules/scheduler/htcondor-configure/versions.tf
+++ b/community/modules/scheduler/htcondor-configure/versions.tf
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.0, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+
+  required_version = ">= 0.13.0"
+}

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -1,0 +1,30 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_gcp_service_list"></a> [gcp\_service\_list](#output\_gcp\_service\_list) | Google Cloud APIs required by HTCondor |
+| <a name="output_install_htcondor_runner"></a> [install\_htcondor\_runner](#output\_install\_htcondor\_runner) | Runner to install HTCondor using startup-scripts |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -1,0 +1,61 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: ensure HTCondor is installed
+  hosts: all
+  become: true
+  tasks:
+  - name: Upgrade all packages
+    yum:
+      name: '*'
+      state: latest
+  - name: setup HTCondor yum repository
+    yum:
+      name:
+      - epel-release
+      - https://research.cs.wisc.edu/htcondor/repo/9.x/htcondor-release-current.el7.noarch.rpm
+  - name: install HTCondor
+    yum:
+      name: condor
+      state: latest
+  - name: ensure token directory
+    file:
+      path: /etc/condor/tokens.d
+      mode: 0700
+      owner: root
+      group: root
+      recurse: true
+  - name: Ensure HTCondor is stopped and disabled. Must configure at boot!
+    ansible.builtin.service:
+      name: condor
+      enabled: false
+      state: stopped
+  - name: Ensure that firewall is started and enabled
+    ansible.builtin.service:
+      name: firewalld
+      enabled: true
+      state: started
+  - name: Ensure that only root and condor users can access service account
+    shell: |
+      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 1 \
+          -m owner --uid-owner root -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
+      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 2 \
+          -m owner --uid-owner condor -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
+      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 3 \
+          -p tcp -d metadata.google.internal --dport 80 -j DROP
+      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 4 \
+          -p tcp -d metadata.google.internal --dport 8080 -j DROP
+      firewall-cmd --permanent --zone=public --add-port=9618/tcp
+      firewall-cmd --reload

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  install_htcondor_runner = {
+    "type"        = "ansible-local"
+    "source"      = "${path.module}/files/install-htcondor.yaml"
+    "destination" = "install-htcondor.yaml"
+  }
+
+  required_apis = [
+    "compute.googleapis.com",
+    "secretmanager.googleapis.com",
+  ]
+}

--- a/community/modules/scripts/htcondor-install/outputs.tf
+++ b/community/modules/scripts/htcondor-install/outputs.tf
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "install_htcondor_runner" {
+  description = "Runner to install HTCondor using startup-scripts"
+  value       = local.install_htcondor_runner
+}
+
+output "gcp_service_list" {
+  description = "Google Cloud APIs required by HTCondor"
+  value       = local.required_apis
+}

--- a/community/modules/scripts/htcondor-install/versions.tf
+++ b/community/modules/scripts/htcondor-install/versions.tf
@@ -1,0 +1,17 @@
+#  Copyright 2022 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+terraform {
+  required_version = ">= 0.13.0"
+}

--- a/modules/README.md
+++ b/modules/README.md
@@ -111,7 +111,11 @@ Modules that are still in development and less stable are labeled with the
   controller node using [slurm-gcp].
 * **[SchedMD-slurm-on-gcp-login-node]** ![community-badge] : Creates a Slurm
   login node using [slurm-gcp].
+* **[htcondor-configure]** ![community-badge] ![experimental-badge] : Creates
+  Toolkit runners and service accounts to configure an HTCondor Central Manager
+  and Access Point.
 
+[htcondor-configure]: ../community/modules/scheduler/htcondor-configure/README.md
 [schedmd-slurm-on-gcp-controller]: ../community/modules/scheduler/SchedMD-slurm-on-gcp-controller/README.md
 [schedmd-slurm-on-gcp-login-node]: ../community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/README.md
 [slurm-gcp]: https://github.com/SchedMD/slurm-gcp/tree/v4.1.5
@@ -120,6 +124,9 @@ Modules that are still in development and less stable are labeled with the
 
 * **[startup-script]** ![core-badge] : Creates a customizable startup script
   that can be fed into compute VMs.
+* **[htcondor-install]** ![community-badge] ![experimental-badge] : Creates
+  a Toolkit runner to install HTCondor and a list of required APIs for use with
+  [service-enablement].
 * **[omnia-install]** ![community-badge] ![experimental-badge] : Installs Slurm
   via [Dell Omnia](https://github.com/dellhpc/omnia) onto a cluster of compute
   VMs.
@@ -130,6 +137,7 @@ Modules that are still in development and less stable are labeled with the
   successful completion of a startup script on a compute VM.
 
 [startup-script]: scripts/startup-script/README.md
+[htcondor-install]: ../community/modules/scripts/htcondor-install/README.md
 [omnia-install]: ../community/modules/scripts/omnia-install/README.md
 [spack-install]: ../community/modules/scripts/spack-install/README.md
 [wait-for-startup]: ../community/modules/scripts/wait-for-startup/README.md

--- a/tools/validate_configs/test_configs/htcondor-pool.yaml
+++ b/tools/validate_configs/test_configs/htcondor-pool.yaml
@@ -1,0 +1,115 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+blueprint_name: htcondor-pool
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: htcondor-001
+  region: us-central1
+  zone: us-central1-c
+  image_family: htcondor-9x
+  network_name: htcondor-pool
+  subnetwork_name: htcondor-pool-usc1
+
+deployment_groups:
+- group: htcondor-env
+  modules:
+  - source: modules/network/vpc
+    kind: terraform
+    id: network1
+    outputs:
+    - network_name
+  - source: community/modules/scripts/htcondor-install
+    kind: terraform
+    id: htcondor_install
+  - source: community/modules/project/service-enablement
+    kind: terraform
+    id: htcondor_services
+    use:
+    - htcondor_install
+  - source: modules/scripts/startup-script
+    kind: terraform
+    id: htcondor_install_scripts
+    settings:
+      runners:
+      - type: shell
+        source: modules/startup-script/examples/install_ansible.sh
+        destination: install_ansible.sh
+      - $(htcondor_install.install_htcondor_runner)
+    outputs:
+    - startup_script
+- group: packer
+  modules:
+  - source: modules/packer/custom-image
+    kind: packer
+    id: custom-image
+- group: pool
+  modules:
+  - source: modules/network/pre-existing-vpc
+    kind: terraform
+    id: cluster_network
+  - source: community/modules/scheduler/htcondor-configure
+    kind: terraform
+    id: htcondor_configure
+  - source: modules/scripts/startup-script
+    kind: terraform
+    id: htcondor_configure_central_manager
+    settings:
+      runners: $(htcondor_configure.central_manager_runners)
+  - source: modules/scripts/startup-script
+    kind: terraform
+    id: htcondor_configure_access_point
+    settings:
+      runners: $(htcondor_configure.access_point_runners)
+  - source: modules/compute/vm-instance
+    kind: terraform
+    id: htcondor_cm
+    use:
+    - cluster_network
+    - htcondor_configure_central_manager
+    settings:
+      name_prefix: central-manager
+      machine_type: c2-standard-4
+      disable_public_ips: true
+      instance_image:
+        family: ((var.image_family))
+        project: ((var.project_id))
+      service_account:
+        email: ((module.htcondor_configure.central_manager_service_account))
+        scopes:
+        - cloud-platform
+    outputs:
+    - internal_ip
+  - source: modules/compute/vm-instance
+    kind: terraform
+    id: htcondor_access
+    use:
+    - cluster_network
+    - htcondor_configure_access_point
+    settings:
+      name_prefix: access-point
+      machine_type: c2-standard-4
+      metadata:
+        central-manager: ((module.htcondor_cm.internal_ip[0]))
+      instance_image:
+        family: ((var.image_family))
+        project: ((var.project_id))
+      service_account:
+        email: ((module.htcondor_configure.access_point_service_account))
+        scopes:
+        - cloud-platform
+    outputs:
+    - external_ip


### PR DESCRIPTION
This PR adds:

- Toolkit Runner that can build a VM image with HTCondor software installed
- Toolkit Runner that configures an HTCondor Central Manager and Access Point
- Module to provision least-permissions service accounts
- An experimental "test-only" HTCondor pool blueprint using the `vm-instance` module
- An integration check that tests the health of the HTCondor pool

It does _not_ yet implement pool auto-scaling. In the interest of keeping PRs limited in scale for review-ability, I believe this merits evaluation for the module and blueprint architecture and inclusion on develop while we add support for auto-scaling in development branches.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?