### PR TITLE
Return correct code from ansible-local runners

### DIFF
--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -12,10 +12,11 @@ stdlib::run_playbook() {
     exit 1
   fi
   ansible-playbook $${python_interpreter_flag} --connection=local --inventory=localhost, --limit localhost $1 $2
+  ret_code=$?
   if [ -d /usr/local/ghpc-venv ]; then
     deactivate
   fi
-  return $?
+  return $${ret_code}
 }
 
 stdlib::runner() {


### PR DESCRIPTION
Fixes a bug where the incorrect return code was returned from the ansible runner function of startup scripts.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
