### PR TITLE
Add check for startup script failure, montoring

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
@@ -21,6 +21,10 @@
     search_regex: '.*{{ remote_node }}.*startup-script exit status ([0-9]+)'
     timeout: 600
   register: startup_status
+- name: Fail if startup script exited with a non-zero return code
+  fail:
+    msg: There was a failure in the startup script
+  when: startup_status['match_groups'][0] != "0"
 - name: Fail if ops agent is not running
   become: true
   ansible.builtin.command: systemctl is-active {{ item }}


### PR DESCRIPTION
A test for a successful startup script execution was not included for the monitoring integration test, this adds it back in similar to the spack integration test.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
