### PR TITLE
Updating DNN community module to Cloud 6.0.1

### DIFF
--- a/community/modules/file-system/DDN-EXAScaler/main.tf
+++ b/community/modules/file-system/DDN-EXAScaler/main.tf
@@ -36,7 +36,7 @@ locals {
 }
 
 module "ddn_exascaler" {
-  source          = "github.com/DDNStorage/exascaler-cloud-terraform//gcp?ref=76ab7fc"
+  source          = "github.com/DDNStorage/exascaler-cloud-terraform//gcp?ref=3eec46e"
   fsname          = var.fsname
   zone            = var.zone
   project         = var.project_id


### PR DESCRIPTION
This is to include the fixes in
https://github.com/DDNStorage/exascaler-cloud-terraform/issues/11 to
remove the use of a deprecated terraform API which could cause some
blocking issues on the newest versions of terraform

Fixes #445

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
