### PR TITLE
Add security setting for go-getter

### DIFF
--- a/pkg/sourcereader/github.go
+++ b/pkg/sourcereader/github.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/hashicorp/go-getter"
 )
@@ -31,7 +32,7 @@ var goGetterDetectors = []getter.Detector{
 }
 
 var goGetterGetters = map[string]getter.Getter{
-	"git": new(getter.GitGetter),
+	"git": &getter.GitGetter{Timeout: 5 * time.Minute},
 }
 
 var goGetterDecompressors = map[string]getter.Decompressor{}


### PR DESCRIPTION
[A vulnerability in go-getter](https://discuss.hashicorp.com/t/hcsec-2022-13-multiple-vulnerabilities-in-go-getter-library/39930) was discovered. It is partially addressed by upgrading to 1.6.1 (already done on develop) but it also introduces new security settings that we should review and maybe (or not!) adopt. A version upgrade in this toolkit was done by #350 (@tpdownes).

The announcement indicates that the security concerns are greater for server-based go-getter solutions while we are a client, but we support the new setting in this toolkit as well.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
