### PR TITLE
Adding option to enable public ips on Slurm-GCP V5

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
@@ -110,6 +110,7 @@ No resources.
 | <a name="input_compute_startup_script"></a> [compute\_startup\_script](#input\_compute\_startup\_script) | Startup script used by the compute VMs. | `string` | `""` | no |
 | <a name="input_controller_startup_script"></a> [controller\_startup\_script](#input\_controller\_startup\_script) | Startup script used by the controller VM. | `string` | `""` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment. | `string` | n/a | yes |
+| <a name="input_disable_controller_public_ips"></a> [disable\_controller\_public\_ips](#input\_disable\_controller\_public\_ips) | If set to false. The controller will have a random public IP assigned to it. Ignored if access\_config is set. | `bool` | `true` | no |
 | <a name="input_disable_default_mounts"></a> [disable\_default\_mounts](#input\_disable\_default\_mounts) | Disable default global network storage from the controller<br>* /usr/local/etc/slurm<br>* /etc/munge<br>* /home<br>* /apps<br>Warning: If these are disabled, the slurm etc and munge dirs must be added<br>manually, or some other mechanism must be used to synchronize the slurm conf<br>files and the munge key across the cluster. | `bool` | `false` | no |
 | <a name="input_disable_smt"></a> [disable\_smt](#input\_disable\_smt) | Disables Simultaneous Multi-Threading (SMT) on instance. | `bool` | `false` | no |
 | <a name="input_disk_auto_delete"></a> [disk\_auto\_delete](#input\_disk\_auto\_delete) | Whether or not the boot disk should be auto-deleted. | `bool` | `true` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
@@ -27,12 +27,16 @@ locals {
   # Also, slurm imposed a lot of restrictions to this name, so we format it to an acceptable string
   tmp_cluster_name   = substr(replace(lower(var.deployment_name), "/^[^a-z]*|[^a-z0-9]/", ""), 0, 8)
   slurm_cluster_name = var.slurm_cluster_name != null ? var.slurm_cluster_name : local.tmp_cluster_name
+
+  enable_public_ip_access_config = var.disable_controller_public_ips ? [] : [{ nat_ip = null, network_tier = null }]
+  access_config                  = length(var.access_config) == 0 ? local.enable_public_ip_access_config : var.access_config
+
 }
 
 module "slurm_controller_instance" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_instance?ref=v5.0.3"
 
-  access_config                = var.access_config
+  access_config                = local.access_config
   slurm_cluster_name           = local.slurm_cluster_name
   instance_template            = module.slurm_controller_template.self_link
   project_id                   = var.project_id

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
@@ -103,6 +103,12 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "disable_controller_public_ips" {
+  description = "If set to false. The controller will have a random public IP assigned to it. Ignored if access_config is set."
+  type        = bool
+  default     = true
+}
+
 variable "disable_default_mounts" {
   description = <<-EOD
     Disable default global network storage from the controller

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
@@ -88,6 +88,7 @@ No resources.
 | <a name="input_can_ip_forward"></a> [can\_ip\_forward](#input\_can\_ip\_forward) | Enable IP forwarding, for NAT instances for example. | `bool` | `false` | no |
 | <a name="input_controller_instance_id"></a> [controller\_instance\_id](#input\_controller\_instance\_id) | The server-assigned unique identifier of the controller instance, typically<br>supplied as an output of the controler module. | `string` | n/a | yes |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment. | `string` | n/a | yes |
+| <a name="input_disable_login_public_ips"></a> [disable\_login\_public\_ips](#input\_disable\_login\_public\_ips) | If set to false. The login will have a random public IP assigned to it. Ignored if access\_config is set. | `bool` | `true` | no |
 | <a name="input_disable_smt"></a> [disable\_smt](#input\_disable\_smt) | Disables Simultaneous Multi-Threading (SMT) on instance. | `bool` | `false` | no |
 | <a name="input_disk_auto_delete"></a> [disk\_auto\_delete](#input\_disk\_auto\_delete) | Whether or not the boot disk should be auto-deleted. | `bool` | `true` | no |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB. | `number` | `50` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
@@ -23,6 +23,9 @@ locals {
   # Also, slurm imposed a lot of restrictions to this name, so we format it to an acceptable string
   tmp_cluster_name   = substr(replace(lower(var.deployment_name), "/^[^a-z]*|[^a-z0-9]/", ""), 0, 8)
   slurm_cluster_name = var.slurm_cluster_name != null ? var.slurm_cluster_name : local.tmp_cluster_name
+
+  enable_public_ip_access_config = var.disable_login_public_ips ? [] : [{ nat_ip = null, network_tier = null }]
+  access_config                  = length(var.access_config) == 0 ? local.enable_public_ip_access_config : var.access_config
 }
 
 module "slurm_login_template" {
@@ -64,7 +67,7 @@ module "slurm_login_template" {
 module "slurm_login_instance" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_login_instance?ref=v5.0.3"
 
-  access_config         = var.access_config
+  access_config         = local.access_config
   slurm_cluster_name    = local.slurm_cluster_name
   instance_template     = module.slurm_login_template.self_link
   network               = var.network_self_link

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
@@ -39,6 +39,12 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "disable_login_public_ips" {
+  description = "If set to false. The login will have a random public IP assigned to it. Ignored if access_config is set."
+  type        = bool
+  default     = true
+}
+
 variable "slurm_cluster_name" {
   type        = string
   description = "Cluster name, used for resource naming and slurm accounting. If not provided it will default to the first 8 characters of the deployment name (removing any invalid characters)."


### PR DESCRIPTION
Through disable_login_public_ips in login node and disable_controller_public_ips in the controller.
It a weird semmantic, since it is true by default, but it was chosen
this way to maintain compatibility with V4.

By default, both the controller and the login node will have disable
public ips set to true. If set to false, and access_config is not
provided, it will generated a random public ip for each one of these

The partition doesn't seem to have the option available, and since it is
also typically less desirable, I did not add it.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
