### PR TITLE
Patch omnia-install to continue working with 1.0

### DIFF
--- a/community/modules/scripts/omnia-install/templates/install_omnia.tpl
+++ b/community/modules/scripts/omnia-install/templates/install_omnia.tpl
@@ -74,6 +74,16 @@
       path: "{{ omnia_dir }}/omnia.yml"
       regexp: '- name(.*)'
       replace: '- name\1\n  become: yes'
+  - name: Patch Slurm source URL
+    replace:
+      path: "{{ omnia_dir }}/roles/slurm_manager/vars/main.yml"
+      regexp: '(.*)slurm-20.11.7.tar.bz2(.*)'
+      replace: '\1slurm-20.11.9.tar.bz2\2'
+  - name: Patch Slurm source checksum
+    replace:
+      path: "{{ omnia_dir }}/roles/slurm_manager/vars/main.yml"
+      regexp: '^slurm_md5: .*'
+      replace: 'slurm_md5: "md5:79b39943768ef21b83585e2f5087d9af"'
 
 - name: Run the Omnia installation once all nodes are ready
   hosts: localhost


### PR DESCRIPTION
Requires changing the path to the slurm source tar file from *.7 to *.9.
Long-term, the plan is to update the module to support the latest
release.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
