### PR TITLE
Make Slurm integration tests more strict

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -188,3 +188,8 @@
       command:
         cmd: terraform destroy -auto-approve
         chdir: "{{ workspace }}/{{ deployment_name }}/primary"
+    - name: Check if there were failures
+      ansible.builtin.assert:
+        that:
+        - '" ERROR: " not in resume_output.stdout'
+        - '" ERROR: " not in suspend_output.stdout'


### PR DESCRIPTION
This modification will make all Slurm integration tests fail if "ERROR:"
appears in the autoscaler logs (resume.log or suspend.log)

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?