### PR TITLE
Use simplier gcloud image for project cleanup

### DIFF
--- a/tools/cloud-build/project-cleanup.yaml
+++ b/tools/cloud-build/project-cleanup.yaml
@@ -15,7 +15,7 @@
 ---
 
 steps:
-- name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+- name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   env:
   - "BUILD_ID=${BUILD_ID}"


### PR DESCRIPTION
This should run faster as the full HPC Toolkit image doesn't need to be
pulled in order to execute the task.

This was tested with `gcloud builds submit ...` and it succeeded.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
