### PR TITLE
Add HTCondor Install module

### DIFF
--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -35,7 +35,9 @@ No resources.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_block_metadata_server"></a> [block\_metadata\_server](#input\_block\_metadata\_server) | Use Linux firewall to block the instance metadata server for users other than root and HTCondor daemons | `bool` | `true` | no |
 
 ## Outputs
 

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -1,4 +1,20 @@
+## License
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 ## Requirements
 
 | Name | Version |

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -1,3 +1,25 @@
+## Description
+
+**THIS MODULE IS PRE-RELEASE AND DOES NOT YET SUPPORT A FULLY FUNCTIONAL
+HTCONDOR POOL**
+
+This module creates a Toolkit runner that will install HTCondor on RedHat 7 or
+derivative operating systems such as the CentOS 7 release in the [HPC VM
+Image][hpcvmimage].
+
+It also exports a list of Google Cloud APIs which must be enabled prior to
+provisioning an HTCondor Pool.
+
+[hpcvmimage]: https://cloud.google.com/compute/docs/instances/create-hpc-vm
+
+## Important note
+
+This module enables Linux firewall rules that block access to the instance
+metadata server for any POSIX user that is not `root` or `condor`. This prevents
+user jobs from being able to escalate privileges to act as the VM. System
+services and HTCondor itself can continue to do so, such as writing to Cloud
+Logging. This [feature can be disabled](#input_block_metadata_server).
+
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -1,0 +1,30 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_gcp_service_list"></a> [gcp\_service\_list](#output\_gcp\_service\_list) | Google Cloud APIs required by HTCondor |
+| <a name="output_install_htcondor_runner"></a> [install\_htcondor\_runner](#output\_install\_htcondor\_runner) | Runner to install HTCondor using startup-scripts |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -1,0 +1,61 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: ensure HTCondor is installed
+  hosts: all
+  become: true
+  tasks:
+  - name: Upgrade all packages
+    yum:
+      name: '*'
+      state: latest
+  - name: setup HTCondor yum repository
+    yum:
+      name:
+      - epel-release
+      - https://research.cs.wisc.edu/htcondor/repo/9.x/htcondor-release-current.el7.noarch.rpm
+  - name: install HTCondor
+    yum:
+      name: condor
+      state: latest
+  - name: ensure token directory
+    file:
+      path: /etc/condor/tokens.d
+      mode: 0700
+      owner: root
+      group: root
+      recurse: true
+  - name: Ensure HTCondor is stopped and disabled. Must configure at boot!
+    ansible.builtin.service:
+      name: condor
+      enabled: false
+      state: stopped
+  - name: Ensure that firewall is started and enabled
+    ansible.builtin.service:
+      name: firewalld
+      enabled: true
+      state: started
+  - name: Ensure that only root and condor users can access service account
+    shell: |
+      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 1 \
+          -m owner --uid-owner root -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
+      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 2 \
+          -m owner --uid-owner condor -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
+      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 3 \
+          -p tcp -d metadata.google.internal --dport 80 -j DROP
+      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 4 \
+          -p tcp -d metadata.google.internal --dport 8080 -j DROP
+      firewall-cmd --permanent --zone=public --add-port=9618/tcp
+      firewall-cmd --reload

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -15,6 +15,8 @@
 ---
 - name: ensure HTCondor is installed
   hosts: all
+  vars:
+    block_metadata_server: true
   become: true
   tasks:
   - name: Upgrade all packages
@@ -48,7 +50,8 @@
       enabled: true
       state: started
   - name: Ensure that only root and condor users can access service account
-    shell: |
+    when: block_metadata_server | bool # allows string to be passed at CLI
+    ansible.builtin.shell: |
       firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 1 \
           -m owner --uid-owner root -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
       firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 2 \

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -19,21 +19,17 @@
     block_metadata_server: true
   become: true
   tasks:
-  - name: Upgrade all packages
-    yum:
-      name: '*'
-      state: latest
   - name: setup HTCondor yum repository
-    yum:
+    ansible.builtin.yum:
       name:
       - epel-release
       - https://research.cs.wisc.edu/htcondor/repo/9.x/htcondor-release-current.el7.noarch.rpm
   - name: install HTCondor
-    yum:
+    ansible.builtin.yum:
       name: condor
       state: latest
   - name: ensure token directory
-    file:
+    ansible.builtin.file:
       path: /etc/condor/tokens.d
       mode: 0700
       owner: root
@@ -45,10 +41,11 @@
       enabled: false
       state: stopped
   - name: Ensure that firewall is started and enabled
-    ansible.builtin.service:
+    ansible.builtin.systemd:
       name: firewalld
       enabled: true
       state: started
+      masked: no
   - name: Ensure that only root and condor users can access service account
     when: block_metadata_server | bool # allows string to be passed at CLI
     ansible.builtin.shell: |

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  install_htcondor_runner = {
+    "type"        = "ansible-local"
+    "source"      = "${path.module}/files/install-htcondor.yaml"
+    "destination" = "install-htcondor.yaml"
+  }
+
+  required_apis = [
+    "compute.googleapis.com",
+    "secretmanager.googleapis.com",
+  ]
+}

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -1,16 +1,18 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 locals {
   install_htcondor_runner = {

--- a/community/modules/scripts/htcondor-install/outputs.tf
+++ b/community/modules/scripts/htcondor-install/outputs.tf
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "install_htcondor_runner" {
+  description = "Runner to install HTCondor using startup-scripts"
+  value       = local.install_htcondor_runner
+}
+
+output "gcp_service_list" {
+  description = "Google Cloud APIs required by HTCondor"
+  value       = local.required_apis
+}

--- a/community/modules/scripts/htcondor-install/outputs.tf
+++ b/community/modules/scripts/htcondor-install/outputs.tf
@@ -1,16 +1,18 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 output "install_htcondor_runner" {
   description = "Runner to install HTCondor using startup-scripts"

--- a/community/modules/scripts/htcondor-install/variables.tf
+++ b/community/modules/scripts/htcondor-install/variables.tf
@@ -14,16 +14,8 @@
  * limitations under the License.
  */
 
-locals {
-  install_htcondor_runner = {
-    "type"        = "ansible-local"
-    "source"      = "${path.module}/files/install-htcondor.yaml"
-    "destination" = "install-htcondor.yaml"
-    "args"        = "-e block_metadata_server=${var.block_metadata_server}"
-  }
-
-  required_apis = [
-    "compute.googleapis.com",
-    "secretmanager.googleapis.com",
-  ]
+variable "block_metadata_server" {
+  description = "Use Linux firewall to block the instance metadata server for users other than root and HTCondor daemons"
+  type        = bool
+  default     = true
 }

--- a/community/modules/scripts/htcondor-install/versions.tf
+++ b/community/modules/scripts/htcondor-install/versions.tf
@@ -1,0 +1,17 @@
+#  Copyright 2022 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+terraform {
+  required_version = ">= 0.13.0"
+}

--- a/community/modules/scripts/htcondor-install/versions.tf
+++ b/community/modules/scripts/htcondor-install/versions.tf
@@ -1,16 +1,18 @@
-#  Copyright 2022 Google LLC
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 terraform {
   required_version = ">= 0.13.0"

--- a/modules/README.md
+++ b/modules/README.md
@@ -120,6 +120,9 @@ Modules that are still in development and less stable are labeled with the
 
 * **[startup-script]** ![core-badge] : Creates a customizable startup script
   that can be fed into compute VMs.
+* **[htcondor-install]** ![community-badge] ![experimental-badge] : Creates
+  a Toolkit runner to install HTCondor and a list of required APIs for use with
+  [service-enablement].
 * **[omnia-install]** ![community-badge] ![experimental-badge] : Installs Slurm
   via [Dell Omnia](https://github.com/dellhpc/omnia) onto a cluster of compute
   VMs.
@@ -130,6 +133,7 @@ Modules that are still in development and less stable are labeled with the
   successful completion of a startup script on a compute VM.
 
 [startup-script]: scripts/startup-script/README.md
+[htcondor-install]: ../community/modules/scripts/htcondor-install/README.md
 [omnia-install]: ../community/modules/scripts/omnia-install/README.md
 [spack-install]: ../community/modules/scripts/spack-install/README.md
 [wait-for-startup]: ../community/modules/scripts/wait-for-startup/README.md

--- a/modules/README.md
+++ b/modules/README.md
@@ -121,8 +121,7 @@ Modules that are still in development and less stable are labeled with the
 * **[startup-script]** ![core-badge] : Creates a customizable startup script
   that can be fed into compute VMs.
 * **[htcondor-install]** ![community-badge] ![experimental-badge] : Creates
-  a Toolkit runner to install HTCondor and a list of required APIs for use with
-  [service-enablement].
+  a startup script to install HTCondor and exports a list of required APIs
 * **[omnia-install]** ![community-badge] ![experimental-badge] : Installs Slurm
   via [Dell Omnia](https://github.com/dellhpc/omnia) onto a cluster of compute
   VMs.


### PR DESCRIPTION
- creates a runner to install HTCondor software on a VM (performs no configuration of HTCondor because there are many different roles an HTCondor machine can perform from a base package installation)
- add a firewall to prevent user jobs from escalating to privileges attached to the VM (an HTCondor machine is a mix of POSIX users)
- output a list of required GCP APIs to be enabled

It is a deliberate choice to only support (for now) the [HPC VM Image][hpcvmimage] or other RHEL7 derivative operating systems. This is primarily aimed at the "build an image" use case however nothing prevents it from being applied to VMs at boot.

[hpcvmimage]: https://cloud.google.com/blog/topics/hpc/introducing-hpc-vm-images

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?