### PR TITLE
Fix rare failure modes of monitoring test

### DIFF
--- a/tools/cloud-build/ansible.cfg
+++ b/tools/cloud-build/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 stdout_callback=debug
 stderr_callback=debug
+remote_tmp=/tmp/ansible

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -33,6 +33,7 @@
   - name: Create Deployment Directory
     command: "{{ scripts_dir }}/create_deployment.sh"
     environment:
+      ALWAYS_RECOMPILE: "no"
       EXAMPLE_YAML: "{{ blueprint_yaml }}"
       PROJECT_ID: "{{ project }}"
       ROOT_DIR: "{{ workspace }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -23,6 +23,7 @@
   - name: Create Deployment Directory
     command: "{{ scripts_dir }}/create_deployment.sh"
     environment:
+      ALWAYS_RECOMPILE: "no"
       EXAMPLE_YAML: "{{ blueprint_yaml }}"
       PROJECT_ID: "{{ project }}"
       ROOT_DIR: "{{ workspace }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -33,6 +33,7 @@
   - name: Create Deployment Directory
     command: "{{ scripts_dir }}/create_deployment.sh"
     environment:
+      ALWAYS_RECOMPILE: "no"
       MAX_NODES: "{{ max_nodes }}"
       EXAMPLE_YAML: "{{ blueprint_yaml }}"
       PROJECT_ID: "{{ project }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
@@ -16,9 +16,10 @@
 
 - name: Wait for startup script to complete
   become: true
-  wait_for:
+  ansible.builtin.wait_for:
     path: /var/log/messages
     search_regex: '.*{{ remote_node }}.*startup-script exit status ([0-9]+)'
+    timeout: 600
   register: startup_status
 - name: Fail if ops agent is not running
   become: true

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
@@ -23,19 +23,19 @@
   register: startup_status
 - name: Fail if ops agent is not running
   become: true
-  command: systemctl is-active {{ item }}
+  ansible.builtin.command: systemctl is-active {{ item }}
   with_items:
   - google-cloud-ops-agent.service
   - google-cloud-ops-agent-fluent-bit.service
   - google-cloud-ops-agent-opentelemetry-collector.service
 - name: Check that monitoring dashboard has been created
-  command: gcloud monitoring dashboards list --format="get(displayName)"
+  ansible.builtin.command: gcloud monitoring dashboards list --format="get(displayName)"
   run_once: true
   delegate_to: localhost
   register: dashboards
 - debug:
     var: dashboards
 - name: Fail if the HPC Dashboard hasn't been created
-  fail:
+  ansible.builtin.fail:
     msg: Failed to create dashboard
   when: "deployment_name not in dashboards.stdout"

--- a/tools/cloud-build/daily-tests/create_deployment.sh
+++ b/tools/cloud-build/daily-tests/create_deployment.sh
@@ -20,6 +20,8 @@ BLUEPRINT_DIR=${BLUEPRINT_DIR:-blueprint}
 DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-missing-deployment-name}
 NETWORK=${NETWORK:-missing-network-name}
 MAX_NODES=${MAX_NODES:-2}
+ALWAYS_RECOMPILE=${ALWAYS_RECOMPILE:-yes}
+
 echo "Creating blueprint from ${EXAMPLE_YAML} in project ${PROJECT}"
 
 ## Add GCS Backend to example
@@ -39,7 +41,12 @@ cd "$ROOT_DIR" ||
 		echo "*** ERROR: failed to access root directory ${ROOT_DIR} when creating blueprint"
 		exit 1
 	}
-make
+
+if [[ $ALWAYS_RECOMPILE != "no" || ! -f ghpc ]]; then
+	make
+else
+	echo "Skipping recompilation due to pre-existing ghpc binary and ALWAYS_RECOMPILE == 'no'"
+fi
 
 ## Customize config yaml
 sed -i "s/blueprint_name: .*/blueprint_name: ${BLUEPRINT_DIR}/" "${EXAMPLE_YAML}" ||


### PR DESCRIPTION
Address 3 intermittent issues with integration test 3:

- timeout on startup-script completion (change 5 minutes to 10 minutes)
- failure to create an Ansible tmp directory under /home when /home is mounted over NFS during startup-script
- rare occasions when ghpc binary is over-written during execution because of multiple invocations of `create_deployment.sh` in a single build

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?
