### PR TITLE
Enable ansible lint pre-commit hook

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,10 @@ skip_list:
 
 mock_roles:
 - googlecloudplatform.google_cloud_ops_agents
+
+kinds:
+  - playbook: "**/ansible_playbooks/*test.{yml,yaml}"
+  - playbook: "**/files/*.{yml,yaml}"
+  - playbook: "**/scripts/*.{yml,yaml}"
+  - tasks: "**/ansible_playbooks/test*.{yml,yaml}"
+  - tasks: "**/tasks/*"

--- a/community/modules/compute/htcondor-execute-point/files/htcondor_configure_autoscaler.yml
+++ b/community/modules/compute/htcondor-execute-point/files/htcondor_configure_autoscaler.yml
@@ -38,4 +38,4 @@
     ansible.builtin.cron:
       name: "run HTCondor autoscaler"
       user: condor
-      job: "{{ python }} {{ autoscaler}} --p {{ project_id }} --r {{ region }} --z {{ zone }} --mz --g {{ mig_id }} --c {{ max_size}} | /bin/logger"
+      job: "{{ python }} {{ autoscaler }} --p {{ project_id }} --r {{ region }} --z {{ zone }} --mz --g {{ mig_id }} --c {{ max_size }} | /bin/logger"

--- a/community/modules/file-system/nfs-server/scripts/mount.yaml
+++ b/community/modules/file-system/nfs-server/scripts/mount.yaml
@@ -23,17 +23,17 @@
   tasks:
   - name: Read metadata network_storage information
     uri:
-      url: "{{url}}/{{meta_key}}"
+      url: "{{ url }}/{{ meta_key }}"
       method: GET
       headers:
         Metadata-Flavor: "Google"
     register: storage
   - name: Mount file systems
     mount:
-      src: "{{item.server_ip}}:/{{item.remote_mount}}"
-      path: "{{item.local_mount}}"
-      opts: "{{item.mount_options}}"
+      src: "{{ item.server_ip }}:/{{ item.remote_mount }}"
+      path: "{{ item.local_mount }}"
+      opts: "{{ item.mount_options }}"
       boot: true
-      fstype: "{{item.fs_type}}"
+      fstype: "{ {item.fs_type }}"
       state: "mounted"
-    loop: "{{storage.json}}"
+    loop: "{{ storage.json }}"

--- a/community/modules/scripts/htcondor-install/files/install-htcondor-autoscaler-deps.yml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor-autoscaler-deps.yml
@@ -24,13 +24,13 @@
   - name: Create virtual environment for HTCondor autoscaler
     ansible.builtin.pip:
       name: pip
-      version: 21.3.1
+      version: 21.3.1 # last Python 2.7-compatible release
       virtualenv: /usr/local/htcondor
       virtualenv_command: /usr/bin/python3 -m venv
   - name: Install latest setuptools
     ansible.builtin.pip:
       name: setuptools
-      state: latest
+      state: 44.1.1 # last Python 2.7-compatible release
       virtualenv: /usr/local/htcondor
       virtualenv_command: /usr/bin/python3 -m venv
   - name: Install HTCondor autoscaler dependencies
@@ -41,6 +41,6 @@
     - htcondor
     ansible.builtin.pip:
       name: "{{ item }}"
-      state: latest
+      state: present # rely on pip resolver to pick latest compatible releases
       virtualenv: /usr/local/htcondor
       virtualenv_command: /usr/bin/python3 -m venv

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -28,7 +28,7 @@
   - name: install HTCondor
     ansible.builtin.yum:
       name: condor
-      state: latest
+      state: present
   - name: ensure token directory
     ansible.builtin.file:
       path: /etc/condor/tokens.d

--- a/modules/file-system/filestore/scripts/mount.yaml
+++ b/modules/file-system/filestore/scripts/mount.yaml
@@ -23,17 +23,17 @@
   tasks:
   - name: Read metadata network_storage information
     uri:
-      url: "{{url}}/{{meta_key}}"
+      url: "{{ url }}/{{ meta_key }}"
       method: GET
       headers:
         Metadata-Flavor: "Google"
     register: storage
   - name: Mount file systems
     mount:
-      src: "{{item.server_ip}}:/{{item.remote_mount}}"
-      path: "{{item.local_mount}}"
-      opts: "{{item.mount_options}}"
+      src: "{{ item.server_ip }}:/{{ item.remote_mount }}"
+      path: "{{ item.local_mount }}"
+      opts: "{{ item.mount_options }}"
       boot: true
-      fstype: "{{item.fs_type}}"
+      fstype: "{{ item.fs_type }}"
       state: "mounted"
-    loop: "{{storage.json}}"
+    loop: "{{ storage.json }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -56,6 +56,7 @@
       - "terraform init"
       - "terraform apply -auto-approve -no-color"
     - name: Gather instance information
+      changed_when: false
       delegate_to: localhost
       register: instances_list
       command: >-
@@ -66,6 +67,7 @@
       ansible.builtin.debug:
         var: instances_list.stdout_lines
     - name: Get remote IP
+      changed_when: false
       register: remote_ip
       command: >-
         gcloud compute instances describe --zone={{ zone }} {{ remote_node }}
@@ -73,11 +75,14 @@
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
+      changed_when: false
       shell: >-
         dig TXT +short o-o.myaddr.l.google.com @ns1.google.com |
          awk -F'"' '{print $2}'
       register: build_ip
     - name: Create firewall rule
+      register: fw_result
+      changed_when: fw_result.rc == 0
       command:
         argv:
         - gcloud
@@ -93,6 +98,8 @@
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}
     - name: 'Add SSH Keys to OS-Login'
+      register: key_result
+      changed_when: key_result.rc == 0
       command:
         argv:
         - gcloud
@@ -113,6 +120,9 @@
     ## Cleanup and fail gracefully
     rescue:
     - name: Delete Firewall Rule
+      register: fw_deleted
+      changed_when: fw_deleted.rc == 0
+      failed_when: false
       command:
         argv:
         - gcloud
@@ -120,9 +130,9 @@
         - firewall-rules
         - delete
         - "{{ deployment_name }}"
-      ignore_errors: true
     - name: Tear Down Cluster
       run_once: true
+      changed_when: true # assume something got destroyed
       delegate_to: localhost
       environment:
         TF_IN_AUTOMATION: "TRUE"
@@ -161,6 +171,9 @@
     ## Always cleanup, even on failure
     always:
     - name: Delete Firewall Rule
+      register: fw_deleted
+      changed_when: fw_deleted.rc == 0
+      failed_when: false
       run_once: true
       delegate_to: localhost
       command:
@@ -170,9 +183,9 @@
         - firewall-rules
         - delete
         - "{{ deployment_name }}"
-      ignore_errors: true
     - name: Tear Down Cluster
       run_once: true
+      changed_when: true # assume something got destroyed
       delegate_to: localhost
       environment:
         TF_IN_AUTOMATION: "TRUE"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -62,7 +62,8 @@
         gcloud compute instances list
         --filter="labels.ghpc_deployment={{ deployment_name }}"
         --format='table(name,zone,id,status)'
-    - debug:
+    - name: Print instance information
+      ansible.builtin.debug:
         var: instances_list.stdout_lines
     - name: Get remote IP
       register: remote_ip

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -57,6 +57,7 @@
       - terraform apply -auto-approve -no-color
     - name: Get startup_script
       register: network_name
+      changed_when: false
       args:
         chdir: "{{ workspace }}/{{ deployment_name }}/htcondor-env"
         executable: /bin/bash
@@ -65,6 +66,7 @@
           ../packer/custom-image/startup_script.sh
     - name: Create VM image with Packer
       register: image_created
+      changed_when: image_created.rc == 0
       args:
         chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
         executable: /bin/bash
@@ -86,6 +88,7 @@
       - terraform apply -auto-approve -no-color
     - name: Get Access Point public IP address
       register: access_ip
+      changed_when: false
       args:
         chdir: "{{ workspace }}/{{ deployment_name }}/pool"
         executable: /bin/bash
@@ -98,11 +101,14 @@
         groups: [remote_host]
     ## Setup firewall for cloud build
     - name: Get Builder IP
+      register: build_ip
+      changed_when: false
       ansible.builtin.shell: >-
         dig TXT +short o-o.myaddr.l.google.com @ns1.google.com |
          awk -F'"' '{print $2}'
-      register: build_ip
     - name: Create firewall rule
+      register: fw_result
+      changed_when: fw_result.rc == 0
       ansible.builtin.command:
         argv:
         - gcloud
@@ -118,6 +124,8 @@
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}
     - name: Add SSH Keys to OS Login
+      register: key_result
+      changed_when: key_result.rc == 0
       ansible.builtin.command:
         argv:
         - gcloud
@@ -130,6 +138,9 @@
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
     rescue:
     - name: Delete Firewall Rule
+      register: fw_deleted
+      changed_when: fw_deleted.rc == 0
+      failed_when: false # keep cleaning up
       ansible.builtin.command:
         argv:
         - gcloud
@@ -137,8 +148,9 @@
         - firewall-rules
         - delete
         - "{{ deployment_name }}"
-      ignore_errors: true
     - name: Tear Down Pool
+      changed_when: true # assume something destroyed
+      failed_when: false # keep cleaning up
       run_once: true
       delegate_to: localhost
       environment:
@@ -159,10 +171,13 @@
         set -o pipefail
         jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d ":" -f2
     - name: Delete custom image
+      register: image_deleted
       when: image_created is defined and image_created.rc == 0
+      changed_when: image_deleted.rc == 0
       ansible.builtin.command:
         cmd: gcloud compute images delete {{ image_name.stdout }}
     - name: Tear Down Network
+      changed_when: true # assume something destroyed
       delegate_to: localhost
       environment:
         TF_IN_AUTOMATION: "TRUE"
@@ -203,6 +218,7 @@
         loop_var: test
     always:
     - name: Tear Down Pool
+      changed_when: true # assume something destroyed
       delegate_to: localhost
       run_once: true
       environment:
@@ -214,6 +230,7 @@
       - terraform init
       - terraform destroy -auto-approve
     - name: Get image name
+      changed_when: false
       run_once: true
       delegate_to: localhost
       register: image_name
@@ -224,11 +241,17 @@
         set -o pipefail
         jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d ":" -f2
     - name: Delete custom image
+      register: image_deleted
+      changed_when: image_deleted.rc == 0
+      failed_when: false # keep cleaning up
       run_once: true
       delegate_to: localhost
       ansible.builtin.command:
         cmd: gcloud compute images delete {{ image_name.stdout }}
     - name: Delete Firewall Rule
+      register: fw_deleted
+      changed_when: fw_deleted.rc == 0
+      failed_when: false # keep cleaning up
       run_once: true
       delegate_to: localhost
       ansible.builtin.command:
@@ -238,8 +261,8 @@
         - firewall-rules
         - delete
         - "{{ deployment_name }}"
-      ignore_errors: true
     - name: Tear Down Network
+      changed_when: true # assume something destroyed
       run_once: true
       delegate_to: localhost
       environment:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -29,6 +29,7 @@
       ROOT_DIR: "{{ workspace }}"
       BLUEPRINT_DIR: "{{ blueprint_dir }}"
       DEPLOYMENT_NAME: "{{ deployment_name }}"
+      NETWORK: "{{ network }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
   - name: Create Infrastructure and test

--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -46,14 +46,20 @@
       - terraform validate
       - terraform apply -auto-approve -no-color
     - name: Create VM image with Packer
-      command:
-        cmd: "{{ item }}"
+      register: image_created
+      changed_when: image_created.rc == 0
+      ansible.builtin.shell: |
+        set -e -o pipefail
+        packer init .
+        packer validate .
+        packer build .
+      args:
         chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
-      with_items:
-      - packer init .
-      - packer validate .
-      - packer build .
+        executable: /bin/bash
     - name: Delete VM Image
+      register: image_deleted
+      changed_when: image_deleted.rc == 0
+      when: image_created.rc == 0
       ansible.builtin.shell: |
         gcloud compute images delete --project={{ project }} --quiet $(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d ":" -f2)
       args:
@@ -61,6 +67,7 @@
     ## Always cleanup network
     always:
     - name: Tear Down Network
+      changed_when: true # assume something destroyed
       run_once: true
       delegate_to: localhost
       environment:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -57,6 +57,7 @@
       - "terraform init"
       - "terraform apply -auto-approve -no-color"
     - name: Gather instance information
+      changed_when: false
       delegate_to: localhost
       register: instances_list
       command: >-
@@ -67,11 +68,13 @@
       ansible.builtin.debug:
         var: instances_list.stdout_lines
     - name: Get login IP
+      changed_when: false
       register: login_ip
       command: >-
         gcloud compute instances describe --zone={{ zone }} {{ login_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
     - name: Get Controller IP
+      changed_when: false
       register: controller_ip
       command: >-
         gcloud compute instances describe --zone={{ zone }} {{ controller_node }}
@@ -79,11 +82,14 @@
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
+      changed_when: false
       shell: >-
         dig TXT +short o-o.myaddr.l.google.com @ns1.google.com |
          awk -F'"' '{print $2}'
       register: build_ip
     - name: Create firewall rule
+      register: fw_created
+      changed_when: fw_created.rc == 0
       command:
         argv:
         - gcloud
@@ -99,6 +105,8 @@
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}
     - name: 'Add SSH Keys to OS-Login'
+      register: key_created
+      changed_when: key_created.rc == 0
       command:
         argv:
         - gcloud
@@ -117,6 +125,9 @@
     ## Cleanup and fail gracefully
     rescue:
     - name: Delete Firewall Rule
+      register: fw_deleted
+      changed_when: fw_deleted.rc == 0
+      failed_when: false # keep cleaning up
       command:
         argv:
         - gcloud
@@ -124,8 +135,8 @@
         - firewall-rules
         - delete
         - "{{ deployment_name }}"
-      ignore_errors: true
     - name: Tear Down Cluster
+      changed_when: true # assume something destroyed
       run_once: true
       delegate_to: localhost
       environment:
@@ -171,22 +182,27 @@
     ## Always cleanup, even on failure
     always:
     - name: Recover Resume Logs
+      changed_when: false
+      failed_when: false
       delegate_to: "{{ hostvars['localhost']['controller_ip']['stdout'] }}"
       command: cat /var/log/slurm/resume.log
       register: resume_output
-      ignore_errors: true
     - name: Print Slurm resume.log
       ansible.builtin.debug:
         var: resume_output.stdout_lines
     - name: Recover Suspend Logs
+      changed_when: false
+      failed_when: false
       delegate_to: "{{ hostvars['localhost']['controller_ip']['stdout'] }}"
       command: cat /var/log/slurm/suspend.log
       register: suspend_output
-      ignore_errors: true
     - name: Print Slurm suspend.log
       ansible.builtin.debug:
         var: suspend_output.stdout_lines
     - name: Delete Firewall Rule
+      register: fw_deleted
+      changed_when: fw_deleted.rc == 0
+      failed_when: false # keep cleaning up
       run_once: true
       delegate_to: localhost
       command:
@@ -196,8 +212,8 @@
         - firewall-rules
         - delete
         - "{{ deployment_name }}"
-      ignore_errors: true
     - name: Tear Down Cluster
+      changed_when: true # assume something destroyed
       run_once: true
       delegate_to: localhost
       environment:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -63,7 +63,8 @@
         gcloud compute instances list
         --filter="labels.ghpc_deployment={{ deployment_name }}"
         --format='table(name,zone,id,status)'
-    - debug:
+    - name: Print instance information
+      ansible.builtin.debug:
         var: instances_list.stdout_lines
     - name: Get login IP
       register: login_ip
@@ -174,17 +175,17 @@
       command: cat /var/log/slurm/resume.log
       register: resume_output
       ignore_errors: true
-    - debug:
+    - name: Print Slurm resume.log
+      ansible.builtin.debug:
         var: resume_output.stdout_lines
-
     - name: Recover Suspend Logs
       delegate_to: "{{ hostvars['localhost']['controller_ip']['stdout'] }}"
       command: cat /var/log/slurm/suspend.log
       register: suspend_output
       ignore_errors: true
-    - debug:
+    - name: Print Slurm suspend.log
+      ansible.builtin.debug:
         var: suspend_output.stdout_lines
-
     - name: Delete Firewall Rule
       run_once: true
       delegate_to: localhost

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-batch-submission.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-batch-submission.yml
@@ -26,8 +26,11 @@
 - name: Batch Job Block
   block:
   - name: Submit batch job
+    register: batch_submission
+    changed_when: batch_submission.rc == 0
     ansible.builtin.command: gcloud alpha batch jobs submit {{ deployment_name }} --config=/home/batch-jobs/cloud-batch-{{ deployment_name }}.json --location=us-central1 --project={{ custom_vars.project }}
   - name: Wait for job to run
+    changed_when: false
     ansible.builtin.command: gcloud alpha batch jobs describe {{ deployment_name }} --location=us-central1 --project={{ custom_vars.project }}
     register: result
     until: result.stdout.find("SUCCEEDED") != -1
@@ -36,4 +39,6 @@
 
   always:
   - name: delete job
+    register: batch_deletion
+    changed_when: batch_deletion.rc == 0
     ansible.builtin.command: gcloud alpha batch jobs delete {{ deployment_name }} --location=us-central1 --project={{ custom_vars.project }}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
@@ -37,7 +37,8 @@
   run_once: true
   delegate_to: localhost
   register: dashboards
-- debug:
+- name: Print dashboard information
+  ansible.builtin.debug:
     var: dashboards
 - name: Fail if the HPC Dashboard hasn't been created
   ansible.builtin.fail:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
@@ -25,13 +25,15 @@
   fail:
     msg: There was a failure in the startup script
   when: startup_status['match_groups'][0] != "0"
-- name: Fail if ops agent is not running
+- name: Gather service facts
   become: true
-  ansible.builtin.command: systemctl is-active {{ item }}
-  with_items:
-  - google-cloud-ops-agent.service
-  - google-cloud-ops-agent-fluent-bit.service
-  - google-cloud-ops-agent-opentelemetry-collector.service
+  ansible.builtin.service_facts:
+- name: Fail if ops agent is not running
+  ansible.builtin.assert:
+    that:
+    - ansible_facts.services["google-cloud-ops-agent.service"].status == "enabled"
+    - ansible_facts.services["google-cloud-ops-agent-fluent-bit.service"].state == "running"
+    - ansible_facts.services["google-cloud-ops-agent-opentelemetry-collector.service"].state == "running"
 - name: Check that monitoring dashboard has been created
   ansible.builtin.command: gcloud monitoring dashboards list --format="get(displayName)"
   run_once: true

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
@@ -35,6 +35,7 @@
     - ansible_facts.services["google-cloud-ops-agent-fluent-bit.service"].state == "running"
     - ansible_facts.services["google-cloud-ops-agent-opentelemetry-collector.service"].state == "running"
 - name: Check that monitoring dashboard has been created
+  changed_when: false
   ansible.builtin.command: gcloud monitoring dashboards list --format="get(displayName)"
   run_once: true
   delegate_to: localhost

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
@@ -44,9 +44,13 @@
   when: not item.stat.exists
   loop: "{{ stat_mounts.results }}"
 - name: Test Mounts on partitions
+  register: srun_mounts
+  changed_when: srun_mounts.rc == 0
   ansible.builtin.command: "srun -N 1 ls -laF {{ mounts | join(' ') }}"
   loop: "{{ partitions }}"
 - name: Test partitions with hostname
+  register: srun_hostname
+  changed_when: srun_hostname.rc == 0
   ansible.builtin.command: srun -N 2 --partition {{ item }} hostname
   loop: "{{ partitions }}"
 - name: Ensure all nodes are powered down

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
@@ -44,14 +44,13 @@
   when: not item.stat.exists
   loop: "{{ stat_mounts.results }}"
 - name: Test Mounts on partitions
-  ansible.builtin.shell: srun -N 1 ls -laF {{ mounts | join(' ') }}
+  ansible.builtin.command: "srun -N 1 ls -laF {{ mounts | join(' ') }}"
   loop: "{{ partitions }}"
 - name: Test partitions with hostname
-  ansible.builtin.shell: srun -N 2 --partition {{ item }} hostname
+  ansible.builtin.command: srun -N 2 --partition {{ item }} hostname
   loop: "{{ partitions }}"
 - name: Ensure all nodes are powered down
-  ansible.builtin.shell:
-    sinfo -t 'IDLE&POWERED_DOWN' --noheader --format "%n"
+  ansible.builtin.command: sinfo -t 'IDLE&POWERED_DOWN' --noheader --format "%n"
   register: final_node_count
   changed_when: False
   until: final_node_count.stdout_lines | length == initial_node_count.stdout_lines | length

--- a/tools/cloud-build/daily-tests/tests/packer.yml
+++ b/tools/cloud-build/daily-tests/tests/packer.yml
@@ -19,3 +19,4 @@ zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/image-builder.yaml"
 blueprint_dir: image-builder
+network: "{{ deployment_name }}-net"


### PR DESCRIPTION
This change informs ansible where to look for ansible related files. `pre-commit` now detects `ansible-lint` errors.

```
Finished with 61 failure(s), 6 warning(s) on 312 files.
```

I have not yet done the work of correcting the errors. I played with the `--progressive` option to attempt incremental implementation but could not get it to work with `pre-commit`.

To invoke pre-commit to highlight these errors, without actually committing, run the following command:
```
pre-commit run ansible-lint -a
``` 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
