### PR TITLE
Remove deprecated interpolation-only expression from nfs-server output

### DIFF
--- a/community/modules/file-system/nfs-server/outputs.tf
+++ b/community/modules/file-system/nfs-server/outputs.tf
@@ -18,7 +18,7 @@ output "network_storage" {
   description = "export of all desired folder directories"
   value = [for mount in var.local_mounts : {
     remote_mount  = "/exports${mount}"
-    local_mount   = "${mount}"
+    local_mount   = mount
     fs_type       = "nfs"
     mount_options = "defaults,hard,intr"
     server_ip     = google_compute_instance.compute_instance.network_interface[0].network_ip

--- a/tools/validate_configs/test_configs/2-nfs-servers.yaml
+++ b/tools/validate_configs/test_configs/2-nfs-servers.yaml
@@ -33,12 +33,16 @@ deployment_groups:
     kind: terraform
     id: homefs
     use: [network1]
+    outputs: [network_storage]
     settings:
       local_mounts: ["/home"]
+      auto_delete_disk: true
 
   - source: ./community/modules/file-system/nfs-server
     kind: terraform
     id: appsfs
     use: [network1]
+    outputs: [network_storage]
     settings:
       local_mounts: ["/apps"]
+      auto_delete_disk: true

--- a/tools/validate_configs/test_configs/README.md
+++ b/tools/validate_configs/test_configs/README.md
@@ -8,6 +8,11 @@ verify a local `ghpc` build.
 
 ## Blueprint Descriptions
 
+**2-nfs-servers.yaml**: Creates 2 NFS servers with different local mount points,
+but otherwise the same variables. This test exists to ensure there will be no
+naming collisions when more than one NFS server is created in a projects with
+the same deployment name.
+
 **hpc-cluster-simple.yaml**: Creates a simple cluster with a single compute VM,
 filestore as a /home directory and a network. This has been used as a demo
 blueprint when presenting the toolkit.


### PR DESCRIPTION
nfs-server module referred to a for loop variable as an interpolation
only expression, which has been deprecated as of terraform 0.12.14. The
terraform linter caught this after a recent update in the builder.

An existing test in test_configs was used to validate, the test has been updated and documented as well. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
