### PR TITLE
Adding slurm-gcp-v5-centos7 to integration tests.

### DIFF
--- a/community/examples/slurm-gcp-v5-hpc-centos7.yaml
+++ b/community/examples/slurm-gcp-v5-hpc-centos7.yaml
@@ -80,5 +80,6 @@ deployment_groups:
     use:
     - network1
     - slurm_controller
+    - homefs
     settings:
       machine_type: n2-standard-4

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -59,6 +59,9 @@
       changed_when: false
       delegate_to: localhost
       register: instances_list
+      retries: 2
+      delay: 60
+      until: instances_list.rc == 0
       command: >-
         gcloud compute instances list
         --filter="labels.ghpc_deployment={{ deployment_name }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -43,6 +43,10 @@
       NETWORK: "{{ network }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
+    register: create_output
+  - name: Print ghpc blueprint information
+    ansible.builtin.debug:
+      var: create_output.stdout_lines
   - name: Create Infrastructure and test
     block:
     - name: Create Cluster with Terraform
@@ -60,6 +64,9 @@
       changed_when: false
       delegate_to: localhost
       register: instances_list
+      retries: 2
+      delay: 60
+      until: instances_list.rc == 0
       command: >-
         gcloud compute instances list
         --filter="labels.ghpc_deployment={{ deployment_name }}"
@@ -67,18 +74,31 @@
     - name: Print instance information
       ansible.builtin.debug:
         var: instances_list.stdout_lines
-    - name: Get login IP
+    - name: Get first login node IP
       changed_when: false
       register: login_ip
-      command: >-
-        gcloud compute instances describe --zone={{ zone }} {{ login_node }}
-        --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+      shell: |
+        set -e
+        LOGIN_NODES=$(gcloud compute instances list --zones={{ zone }} --filter="name ~ {{ login_node }}" --format='value(name)')
+        for login in $LOGIN_NODES
+        do
+          gcloud compute instances describe --zone={{ zone }} $login --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+          exit 0
+        done
+        echo "Login Node IP not found. List of login nodes: [$LOGIN_NODES]"
+        exit 1
+    - name: Print login public IP
+      ansible.builtin.debug:
+        var: login_ip.stdout_lines
     - name: Get Controller IP
       changed_when: false
       register: controller_ip
       command: >-
         gcloud compute instances describe --zone={{ zone }} {{ controller_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+    - name: Print Controller public IP
+      ansible.builtin.debug:
+        var: controller_ip.stdout_lines
 
     ## Setup firewall for cloud build
     - name: Get Builder IP

--- a/tools/cloud-build/daily-tests/blueprints/slurm-gcp-v5-hpc-centos7.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/slurm-gcp-v5-hpc-centos7.yaml
@@ -14,16 +14,18 @@
 
 ---
 
-blueprint_name: slurm-gcp-v5-ubuntu2004
+blueprint_name: slurm-gcp-v5-hpc-centos7
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: slurm-gcp-v5
   region: us-central1
   zone: us-central1-c
-  source_image_family: "schedmd-v5-slurm-22-05-2-ubuntu-2004-lts"
-  source_image_project: "projects/schedmd-slurm-public/global/images/family"
+  disable_login_public_ips: false
+  disable_controller_public_ips: false
 
+# Documentation for each of the modules used below can be found at
+# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
 
 deployment_groups:
 - group: primary

--- a/tools/cloud-build/daily-tests/integration-group-1.yaml
+++ b/tools/cloud-build/daily-tests/integration-group-1.yaml
@@ -17,6 +17,7 @@
 # ├── build_ghpc
 # └── fetch_builder
 #    ├── hpc-high-io (group 1)
+#    ├── slurm-gcp-v5-centos7 (group 1)
 
 
 timeout: 14400s  # 4hr
@@ -60,3 +61,23 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-high-io.yml"
+## Test Slurm V5 with HPC CentOS 7
+- id: slurm-v5-centos7
+  waitFor:
+  - hpc-high-io
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    BUILD_ID_EXTRA_SHORT=$${BUILD_ID_FULL:0:2}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} buildxshort=$${BUILD_ID_EXTRA_SHORT}" --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-gcp-v5-centos7.yml"

--- a/tools/cloud-build/daily-tests/tests/slurm-gcp-v5-centos7.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-gcp-v5-centos7.yml
@@ -1,0 +1,35 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+deployment_name: "slrmv5-{{ build }}"
+zone: us-central1-c
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/slurm-gcp-v5-hpc-centos7.yaml"
+blueprint_dir: blueprint-slurm-v5-hpc-centos7
+network: "default"
+max_nodes: 5
+login_node: "slrmv5{{ buildxshort }}-login"
+controller_node: "slrmv5{{ buildxshort }}-controller"
+
+post_deploy_tests:
+- test-mounts.yml
+- test-partitions.yml
+custom_vars:
+  partitions:
+  - debug
+  - compute
+  mounts:
+  - /home


### PR DESCRIPTION
This IS CURRENTLY broken as the login node seems unreachable after the
cluster is deployed. More investigation is needed.

In addition to adding the required files and changes for the integration
tests, this commig contains:
- fixes to the public examples where the login
nodes associated with Slurm v5 did not mount /home
- improvements to slurm and base-integration-tests, adding retries to
  "instances_list".
- improved messages during the slurm integration tests
- create_deployment.sh now uploads the deployment folder to the same
  folder as the backend state on GCS. This allow quickly recovering,
  tearing down or reproducing a build deployment.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
