### PR TITLE
Update ansible install script

### DIFF
--- a/community/modules/file-system/nfs-server/README.md
+++ b/community/modules/file-system/nfs-server/README.md
@@ -6,6 +6,10 @@ files with other clients over a network. `nfs-server` can be used by
 [vm-instance](../../../../modules/compute/vm-instance/README.md) and SchedMD
 community modules that create compute VMs.
 
+> **_WARNING:_** This module has only been tested against the HPC centos7 OS
+> disk image (the default). Using other images may work, but have not been
+> verified.
+
 [disk]: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk
 
 ### Example

--- a/community/modules/file-system/nfs-server/scripts/install-nfs-client.sh
+++ b/community/modules/file-system/nfs-server/scripts/install-nfs-client.sh
@@ -24,7 +24,7 @@ if [ ! "$(which mount.nfs)" ]; then
 			enable_repo="baseos"
 		else
 			echo "Unsupported version of centos/RHEL/Rocky"
-			exit 1
+			return 1
 		fi
 		yum install --disablerepo="*" --enablerepo=${enable_repo} -y nfs-utils
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
@@ -32,6 +32,6 @@ if [ ! "$(which mount.nfs)" ]; then
 		apt-get -y install nfs-common
 	else
 		echo 'Unsuported distribution'
-		exit 1
+		return 1
 	fi
 fi

--- a/community/modules/scripts/spack-install/templates/install_spack.tpl
+++ b/community/modules/scripts/spack-install/templates/install_spack.tpl
@@ -9,6 +9,11 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
+# Activate ghpc-venv virtual environment if it exists
+if [ -d /usr/local/ghpc-venv ]; then
+  source /usr/local/ghpc-venv/bin/activate
+fi
+
 # Only install and configure spack if ${INSTALL_DIR} doesn't exist
 if [ ! -d ${INSTALL_DIR} ]; then
 

--- a/modules/file-system/filestore/scripts/install-nfs-client.sh
+++ b/modules/file-system/filestore/scripts/install-nfs-client.sh
@@ -24,7 +24,7 @@ if [ ! "$(which mount.nfs)" ]; then
 			enable_repo="baseos"
 		else
 			echo "Unsupported version of centos/RHEL/Rocky"
-			exit 1
+			return 1
 		fi
 		yum install --disablerepo="*" --enablerepo=${enable_repo} -y nfs-utils
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
@@ -32,6 +32,6 @@ if [ ! "$(which mount.nfs)" ]; then
 		apt-get -y install nfs-common
 	else
 		echo 'Unsuported distribution'
-		exit 1
+		return 1
 	fi
 fi

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -53,6 +53,34 @@ Each runner receives the following attributes:
   Therefore`args` should not include any arguments that alter this behavior,
   such as `--connection`, `--inventory`, or `--limit`.
 
+### Runner dependencies
+
+The `ansible-local` runner requires ansible to be installed in the VM before
+running. To support other playbook runners in the HPC Toolkit, we require
+version 2.11 of ansible-core or higher. Note that this is distinct from the
+package version used to install ansible with pip. The minimum pip package
+of ansible is 4.10.0.
+
+To install ansible, a runner supplied by this module can be added as a prior
+runner. An example of this can be found in the [Example](#example) section below
+as the first runner in the list of runners. This script will do the following in
+your VM instance:
+
+- Install python3 if not already installed using system package managers (yum,
+  apt-get, etc)
+- Install pip3 if not already installed and upgrade pip3 if the version is not
+  at least 18.0.
+- Install and create a virtualenv located at `/usr/local/ghpc-venv`.
+- Install ansible into this virtualenv if the current version of ansible is not
+  version 2.11 or higher.
+
+To use the virtualenv created by this script, you can activate it by running the
+following commmand on the VM:
+
+```shell
+source /usr/local/ghpc-venv/bin/activate
+```
+
 ### Staging the runners
 
 Runners will be uploaded to a

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -66,13 +66,13 @@ runner. An example of this can be found in the [Example](#example) section below
 as the first runner in the list of runners. This script will do the following in
 your VM instance:
 
-- Install python3 if not already installed using system package managers (yum,
-  apt-get, etc)
-- Install pip3 if not already installed and upgrade pip3 if the version is not
-  at least 18.0.
-- Install and create a virtualenv located at `/usr/local/ghpc-venv`.
-- Install ansible into this virtualenv if the current version of ansible is not
-  version 2.11 or higher.
+- Install system-wide python3 if not already installed using system package
+  managers (yum, apt-get, etc)
+- Install system-wide pip3 if not already installed and upgrade pip3 if the
+  version is not at least 18.0.
+- Install and create a virtual environment located at `/usr/local/ghpc-venv`.
+- Install ansible into this virtual environment if the current version of
+  ansible is not version 2.11 or higher.
 
 To use the virtualenv created by this script, you can activate it by running the
 following commmand on the VM:

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -68,18 +68,33 @@ your VM instance:
 
 - Install system-wide python3 if not already installed using system package
   managers (yum, apt-get, etc)
+- Install `python3-distutils` system-wide in debian and ubuntu based
+  environments. This can be a missing dependency on system installations of
+  python3 for installing and upgrading pip.
 - Install system-wide pip3 if not already installed and upgrade pip3 if the
   version is not at least 18.0.
 - Install and create a virtual environment located at `/usr/local/ghpc-venv`.
 - Install ansible into this virtual environment if the current version of
   ansible is not version 2.11 or higher.
 
-To use the virtualenv created by this script, you can activate it by running the
-following commmand on the VM:
+To use the virtual environment created by this script, you can activate it by
+running the following commmand on the VM:
 
 ```shell
 source /usr/local/ghpc-venv/bin/activate
 ```
+
+You may also need to provide the correct python interpreter as the python3
+binary in the virtual environment. This can be done by adding the following flag
+when calling `ansible-playbook`:
+
+```shell
+-e ansible_python_interpreter=/usr/local/ghpc-venv/bin/activate
+```
+
+> **_NOTE:_** ansible-playbook and other ansible command line tools will only be
+> accessible from the command line (and in your PATH variable) after activating
+> this environment.
 
 ### Staging the runners
 

--- a/modules/scripts/startup-script/examples/install_ansible.sh
+++ b/modules/scripts/startup-script/examples/install_ansible.sh
@@ -34,7 +34,7 @@ apt_wait() {
 install_python_deps() {
 	if [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release 2>/dev/null ||
 		grep -qi ubuntu /etc/os-release 2>/dev/null; then
-		apt install -y python3-distutils
+		apt-get install -y python3-distutils
 	fi
 }
 
@@ -68,15 +68,15 @@ get_python_minor_version() {
 install_python3_yum() {
 	## TODO restrict repos to search through in centos to decrease overhead
 	yum install -y python3
-	python_path=$(rpm -ql python3 | grep 'python3$')
+	python_path=$(rpm -ql python3 | grep 'bin/python3$')
 }
 
 # Install python3 with the apt package manager. Updates python_path to the
 # newly installed packaged.
 install_python3_apt() {
 	apt_wait
-	apt install -y python3 python3-distutils
-	python_path=$(dpkg -L python3 | grep 'python3$')
+	apt-get install -y python3 python3-distutils
+	python_path=$(which python3)
 }
 
 install_python3() {

--- a/modules/scripts/startup-script/examples/install_ansible.sh
+++ b/modules/scripts/startup-script/examples/install_ansible.sh
@@ -15,21 +15,21 @@
 
 REQ_ANSIBLE_VERSION=2.11
 REQ_ANSIBLE_PIP_VERSION=4.10.0
-REQ_PIP_VERSION=18
+REQ_PIP_MINOR_VERSION=18
 REQ_PYTHON3_VERSION=6
 
 apt_wait() {
-	while fuser /var/lib/dpkg/lock 2>/dev/null 2>&1; do
+	while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do
 		echo "Sleeping for dpkg lock"
 		sleep 3
 	done
-	while fuser /var/lib/apt/lists/lock 2>/dev/null 2>&1; do
+	while fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
 		echo "Sleeping for apt lists lock"
 		sleep 3
 	done
 	if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
 		echo "Sleeping until unattended-upgrades finishes"
-		while fuser /var/log/unattended-upgrades/unattended-upgrades.log 2>/dev/null 2>&1; do
+		while fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1; do
 			sleep 3
 		done
 	fi
@@ -165,8 +165,7 @@ main() {
 	fi
 	pip_version=$(${python_path} -m pip --version | sed -nr 's/^pip ([0-9]+\.[0-9]+).*$/\1/p')
 	pip_major_version=$(echo "${pip_version}" | cut -d '.' -f 1)
-	echo "pip version: ${pip_version}"
-	if [ "${pip_major_version}" -lt "${REQ_PIP_VERSION}" ]; then
+	if [ "${pip_major_version}" -lt "${REQ_PIP_MINOR_VERSION}" ]; then
 		${python_path} -m pip install --upgrade pip
 	fi
 

--- a/modules/scripts/startup-script/examples/install_ansible.sh
+++ b/modules/scripts/startup-script/examples/install_ansible.sh
@@ -14,40 +14,117 @@
 # limitations under the License.
 
 apt_wait() {
-	while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do
+	while fuser /var/lib/dpkg/lock 2>/dev/null 2>&1; do
 		echo "Sleeping for dpkg lock"
 		sleep 3
 	done
-	while fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
+	while fuser /var/lib/apt/lists/lock 2>/dev/null 2>&1; do
 		echo "Sleeping for apt lists lock"
 		sleep 3
 	done
 	if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
 		echo "Sleeping until unattended-upgrades finishes"
-		while fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1; do
+		while fuser /var/log/unattended-upgrades/unattended-upgrades.log 2>/dev/null 2>&1; do
 			sleep 3
 		done
 	fi
 }
 
-if [ ! -h /usr/bin/ansible-playbook ] || [ ! -f /usr/bin/ansible-playbook ]; then
-	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
-		if [ ! -f /bin/pip ]; then
-			curl -Os https://bootstrap.pypa.io/pip/2.7/get-pip.py
-			/usr/bin/python get-pip.py
-		fi
-		/usr/bin/python -m pip install virtualenv
-		/usr/bin/python -m virtualenv /usr/local/toolkit
-		/usr/local/toolkit/bin/python -m pip install wheel
-		/usr/local/toolkit/bin/python -m pip install ansible==2.9.27
-		ln -s /usr/local/toolkit/bin/ansible-playbook /usr/bin/ansible-playbook
-	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
-		echo 'WARNING: unsupported installation of ansible in debian / ubuntu'
-		apt_wait
-		apt-get update
-		DEBIAN_FRONTEND=noninteractive apt-get install -y ansible
-	else
-		echo 'Unsupported distribution'
-		exit 1
+# Installs any dependencies needed for python based on the OS
+install_python_deps() {
+	if [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release 2>/dev/null ||
+		grep -qi ubuntu /etc/os-release 2>/dev/null; then
+		apt install -y python3-distutils
 	fi
-fi
+}
+
+# Gets the name of the python executable for python starting with python3, then
+# checking python. Sets the variable to an empty string if neither are found.
+get_python_path() {
+	python_path=""
+	if [ -f /bin/python3 ]; then
+		python_path="/bin/python3"
+	elif [ -f /bin/python ]; then
+		python_path="/bin/python"
+	fi
+}
+
+# Returns the python major version. If provided, it will use the first argument
+# as the python executable, otherwise it will default to simply "python".
+get_python_major_version() {
+	python_path=${1:-python}
+	python_major_version=$(${python_path} -c "import sys; print(sys.version_info.major)")
+}
+
+# Returns the python minor version. If provided, it will use the first argument
+# as the python executable, otherwise it will default to simply "python".
+get_python_minor_version() {
+	python_path=${1:-python}
+	python_minor_version=$(${python_path} -c "import sys; print(sys.version_info.minor)")
+}
+
+# Install python3 with the yum package manager. Updates python_path to the
+# newly installed packaged.
+install_python3_yum() {
+	## TODO restrict repos to search through in centos to decrease overhead
+	yum install -y python3
+	python_path=$(rpm -ql python3 | grep 'python3$')
+}
+
+# Install python3 with the apt package manager. Updates python_path to the
+# newly installed packaged.
+install_python3_apt() {
+	apt_wait
+	apt install -y python3 python3-distutils
+	python_path=$(dpkg -L python3 | grep 'python3$')
+}
+
+install_python3() {
+	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] ||
+		[ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
+		install_python3_yum
+	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release 2>/dev/null ||
+		grep -qi ubuntu /etc/os-release 2>/dev/null; then
+		install_python3_apt
+	else
+		echo "Error: Unsupported Distribution"
+		return 1
+	fi
+}
+
+main() {
+	# Get the python3 executable, or install it if not found
+	get_python_path
+	if [ "${python_path}" = "" ]; then
+		if ! install_python3; then
+			return 1
+		fi
+	fi
+	get_python_major_version "${python_path}"
+	if [ "${python_major_version}" = "2" ]; then
+		if ! install_python3; then
+			return 1
+		fi
+	fi
+	install_python_deps
+
+	# Install and/or upgrade pip
+	get_python_minor_version "${python_path}"
+	if [ "${python_minor_version}" -lt 7 ]; then
+		get_pip_url="https://bootstrap.pypa.io/pip/${python_major_version}.${python_minor_version}/get-pip.py"
+	else
+		get_pip_url="https://bootstrap.pypa.io/pip/get-pip.py"
+	fi
+	curl -Os ${get_pip_url}
+	${python_path} get-pip.py
+
+	# Create pip virtual environment for HPC Toolkit
+	${python_path} -m pip install virtualenv
+	${python_path} -m virtualenv /usr/local/ghpc-venv
+	python_path=/usr/local/ghpc-venv/bin/python3
+
+	# Install ansible
+	${python_path} -m pip install ansible==4.10.0
+}
+
+main

--- a/modules/scripts/startup-script/examples/install_ansible.sh
+++ b/modules/scripts/startup-script/examples/install_ansible.sh
@@ -47,12 +47,10 @@ install_python_deps() {
 # checking python. Sets the variable to an empty string if neither are found.
 get_python_path() {
 	python_path=""
-	if [ -f /bin/python3 ]; then
-		python_path="/bin/python3"
-	elif [ -f /bin/python ]; then
-		python_path="/bin/python"
-	else
+	if which python3 2>/dev/null; then
 		python_path=$(which python3 2>/dev/null)
+	elif which python 2>/dev/null; then
+		python_path=$(which python 2>/dev/null)
 	fi
 }
 

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -1,7 +1,7 @@
 
 
 stdlib::run_playbook() {
-  if [ -f /usr/local/ghpc-venv ]; then
+  if [ -d /usr/local/ghpc-venv ]; then
     . /usr/local/ghpc-venv/bin/activate
   fi
   if [ ! "$(which ansible-playbook)" ]; then
@@ -9,8 +9,8 @@ stdlib::run_playbook() {
     "Please install ansible before running ansible-local runners."
     exit 1
   fi
-  /usr/bin/ansible-playbook --connection=local --inventory=localhost, --limit localhost $1 $2
-  if [ -f /usr/local/ghpc-venv ]; then
+  ansible-playbook --connection=local --inventory=localhost, --limit localhost $1 $2
+  if [ -d /usr/local/ghpc-venv ]; then
     deactivate
   fi
   return $?

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -1,15 +1,17 @@
 
 
 stdlib::run_playbook() {
+  python_interpreter_flag=""
   if [ -d /usr/local/ghpc-venv ]; then
     . /usr/local/ghpc-venv/bin/activate
+    python_interpreter_flag="-e ansible_python_interpreter=/usr/local/ghpc-venv/bin/python3"
   fi
   if [ ! "$(which ansible-playbook)" ]; then
     stdlib::error "ansible-playbook not found"\
     "Please install ansible before running ansible-local runners."
     exit 1
   fi
-  ansible-playbook --connection=local --inventory=localhost, --limit localhost $1 $2
+  ansible-playbook $${python_interpreter_flag} --connection=local --inventory=localhost, --limit localhost $1 $2
   if [ -d /usr/local/ghpc-venv ]; then
     deactivate
   fi

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -1,12 +1,18 @@
 
 
 stdlib::run_playbook() {
+  if [ -f /usr/local/ghpc-venv ]; then
+    . /usr/local/ghpc-venv/bin/activate
+  fi
   if [ ! "$(which ansible-playbook)" ]; then
     stdlib::error "ansible-playbook not found"\
     "Please install ansible before running ansible-local runners."
     exit 1
   fi
   /usr/bin/ansible-playbook --connection=local --inventory=localhost, --limit localhost $1 $2
+  if [ -f /usr/local/ghpc-venv ]; then
+    deactivate
+  fi
   return $?
 }
 

--- a/tools/validate_configs/test_configs/centos8-ss.yaml
+++ b/tools/validate_configs/test_configs/centos8-ss.yaml
@@ -42,7 +42,6 @@ deployment_groups:
     kind: terraform
     use: [network1]
     settings:
-      image: centos-cloud/centos-stream-8
       auto_delete_disk: true
 
   - id: spack
@@ -94,6 +93,7 @@ deployment_groups:
         destination: "install-nfs-client.sh"
       - $(appsfs.install_nfs_client_runner)
       - $(nfs.mount_runner)
+      - $(spack.install_spack_deps_runner)
       - type: shell
         content: $(spack.startup_script)
         destination: "/apps/spack-install.sh"

--- a/tools/validate_configs/test_configs/centos8-ss.yaml
+++ b/tools/validate_configs/test_configs/centos8-ss.yaml
@@ -50,19 +50,11 @@ deployment_groups:
     settings:
       install_dir: /apps/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.17.0
-      spack_cache_url:
-      - mirror_name: 'gcs_cache'
-        mirror_url: gs://example-buildcache/linux-centos7
+      spack_ref: v0.18.0
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:
       - cmake%gcc@10.3.0 target=x86_64
-      - intel-mkl%gcc@10.3.0 target=skylake
-      - intel-mpi@2018.4.274%gcc@10.3.0 target=skylake
-      - >-
-        fftw%intel@18.0.5 target=skylake ^intel-mpi@2018.4.274%intel@18.0.5
-        target=x86_64
 
   - id: startup
     source: ./modules/scripts/startup-script

--- a/tools/validate_configs/test_configs/debian-ss.yaml
+++ b/tools/validate_configs/test_configs/debian-ss.yaml
@@ -55,11 +55,6 @@ deployment_groups:
       - gcc@10.3.0 target=x86_64
       packages:
       - cmake%gcc@10.3.0 target=x86_64
-      - intel-mkl%gcc@10.3.0 target=skylake
-      - intel-mpi@2018.4.274%gcc@10.3.0 target=skylake
-      - >-
-        fftw%intel@18.0.5 target=skylake ^intel-mpi@2018.4.274%intel@18.0.5
-        target=x86_64
 
   - id: startup
     source: ./modules/scripts/startup-script

--- a/tools/validate_configs/test_configs/debian-ss.yaml
+++ b/tools/validate_configs/test_configs/debian-ss.yaml
@@ -42,7 +42,6 @@ deployment_groups:
     kind: terraform
     use: [network1]
     settings:
-      image: debian-cloud/debian-10
       auto_delete_disk: true
 
   - id: spack
@@ -51,10 +50,7 @@ deployment_groups:
     settings:
       install_dir: /apps/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.17.0
-      spack_cache_url:
-      - mirror_name: 'gcs_cache'
-        mirror_url: gs://example-buildcache/linux-centos7
+      spack_ref: v0.18.0
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:
@@ -93,7 +89,8 @@ deployment_groups:
         content: $(nfs.install_nfs_client)
         destination: "install-nfs-client.sh"
       - $(appsfs.install_nfs_client_runner)
-      - $(nfs.mount_runner)
+      - $(appsfs.mount_runner)
+      - $(spack.install_spack_deps_runner)
       - type: shell
         content: $(spack.startup_script)
         destination: "/apps/spack-install.sh"

--- a/tools/validate_configs/test_configs/hpc-centos-ss.yaml
+++ b/tools/validate_configs/test_configs/hpc-centos-ss.yaml
@@ -93,6 +93,7 @@ deployment_groups:
         destination: "install-nfs-client.sh"
       - $(appsfs.install_nfs_client_runner)
       - $(nfs.mount_runner)
+      - $(spack.install_spack_deps_runner)
       - type: shell
         content: $(spack.startup_script)
         destination: "/apps/spack-install.sh"

--- a/tools/validate_configs/test_configs/hpc-centos-ss.yaml
+++ b/tools/validate_configs/test_configs/hpc-centos-ss.yaml
@@ -50,19 +50,11 @@ deployment_groups:
     settings:
       install_dir: /apps/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.17.0
-      spack_cache_url:
-      - mirror_name: 'gcs_cache'
-        mirror_url: gs://example-buildcache/linux-centos7
+      spack_ref: v0.18.0
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:
       - cmake%gcc@10.3.0 target=x86_64
-      - intel-mkl%gcc@10.3.0 target=skylake
-      - intel-mpi@2018.4.274%gcc@10.3.0 target=skylake
-      - >-
-        fftw%intel@18.0.5 target=skylake ^intel-mpi@2018.4.274%intel@18.0.5
-        target=x86_64
 
   - id: startup
     source: ./modules/scripts/startup-script

--- a/tools/validate_configs/test_configs/rocky-linux.yaml
+++ b/tools/validate_configs/test_configs/rocky-linux.yaml
@@ -53,8 +53,6 @@ deployment_groups:
       spack_url: https://github.com/spack/spack
       spack_ref: v0.17.0
       spack_cache_url:
-      - mirror_name: 'gcs_cache'
-        mirror_url: gs://example-buildcache/linux-centos7
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:
@@ -94,6 +92,7 @@ deployment_groups:
         destination: "install-nfs-client.sh"
       - $(appsfs.install_nfs_client_runner)
       - $(nfs.mount_runner)
+      - $(spack.install_spack_deps_runner)
       - type: shell
         content: $(spack.startup_script)
         destination: "/apps/spack-install.sh"

--- a/tools/validate_configs/test_configs/rocky-ss.yaml
+++ b/tools/validate_configs/test_configs/rocky-ss.yaml
@@ -51,17 +51,12 @@ deployment_groups:
     settings:
       install_dir: /apps/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.17.0
+      spack_ref: v0.18.0
       spack_cache_url:
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:
       - cmake%gcc@10.3.0 target=x86_64
-      - intel-mkl%gcc@10.3.0 target=skylake
-      - intel-mpi@2018.4.274%gcc@10.3.0 target=skylake
-      - >-
-        fftw%intel@18.0.5 target=skylake ^intel-mpi@2018.4.274%intel@18.0.5
-        target=x86_64
 
   - id: startup
     source: ./modules/scripts/startup-script

--- a/tools/validate_configs/test_configs/ubuntu-ss.yaml
+++ b/tools/validate_configs/test_configs/ubuntu-ss.yaml
@@ -42,7 +42,6 @@ deployment_groups:
     kind: terraform
     use: [network1]
     settings:
-      image: ubuntu-os-cloud/ubuntu-1804-lts
       auto_delete_disk: true
 
   - id: spack
@@ -51,10 +50,8 @@ deployment_groups:
     settings:
       install_dir: /apps/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.17.0
+      spack_ref: v0.18.0
       spack_cache_url:
-      - mirror_name: 'gcs_cache'
-        mirror_url: gs://example-buildcache/linux-centos7
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:
@@ -94,6 +91,7 @@ deployment_groups:
         destination: "install-nfs-client.sh"
       - $(appsfs.install_nfs_client_runner)
       - $(nfs.mount_runner)
+      - $(spack.install_spack_deps_runner)
       - type: shell
         content: $(spack.startup_script)
         destination: "/apps/spack-install.sh"


### PR DESCRIPTION
Overhaul of the install_ansible startup script runner. The goal of this update is to provide a more generalizable process for installing python, pip and ansible on a variety of VM OS images and environments.

This has been tested against the following VM images using the startups script test_configs:
* debian-10
* centos8
* hpc-centos7
* ubuntu 20.04
* rocky8

Other OS images have been tested against the install_ansible.sh script alone (i.e not testing against follow-on runners like install-nfs.sh)

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
