### PR TITLE
Decrease overhead of nfs client package installation

### DIFF
--- a/community/modules/file-system/nfs-server/scripts/install-nfs-client.sh
+++ b/community/modules/file-system/nfs-server/scripts/install-nfs-client.sh
@@ -14,10 +14,9 @@
 # limitations under the License.
 
 if [ ! "$(which mount.nfs)" ]; then
-	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
-
-		yum -y update
-		yum install -y nfs-utils
+	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] ||
+		[ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
+		yum install --disablerepo="*" --enablerepo="base,epel" -y nfs-utils
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
 		apt-get -y update
 		apt-get -y install nfs-common

--- a/community/modules/file-system/nfs-server/scripts/mount.yaml
+++ b/community/modules/file-system/nfs-server/scripts/mount.yaml
@@ -34,6 +34,6 @@
       path: "{{ item.local_mount }}"
       opts: "{{ item.mount_options }}"
       boot: true
-      fstype: "{ {item.fs_type }}"
+      fstype: "{{ item.fs_type }}"
       state: "mounted"
     loop: "{{ storage.json }}"

--- a/modules/file-system/filestore/scripts/install-nfs-client.sh
+++ b/modules/file-system/filestore/scripts/install-nfs-client.sh
@@ -14,10 +14,9 @@
 # limitations under the License.
 
 if [ ! "$(which mount.nfs)" ]; then
-	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
-
-		yum -y update
-		yum install -y nfs-utils
+	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] ||
+		[ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
+		yum install --disablerepo="*" --enablerepo="base,epel" -y nfs-utils
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
 		apt-get -y update
 		apt-get -y install nfs-common


### PR DESCRIPTION
Remove yum update as it's not needed
Add `--disablerepo="*" --enablerepo="base,epel"` to the install command to limit the repos evaluated by yum.

In testing, this brings the average runtime of the runner from 4:13 to 0:10.

In addition, a typo fix to the mount playbook for nfs-server is included in this PR.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
