### PR TITLE
Fix Filestore cleanup

### DIFF
--- a/tools/clean-filestore-limit.sh
+++ b/tools/clean-filestore-limit.sh
@@ -24,7 +24,7 @@ fi
 
 ACTIVE_BUILDS=$(gcloud builds list --project "${PROJECT_ID}" --filter="id!=\"${BUILD_ID}\"" --ongoing 2>/dev/null)
 ACTIVE_FILESTORE=$(gcloud filestore instances list --project "${PROJECT_ID}" --format='value(name)')
-if [[ -z "$ACTIVE_BUILDS" && -z "$ACTIVE_FILESTORE" ]]; then
+if [[ ! (-n "$ACTIVE_BUILDS" || -n "$ACTIVE_FILESTORE") ]]; then
 	echo "Disabling Filestore API..."
 	gcloud services disable file.googleapis.com --force --project "${PROJECT_ID}"
 	echo "Re-enabling Filestore API..."


### PR DESCRIPTION
The Filestore cleanup should run if either or both of its blocking conditions are true, not only when both are true.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?