### PR TITLE
Address bug in Shared VPC Filestore blueprint

### DIFF
--- a/community/examples/hpc-cluster-small-sharedvpc.yaml
+++ b/community/examples/hpc-cluster-small-sharedvpc.yaml
@@ -31,8 +31,6 @@ blueprint_name: hpc-cluster-small-sharedvpc
 vars:
   project_id:  ## Set GCP Project ID Here ##
   host_project_id: your-host-project
-  network_name: your-shared-network
-  subnetwork_name: your-shared-subnetwork
   deployment_name: hpc-small-shared-vpc
   region: us-central1
   zone: us-central1-c
@@ -45,6 +43,8 @@ deployment_groups:
     id: network1
     settings:
       project_id: $(vars.host_project_id)
+      network_name: your-shared-network
+      subnetwork_name: your-shared-subnetwork
 
   - source: modules/file-system/filestore
     kind: terraform
@@ -52,9 +52,8 @@ deployment_groups:
     use: [network1]
     settings:
       local_mount: /home
-      project_id: $(vars.host_project_id)
       connect_mode: PRIVATE_SERVICE_ACCESS
-
+      network_name: $(network1.network_id)
 
   # This debug_partition will work out of the box without requesting additional GCP quota.
   - source: community/modules/compute/SchedMD-slurm-on-gcp-partition

--- a/modules/network/pre-existing-vpc/README.md
+++ b/modules/network/pre-existing-vpc/README.md
@@ -80,8 +80,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | The name of the network created |
-| <a name="output_network_self_link"></a> [network\_self\_link](#output\_network\_self\_link) | The URI of the VPC being created |
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | The ID of the existing network |
+| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | The name of the existing network |
+| <a name="output_network_self_link"></a> [network\_self\_link](#output\_network\_self\_link) | The URI of the existing network |
 | <a name="output_subnetwork"></a> [subnetwork](#output\_subnetwork) | The subnetwork in the specified primary region |
 | <a name="output_subnetwork_address"></a> [subnetwork\_address](#output\_subnetwork\_address) | The subnetwork address in the specified primary region |
 | <a name="output_subnetwork_name"></a> [subnetwork\_name](#output\_subnetwork\_name) | The name of the subnetwork in the specified primary region |

--- a/modules/network/pre-existing-vpc/outputs.tf
+++ b/modules/network/pre-existing-vpc/outputs.tf
@@ -15,12 +15,17 @@
 */
 
 output "network_name" {
-  description = "The name of the network created"
+  description = "The name of the existing network"
   value       = data.google_compute_network.vpc.name
 }
 
+output "network_id" {
+  description = "The ID of the existing network"
+  value       = data.google_compute_network.vpc.id
+}
+
 output "network_self_link" {
-  description = "The URI of the VPC being created"
+  description = "The URI of the existing network"
   value       = data.google_compute_network.vpc.self_link
 }
 

--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -152,6 +152,7 @@ No resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_nat_ips"></a> [nat\_ips](#output\_nat\_ips) | the external IPs assigned to the NAT |
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | The ID of the network created |
 | <a name="output_network_name"></a> [network\_name](#output\_network\_name) | The name of the network created |
 | <a name="output_network_self_link"></a> [network\_self\_link](#output\_network\_self\_link) | The URI of the VPC being created |
 | <a name="output_subnetwork"></a> [subnetwork](#output\_subnetwork) | The primary subnetwork object created by the input variable primary\_subnetwork |

--- a/modules/network/vpc/outputs.tf
+++ b/modules/network/vpc/outputs.tf
@@ -20,6 +20,12 @@ output "network_name" {
   depends_on  = [module.firewall_rules, module.cloud_router]
 }
 
+output "network_id" {
+  description = "The ID of the network created"
+  value       = module.vpc.network_id
+  depends_on  = [module.firewall_rules, module.cloud_router]
+}
+
 output "network_self_link" {
   description = "The URI of the VPC being created"
   value       = module.vpc.network_self_link


### PR DESCRIPTION
Filestore Shared VPC blueprint was setting the entire Filestore instance to use the host project as a means of attaching to the network, identified by name alone. Resolve this problem by referring to the network by its ID (projects/HOST_PROJECT/.../network_name). Requires adding output value to pre-existing-vpc module. This value is added to the VPC creation module for good measure.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?