### PR TITLE
fix errors when missing deployment_name

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -523,8 +523,8 @@ func ConvertMapToCty(iMap map[string]interface{}) (map[string]cty.Value, error) 
 // global variables, then they are replaced by the cty.Value of the
 // corresponding entry in the origin. All other cty.Values are unmodified.
 // ERROR: if (somehow) the cty.String cannot be converted to a Go string
-// ERROR: rely on HCL TraverseAbs to bubble up "diagnostics" when the global variable
-//        being resolved does not exist in b.Vars
+// ERROR: rely on HCL TraverseAbs to bubble up "diagnostics" when the global
+//        variable being resolved does not exist in b.Vars
 func ResolveVariables(
 	ctyMap map[string]cty.Value,
 	origin map[string]cty.Value,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -396,6 +396,10 @@ func checkUsedModuleNames(
 
 // validateConfig runs a set of simple early checks on the imported input YAML
 func (dc *DeploymentConfig) validateConfig() {
+	_, err := dc.Config.DeploymentName()
+	if err != nil {
+		log.Fatal(err)
+	}
 	moduleToGroup, err := checkModuleAndGroupNames(dc.Config.DeploymentGroups)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -214,14 +214,6 @@ func getRole(source string) string {
 	return role
 }
 
-func getDeploymentName(vars map[string]interface{}) string {
-	deployName, exists := vars["deployment_name"]
-	if exists {
-		return deployName.(string)
-	}
-	return "undefined"
-}
-
 func toStringInterfaceMap(i interface{}) (map[string]interface{}, error) {
 	var ret map[string]interface{}
 	switch val := i.(type) {
@@ -247,7 +239,7 @@ func toStringInterfaceMap(i interface{}) (map[string]interface{}, error) {
 func (dc *DeploymentConfig) combineLabels() error {
 	defaultLabels := map[string]interface{}{
 		blueprintLabel:  dc.Config.BlueprintName,
-		deploymentLabel: getDeploymentName(dc.Config.Vars),
+		deploymentLabel: dc.Config.Vars["deployment_name"],
 	}
 	labels := "labels"
 	var globalLabels map[string]interface{}

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -43,7 +43,8 @@ func (s *MySuite) TestExpandBackends(c *C) {
 	grp := dc.Config.DeploymentGroups[0]
 	c.Assert(grp.TerraformBackend.Type, Not(Equals), "")
 	gotPrefix := grp.TerraformBackend.Configuration["prefix"]
-	expPrefix := fmt.Sprintf("%s/%s", dc.Config.BlueprintName, grp.Name)
+	expPrefix := fmt.Sprintf("%s/%s/%s", dc.Config.BlueprintName,
+		dc.Config.Vars["deployment_name"], grp.Name)
 	c.Assert(gotPrefix, Equals, expPrefix)
 
 	// Add a new resource group, ensure each group name is included
@@ -51,7 +52,6 @@ func (s *MySuite) TestExpandBackends(c *C) {
 		Name: "group2",
 	}
 	dc.Config.DeploymentGroups = append(dc.Config.DeploymentGroups, newGroup)
-	dc.Config.Vars["deployment_name"] = "testDeployment"
 	err = dc.expandBackends()
 	c.Assert(err, IsNil)
 	newGrp := dc.Config.DeploymentGroups[1]
@@ -264,7 +264,7 @@ func (s *MySuite) TestCombineLabels(c *C) {
 	// Was the ghpc_deployment label set correctly?
 	ghpcDeployment, exists := globalLabels[deploymentLabel]
 	c.Assert(exists, Equals, true)
-	c.Assert(ghpcDeployment, Equals, "undefined")
+	c.Assert(ghpcDeployment, Equals, "deployment_name")
 
 	// Was "labels" created for the module with no settings?
 	_, exists = dc.Config.DeploymentGroups[0].Modules[0].Settings["labels"]


### PR DESCRIPTION
### Changes:
- Used existing func `DeploymentName()` to validate `deployment_name` is a valid string, and fail early with a user-friendly `DeploymentNameError()` otherwise. If `deployment_name` is:
  - **not set**: `deployment_name must be a string and cannot be empty, cause: deployment_name variable not defined.`
  - **an empty string** `""`: `deployment_name must be a string and cannot be empty, cause: deployment_name was an empty string.`
  - **not a string** (i.e. an integer `100`): `deployment_name must be a string and cannot be empty, cause: deployment_name was not of type string.`
  - **empty**: `deployment_name must be a string and cannot be empty, cause: deployment_name was not of type string.`
-  removed `getDeploymentName()` that returned `undefined` when `deployment_name` was not set. Early error checking renders this obsolete.
- Added a default `deployment_name` to test configs returned from `func getBasicDeploymentConfigWithTestModule()` and `func getDeploymentConfigForTest()` used during unit tests, and updated relevant unit tests accordingly

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
