### PR TITLE
Breakout startup wait to new file & update Batch test

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - vm_name is defined
+
+- name: Wait for startup script to complete
+  become: true
+  ansible.builtin.wait_for:
+    path: /var/log/messages
+    search_regex: '.*{{ vm_name }}.*startup-script exit status ([0-9]+)'
+    timeout: 600
+  register: startup_status
+- name: Fail if startup script exited with a non-zero return code
+  fail:
+    msg: There was a failure in the startup script
+  when: startup_status['match_groups'][0] != "0"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
@@ -16,13 +16,14 @@
   ansible.builtin.assert:
     that:
     - vm_name is defined
+    - timeout_seconds is defined
 
 - name: Wait for startup script to complete
   become: true
   ansible.builtin.wait_for:
     path: /var/log/messages
     search_regex: '.*{{ vm_name }}.*startup-script exit status ([0-9]+)'
-    timeout: 600
+    timeout: "{{ timeout_seconds }}"
   register: startup_status
 - name: Fail if startup script exited with a non-zero return code
   fail:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-batch-submission.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-batch-submission.yml
@@ -12,17 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Wait for startup script to complete
-  become: true
-  ansible.builtin.wait_for:
-    path: /var/log/messages
-    search_regex: '.*{{ remote_node }}.*startup-script exit status ([0-9]+)'
-    timeout: 600
-  register: startup_status
-- name: Fail if startup script exited with a non-zero return code
-  fail:
-    msg: There was a failure in the startup script
-  when: startup_status['match_groups'][0] != "0"
+- name: Wait for startup script
+  ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
+  vars:
+    vm_name: "{{ remote_node }}"
+
 - name: Batch Job Block
   block:
   - name: Submit batch job

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-batch-submission.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-batch-submission.yml
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Wait for startup script
+- name: Include wait for startup script
   ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
   vars:
     vm_name: "{{ remote_node }}"
+    timeout_seconds: 600
 
 - name: Batch Job Block
   block:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-monitoring.yml
@@ -14,17 +14,11 @@
 
 ---
 
-- name: Wait for startup script to complete
-  become: true
-  ansible.builtin.wait_for:
-    path: /var/log/messages
-    search_regex: '.*{{ remote_node }}.*startup-script exit status ([0-9]+)'
-    timeout: 600
-  register: startup_status
-- name: Fail if startup script exited with a non-zero return code
-  fail:
-    msg: There was a failure in the startup script
-  when: startup_status['match_groups'][0] != "0"
+- name: Include wait for startup script
+  ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
+  vars:
+    vm_name: "{{ remote_node }}"
+    timeout_seconds: 600
 - name: Gather service facts
   become: true
   ansible.builtin.service_facts:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-spack.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-spack.yml
@@ -14,18 +14,11 @@
 
 ---
 
-- name: Wait for startup script to complete
-  become: true
-  wait_for:
-    path: /var/log/messages
-    search_regex: '.*{{ login_node }}.*startup-script exit status ([0-9]+)'
-    timeout: 7200
-    state: present
-  register: startup_status
-- name: Fail if startup script exited with a non-zero return code
-  fail:
-    msg: There was a failure in the startup script
-  when: startup_status['match_groups'][0] != "0"
+- name: Include wait for startup script
+  ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
+  vars:
+    vm_name: "{{ login_node }}"
+    timeout_seconds: 7200
 - name: Ensure spack is installed
   command: spack --version
   changed_when: False


### PR DESCRIPTION
Breakout the common Ansible task of waiting for startup script to finish so that it can be reused in various tests.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
