### PR TITLE
Add public example for HTCondor Pool

### DIFF
--- a/community/examples/README.md
+++ b/community/examples/README.md
@@ -32,3 +32,7 @@ Examples using Intel HPC technologies can be found in the
 ### slurm-gcp-v5-cluster.yaml
 
 [See description in core](../../examples/README.md#slurm-gcp-v5-clusteryaml--)
+
+### htcondor-pool.yaml
+
+[See description in core](../../examples/README.md#htcondor-poolyaml--)

--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -1,0 +1,136 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+blueprint_name: htcondor-pool
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: htcondor-001
+  region: us-central1
+  zone: us-central1-c
+
+deployment_groups:
+- group: htcondor
+  modules:
+  - source: modules/network/vpc
+    kind: terraform
+    id: network1
+    settings:
+      network_name: htcondor-pool
+      subnetwork_name: htcondor-pool-usc1
+    outputs:
+    - network_name
+
+  - source: community/modules/scripts/htcondor-install
+    kind: terraform
+    id: htcondor_install
+
+  - source: community/modules/project/service-enablement
+    kind: terraform
+    id: htcondor_services
+    use:
+    - htcondor_install
+
+  - source: community/modules/scheduler/htcondor-configure
+    kind: terraform
+    id: htcondor_configure
+
+  - source: modules/scripts/startup-script
+    kind: terraform
+    id: htcondor_configure_central_manager
+    settings:
+      runners:
+      - type: shell
+        source: modules/startup-script/examples/install_ansible.sh
+        destination: install_ansible.sh
+      - $(htcondor_install.install_htcondor_runner)
+      - $(htcondor_configure.central_manager_runner)
+
+  - source: modules/scripts/startup-script
+    kind: terraform
+    id: htcondor_configure_access_point
+    settings:
+      runners:
+      - type: shell
+        source: modules/startup-script/examples/install_ansible.sh
+        destination: install_ansible.sh
+      - $(htcondor_install.install_htcondor_runner)
+      - $(htcondor_install.install_autoscaler_deps_runner)
+      - $(htcondor_install.install_autoscaler_runner)
+      - $(htcondor_configure.access_point_runner)
+      - $(htcondor_execute_point.configure_autoscaler_runner)
+
+  - source: modules/scripts/startup-script
+    kind: terraform
+    id: htcondor_configure_execute_point
+    settings:
+      runners:
+      - type: shell
+        source: modules/startup-script/examples/install_ansible.sh
+        destination: install_ansible.sh
+      - $(htcondor_install.install_htcondor_runner)
+      - $(htcondor_configure.execute_point_runner)
+
+  - source: modules/compute/vm-instance
+    kind: terraform
+    id: htcondor_cm
+    use:
+    - network1
+    - htcondor_configure_central_manager
+    settings:
+      enable_oslogin: DISABLE
+      name_prefix: central-manager
+      machine_type: c2-standard-4
+      disable_public_ips: true
+      service_account:
+        email: $(htcondor_configure.central_manager_service_account)
+        scopes:
+        - cloud-platform
+    outputs:
+    - internal_ip
+
+  - source: community/modules/compute/htcondor-execute-point
+    kind: terraform
+    id: htcondor_execute_point
+    use:
+    - network1
+    - htcondor_configure_execute_point
+    settings:
+      metadata:
+        central-manager: ((module.htcondor_cm.internal_ip[0]))
+        enable-oslogin: "FALSE"
+      service_account:
+        email: $(htcondor_configure.execute_point_service_account)
+        scopes:
+        - cloud-platform
+
+  - source: modules/compute/vm-instance
+    kind: terraform
+    id: htcondor_access
+    use:
+    - network1
+    - htcondor_configure_access_point
+    settings:
+      enable_oslogin: DISABLE
+      name_prefix: access-point
+      machine_type: c2-standard-4
+      metadata:
+        central-manager: ((module.htcondor_cm.internal_ip[0]))
+      service_account:
+        email: $(htcondor_configure.access_point_service_account)
+        scopes:
+        - cloud-platform
+    outputs:
+    - external_ip

--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -58,31 +58,6 @@ deployment_groups:
       - $(htcondor_install.install_htcondor_runner)
       - $(htcondor_configure.central_manager_runner)
 
-  - source: modules/scripts/startup-script
-    kind: terraform
-    id: htcondor_configure_access_point
-    settings:
-      runners:
-      - type: shell
-        source: modules/startup-script/examples/install_ansible.sh
-        destination: install_ansible.sh
-      - $(htcondor_install.install_htcondor_runner)
-      - $(htcondor_install.install_autoscaler_deps_runner)
-      - $(htcondor_install.install_autoscaler_runner)
-      - $(htcondor_configure.access_point_runner)
-      - $(htcondor_execute_point.configure_autoscaler_runner)
-
-  - source: modules/scripts/startup-script
-    kind: terraform
-    id: htcondor_configure_execute_point
-    settings:
-      runners:
-      - type: shell
-        source: modules/startup-script/examples/install_ansible.sh
-        destination: install_ansible.sh
-      - $(htcondor_install.install_htcondor_runner)
-      - $(htcondor_configure.execute_point_runner)
-
   - source: modules/compute/vm-instance
     kind: terraform
     id: htcondor_cm
@@ -101,6 +76,17 @@ deployment_groups:
     outputs:
     - internal_ip
 
+  - source: modules/scripts/startup-script
+    kind: terraform
+    id: htcondor_configure_execute_point
+    settings:
+      runners:
+      - type: shell
+        source: modules/startup-script/examples/install_ansible.sh
+        destination: install_ansible.sh
+      - $(htcondor_install.install_htcondor_runner)
+      - $(htcondor_configure.execute_point_runner)
+
   - source: community/modules/compute/htcondor-execute-point
     kind: terraform
     id: htcondor_execute_point
@@ -115,6 +101,20 @@ deployment_groups:
         email: $(htcondor_configure.execute_point_service_account)
         scopes:
         - cloud-platform
+
+  - source: modules/scripts/startup-script
+    kind: terraform
+    id: htcondor_configure_access_point
+    settings:
+      runners:
+      - type: shell
+        source: modules/startup-script/examples/install_ansible.sh
+        destination: install_ansible.sh
+      - $(htcondor_install.install_htcondor_runner)
+      - $(htcondor_install.install_autoscaler_deps_runner)
+      - $(htcondor_install.install_autoscaler_runner)
+      - $(htcondor_configure.access_point_runner)
+      - $(htcondor_execute_point.configure_autoscaler_runner)
 
   - source: modules/compute/vm-instance
     kind: terraform

--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -1,8 +1,5 @@
 ## Description
 
-**THIS MODULE IS PRE-RELEASE AND DOES NOT YET SUPPORT A FULLY FUNCTIONAL
-HTCONDOR POOL**
-
 This module performs the following tasks:
 
 - store an HTCondor Pool password in Google Cloud Secret Manager
@@ -11,7 +8,66 @@ This module performs the following tasks:
 - create a Toolkit runner for an Access Point
 - create a Toolkit runner for a Central Manager
 
+It is expected to be used with the [htcondor-install] and
+[htcondor-execute-point] modules.
+
+[hpcvmimage]: https://cloud.google.com/compute/docs/instances/create-hpc-vm
+[htcondor-install]: ../../scripts/htcondor-configure/README.md
+[htcondor-execute-point]: ../../compute/htcondor-execute-point/README.md
+
 [htcrole]: https://htcondor.readthedocs.io/en/latest/getting-htcondor/admin-quick-start.html#what-get-htcondor-does-to-configure-a-role
+
+### Example
+
+The following code snippet uses this module to create startup scripts that
+install the HTCondor software and adds custom configurations using
+[htcondor-configure] and [htcondor-execute-point].
+
+```yaml
+- source: community/modules/scripts/htcondor-install
+  kind: terraform
+  id: htcondor_install
+
+- source: modules/scripts/startup-script
+  kind: terraform
+  id: htcondor_configure_central_manager
+  settings:
+    runners:
+    - type: shell
+      source: modules/startup-script/examples/install_ansible.sh
+      destination: install_ansible.sh
+    - $(htcondor_install.install_htcondor_runner)
+    - $(htcondor_configure.central_manager_runner)
+
+- source: modules/scripts/startup-script
+  kind: terraform
+  id: htcondor_configure_access_point
+  settings:
+    runners:
+    - type: shell
+      source: modules/startup-script/examples/install_ansible.sh
+      destination: install_ansible.sh
+    - $(htcondor_install.install_htcondor_runner)
+    - $(htcondor_install.install_autoscaler_deps_runner)
+    - $(htcondor_install.install_autoscaler_runner)
+    - $(htcondor_configure.access_point_runner)
+    - $(htcondor_execute_point.configure_autoscaler_runner)
+```
+
+A full example can be found in the [examples README][htc-example].
+
+[htc-example]: ../../../../examples/README.md#htcondor-poolyaml--
+
+## Support
+
+HTCondor is maintained by the [Center for High Throughput Computing][chtc] at
+the University of Wisconsin-Madison. Support for HTCondor is available via:
+
+- [Discussion lists](https://htcondor.org/mail-lists/)
+- [HTCondor on GitHub](https://github.com/htcondor/htcondor/)
+- [HTCondor manual](https://htcondor.readthedocs.io/en/latest/)
+
+[chtc]: https://chtc.cs.wisc.edu/
 
 ## License
 

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -1,8 +1,5 @@
 ## Description
 
-**THIS MODULE IS PRE-RELEASE AND DOES NOT YET SUPPORT A FULLY FUNCTIONAL
-HTCONDOR POOL**
-
 This module creates a Toolkit runner that will install HTCondor on RedHat 7 or
 derivative operating systems such as the CentOS 7 release in the [HPC VM
 Image][hpcvmimage].
@@ -10,7 +7,53 @@ Image][hpcvmimage].
 It also exports a list of Google Cloud APIs which must be enabled prior to
 provisioning an HTCondor Pool.
 
+It is expected to be used with the [htcondor-configure] and
+[htcondor-execute-point] modules.
+
 [hpcvmimage]: https://cloud.google.com/compute/docs/instances/create-hpc-vm
+[htcondor-configure]: ../../scheduler/htcondor-configure/README.md
+[htcondor-execute-point]: ../../compute/htcondor-execute-point/README.md
+
+### Example
+
+The following code snippet uses this module to create startup scripts that
+install the HTCondor software and adds custom configurations using
+[htcondor-configure] and [htcondor-execute-point].
+
+```yaml
+- source: community/modules/scripts/htcondor-install
+  kind: terraform
+  id: htcondor_install
+
+- source: modules/scripts/startup-script
+  kind: terraform
+  id: htcondor_configure_central_manager
+  settings:
+    runners:
+    - type: shell
+      source: modules/startup-script/examples/install_ansible.sh
+      destination: install_ansible.sh
+    - $(htcondor_install.install_htcondor_runner)
+    - $(htcondor_configure.central_manager_runner)
+
+- source: modules/scripts/startup-script
+  kind: terraform
+  id: htcondor_configure_access_point
+  settings:
+    runners:
+    - type: shell
+      source: modules/startup-script/examples/install_ansible.sh
+      destination: install_ansible.sh
+    - $(htcondor_install.install_htcondor_runner)
+    - $(htcondor_install.install_autoscaler_deps_runner)
+    - $(htcondor_install.install_autoscaler_runner)
+    - $(htcondor_configure.access_point_runner)
+    - $(htcondor_execute_point.configure_autoscaler_runner)
+```
+
+A full example can be found in the [examples README][htc-example].
+
+[htc-example]: ../../../../examples/README.md#htcondor-poolyaml--
 
 ## Important note
 
@@ -19,6 +62,17 @@ metadata server for any POSIX user that is not `root` or `condor`. This prevents
 user jobs from being able to escalate privileges to act as the VM. System
 services and HTCondor itself can continue to do so, such as writing to Cloud
 Logging. This [feature can be disabled](#input_block_metadata_server).
+
+## Support
+
+HTCondor is maintained by the [Center for High Throughput Computing][chtc] at
+the University of Wisconsin-Madison. Support for HTCondor is available via:
+
+- [Discussion lists](https://htcondor.org/mail-lists/)
+- [HTCondor on GitHub](https://github.com/htcondor/htcondor/)
+- [HTCondor manual](https://htcondor.readthedocs.io/en/latest/)
+
+[chtc]: https://chtc.cs.wisc.edu/
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [spack-gromacs.yaml](#spack-gromacsyaml--)
   * [omnia-cluster.yaml](#omnia-clusteryaml--)
   * [hpc-cluster-small-sharedvpc.yaml](#hpc-cluster-small-sharedvpcyaml--)
+  * [htcondor-pool.yaml](#htcondor-poolyaml--)
 * [Blueprint Schema](#blueprint-schema)
 * [Writing an HPC Blueprint](#writing-an-hpc-blueprint)
   * [Top Level Parameters](#top-level-parameters)
@@ -470,6 +471,15 @@ a Shared VPC service project][fs-shared-vpc].
 
 [hpc-cluster-small-sharedvpc.yaml]: ../community/examples/hpc-cluster-small-sharedvpc.yaml
 [fs-shared-vpc]: https://cloud.google.com/filestore/docs/shared-vpc
+
+### [htcondor-pool.yaml] ![community-badge] ![experimental-badge]
+
+This blueprint provisions an auto-scaling [HTCondor][htcondor] pool based upon
+the [HPC VM Image][hpcvmimage].
+
+[htcondor]: https://htcondor.org/
+[htcondor-pool.yaml]: ../community/examples/htcondor-pool.yaml
+[hpcvmimage]: https://cloud.google.com/compute/docs/instances/create-hpc-vm
 
 ## Blueprint Schema
 


### PR DESCRIPTION
This is blocked by PR #417 and #418. Once all 3 are merged I will follow up with

- PR to replace HTCondor integration test to use this example
- PR to remove functionality warnings from `htcondor-*` README

I will preemptively discuss a likely concern:

- OS Login is explicitly disabled because empirically HTCondor's internal notion of users fails to detect the username properly when using the extremely high UIDs generated by OS Login but works with UIDs ~1000 (or perhaps a problem with the `_` underscore characters); I interpret this an HTCondor bug which I will discuss with them

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?