### PR TITLE
Fix Cloud Build Filestore cleanup

### DIFF
--- a/tools/clean-filestore-limit.sh
+++ b/tools/clean-filestore-limit.sh
@@ -15,13 +15,14 @@
 
 set -e -o pipefail
 
+BUILD_ID=${BUILD_ID:-non-existent-build}
 PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value project)}
 if [ -z "$PROJECT_ID" ]; then
 	echo "PROJECT_ID must be defined"
 	exit 1
 fi
 
-ACTIVE_BUILDS=$(gcloud builds list --project "${PROJECT_ID}" --ongoing 2>/dev/null)
+ACTIVE_BUILDS=$(gcloud builds list --project "${PROJECT_ID}" --filter="id!=\"${BUILD_ID}\"" --ongoing 2>/dev/null)
 ACTIVE_FILESTORE=$(gcloud filestore instances list --project "${PROJECT_ID}" --format='value(name)')
 if [[ -z "$ACTIVE_BUILDS" && -z "$ACTIVE_FILESTORE" ]]; then
 	echo "Disabling Filestore API..."

--- a/tools/cloud-build/project-cleanup.yaml
+++ b/tools/cloud-build/project-cleanup.yaml
@@ -18,6 +18,7 @@ steps:
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash
   env:
+  - "BUILD_ID=${BUILD_ID}"
   - "PROJECT_ID=${PROJECT_ID}"
   args:
   - -c


### PR DESCRIPTION
When testing whether there are active Cloud Build operations, the script
must filter against its own build ID.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?