### PR TITLE
Install compatible protobuf for older Python

### DIFF
--- a/community/modules/scripts/spack-install/scripts/install_spack_deps.yml
+++ b/community/modules/scripts/spack-install/scripts/install_spack_deps.yml
@@ -15,14 +15,24 @@
 ---
 
 - name: Install dependencies for spack installation
+  become: yes
   hosts: localhost
   tasks:
   - name: Install pip3 and git
-    package:
+    ansible.builtin.package:
       name:
       - python3-pip
       - git
+  - name: Gather the package facts
+    ansible.builtin.package_facts:
+      manager: auto
+  - name: Install protobuf for old releases of Python
+    when: ansible_facts.packages["python3"][0].version is version("3.7", "<") and ansible_facts.packages["python3"][0].version is version("3.5", ">=")
+    ansible.builtin.pip:
+      name: protobuf
+      version: 3.19.4
+      executable: pip3
   - name: Install google cloud storage
-    pip:
+    ansible.builtin.pip:
       name: google-cloud-storage
       executable: pip3


### PR DESCRIPTION
The protobuf library is heavily used by other Google Cloud libraries. We can use the Ansible fact for the Python 3 package version to ensure that we are installing a compatible release of protobuf on systems with out-of-date Python (e.g. CentOS 7 and the "HPC VM Image").

Resolves #368

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?