### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 ---
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.64.0
+  rev: v1.74.1
   hooks:
   - id: terraform_fmt
   - id: terraform_tflint
@@ -61,12 +61,12 @@ repos:
   hooks:
   - id: ansible-lint
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.26.3
+  rev: v1.27.1
   hooks:
   - id: yamllint
     args: [-c=.yamllint]
 - repo: https://github.com/jackdewinter/pymarkdown
-  rev: v0.9.5
+  rev: v0.9.7
   hooks:
   - id: pymarkdown
     # Rules at https://github.com/jackdewinter/pymarkdown/tree/main/docs/rules


### PR DESCRIPTION
Do not upgrade ansible-lint hook because of Ansible version (2.9) compatibility reasons.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?