### PR TITLE
Remove reference to cache override from app tutorials

### DIFF
--- a/docs/tutorials/gromacs/spack-gromacs.md
+++ b/docs/tutorials/gromacs/spack-gromacs.md
@@ -99,8 +99,7 @@ folder by running:
 ```
 
 > **_NOTE:_** The `--vars` argument is used to override `project_id` in the
-> deployment variables. Similarly we are using a prebuilt Spack cache to speed
-> up deployment.
+> deployment variables.
 
 This will create a deployment directory named `spack-gromacs/`, which
 contains the terraform needed to deploy your cluster.

--- a/docs/tutorials/openfoam/spack-openfoam.md
+++ b/docs/tutorials/openfoam/spack-openfoam.md
@@ -99,8 +99,7 @@ folder by running:
 ```
 
 > **_NOTE:_** The `--vars` argument is used to override `project_id` in the
-> deployment variables. Similarly we are using a prebuilt Spack cache to speed
-> up deployment.
+> deployment variables.
 
 This will create a deployment directory named `spack-openfoam/`, which
 contains the terraform needed to deploy your cluster.

--- a/docs/tutorials/wrfv3/spack-wrfv3.md
+++ b/docs/tutorials/wrfv3/spack-wrfv3.md
@@ -99,8 +99,7 @@ folder by running:
 ```
 
 > **_NOTE:_** The `--vars` argument is used to override `project_id` in the
-> deployment variables. Similarly we are using a prebuilt Spack cache to speed
-> up deployment.
+> deployment variables.
 
 This will create a deployment directory named `spack-wrfv3/`, which
 contains the terraform needed to deploy your cluster.


### PR DESCRIPTION
The reference to the cache was removed in a previous PR. This is just cleaning a missed reference in the tutorial. AKA: The tutorial does not use a Spack cache. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
