### PR TITLE
Additional validation for blueprint_name

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -526,7 +526,7 @@ A user defined blueprint should follow the following schema:
 
 ```yaml
 # Required: Name your blueprint.
-blueprint_name: MyBlueprintName
+blueprint_name: my-blueprint-name
 
 # Top-level variables, these will be pulled from if a required variable is not
 # provided as part of a module. Any variables can be set here by the user,
@@ -586,6 +586,10 @@ below.
 
 * **blueprint_name** (required): This name can be used to track resources and
   usage across multiple deployments that come from the same blueprint.
+  `blueprint_name` is used as a value for the `ghpc_blueprint` label key, and
+   must abide to label value naming constraints: `blueprint_name` must be at most
+   63 characters long, and can only contain lowercase letters, numeric
+   characters, underscores and dashes.
 
 ### Deployment Variables
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,10 @@ import (
 	"hpc-toolkit/pkg/sourcereader"
 )
 
-const expectedVarFormat = "$(vars.var_name) or $(module_id.var_name)"
+const (
+	expectedVarFormat string = "$(vars.var_name) or $(module_id.var_name)"
+	matchLabelExp     string = `^[\p{Ll}\p{Lo}\p{N}_-]{1,63}$`
+)
 
 var errorMessages = map[string]string{
 	// general
@@ -66,6 +69,10 @@ var errorMessages = map[string]string{
 	"emptyGroupName":     "group name must be set for each deployment group",
 	"illegalChars":       "invalid character(s) found in group name",
 	"invalidOutput":      "requested output was not found in the module",
+	"varNotDefined":      "variable not defined",
+	"valueNotString":     "value was not of type string",
+	"valueEmptyString":   "value is an empty string",
+	"labelReqs":          "value can only contain lowercase letters, numeric characters, underscores and dashes, and must be between 1 and 63 characters long.",
 }
 
 // DeploymentGroup defines a group of Modules that are all executed together
@@ -563,22 +570,14 @@ func ResolveVariables(
 	return nil
 }
 
-// DeploymentNameError signifies a problem with the blueprint deployment name.
-type DeploymentNameError struct {
-	cause string
+// InputValueError signifies a problem with the blueprint name.
+type InputValueError struct {
+	inputKey string
+	cause    string
 }
 
-func (err *DeploymentNameError) Error() string {
-	return fmt.Sprintf("deployment_name must be a string and cannot be empty, cause: %v", err.cause)
-}
-
-// BlueprintNameError signifies a problem with the blueprint name.
-type BlueprintNameError struct {
-	cause string
-}
-
-func (err *BlueprintNameError) Error() string {
-	return fmt.Sprintf("blueprint_name input error, cause: %v", err.cause)
+func (err *InputValueError) Error() string {
+	return fmt.Sprintf("%v input error, cause: %v", err.inputKey, err.cause)
 }
 
 // ResolveGlobalVariables will resolve literal variables "((var.*))" in the
@@ -596,17 +595,35 @@ func (b Blueprint) ResolveGlobalVariables(ctyVars map[string]cty.Value) error {
 func (b *Blueprint) DeploymentName() (string, error) {
 	nameInterface, found := b.Vars["deployment_name"]
 	if !found {
-		return "", &DeploymentNameError{"deployment_name variable not defined."}
+		return "", &InputValueError{
+			inputKey: "deployment_name",
+			cause:    errorMessages["varNotFound"],
+		}
 	}
 
 	deploymentName, ok := nameInterface.(string)
 	if !ok {
-		return "", &DeploymentNameError{"deployment_name was not of type string."}
+		return "", &InputValueError{
+			inputKey: "deployment_name",
+			cause:    errorMessages["valueNotString"],
+		}
 	}
 
 	if len(deploymentName) == 0 {
-		return "", &DeploymentNameError{"deployment_name was an empty string."}
+		return "", &InputValueError{
+			inputKey: "deployment_name",
+			cause:    errorMessages["valueEmptyString"],
+		}
 	}
+
+	// Check that deployment_name is a valid label
+	if !regexp.MustCompile(matchLabelExp).MatchString(deploymentName) {
+		return "", &InputValueError{
+			inputKey: "deployment_name",
+			cause:    errorMessages["labelReqs"],
+		}
+	}
+
 	return deploymentName, nil
 }
 
@@ -614,8 +631,11 @@ func (b *Blueprint) DeploymentName() (string, error) {
 // requirements for correct label values as per https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements
 func (b *Blueprint) checkBlueprintName() error {
 
-	if !regexp.MustCompile(`^[\p{Ll}\p{Lo}\p{N}_-]{1,63}$`).MatchString(b.BlueprintName) {
-		return &BlueprintNameError{"blueprint_name can only contain lowercase letters, numeric characters, underscores and dashes, and must be between 1 and 63 characters long."}
+	if !regexp.MustCompile(matchLabelExp).MatchString(b.BlueprintName) {
+		return &InputValueError{
+			inputKey: "blueprint_name",
+			cause:    errorMessages["labelReqs"],
+		}
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -232,6 +232,7 @@ func getBasicDeploymentConfigWithTestModule() DeploymentConfig {
 	}
 	return DeploymentConfig{
 		Config: Blueprint{
+			BlueprintName:    "simple",
 			Vars:             map[string]interface{}{"deployment_name": "deployment_name"},
 			DeploymentGroups: []DeploymentGroup{testDeploymentGroup},
 		},
@@ -341,6 +342,30 @@ func (s *MySuite) TestDeploymentName(c *C) {
 	delete(dc.Config.Vars, "deployment_name")
 	deploymentName, err = dc.Config.DeploymentName()
 	c.Assert(deploymentName, Equals, "")
+	c.Check(errors.As(err, &e), Equals, true)
+}
+
+func (s *MySuite) TestCheckBlueprintName(c *C) {
+	dc := getDeploymentConfigForTest()
+	var e *BlueprintNameError
+
+	// Is blueprint_name a valid string?
+	err := dc.Config.checkBlueprintName()
+	c.Assert(err, IsNil)
+
+	// Is blueprint_name an empty string?
+	dc.Config.BlueprintName = ""
+	err = dc.Config.checkBlueprintName()
+	c.Check(errors.As(err, &e), Equals, true)
+
+	// Is blueprint_name longer than 63 characters?
+	dc.Config.BlueprintName = "blueprint-name-blueprint-name-blueprint-name-blueprint-name-0123"
+	err = dc.Config.checkBlueprintName()
+	c.Check(errors.As(err, &e), Equals, true)
+
+	// Does deployment_name contain special characters other than dashes or underscores?
+	dc.Config.BlueprintName = "blueprint.name"
+	err = dc.Config.checkBlueprintName()
 	c.Check(errors.As(err, &e), Equals, true)
 }
 

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -227,7 +227,7 @@ func (s *MySuite) TestWriteDeployment(c *C) {
 
 func (s *MySuite) TestWriteDeployment_BadDeploymentName(c *C) {
 	testBlueprint := getBlueprintForTest()
-	var e *config.DeploymentNameError
+	var e *config.InputValueError
 
 	testBlueprint.Vars = map[string]interface{}{"deployment_name": 100}
 	err := WriteDeployment(&testBlueprint, testDir, false /* overwriteFlag */)

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -19,7 +19,7 @@ run_test() {
 	example=$1
 	tmpdir="$(mktemp -d)"
 	exampleFile=$(basename "$example")
-	DEPLOYMENT="${exampleFile%.yaml}-$(basename "${tmpdir##*.}")"
+	DEPLOYMENT=$(echo "${exampleFile%.yaml}-$(basename "${tmpdir##*.}")" | sed -e 's/\(.*\)/\L\1/')
 	PROJECT="invalid-project"
 
 	echo "testing ${example} in ${tmpdir}"


### PR DESCRIPTION
### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?

### Changes
Proposing a change to validate `blueprint_name` against label value naming constraints as defined in the Google Cloud [docs](https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements).