### PR TITLE
Update minimum Packer release

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ See
 
 The Toolkit supports Packer templates in the contemporary [HCL2 file
 format][pkrhcl2] and not in the legacy JSON file format. We require the use of
-Packer 1.7 or above, and recommend using the latest release.
+Packer 1.7.9 or above, and recommend using the latest release.
 
 The Toolkit's [Packer template module documentation][pkrmodreadme] describes
 input variables and their behavior. An [image-building example][pkrexample]

--- a/modules/packer/custom-image/versions.pkr.hcl
+++ b/modules/packer/custom-image/versions.pkr.hcl
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 packer {
-  required_version = "~> 1.7"
+  required_version = ">= 1.7.9, < 2.0.0"
 
   required_plugins {
     googlecompute = {


### PR DESCRIPTION
The ability to use a variable input in the build name was not introduced
until Packer 1.7.9. This commits enforces that minimum release while
continuing to pre-emptively declare incompatibility with Packer 2.0
(which does not yet exist).

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?