### PR TITLE
Improve detection of Slurm startup

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -103,8 +103,6 @@
       add_host:
         hostname: "{{ login_ip.stdout }}"
         groups: [remote_host]
-    - name: Wait for cluster
-      wait_for_connection:
 
     ## Cleanup and fail gracefully
     rescue:
@@ -132,15 +130,23 @@
 
 - name: Run Integration Tests
   hosts: remote_host
-  gather_facts: false
+  gather_facts: no # must wait until host is reachable
+  ignore_unreachable: true # ensure always block will run even if SSH fails
   tasks:
   - name: Slurm Test Block
     vars:
       ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
     block:
-    - name: Pause for 2 minutes to allow cluster setup
-      pause:
-        minutes: 2
+    - name: Wait until host is reachable
+      ansible.builtin.wait_for_connection:
+        delay: 60
+        timeout: 300
+    - name: Gather facts
+      ansible.builtin.setup:
+    - name: Wait until Munge is active
+      ansible.builtin.wait_for:
+        path: /var/run/munge/munge.socket.2
+        timeout: 600
     - name: Run Integration tests for HPC toolkit
       include_tasks: "{{ test }}"
       run_once: true

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
@@ -18,6 +18,9 @@
   ansible.builtin.command: sinfo --format='%P' --noheader
   changed_when: False
   register: partition_output
+  retries: 10
+  delay: 12
+  until: partition_output.rc == 0
 - name: Clount Slurm nodes
   ansible.builtin.shell:
     sinfo -t 'IDLE&POWERED_DOWN' --noheader --format "%n"


### PR DESCRIPTION
Avoids transient failure recently observed in "Get partition info" step of Slurm integration tests by waiting until Munge has started to run `sinfo` and to configure the `sinfo` step to retry for up to 2 minutes.

To my awareness a Slurm login node has no active Slurm daemons, just munge for authenticating to the controller.

```
TASK [Get partition info] ******************************************************
fatal: [35.224.219.218]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "cmd": [
        "sinfo",
        "--format=%P",
        "--noheader"
    ],
    "delta": "0:00:02.508607",
    "end": "2022-06-13 21:07:38.976905",
    "rc": 1,
    "start": "2022-06-13 21:07:36.468298"
}

STDERR:

sinfo: error: If munged is up, restart with --num-threads=10
sinfo: error: Munge encode failed: Failed to access "/var/run/munge/munge.socket.2": No such file or directory
sinfo: error: slurm_send_node_msg: auth_g_create: REQUEST_PARTITION_INFO has authentication error
slurm_load_partitions: Protocol authentication error
```

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?