### PR TITLE
Reduce HTCondor SchedD update interval

### DIFF
--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -57,6 +57,15 @@
         mode: 0644
         content: |
           CONDOR_HOST={{ cm.content }}
+  - name: Configure HTCondor SchedD
+    when: htcondor_role == 'get_htcondor_submit'
+    block:
+    - name: Create SchedD configuration file
+      ansible.builtin.copy:
+        dest: /etc/condor/config.d/02-schedd
+        mode: 0644
+        content: |
+          SCHEDD_INTERVAL=15
   - name: Set HTCondor credentials
     ansible.builtin.shell: |
       set -e -o pipefail


### PR DESCRIPTION
This commit increases the frequency at which the SchedD will update the collector with ClassAd information. Although this is not strictly necessary for jobs to run, it does ensure that `condor_status -schedd` returns information about the scheduler more quickly. For Toolkit, this will ensure integration tests succeed or fail on the merits rather than due to a race condition.

Although the default is 300s, and this reduces it to 15s, I believe this interval is perfectly reasonable and will not impose a load burden.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?
