### PR TITLE
Print instance ID and information in daily tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -55,6 +55,15 @@
       with_items:
       - "terraform init"
       - "terraform apply -auto-approve -no-color"
+    - name: Gather instance information
+      delegate_to: localhost
+      register: instances_list
+      command: >-
+        gcloud compute instances list
+        --filter="labels.ghpc_deployment={{ deployment_name }}"
+        --format='table(name,zone,id,status)'
+    - debug:
+        var: instances_list.stdout_lines
     - name: Get remote IP
       register: remote_ip
       command: >-

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -56,6 +56,15 @@
       with_items:
       - "terraform init"
       - "terraform apply -auto-approve -no-color"
+    - name: Gather instance information
+      delegate_to: localhost
+      register: instances_list
+      command: >-
+        gcloud compute instances list
+        --filter="labels.ghpc_deployment={{ deployment_name }}"
+        --format='table(name,zone,id,status)'
+    - debug:
+        var: instances_list.stdout_lines
     - name: Get login IP
       register: login_ip
       command: >-


### PR DESCRIPTION
Print instance name, id, zone and status using gcloud compute instance
list based on the deployment name. Used for debugging and filtering
logs.

Example output:
```
Step #2 - "spack-gromacs": TASK [Gather instance information] *********************************************
Step #2 - "spack-gromacs": changed: [localhost]
Step #2 - "spack-gromacs": 
Step #2 - "spack-gromacs": TASK [debug] *******************************************************************
Step #2 - "spack-gromacs": ok: [localhost] => {
Step #2 - "spack-gromacs":     "instances_list.stdout_lines": [
Step #2 - "spack-gromacs":         "NAME                                   ZONE           ID                   STATUS",
Step #2 - "spack-gromacs":         "slurm-spack-gromacs-4cdb29-controller  us-central1-c  3611667354173501289  RUNNING",
Step #2 - "spack-gromacs":         "slurm-spack-gromacs-4cdb29-login0      us-central1-c  3567615072914304873  RUNNING"
Step #2 - "spack-gromacs":     ]
Step #2 - "spack-gromacs": }
```

Integration Tests Group 2 ran independently, logs can be viewed here: https://pantheon.corp.google.com/cloud-build/builds;region=global/4cdb29aa-c89f-411e-acf6-5753157bbbb9?project=hpc-toolkit-dev

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
