### PR TITLE
Update tutorials to use native api enablement

### DIFF
--- a/docs/tutorials/basic.md
+++ b/docs/tutorials/basic.md
@@ -24,12 +24,7 @@ In a new Google Cloud project there are several apis that must be enabled to
 deploy your HPC cluster. These will be caught when you perform `terraform apply`
 but you can save time by enabling them now by running:
 
-<!-- Tried the native way to do this and it timed out. Leaving comment here for future reference. -->
-<!-- <walkthrough-enable-apis apis="file.googleapis.com,compute.googleapis.com"></walkthrough-enable-apis> -->
-
-```bash
-gcloud services enable --project <walkthrough-project-id/> file.googleapis.com compute.googleapis.com 
-```
+<walkthrough-enable-apis apis="file.googleapis.com,compute.googleapis.com"></walkthrough-enable-apis>
 
 We also need to grant the default compute service account project edit access so
 the slurm controller can perform actions such as auto-scaling.

--- a/docs/tutorials/intel-select/intel-select.md
+++ b/docs/tutorials/intel-select/intel-select.md
@@ -25,12 +25,7 @@ In a new Google Cloud project there are several apis that must be enabled to
 deploy your HPC cluster. These will be caught when you perform `terraform apply`
 but you can save time by enabling them now by running:
 
-<!-- Tried the native way to do this and it timed out. Leaving comment here for future reference. -->
-<!-- <walkthrough-enable-apis apis="file.googleapis.com,compute.googleapis.com"></walkthrough-enable-apis> -->
-
-```bash
-gcloud services enable --project <walkthrough-project-id/> file.googleapis.com compute.googleapis.com
-```
+<walkthrough-enable-apis apis="file.googleapis.com,compute.googleapis.com"></walkthrough-enable-apis>
 
 We also need to grant the default compute service account project edit access so
 the slurm controller can perform actions such as auto-scaling.


### PR DESCRIPTION
During review of #466 it was discovered that this is now fixed. 

Tested: Previewed functionality on new project using the cloud shell `teachme` command.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
