### PR TITLE
Extend periodic cleanup to reset Filestore API

### DIFF
--- a/tools/clean-filestore-limit.sh
+++ b/tools/clean-filestore-limit.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -o pipefail
+
+PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value project)}
+if [ -z "$PROJECT_ID" ]; then
+	echo "PROJECT_ID must be defined"
+	exit 1
+fi
+
+ACTIVE_BUILDS=$(gcloud builds list --project "${PROJECT_ID}" --ongoing 2>/dev/null)
+ACTIVE_FILESTORE=$(gcloud filestore instances list --project "${PROJECT_ID}" --format='value(name)')
+if [[ -z "$ACTIVE_BUILDS" && -z "$ACTIVE_FILESTORE" ]]; then
+	echo "Disabling Filestore API..."
+	gcloud services disable file.googleapis.com --force --project "${PROJECT_ID}"
+	echo "Re-enabling Filestore API..."
+	gcloud services enable file.googleapis.com --project "${PROJECT_ID}"
+	echo "Re-enabled Filestore API..."
+elif [[ -n "$ACTIVE_BUILDS" ]]; then
+	echo "There are active Cloud Build jobs. Refusing to disable/enable Filestore to reset internal limit."
+elif [[ -n "$ACTIVE_FILESTORE" ]]; then
+	echo "There are active Filestore instances. These may require manual cleanup."
+fi
+
+exit 0

--- a/tools/cloud-build/project-cleanup.yaml
+++ b/tools/cloud-build/project-cleanup.yaml
@@ -24,3 +24,4 @@ steps:
   - |
     set -e
     /workspace/tools/clean-resource-policies.sh
+    /workspace/tools/clean-filestore-limit.sh


### PR DESCRIPTION
Cloud Filestore has a limit on the number of internal networks that can be created to peer the Filestore managed service to the user's VPCs. One can avoid this problem by reusing names of Filestore instances (undesirable if one wants to run builds in parallel) or periodically resetting the Filestore API. This commit implements the reset.

https://cloud.google.com/filestore/docs/troubleshooting#system_limit_for_internal_resources_has_been_reached_error_when_creating_an_instance

I do not believe that either of the `elif` blocks should constitute failure of the script. It's OK for them to exit that way, but if we are regularly exiting via those blocks we should consider scheduling the cleanup at a different time of day.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?