### PR TITLE
fix: install_nfs_client_runner was using 'content' instead of 'source'

### DIFF
--- a/community/modules/file-system/nfs-server/main.tf
+++ b/community/modules/file-system/nfs-server/main.tf
@@ -22,7 +22,7 @@ locals {
   name = var.name != null ? var.name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
   install_nfs_client_runner = {
     "type"        = "shell"
-    "content"     = "${path.module}/scripts/install-nfs-client.sh"
+    "source"      = "${path.module}/scripts/install-nfs-client.sh"
     "destination" = "install-nfs.sh"
   }
   mount_runner = {

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -22,7 +22,7 @@ locals {
   timeouts = var.filestore_tier == "HIGH_SCALE_SSD" ? [1] : []
   install_nfs_client_runner = {
     "type"        = "shell"
-    "content"     = "${path.module}/scripts/install-nfs-client.sh"
+    "source"      = "${path.module}/scripts/install-nfs-client.sh"
     "destination" = "install-nfs.sh"
   }
   mount_runner = {


### PR DESCRIPTION
Tested:
- Manually tested and verified that errors in startup script logs go away
- Run group 3 integration tests, which include omnia, which uses this runner

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
