### PR TITLE
Enhance HTCondor pool support

### DIFF
--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -22,6 +22,7 @@
       that:
       - htcondor_role is defined
       - password_id is defined
+      - project_id is defined
   - name: Remove default HTCondor configuration
     ansible.builtin.file:
       name: /etc/condor/config.d/00-htcondor-9.0.config
@@ -66,6 +67,10 @@
         mode: 0644
         content: |
           SCHEDD_INTERVAL=15
+          UID_DOMAIN = c.{{ project_id }}.internal
+          TRUST_UID_DOMAIN = True
+          SUBMIT_ATTRS = RunAsOwner
+          RunAsOwner = True
   - name: Configure HTCondor StartD
     when: htcondor_role == 'get_htcondor_execute'
     block:
@@ -76,6 +81,9 @@
         content: |
           use feature:PartitionableSlot
           use feature:CommonCloudAttributesGoogle("-c created-by")
+          UID_DOMAIN = c.{{ project_id }}.internal
+          TRUST_UID_DOMAIN = True
+          STARTER_ALLOW_RUNAS_OWNER = True
   - name: Set HTCondor credentials
     ansible.builtin.shell: |
       set -e -o pipefail
@@ -92,3 +100,8 @@
       name: condor
       state: started
       enabled: true
+  - name: inform users
+    changed_when: false
+    ansible.builtin.shell: |
+      set -e -o pipefail
+      wall "******* HTCondor system configuration complete ********"

--- a/community/modules/scheduler/htcondor-configure/main.tf
+++ b/community/modules/scheduler/htcondor-configure/main.tf
@@ -28,21 +28,33 @@ locals {
     "type"        = "ansible-local"
     "content"     = file("${path.module}/files/htcondor_configure.yml")
     "destination" = "htcondor_configure.yml"
-    "args"        = "-e htcondor_role=get_htcondor_central_manager -e password_id=${google_secret_manager_secret.pool_password.secret_id}"
+    "args" = join(" ", [
+      "-e htcondor_role=get_htcondor_central_manager",
+      "-e password_id=${google_secret_manager_secret.pool_password.secret_id}",
+      "-e project_id=${var.project_id}",
+    ])
   }
 
   runner_access_role = {
     "type"        = "ansible-local"
     "content"     = file("${path.module}/files/htcondor_configure.yml")
     "destination" = "htcondor_configure.yml"
-    "args"        = "-e htcondor_role=get_htcondor_submit -e password_id=${google_secret_manager_secret.pool_password.secret_id}"
+    "args" = join(" ", [
+      "-e htcondor_role=get_htcondor_submit",
+      "-e password_id=${google_secret_manager_secret.pool_password.secret_id}",
+      "-e project_id=${var.project_id}",
+    ])
   }
 
   runner_execute_role = {
     "type"        = "ansible-local"
     "content"     = file("${path.module}/files/htcondor_configure.yml")
     "destination" = "htcondor_configure.yml"
-    "args"        = "-e htcondor_role=get_htcondor_execute -e password_id=${google_secret_manager_secret.pool_password.secret_id}"
+    "args" = join(" ", [
+      "-e htcondor_role=get_htcondor_execute",
+      "-e password_id=${google_secret_manager_secret.pool_password.secret_id}",
+      "-e project_id=${var.project_id}",
+    ])
   }
 }
 

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -60,6 +60,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_block_metadata_server"></a> [block\_metadata\_server](#input\_block\_metadata\_server) | Use Linux firewall to block the instance metadata server for users other than root and HTCondor daemons | `bool` | `true` | no |
+| <a name="input_enable_docker"></a> [enable\_docker](#input\_enable\_docker) | Install and enable docker daemon alongside HTCondor | `bool` | `true` | no |
 
 ## Outputs
 

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -17,6 +17,7 @@
   hosts: all
   vars:
     block_metadata_server: true
+    enable_docker: true
   become: true
   tasks:
   - name: setup HTCondor yum repository
@@ -40,6 +41,34 @@
       enabled: true
       state: started
       masked: no
+  - name: Install Docker and configure HTCondor to use it
+    when: enable_docker | bool  # allows string to be passed at CLI
+    block:
+    - name: Setup Docker repo
+      ansible.builtin.yum_repository:
+        name: docker-ce-stable
+        description: Docker CE Stable - $basearch
+        baseurl: https://download.docker.com/linux/centos/$releasever/$basearch/stable
+        enabled: yes
+        gpgcheck: yes
+        gpgkey: https://download.docker.com/linux/centos/gpg
+    - name: Install Docker
+      ansible.builtin.yum:
+        name:
+        - docker-ce
+        - docker-ce-cli
+        - containerd.io
+        - docker-compose-plugin
+    - name: Enable Docker
+      ansible.builtin.service:
+        name: docker
+        state: started
+        enabled: true
+    - name: Add condor to docker group
+      ansible.builtin.user:
+        name: condor
+        groups: docker
+        append: yes
   - name: Ensure that only root and condor users can access service account
     when: block_metadata_server | bool # allows string to be passed at CLI
     ansible.builtin.shell: |

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -19,7 +19,10 @@ locals {
     "type"        = "ansible-local"
     "source"      = "${path.module}/files/install-htcondor.yaml"
     "destination" = "install-htcondor.yaml"
-    "args"        = "-e block_metadata_server=${var.block_metadata_server}"
+    "args" = join(" ", [
+      "-e block_metadata_server=${var.block_metadata_server}",
+      "-e enable_docker=${var.enable_docker}"
+    ])
   }
 
   runner_install_autoscaler_deps = {

--- a/community/modules/scripts/htcondor-install/variables.tf
+++ b/community/modules/scripts/htcondor-install/variables.tf
@@ -19,3 +19,9 @@ variable "block_metadata_server" {
   type        = bool
   default     = true
 }
+
+variable "enable_docker" {
+  description = "Install and enable docker daemon alongside HTCondor"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
- Add proper UID_DOMAIN support to ensure that jobs run with uid of the submitter
  - See [relevant section of HTCondor manual](https://htcondor.readthedocs.io/en/latest/admin-manual/security.html#who-jobs-run-as)
- Add optional, on-by-default, support for Docker on HTCondor execute points

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?