### PR TITLE
Remove exit 0 command from Spack install

### DIFF
--- a/community/modules/scripts/spack-install/templates/install_spack.tpl
+++ b/community/modules/scripts/spack-install/templates/install_spack.tpl
@@ -151,4 +151,3 @@ echo "source ${INSTALL_DIR}/share/spack/setup-env.sh" >> /etc/profile.d/spack.sh
 chmod a+rx /etc/profile.d/spack.sh
 
 echo "$PREFIX Setup complete..."
-exit 0


### PR DESCRIPTION
- exit 0 at end of a script is mostly redundant
- due to e8509cc, exit command now causes entire startup script to exit
  prematurely

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?