### PR TITLE
Add HTCondor tutorial

### DIFF
--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -119,9 +119,9 @@ deployment_groups:
         content: |
           universe       = docker
           docker_image   = hello-world
-          output         = out.$(Cluster)-$(Process)
-          error          = err.$(Cluster)-$(Process)
-          log            = log.$(Cluster)-$(Process)
+          output         = out
+          error          = err
+          log            = log
           request_cpus   = 1
           request_memory = 100MB
           queue

--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -65,7 +65,6 @@ deployment_groups:
     - network1
     - htcondor_configure_central_manager
     settings:
-      enable_oslogin: DISABLE
       name_prefix: central-manager
       machine_type: c2-standard-4
       disable_public_ips: true
@@ -95,8 +94,8 @@ deployment_groups:
     - htcondor_configure_execute_point
     settings:
       metadata:
+        enable-oslogin: "TRUE"
         central-manager: ((module.htcondor_cm.internal_ip[0]))
-        enable-oslogin: "FALSE"
       service_account:
         email: $(htcondor_configure.execute_point_service_account)
         scopes:
@@ -115,7 +114,17 @@ deployment_groups:
       - $(htcondor_install.install_autoscaler_runner)
       - $(htcondor_configure.access_point_runner)
       - $(htcondor_execute_point.configure_autoscaler_runner)
-
+      - type: data
+        destination: /var/tmp/helloworld.sub
+        content: |
+          universe       = docker
+          docker_image   = hello-world
+          output         = out.$(Cluster)-$(Process)
+          error          = err.$(Cluster)-$(Process)
+          log            = log.$(Cluster)-$(Process)
+          request_cpus   = 1
+          request_memory = 100MB
+          queue
   - source: modules/compute/vm-instance
     kind: terraform
     id: htcondor_access
@@ -123,9 +132,9 @@ deployment_groups:
     - network1
     - htcondor_configure_access_point
     settings:
-      enable_oslogin: DISABLE
       name_prefix: access-point
       machine_type: c2-standard-4
+      disable_public_ips: true
       metadata:
         central-manager: ((module.htcondor_cm.internal_ip[0]))
       service_account:
@@ -133,4 +142,4 @@ deployment_groups:
         scopes:
         - cloud-platform
     outputs:
-    - external_ip
+    - internal_ip

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -35,7 +35,7 @@ Click the button below to launch the Intel Select tutorial.
 ## HTCondor Tutorial
 
 Walk through deploying an HTCondor pool that supports jobs running inside Docker
-containers or the base [HPC VM Image][hpc-vm-mage].
+containers or the base [HPC VM Image][hpc-vm-image].
 
 Click the button below to launch the HTCondor tutorial.
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -31,3 +31,12 @@ Click the button below to launch the Intel Select tutorial.
 
 [hpc-vm-image]: https://cloud.google.com/compute/docs/instances/create-hpc-vm
 [intel-select]: https://www.intel.com/content/www/us/en/products/solutions/select-solutions/hpc/simulation-modeling.html
+
+## HTCondor Tutorial
+
+Walk through deploying an HTCondor pool that supports jobs running inside Docker
+containers or the base [HPC VM Image][hpc-vm-mage].
+
+Click the button below to launch the HTCondor tutorial.
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fhpc-toolkit&cloudshell_open_in_editor=community%2Fexamples%2Fhtcondor-pool.yaml&cloudshell_tutorial=docs%2Ftutorials%2Fhtcondor.md&cloudshell_git_branch=develop)

--- a/docs/tutorials/htcondor.md
+++ b/docs/tutorials/htcondor.md
@@ -1,0 +1,233 @@
+# HPC Toolkit HTCondor Tutorial
+
+HPC Toolkit is an open-source software offered by Google Cloud which makes it
+easy for customers to deploy HPC environments on Google Cloud.
+
+This tutorial will walk you through deploying a simple HTCondor pool on Google
+Cloud using the HPC Toolkit.
+
+## Select a Project
+
+Select a project in which to deploy an HPC cluster on Google.
+
+<walkthrough-project-setup billing="true"></walkthrough-project-setup>
+
+Once you have selected a project, click START.
+
+## Add Credits to the Project
+
+Talk with your tutorial leader to see if Google Cloud credits are available.
+
+## Enable APIs & Permissions
+
+In a new Google Cloud project there are several apis that must be enabled to
+deploy your HPC cluster. These will be caught when you perform `terraform apply`
+but you can save time by enabling them now by running:
+
+<walkthrough-enable-apis apis="storage.googleapis.com,compute.googleapis.com,secretmanager.googleapis.com"></walkthrough-enable-apis>
+
+## Build the Toolkit Binary
+
+To build HPC Toolkit binary from source run:
+
+```bash
+make
+```
+
+You should now have a binary named ghpc in the current directory. To verify the
+build run:
+
+```bash
+./ghpc --version
+```
+
+This should show you the version of the HPC Toolkit you are using.
+
+(Optional) To install the `ghpc` binary in your home directory under bin,
+run the following command:
+
+```bash
+make install
+exec $SHELL -l
+```
+
+## Generate a Deployment
+
+To create a deployment, an input blueprint file needs to be written or adapted
+from one of the examples found in the `examples/` or `community/examples`
+directories.
+
+This tutorial will use community/examples/htcondor-pool.yaml, which provisions
+a basic auto-scaling HTCondor pool.
+
+* a new VPC network secured from the public internet
+* an HTCondor Access Point for users to submit jobs
+* an HTCondor Central Manager that will operate the pool
+* a Managed Instance Group to scale a pool of HTCondor Execute Points to serve
+  new jobs as they are submitted
+
+The blueprint community/examples/htcondor-pool.yaml should be open in the Cloud
+Shell Editor (on the left).
+
+This file describes the cluster you will deploy. After you have inspected the
+file, use the ghpc binary to create a deployment directory by running:
+
+```bash
+./ghpc create community/examples/htcondor-pool.yaml --vars "project_id=<walkthrough-project-id/>"
+```
+
+> **_NOTE:_** The `--vars` argument is used to override `project_id` in the
+> blueprint variables. The `--vars` argument supports comma-separated list of
+> name=value variables to override blueprint variables. This feature only
+> supports variables of string type.
+
+This will create a deployment directory named `htcondor-001/`, which
+contains the terraform needed to deploy your cluster.
+
+## Deploy the Cluster
+
+Use the following commands to run terraform and deploy your cluster.
+
+```bash
+terraform -chdir=htcondor-001/htcondor init
+terraform -chdir=htcondor-001/htcondor validate
+terraform -chdir=htcondor-001/htcondor apply -auto-approve
+```
+
+If you receive any errors during `apply`, you may re-run it to resolve them.
+The deployment will take about 3 minutes. There should be regular status updates
+in the terminal. If the `apply` is successful, a message similar to the
+following will be displayed:
+
+<!-- Note: Bash blocks give "copy to cloud shell" option.  -->
+<!-- "shell" or "text" is used in places where command should not be run in cloud shell. -->
+
+```shell
+Apply complete! Resources: xx added, 0 changed, 0 destroyed.
+```
+
+## Wait for the pool to be ready
+
+Once terraform has finished, you may SSH to the HTCondor Access Point:
+
+```bash
+gcloud compute ssh access-point-0 --tunnel-through-iap --project <walkthrough-project-id/> --zone us-central1-c
+```
+
+Alternatively, you may browse to the `access-point-0` VM and click on "SSH" in
+the Cloud Console at this address:
+
+```text
+https://console.cloud.google.com/compute?project=<walkthrough-project-id/>
+```
+
+Once you have command line access to the machine, you must wait for HTCondor and
+Docker to complete installation. This will take approximately 5 minutes from
+when `terraform apply` finished. When it is complete, a message will be printed
+to the screen:
+
+```text
+******* HTCondor system configuration complete ********
+```
+
+You should also verify that the pool is operational by executing
+
+```bash
+condor_status -schedd -autoformat Name
+```
+
+and observing output similar to
+
+```text
+access-point-0.us-central1-c.c.<walkthrough-project-id/>.internal
+```
+
+## Submit an example job
+
+The following commands will copy this job into your home directory and submit it
+to the HTCondor pool.
+
+```text
+universe       = docker
+docker_image   = hello-world
+output         = out.$(Cluster)-$(Process)
+error          = err.$(Cluster)-$(Process)
+log            = log.$(Cluster)-$(Process)
+request_cpus   = 1
+request_memory = 100MB
+queue
+```
+
+```bash
+cp /var/tmp/helloworld.sub .
+condor_submit helloworld.sub
+```
+
+The output should resemble
+
+```text
+Submitting job(s).
+1 job(s) submitted to cluster 1.
+```
+
+Run `condor_watch_q` to watch your jobs as they transition from `IDLE` to `RUN`
+to `DONE`. This will take several minutes are the pool autoscales to serve your
+job.
+
+```bash
+condor_watch_q
+```
+
+The output should resemble
+
+```text
+BATCH   IDLE  RUN  DONE  TOTAL  JOB_IDS
+ID: 1     1    -     -      1   1.0
+```
+
+When complete, observe the output of your job:
+
+```bash
+cat out
+```
+
+You should see the output of the Docker [Hello, World][helloworld] image.
+
+[helloworld]: https://hub.docker.com/_/hello-world
+
+## Destroy the Cluster
+
+To avoid incurring ongoing charges we will want to destroy our cluster. Begin by
+ensuring that the pool has scaled to 0 execute points:
+
+```bash
+condor_status -startd -autoformat Name
+```
+
+Once `condor_status` returns empty output (all execute points have scaled down),
+you may logout from the access point:
+
+```bash
+logout
+```
+
+> **_NOTE:_** If terraform destroy is run before HTCondor nodes scale down, you
+> may have leave behind some idle VMs. Please wait until `condor_status`
+> reports no active nodes in the pool.
+
+You should be returned to the Cloud Shell console. You may then destroy your
+HTCondor pool:
+
+```bash
+terraform -chdir=htcondor-001/htcondor destroy -auto-approve
+```
+
+When complete you should see output similar to:
+
+```shell
+Destroy complete! Resources: xx destroyed.
+```
+
+## Tutorial Complete
+
+<walkthrough-conclusion-trophy></walkthrough-conclusion-trophy>

--- a/docs/tutorials/htcondor.md
+++ b/docs/tutorials/htcondor.md
@@ -136,7 +136,10 @@ You should also verify that the pool is operational by executing
 condor_status -schedd -autoformat Name
 ```
 
-and observing output similar to
+Until HTCondor is installed and configured, you may find that this command is
+not yet available ("command not found") or fails to find the pool ("Failed to
+connect"). Installation may take 5 minutes or more. When it succeeds, you will
+observe output similar to
 
 ```text
 access-point-0.us-central1-c.c.<walkthrough-project-id/>.internal
@@ -144,8 +147,16 @@ access-point-0.us-central1-c.c.<walkthrough-project-id/>.internal
 
 ## Submit an example job
 
-The following commands will copy this job into your home directory and submit it
-to the HTCondor pool.
+An example job is automatically copied to your HTCondor access point. The
+following commands will copy the example into your home directory and submit it
+to the pool.
+
+```bash
+cp /var/tmp/helloworld.sub .
+condor_submit helloworld.sub
+```
+
+The job "submit file" will resemble:
 
 ```text
 universe       = docker
@@ -158,12 +169,7 @@ request_memory = 100MB
 queue
 ```
 
-```bash
-cp /var/tmp/helloworld.sub .
-condor_submit helloworld.sub
-```
-
-The output should resemble
+After you submit the job, `condor_submit` will print:
 
 ```text
 Submitting job(s).
@@ -171,8 +177,8 @@ Submitting job(s).
 ```
 
 Run `condor_watch_q` to watch your jobs as they transition from `IDLE` to `RUN`
-to `DONE`. This will take several minutes are the pool autoscales to serve your
-job.
+to `DONE`. This may take 5 or more minutes as the pool autoscales VMs to serve
+your job.
 
 ```bash
 condor_watch_q
@@ -185,7 +191,7 @@ BATCH   IDLE  RUN  DONE  TOTAL  JOB_IDS
 ID: 1     1    -     -      1   1.0
 ```
 
-When complete, observe the output of your job:
+Once the pool autoscales (approx. 5 minutes), observe the output of your job:
 
 ```bash
 cat out


### PR DESCRIPTION
- re-enable OS Login on HTCondor example
- Add tutorial itself
- Add Open in Cloud Shell link to tutorial

The OICS link will not work until this PR lands on develop branch. Manually substituting the fork namespace and branch impacts the tutorial in limited fashion because it causes a "do you trust this repo?" prompt in Cloud Shell which does not occur for repos under @GoogleCloudPlatform. If you fail to check the box the Cloud Shell environment does not receive credentials.

Manual link to [run tutorial off fork+branch](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Ftpdownes%2Fhpc-toolkit&cloudshell_open_in_editor=community%2Fexamples%2Fhtcondor-pool.yaml&cloudshell_tutorial=docs%2Ftutorials%2Fhtcondor.md&cloudshell_git_branch=feat_htcondor_tutorial)

(must click "Trust Repo")

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?