### PR TITLE
Fix ansible-lint errors in spack test

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-spack.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-spack.yml
@@ -28,10 +28,11 @@
   when: startup_status['match_groups'][0] != "0"
 - name: Ensure spack is installed
   command: spack --version
-- name: Ensure gromacs is installed
-  shell: spack load gromacs
+  changed_when: False
 - name: Test gromacs is available on compute nodes
   shell: |
     spack load gromacs
     srun -N 1 gmx_mpi -version
     sleep 120
+  register: srun_gromacs
+  changed_when: srun_gromacs.rc == 0


### PR DESCRIPTION
`spack.yml` was renamed to `test_spack.yml` to match convention of other tests. This was done in parallel with `ansible-lint` update. It was previously not picked up in ansible-lint and now is.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
