### PR TITLE
Fixing deployment_name conflict

### DIFF
--- a/community/examples/slurm-gcp-v5-hpc-centos7.yaml
+++ b/community/examples/slurm-gcp-v5-hpc-centos7.yaml
@@ -18,7 +18,7 @@ blueprint_name: slurm-gcp-v5-hpc-centos7
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: slurm-gcp-v5
+  deployment_name: slurm-gcp-v5-centos7
   region: us-central1
   zone: us-central1-c
 

--- a/community/examples/slurm-gcp-v5-hpc-centos7.yaml
+++ b/community/examples/slurm-gcp-v5-hpc-centos7.yaml
@@ -18,7 +18,7 @@ blueprint_name: slurm-gcp-v5-hpc-centos7
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: slurm-gcp-v5-centos7
+  deployment_name: slurm-centos-v5
   region: us-central1
   zone: us-central1-c
 

--- a/community/examples/slurm-gcp-v5-ubuntu2004.yaml
+++ b/community/examples/slurm-gcp-v5-ubuntu2004.yaml
@@ -18,7 +18,7 @@ blueprint_name: slurm-gcp-v5-ubuntu2004
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: slurm-gcp-v5-ubuntu2004
+  deployment_name: slurm-ubuntu-v5
   region: us-central1
   zone: us-central1-c
   source_image_family: "schedmd-v5-slurm-22-05-2-ubuntu-2004-lts"

--- a/community/examples/slurm-gcp-v5-ubuntu2004.yaml
+++ b/community/examples/slurm-gcp-v5-ubuntu2004.yaml
@@ -18,7 +18,7 @@ blueprint_name: slurm-gcp-v5-ubuntu2004
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: slurm-gcp-v5
+  deployment_name: slurm-gcp-v5-ubuntu2004
   region: us-central1
   zone: us-central1-c
   source_image_family: "schedmd-v5-slurm-22-05-2-ubuntu-2004-lts"


### PR DESCRIPTION
Fixing conflict when working with multiple blueprints by given it a unique deployment_name.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
