### PR TITLE
Add test-mount to Batch integration & move variables into custom_vars

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -161,8 +161,6 @@
       vars:
         remote_node: "{{ remote_node }}"
         deployment_name: "{{ deployment_name }}"
-        mounts: "{{ mounts }}"
-        partitions: "{{ partitions }}"
         custom_vars: "{{ custom_vars }}"
       loop: "{{ post_deploy_tests }}"
       loop_control:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -173,8 +173,7 @@
       run_once: true
       vars:
         login_node: "{{ login_node }}"
-        mounts: "{{ mounts }}"
-        partitions: "{{ partitions }}"
+        custom_vars: "{{ custom_vars }}"
       loop: "{{ post_deploy_tests }}"
       loop_control:
         loop_var: test

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-hello-world.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-hello-world.yml
@@ -14,6 +14,12 @@
 
 # The hello world integration test exists to demonstrate the test interaction between test files
 ---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - top_level_var
+    - custom_vars.bar is defined
+
 - name: Print top_level_var
   debug:
     msg: "{{ top_level_var }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
@@ -19,6 +19,10 @@
     - custom_vars.partitions is defined
     - custom_vars.mounts is defined
 
+- name: Include test mounts
+  ansible.builtin.include_tasks: "test-mounts.yml"
+  vars:
+    custom_vars: "{{ custom_vars }}"
 - name: Get partition info
   ansible.builtin.command: sinfo --format='%P' --noheader
   changed_when: False
@@ -38,16 +42,6 @@
     msg: Test Check Partitions failed
   when: item not in partition_output.stdout
   loop: "{{ custom_vars.partitions }}"
-- name: Get mount info
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  register: stat_mounts
-  loop: "{{ custom_vars.mounts }}"
-- name: Check if mount exists
-  ansible.builtin.fail:
-    msg: "{{ item.item }} not mounted"
-  when: not item.stat.exists
-  loop: "{{ stat_mounts.results }}"
 - name: Test Mounts on partitions
   register: srun_mounts
   changed_when: srun_mounts.rc == 0

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts-and-partitions.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 ---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - custom_vars.partitions is defined
+    - custom_vars.mounts is defined
 
 - name: Get partition info
   ansible.builtin.command: sinfo --format='%P' --noheader
@@ -32,12 +37,12 @@
   ansible.builtin.fail:
     msg: Test Check Partitions failed
   when: item not in partition_output.stdout
-  loop: "{{ partitions }}"
+  loop: "{{ custom_vars.partitions }}"
 - name: Get mount info
   ansible.builtin.stat:
     path: "{{ item }}"
   register: stat_mounts
-  loop: "{{ mounts }}"
+  loop: "{{ custom_vars.mounts }}"
 - name: Check if mount exists
   ansible.builtin.fail:
     msg: "{{ item.item }} not mounted"
@@ -46,13 +51,13 @@
 - name: Test Mounts on partitions
   register: srun_mounts
   changed_when: srun_mounts.rc == 0
-  ansible.builtin.command: "srun -N 1 ls -laF {{ mounts | join(' ') }}"
-  loop: "{{ partitions }}"
+  ansible.builtin.command: "srun -N 1 ls -laF {{ custom_vars.mounts | join(' ') }}"
+  loop: "{{ custom_vars.partitions }}"
 - name: Test partitions with hostname
   register: srun_hostname
   changed_when: srun_hostname.rc == 0
   ansible.builtin.command: srun -N 2 --partition {{ item }} hostname
-  loop: "{{ partitions }}"
+  loop: "{{ custom_vars.partitions }}"
 - name: Ensure all nodes are powered down
   ansible.builtin.command: sinfo -t 'IDLE&POWERED_DOWN' --noheader --format "%n"
   register: final_node_count

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-mounts.yml
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - custom_vars.mounts is defined
+
+- name: Get mount info
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  register: stat_mounts
+  loop: "{{ custom_vars.mounts }}"
+- name: Check if mount exists
+  ansible.builtin.fail:
+    msg: "{{ item.item }} not mounted"
+  when: not item.stat.exists
+  loop: "{{ stat_mounts.results }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
@@ -19,10 +19,6 @@
     - custom_vars.partitions is defined
     - custom_vars.mounts is defined
 
-- name: Include test mounts
-  ansible.builtin.include_tasks: "test-mounts.yml"
-  vars:
-    custom_vars: "{{ custom_vars }}"
 - name: Get partition info
   ansible.builtin.command: sinfo --format='%P' --noheader
   changed_when: False
@@ -37,7 +33,7 @@
     executable: /bin/bash
   changed_when: False
   register: initial_node_count
-- name: Check partition compute exists
+- name: Check partitions exist
   ansible.builtin.fail:
     msg: Test Check Partitions failed
   when: item not in partition_output.stdout

--- a/tools/cloud-build/daily-tests/tests/cloud-build.yml
+++ b/tools/cloud-build/daily-tests/tests/cloud-build.yml
@@ -19,6 +19,9 @@ blueprint_yaml: "{{ workspace }}/community/examples/cloud-batch.yaml"
 blueprint_dir: deployment-cloud-batch
 network: "default"
 remote_node: "{{ deployment_name }}-batch-login"
-post_deploy_tests: [test-batch-submission.yml]
+post_deploy_tests:
+- test-batch-submission.yml
+- test-mounts.yml
 custom_vars:
   project: "{{ project }}"
+  mounts: [/sw]

--- a/tools/cloud-build/daily-tests/tests/hpc-high-io.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-high-io.yml
@@ -25,10 +25,11 @@ login_node: "slurm-{{ deployment_name }}-login0"
 controller_node: "slurm-{{ deployment_name }}-controller"
 post_deploy_tests:
 - test-mounts-and-partitions.yml
-partitions:
-- compute
-- low_cost
-mounts:
-- /home
-- /scratch
-- /projects
+custom_vars:
+  partitions:
+  - compute
+  - low_cost
+  mounts:
+  - /home
+  - /scratch
+  - /projects

--- a/tools/cloud-build/daily-tests/tests/hpc-high-io.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-high-io.yml
@@ -24,7 +24,8 @@ max_nodes: 5
 login_node: "slurm-{{ deployment_name }}-login0"
 controller_node: "slurm-{{ deployment_name }}-controller"
 post_deploy_tests:
-- test-mounts-and-partitions.yml
+- test-mounts.yml
+- test-partitions.yml
 custom_vars:
   partitions:
   - compute

--- a/tools/cloud-build/daily-tests/tests/lustre-new-vpc.yml
+++ b/tools/cloud-build/daily-tests/tests/lustre-new-vpc.yml
@@ -25,8 +25,9 @@ login_node: "slurm-{{ deployment_name }}-login0"
 controller_node: "slurm-{{ deployment_name }}-controller"
 post_deploy_tests:
 - test-mounts-and-partitions.yml
-partitions:
-- compute
-mounts:
-- /home
-- /scratch
+custom_vars:
+  partitions:
+  - compute
+  mounts:
+  - /home
+  - /scratch

--- a/tools/cloud-build/daily-tests/tests/lustre-new-vpc.yml
+++ b/tools/cloud-build/daily-tests/tests/lustre-new-vpc.yml
@@ -24,7 +24,8 @@ max_nodes: 5
 login_node: "slurm-{{ deployment_name }}-login0"
 controller_node: "slurm-{{ deployment_name }}-controller"
 post_deploy_tests:
-- test-mounts-and-partitions.yml
+- test-mounts.yml
+- test-partitions.yml
 custom_vars:
   partitions:
   - compute

--- a/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
+++ b/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
@@ -25,8 +25,9 @@ login_node: slurm-{{ deployment_name }}-login0
 controller_node: slurm-{{ deployment_name }}-controller
 post_deploy_tests:
 - test-spack.yml
-partitions:
-- compute
-mounts:
-- /home
-- /sw
+custom_vars:
+  partitions:
+  - compute
+  mounts:
+  - /home
+  - /sw


### PR DESCRIPTION
This change:
- moves `mount` and `partition` vars into `custom_vars`
- breaks out the `test-mounts.yml` into its own file so it can be called by tests that want to check mounts but don't have partitions
- Adds `test-mounts` to Cloud Batch integration test

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
