### PR TITLE
Uncomment and re-activate the Omnia integration test

### DIFF
--- a/community/examples/omnia-cluster.yaml
+++ b/community/examples/omnia-cluster.yaml
@@ -34,7 +34,7 @@ deployment_groups:
 
   ## Network
   - id: network
-    source: modules/network/vpc
+    source: modules/network/pre-existing-vpc
     kind: terraform
 
   ## File Systems

--- a/tools/cloud-build/daily-tests/integration-group-3.yaml
+++ b/tools/cloud-build/daily-tests/integration-group-3.yaml
@@ -65,31 +65,31 @@ steps:
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/monitoring.yml"
 
-# ## Test Omnia Example
-# - id: omnia
-#   waitFor:
-#   - monitoring
-#   name: >-
-#     us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-#   entrypoint: /bin/bash
-#   env:
-#   - "ANSIBLE_HOST_KEY_CHECKING=false"
-#   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
-#   args:
-#   - -c
-#   - |
-#     set -x -e
-#     BUILD_ID_FULL=$BUILD_ID
-#     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+## Test Omnia Example
+- id: omnia
+  waitFor:
+  - monitoring
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
-#     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-#       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
-#       --extra-vars="@tools/cloud-build/daily-tests/tests/omnia.yml"
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/omnia.yml"
 
 ## Test DDN Lustre with new VPC
 - id: lustre-new-vpc
   waitFor:
-  - monitoring
+  - omnia
   name: >-
     us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash


### PR DESCRIPTION
Updates the Omnia test to use the pre-existing network to match the prior implementation
Reverts d35fe41a2fa3a13e9ce1501eb89d5de7303747af which removed the test temporarily.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
