### PR TITLE
Install HTCondor autoscaler into filesystem and fix node deletion bug

### DIFF
--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -66,8 +66,8 @@ limitations under the License.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_point_roles"></a> [access\_point\_roles](#input\_access\_point\_roles) | Project-wide roles for HTCondor Access Point service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
-| <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/compute.instanceAdmin",<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_access_point_roles"></a> [access\_point\_roles](#input\_access\_point\_roles) | Project-wide roles for HTCondor Access Point service account | `list(string)` | <pre>[<br>  "roles/compute.instanceAdmin",<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_pool_password"></a> [pool\_password](#input\_pool\_password) | HTCondor Pool Password | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |

--- a/community/modules/scheduler/htcondor-configure/main.tf
+++ b/community/modules/scheduler/htcondor-configure/main.tf
@@ -22,14 +22,14 @@ locals {
 
   pool_password = var.pool_password == null ? random_password.pool.result : var.pool_password
 
-  role_runner_cm = {
+  runner_cm_role = {
     "type"        = "ansible-local"
     "content"     = file("${path.module}/files/htcondor_configure.yml")
     "destination" = "htcondor_configure.yml"
     "args"        = "-e htcondor_role=get_htcondor_central_manager -e password_id=${google_secret_manager_secret.pool_password.secret_id}"
   }
 
-  role_runner_access = {
+  runner_access_role = {
     "type"        = "ansible-local"
     "content"     = file("${path.module}/files/htcondor_configure.yml")
     "destination" = "htcondor_configure.yml"

--- a/community/modules/scheduler/htcondor-configure/outputs.tf
+++ b/community/modules/scheduler/htcondor-configure/outputs.tf
@@ -38,10 +38,10 @@ output "pool_password_secret_id" {
 
 output "central_manager_runner" {
   description = "Toolkit Runner to configure an HTCondor Central Manager"
-  value       = local.role_runner_cm
+  value       = local.runner_cm_role
 }
 
 output "access_point_runner" {
   description = "Toolkit Runner to configure an HTCondor Access Point"
-  value       = local.role_runner_access
+  value       = local.runner_access_role
 }

--- a/community/modules/scheduler/htcondor-configure/variables.tf
+++ b/community/modules/scheduler/htcondor-configure/variables.tf
@@ -28,6 +28,7 @@ variable "access_point_roles" {
   description = "Project-wide roles for HTCondor Access Point service account"
   type        = list(string)
   default = [
+    "roles/compute.instanceAdmin",
     "roles/monitoring.metricWriter",
     "roles/logging.logWriter",
     "roles/storage.objectViewer",
@@ -38,7 +39,6 @@ variable "central_manager_roles" {
   description = "Project-wide roles for HTCondor Central Manager service account"
   type        = list(string)
   default = [
-    "roles/compute.instanceAdmin",
     "roles/monitoring.metricWriter",
     "roles/logging.logWriter",
     "roles/storage.objectViewer",

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -66,5 +66,7 @@ No resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_gcp_service_list"></a> [gcp\_service\_list](#output\_gcp\_service\_list) | Google Cloud APIs required by HTCondor |
+| <a name="output_install_autoscaler_deps_runner"></a> [install\_autoscaler\_deps\_runner](#output\_install\_autoscaler\_deps\_runner) | Toolkit Runner to install HTCondor autoscaler dependencies |
+| <a name="output_install_autoscaler_runner"></a> [install\_autoscaler\_runner](#output\_install\_autoscaler\_runner) | Toolkit Runner to install HTCondor autoscaler |
 | <a name="output_install_htcondor_runner"></a> [install\_htcondor\_runner](#output\_install\_htcondor\_runner) | Runner to install HTCondor using startup-scripts |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/htcondor-install/files/install-htcondor-autoscaler-deps.yml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor-autoscaler-deps.yml
@@ -1,0 +1,46 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Install but do not activate HTCondor autoscaler
+  become: true
+  hosts: localhost
+  tasks:
+  - name: Install Python 3 pip
+    ansible.builtin.package:
+      name: python3-pip
+      state: present
+  - name: Create virtual environment for HTCondor autoscaler
+    ansible.builtin.pip:
+      name: pip
+      version: 21.3.1
+      virtualenv: /usr/local/htcondor
+      virtualenv_command: /usr/bin/python3 -m venv
+  - name: Install latest setuptools
+    ansible.builtin.pip:
+      name: setuptools
+      state: latest
+      virtualenv: /usr/local/htcondor
+      virtualenv_command: /usr/bin/python3 -m venv
+  - name: Install HTCondor autoscaler dependencies
+    with_items:
+    - oauth2client
+    - google-api-python-client
+    - absl-py
+    - htcondor
+    ansible.builtin.pip:
+      name: "{{ item }}"
+      state: latest
+      virtualenv: /usr/local/htcondor
+      virtualenv_command: /usr/bin/python3 -m venv

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -15,11 +15,23 @@
  */
 
 locals {
-  install_htcondor_runner = {
+  runner_install_htcondor = {
     "type"        = "ansible-local"
     "source"      = "${path.module}/files/install-htcondor.yaml"
     "destination" = "install-htcondor.yaml"
     "args"        = "-e block_metadata_server=${var.block_metadata_server}"
+  }
+
+  runner_install_autoscaler_deps = {
+    "type"        = "ansible-local"
+    "content"     = file("${path.module}/files/install-htcondor-autoscaler-deps.yml")
+    "destination" = "install-htcondor-autoscaler-deps.yml"
+  }
+
+  runner_install_autoscaler = {
+    "type"        = "data"
+    "content"     = file("${path.module}/files/autoscaler.py")
+    "destination" = "/usr/local/htcondor/bin/autoscaler.py"
   }
 
   required_apis = [

--- a/community/modules/scripts/htcondor-install/outputs.tf
+++ b/community/modules/scripts/htcondor-install/outputs.tf
@@ -16,7 +16,17 @@
 
 output "install_htcondor_runner" {
   description = "Runner to install HTCondor using startup-scripts"
-  value       = local.install_htcondor_runner
+  value       = local.runner_install_htcondor
+}
+
+output "install_autoscaler_deps_runner" {
+  description = "Toolkit Runner to install HTCondor autoscaler dependencies"
+  value       = local.runner_install_autoscaler_deps
+}
+
+output "install_autoscaler_runner" {
+  description = "Toolkit Runner to install HTCondor autoscaler"
+  value       = local.runner_install_autoscaler
 }
 
 output "gcp_service_list" {


### PR DESCRIPTION
- Enhance htcondor-configure
  - anticipate that access point (not central manager) will run autoscaler in most installations
  - there are some harmless variable name changes to harmonize style
- Enhance htcondor-install
  - fix bug in node deletion from regional MIGs (status quo simply doesn't work)
  - create runner that installs a Python virtual environment with autoscaler dependencies
  - create runner that installs the actual autoscaler Python code

This PR does not actually cause the autoscaler to execute. That will be in a forthcoming PR.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?