### PR TITLE
Adopt Google Private Access by default

### DIFF
--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -16,6 +16,14 @@ The following firewall rules are created with the VPC network:
 * Allow SSH access from the Cloud Console ("35.235.240.0/20").
 * Allow traffic between nodes within the VPC
 
+Additionally, [Google Private Access][gpa] is enabled by default on all
+subnetworks unless it is explicitly disabled. This setting ensures that all VMs
+can use Google services such as [Cloud Storage][gcs] even if they do not have
+public IP addresses or Cloud NAT is disabled.
+
+[gpa]: https://cloud.google.com/vpc/docs/private-google-access
+[gcs]: https://cloud.google.com/storage
+
 ### Primary and additional subnetworks
 
 This module will, at minimum, provision a "primary" subnetwork in which most

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -26,7 +26,7 @@ locals {
     subnet_name           = local.subnetwork_name
     subnet_ip             = local.cidr_blocks[0]
     subnet_region         = var.region
-    subnet_private_access = false
+    subnet_private_access = true
     subnet_flow_logs      = false
     description           = "primary subnetwork in ${local.network_name}"
     purpose               = null
@@ -40,7 +40,7 @@ locals {
       subnet_name           = subnet.subnet_name
       subnet_ip             = local.cidr_blocks[index + 1]
       subnet_region         = subnet.subnet_region
-      subnet_private_access = lookup(subnet, "subnet_private_access", false)
+      subnet_private_access = lookup(subnet, "subnet_private_access", true)
       subnet_flow_logs      = lookup(subnet, "subnet_flow_logs", false)
       description           = lookup(subnet, "description", null)
       purpose               = lookup(subnet, "purpose", null)


### PR DESCRIPTION
When the user is not explicit about the Google Private Access setting for a subnetwork, enable it by default.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?