### PR TITLE
Resolve parallel builds

### DIFF
--- a/tools/cloud-build/daily-tests/integration-group-3.yaml
+++ b/tools/cloud-build/daily-tests/integration-group-3.yaml
@@ -88,8 +88,8 @@ steps:
 
 ## Test DDN Lustre with new VPC
 - id: lustre-new-vpc
-  # waitFor:
-  # # - omnia
+  waitFor:
+  - monitoring
   name: >-
     us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash


### PR DESCRIPTION
Commit d35fe41 introduced an accidental parallel build into integration
tests. This commit addresses by that by ensuring the Lustre test waits
for monitoring to complete, as did the Omnia test before.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?