### PR TITLE
Improve ansible installation reliability

### DIFF
--- a/modules/scripts/startup-script/examples/install_ansible.sh
+++ b/modules/scripts/startup-script/examples/install_ansible.sh
@@ -34,10 +34,10 @@ if [ ! -h /usr/bin/ansible-playbook ] || [ ! -f /usr/bin/ansible-playbook ]; the
 	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
 		if [ ! -f /bin/pip ]; then
 			curl -Os https://bootstrap.pypa.io/pip/2.7/get-pip.py
-			python get-pip.py
+			/usr/bin/python get-pip.py
 		fi
-		python -m pip install virtualenv
-		virtualenv /usr/local/toolkit
+		/usr/bin/python -m pip install virtualenv
+		/usr/bin/python -m virtualenv /usr/local/toolkit
 		/usr/local/toolkit/bin/python -m pip install wheel
 		/usr/local/toolkit/bin/python -m pip install ansible==2.9.27
 		ln -s /usr/local/toolkit/bin/ansible-playbook /usr/bin/ansible-playbook

--- a/modules/scripts/startup-script/examples/install_ansible.sh
+++ b/modules/scripts/startup-script/examples/install_ansible.sh
@@ -30,11 +30,17 @@ apt_wait() {
 	fi
 }
 
-if ! command -v ansible-playbook >/dev/null 2>&1; then
+if [ ! -h /usr/bin/ansible-playbook ] || [ ! -f /usr/bin/ansible-playbook ]; then
 	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
-		yum -y install epel-release
-		yum -y install ansible
-
+		if [ ! -f /bin/pip ]; then
+			curl -Os https://bootstrap.pypa.io/pip/2.7/get-pip.py
+			python get-pip.py
+		fi
+		python -m pip install virtualenv
+		virtualenv /usr/local/toolkit
+		/usr/local/toolkit/bin/python -m pip install wheel
+		/usr/local/toolkit/bin/python -m pip install ansible==2.9.27
+		ln -s /usr/local/toolkit/bin/ansible-playbook /usr/bin/ansible-playbook
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
 		echo 'WARNING: unsupported installation of ansible in debian / ubuntu'
 		apt_wait


### PR DESCRIPTION
Address extreme and reasonably frequent slowness of Yum mirrors by adopting pip to install Ansible and installing pip from a bootstrap script built to avoid dependencies. Continue to use the older release of Ansible (2.9.27) that requires using Python2 interpreter until we have tested our playbooks with newer release of Ansible.

Each step in this script interacts with CDN-backed HTTPS websites. It takes the further steps:

1. Installs Ansible into a "toolkit" virtual environment
2. Links ansible-playbook from virtual environment to /usr/bin

I believe 1 is very much best practice to ensure that our dependencies do not interact with dependencies installed by users for workloads. As for 2, it will temporarily ensure we need to make no other changes to our Ansible playbooks to ensure that it uses the correct copy of Ansible and the Python dependencies installed in the virtual environment.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
