### PR TITLE
Reliably detect when nodes fail to be scaled in

### DIFF
--- a/examples/hpc-cluster-high-io.yaml
+++ b/examples/hpc-cluster-high-io.yaml
@@ -95,6 +95,7 @@ deployment_groups:
     - compute_partition
     settings:
       controller_machine_type: c2-standard-8
+      suspend_time: 60
 
   - source: community/modules/scheduler/SchedMD-slurm-on-gcp-login-node
     kind: terraform

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
@@ -15,29 +15,42 @@
 ---
 
 - name: Get partition info
-  command: sinfo --format='%P' --noheader
+  ansible.builtin.command: sinfo --format='%P' --noheader
+  changed_when: False
   register: partition_output
+- name: Clount Slurm nodes
+  ansible.builtin.shell:
+    sinfo -t 'IDLE&POWERED_DOWN' --noheader --format "%n"
+  args:
+    executable: /bin/bash
+  changed_when: False
+  register: initial_node_count
 - name: Check partition compute exists
-  fail:
+  ansible.builtin.fail:
     msg: Test Check Partitions failed
   when: item not in partition_output.stdout
   loop: "{{ partitions }}"
-
 - name: Get mount info
-  stat:
+  ansible.builtin.stat:
     path: "{{ item }}"
   register: stat_mounts
   loop: "{{ mounts }}"
 - name: Check if mount exists
-  fail:
+  ansible.builtin.fail:
     msg: "{{ item.item }} not mounted"
   when: not item.stat.exists
   loop: "{{ stat_mounts.results }}"
-
 - name: Test Mounts on partitions
-  shell: srun -N 1 ls -laF {{ mounts | join(' ') }} && sleep 120
+  ansible.builtin.shell: srun -N 1 ls -laF {{ mounts | join(' ') }}
   loop: "{{ partitions }}"
-
 - name: Test partitions with hostname
-  shell: srun -N 2 --partition {{ item }} hostname && sleep 120
+  ansible.builtin.shell: srun -N 2 --partition {{ item }} hostname
   loop: "{{ partitions }}"
+- name: Ensure all nodes are powered down
+  ansible.builtin.shell:
+    sinfo -t 'IDLE&POWERED_DOWN' --noheader --format "%n"
+  register: final_node_count
+  changed_when: False
+  until: final_node_count.stdout_lines | length == initial_node_count.stdout_lines | length
+  retries: 40
+  delay: 15


### PR DESCRIPTION
This PR makes the following changes:

- for the high IO example, reduce the `suspend_time` to 60 seconds to more rapidly scale in nodes
- for all integration tests that rely on `test-mounts-and-partitions.yml` (all Slurm tests) ensure that all nodes enter the `POWERED_DOWN` state within 10 minutes of the last job submission; if they do not, the integration test fails

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?