### PR TITLE
Change `source` to `.` when calling startup scripts in shell runner

### DIFF
--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -29,7 +29,6 @@ stdlib::runner() {
 
   case "$1" in
     ansible-local) stdlib::run_playbook "$destpath/$filename" "$args";;
-    # shellcheck source=/dev/null
     shell) . $destpath/$filename $args;;
   esac
   

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -29,7 +29,7 @@ stdlib::runner() {
   case "$1" in
     ansible-local) stdlib::run_playbook "$destpath/$filename" "$args";;
     # shellcheck source=/dev/null
-    shell)  sh -c "source '$destpath/$filename' $args";;
+    shell)  sh -c ". '$destpath/$filename' $args";;
   esac
 }
 

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -7,6 +7,7 @@ stdlib::run_playbook() {
     exit 1
   fi
   /usr/bin/ansible-playbook --connection=local --inventory=localhost, --limit localhost $1 $2
+  return $?
 }
 
 stdlib::runner() {
@@ -29,8 +30,15 @@ stdlib::runner() {
   case "$1" in
     ansible-local) stdlib::run_playbook "$destpath/$filename" "$args";;
     # shellcheck source=/dev/null
-    shell)  sh -c ". '$destpath/$filename' $args";;
+    shell) . $destpath/$filename $args;;
   esac
+  
+  exit_code=$?
+  stdlib::info "=== $object finished with exit_code=$exit_code ==="
+  if [ "$exit_code" -ne "0" ] ; then
+    stdlib::error "=== execution of $object failed, exiting ==="
+    exit $exit_code
+  fi
 }
 
 stdlib::load_runners(){

--- a/tools/validate_configs/test_configs/centos8-ss.yaml
+++ b/tools/validate_configs/test_configs/centos8-ss.yaml
@@ -43,7 +43,7 @@ deployment_groups:
     use: [network1]
     settings:
       image: centos-cloud/centos-stream-8
-      #image: rocky-linux-cloud/rocky-linux-8
+      auto_delete_disk: true
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform

--- a/tools/validate_configs/test_configs/centos8-ss.yaml
+++ b/tools/validate_configs/test_configs/centos8-ss.yaml
@@ -14,11 +14,11 @@
 
 ---
 
-blueprint_name: rocky-linux
+blueprint_name: centos8-ss-test
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: rocky-linux
+  deployment_name: centos8-ss-test
   region: us-central1
   zone: us-central1-a
 
@@ -42,7 +42,8 @@ deployment_groups:
     id: nfs
     use: [network1]
     settings:
-      image: rocky-linux-cloud/rocky-linux-8
+      image: centos-cloud/centos-stream-8
+      #image: rocky-linux-cloud/rocky-linux-8
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform
@@ -104,5 +105,5 @@ deployment_groups:
     settings:
       machine_type: e2-standard-4
       instance_image:
-        family: rocky-linux-8
-        project: rocky-linux-cloud
+        family: centos-stream-8
+        project: centos-cloud

--- a/tools/validate_configs/test_configs/debian-ss.yaml
+++ b/tools/validate_configs/test_configs/debian-ss.yaml
@@ -43,6 +43,7 @@ deployment_groups:
     use: [network1]
     settings:
       image: debian-cloud/debian-10
+      auto_delete_disk: true
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform

--- a/tools/validate_configs/test_configs/debian-ss.yaml
+++ b/tools/validate_configs/test_configs/debian-ss.yaml
@@ -14,11 +14,11 @@
 
 ---
 
-blueprint_name: rocky-linux
+blueprint_name: debian-ss-test
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: rocky-linux
+  deployment_name: debian-ss-test
   region: us-central1
   zone: us-central1-a
 
@@ -42,7 +42,7 @@ deployment_groups:
     id: nfs
     use: [network1]
     settings:
-      image: rocky-linux-cloud/rocky-linux-8
+      image: debian-cloud/debian-10
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform
@@ -104,5 +104,5 @@ deployment_groups:
     settings:
       machine_type: e2-standard-4
       instance_image:
-        family: rocky-linux-8
-        project: rocky-linux-cloud
+        family: debian-10
+        project: debian-cloud

--- a/tools/validate_configs/test_configs/hpc-centos-ss.yaml
+++ b/tools/validate_configs/test_configs/hpc-centos-ss.yaml
@@ -14,11 +14,11 @@
 
 ---
 
-blueprint_name: rocky-linux
+blueprint_name: hpc-centos-ss-test
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: rocky-linux
+  deployment_name: hpc-centos-ss-test
   region: us-central1
   zone: us-central1-a
 
@@ -41,8 +41,6 @@ deployment_groups:
     kind: terraform
     id: nfs
     use: [network1]
-    settings:
-      image: rocky-linux-cloud/rocky-linux-8
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform
@@ -103,6 +101,3 @@ deployment_groups:
     use: [network1, startup, nfs, appsfs]
     settings:
       machine_type: e2-standard-4
-      instance_image:
-        family: rocky-linux-8
-        project: rocky-linux-cloud

--- a/tools/validate_configs/test_configs/hpc-centos-ss.yaml
+++ b/tools/validate_configs/test_configs/hpc-centos-ss.yaml
@@ -41,6 +41,8 @@ deployment_groups:
     kind: terraform
     id: nfs
     use: [network1]
+    settings:
+      auto_delete_disk: true
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform

--- a/tools/validate_configs/test_configs/rocky-linux.yaml
+++ b/tools/validate_configs/test_configs/rocky-linux.yaml
@@ -18,7 +18,7 @@ blueprint_name: rocky-linux
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: rocky-linux
+  deployment_name: rocky-ss-test
   region: us-central1
   zone: us-central1-a
 
@@ -43,6 +43,7 @@ deployment_groups:
     use: [network1]
     settings:
       image: rocky-linux-cloud/rocky-linux-8
+      auto_delete_disk: true
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform

--- a/tools/validate_configs/test_configs/ubuntu-ss.yaml
+++ b/tools/validate_configs/test_configs/ubuntu-ss.yaml
@@ -14,11 +14,11 @@
 
 ---
 
-blueprint_name: rocky-linux
+blueprint_name: rocky-ss-test
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: rocky-linux
+  deployment_name: rocky-ss-test
   region: us-central1
   zone: us-central1-a
 
@@ -42,7 +42,7 @@ deployment_groups:
     id: nfs
     use: [network1]
     settings:
-      image: rocky-linux-cloud/rocky-linux-8
+      image: ubuntu-os-cloud/ubuntu-1804-lts
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform
@@ -104,5 +104,5 @@ deployment_groups:
     settings:
       machine_type: e2-standard-4
       instance_image:
-        family: rocky-linux-8
-        project: rocky-linux-cloud
+        family: ubuntu-1804-lts
+        project: ubuntu-os-cloud

--- a/tools/validate_configs/test_configs/ubuntu-ss.yaml
+++ b/tools/validate_configs/test_configs/ubuntu-ss.yaml
@@ -18,7 +18,7 @@ blueprint_name: rocky-ss-test
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: rocky-ss-test
+  deployment_name: ubuntu-ss-test
   region: us-central1
   zone: us-central1-a
 
@@ -43,6 +43,7 @@ deployment_groups:
     use: [network1]
     settings:
       image: ubuntu-os-cloud/ubuntu-1804-lts
+      auto_delete_disk: true
 
   - source: ./community//modules/scripts/spack-install
     kind: terraform


### PR DESCRIPTION
Update the startup script shell runner invocation from source, which is specific to bash, to `.` which is compatible with more shells. 

A set of new test_configs have been added that test startup scripts against different OS images. This change has been deployed and tested against these new test_configs.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
