### PR TITLE
Update Batch list instructions now that Batch response is brief

### DIFF
--- a/community/modules/scheduler/cloud-batch-job/outputs.tf
+++ b/community/modules/scheduler/cloud-batch-job/outputs.tf
@@ -29,7 +29,7 @@ output "instructions" {
     gcloud ${var.gcloud_version} batch jobs delete ${local.job_id} --location=${var.region} --project=${var.project_id}
 
   List all jobs in region:
-    gcloud ${var.gcloud_version} batch jobs list ${var.region} --project=${var.project_id} | grep ^name:
+    gcloud ${var.gcloud_version} batch jobs list ${var.region} --project=${var.project_id}
   EOT
 }
 

--- a/community/modules/scheduler/cloud-batch-login-node/outputs.tf
+++ b/community/modules/scheduler/cloud-batch-login-node/outputs.tf
@@ -37,6 +37,6 @@ output "instructions" {
     gcloud ${var.gcloud_version} batch jobs delete ${var.job_id} --location=${var.region} --project=${var.project_id}
 
   List all jobs in region:
-    gcloud ${var.gcloud_version} batch jobs list ${var.region} --project=${var.project_id} | grep ^name:
+    gcloud ${var.gcloud_version} batch jobs list ${var.region} --project=${var.project_id}
   EOT
 }


### PR DESCRIPTION
The Google Cloud Batch list API response has changed. Prior it was providing verbose information about each job. Now it just lists the names of the jobs.

Example of current output (without grep):

```
NAME                                                                            STATE
projects/nickstroud-demo-2022-02-07/locations/us-central1/jobs/hello-workload   SUCCEEDED
projects/nickstroud-demo-2022-02-07/locations/us-central1/jobs/hello-workload1  SUCCEEDED
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
