### PR TITLE
Update HTCondor installation module

### DIFF
--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -34,12 +34,6 @@
       mode: 0700
       owner: root
       group: root
-      recurse: true
-  - name: Ensure HTCondor is stopped and disabled. Must configure at boot!
-    ansible.builtin.service:
-      name: condor
-      enabled: false
-      state: stopped
   - name: Ensure that firewall is started and enabled
     ansible.builtin.systemd:
       name: firewalld


### PR DESCRIPTION
- support boot-time installation of HTCondor and rebooting machines by
  not explicitly stopping / disabling condor.service (otherwise, upon
  reboot it will start/stop/start)
- do not recurse into tokens directory to modify permissions of files (BUG)

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?