### PR TITLE
Make Packer test more reliable

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -29,6 +29,7 @@
       ROOT_DIR: "{{ workspace }}"
       BLUEPRINT_DIR: "{{ blueprint_dir }}"
       DEPLOYMENT_NAME: "{{ deployment_name }}"
+      NETWORK: "{{ network }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
   - name: Create Infrastructure and test

--- a/tools/cloud-build/daily-tests/integration-group-3.yaml
+++ b/tools/cloud-build/daily-tests/integration-group-3.yaml
@@ -16,10 +16,10 @@
 # Test Packer image building and monitoring dashboard in parallel
 # ├── build_ghpc
 # └── fetch_builder
-#    └── packer      (group 3)
 #    └── monitoring  (group 3)
 #        └── omnia
 #            └── lustre-new-vpc
+#                └── packer
 
 
 timeout: 14400s  # 4hr
@@ -110,8 +110,7 @@ steps:
 # image in it
 - id: packer
   waitFor:
-  - fetch_builder
-  - build_ghpc
+  - lustre-new-vpc
   name: >-
     us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash

--- a/tools/cloud-build/daily-tests/tests/packer.yml
+++ b/tools/cloud-build/daily-tests/tests/packer.yml
@@ -19,3 +19,4 @@ zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/image-builder.yaml"
 blueprint_dir: image-builder
+network: "{{ deployment_name }}-net"


### PR DESCRIPTION
This change does 2 things:
- It makes packer network use a unique name so that two packer tests can be run in parallel
- It puts packer test in sequence with other tests in group (instead of parallel). Without this, when packer fails it will leave up deployed resources from other tests.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
