### PR TITLE
fix: open in cloud shell misinterpreted variable substitution

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -53,15 +53,15 @@ minutes.
 
 ### Gromacs
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fhpc-toolkit&cloudshell_git_branch=develop&cloudshell_open_in_editor=docs%2Ftutorials%2Fgromacs%2Fspack-gromacs.yaml&cloudshell_tutorial=docs%2Ftutorials%2Fgromacs%2Fspack-gromacs.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fhpc-toolkit&cloudshell_git_branch=main&cloudshell_open_in_editor=docs%2Ftutorials%2Fgromacs%2Fspack-gromacs.yaml&cloudshell_tutorial=docs%2Ftutorials%2Fgromacs%2Fspack-gromacs.md)
 
 ### Openfoam
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fhpc-toolkit&cloudshell_git_branch=develop&cloudshell_open_in_editor=docs%2Ftutorials%2Fopenfoam%2Fspack-openfoam.yaml&cloudshell_tutorial=docs%2Ftutorials%2Fopenfoam%2Fspack-openfoam.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fhpc-toolkit&cloudshell_git_branch=main&cloudshell_open_in_editor=docs%2Ftutorials%2Fopenfoam%2Fspack-openfoam.yaml&cloudshell_tutorial=docs%2Ftutorials%2Fopenfoam%2Fspack-openfoam.md)
 
 ### Weather Research and Forecasting (WRF) Model
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fhpc-toolkit&cloudshell_git_branch=develop&cloudshell_open_in_editor=docs%2Ftutorials%2Fwrfv3%2Fspack-wrfv3.yaml&cloudshell_tutorial=docs%2Ftutorials%2Fwrfv3%2Fspack-wrfv3.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fhpc-toolkit&cloudshell_git_branch=main&cloudshell_open_in_editor=docs%2Ftutorials%2Fwrfv3%2Fspack-wrfv3.yaml&cloudshell_tutorial=docs%2Ftutorials%2Fwrfv3%2Fspack-wrfv3.md)
 
 ### Blueprint Diagram for Application Tutorials
 

--- a/docs/tutorials/gromacs/spack-gromacs.md
+++ b/docs/tutorials/gromacs/spack-gromacs.md
@@ -46,9 +46,9 @@ PROJECT_NUMBER=$(gcloud projects list --filter=<walkthrough-project-id/> --forma
 
 echo "granting roles/editor to $PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 
-gcloud iam service-accounts enable --project <walkthrough-project-id/> "$PROJECT_NUMBER"-compute@developer.gserviceaccount.com
+gcloud iam service-accounts enable --project <walkthrough-project-id/> $PROJECT_NUMBER-compute@developer.gserviceaccount.com
 
-gcloud projects add-iam-policy-binding <walkthrough-project-id/> --member=serviceAccount:"$PROJECT_NUMBER"-compute@developer.gserviceaccount.com --role=roles/editor
+gcloud projects add-iam-policy-binding <walkthrough-project-id/> --member=serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com --role=roles/editor
 ```
 
 ## Build the Toolkit Binary

--- a/docs/tutorials/intel-select/intel-select.md
+++ b/docs/tutorials/intel-select/intel-select.md
@@ -37,9 +37,9 @@ PROJECT_NUMBER=$(gcloud projects list --filter=<walkthrough-project-id/> --forma
 
 echo "granting roles/editor to $PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 
-gcloud iam service-accounts enable --project <walkthrough-project-id/> "$PROJECT_NUMBER"-compute@developer.gserviceaccount.com
+gcloud iam service-accounts enable --project <walkthrough-project-id/> $PROJECT_NUMBER-compute@developer.gserviceaccount.com
 
-gcloud projects add-iam-policy-binding <walkthrough-project-id/> --member=serviceAccount:"$PROJECT_NUMBER"-compute@developer.gserviceaccount.com --role=roles/editor
+gcloud projects add-iam-policy-binding <walkthrough-project-id/> --member=serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com --role=roles/editor
 ```
 
 ## Build the Toolkit Binary

--- a/docs/tutorials/openfoam/spack-openfoam.md
+++ b/docs/tutorials/openfoam/spack-openfoam.md
@@ -46,9 +46,9 @@ PROJECT_NUMBER=$(gcloud projects list --filter=<walkthrough-project-id/> --forma
 
 echo "granting roles/editor to $PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 
-gcloud iam service-accounts enable --project <walkthrough-project-id/> "$PROJECT_NUMBER"-compute@developer.gserviceaccount.com
+gcloud iam service-accounts enable --project <walkthrough-project-id/> $PROJECT_NUMBER-compute@developer.gserviceaccount.com
 
-gcloud projects add-iam-policy-binding <walkthrough-project-id/> --member=serviceAccount:"$PROJECT_NUMBER"-compute@developer.gserviceaccount.com --role=roles/editor
+gcloud projects add-iam-policy-binding <walkthrough-project-id/> --member=serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com --role=roles/editor
 ```
 
 ## Build the Toolkit Binary

--- a/docs/tutorials/wrfv3/spack-wrfv3.md
+++ b/docs/tutorials/wrfv3/spack-wrfv3.md
@@ -46,9 +46,9 @@ PROJECT_NUMBER=$(gcloud projects list --filter=<walkthrough-project-id/> --forma
 
 echo "granting roles/editor to $PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 
-gcloud iam service-accounts enable --project <walkthrough-project-id/> "$PROJECT_NUMBER"-compute@developer.gserviceaccount.com
+gcloud iam service-accounts enable --project <walkthrough-project-id/> $PROJECT_NUMBER-compute@developer.gserviceaccount.com
 
-gcloud projects add-iam-policy-binding <walkthrough-project-id/> --member=serviceAccount:"$PROJECT_NUMBER"-compute@developer.gserviceaccount.com --role=roles/editor
+gcloud projects add-iam-policy-binding <walkthrough-project-id/> --member=serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com --role=roles/editor
 ```
 
 ## Build the Toolkit Binary


### PR DESCRIPTION
With prior text it would split line even though there was no space, which caused error:
```
gcloud iam service-accounts enable \
    --project \
    nickstroud-wrf-2022-08-30 \
    "$PROJECT_NUMBER" \
    -compute@developer.gserviceaccount.com
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
