### PR TITLE
Additional validation of setting name conventions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,16 +54,18 @@ var errorMessages = map[string]string{
 	"varInAnotherGroup": "References to other groups are not yet supported",
 	"noOutput":          "Output not found for a variable",
 	// validator
-	"emptyID":        "a module id cannot be empty",
-	"emptySource":    "a module source cannot be empty",
-	"wrongKind":      "a module kind is invalid",
-	"extraSetting":   "a setting was added that is not found in the module",
-	"mixedModules":   "mixing modules of differing kinds in a deployment group is not supported",
-	"duplicateGroup": "group names must be unique",
-	"duplicateID":    "module IDs must be unique",
-	"emptyGroupName": "group name must be set for each deployment group",
-	"illegalChars":   "invalid character(s) found in group name",
-	"invalidOutput":  "requested output was not found in the module",
+	"emptyID":            "a module id cannot be empty",
+	"emptySource":        "a module source cannot be empty",
+	"wrongKind":          "a module kind is invalid",
+	"extraSetting":       "a setting was added that is not found in the module",
+	"settingWithPeriod":  "a setting name contains a period, which is not supported; variable subfields cannot be set independently in a blueprint.",
+	"settingInvalidChar": "a setting name must begin with a non-numeric character and all characters must be either letters, numbers, dashes ('-') or underscores ('_').",
+	"mixedModules":       "mixing modules of differing kinds in a deployment group is not supported",
+	"duplicateGroup":     "group names must be unique",
+	"duplicateID":        "module IDs must be unique",
+	"emptyGroupName":     "group name must be set for each deployment group",
+	"illegalChars":       "invalid character(s) found in group name",
+	"invalidOutput":      "requested output was not found in the module",
 }
 
 // DeploymentGroup defines a group of Modules that are all executed together


### PR DESCRIPTION
Adds a test for:
* A period in a setting name, warn that we do not support setting subfields of
  variables
* Valid characters: HCL does not support characters that are not
  letters, numbers, - or _.
* Valid first letter of setting: Must not be a number

A new error type is added to update our tests to verify error type
rather than error text, which is the best practice.

Test ValidateSettings is reformatted to allow more tests in less space
and to more quickly add new tests.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
