### PR TITLE
Add install path variable to hybrid

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
@@ -163,10 +163,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
 
@@ -176,7 +179,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [null_resource.set_prefix_cloud_conf](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
 
@@ -192,8 +197,9 @@ No resources.
 | <a name="input_enable_reconfigure"></a> [enable\_reconfigure](#input\_enable\_reconfigure) | Enables automatic Slurm reconfigure on when Slurm configuration changes (e.g.<br>slurm.conf.tpl, partition details). Compute instances and resource policies<br>(e.g. placement groups) will be destroyed to align with new configuration.<br>NOTE: Requires Python and Google Pub/Sub API.<br>*WARNING*: Toggling this will impact the running workload. Deployed compute nodes<br>will be destroyed and their jobs will be requeued. | `bool` | `false` | no |
 | <a name="input_epilog_scripts"></a> [epilog\_scripts](#input\_epilog\_scripts) | List of scripts to be used for Epilog. Programs for the slurmd to execute<br>on every node when a user's job completes.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_google_app_cred_path"></a> [google\_app\_cred\_path](#input\_google\_app\_cred\_path) | Path to Google Applicaiton Credentials. | `string` | `null` | no |
+| <a name="input_install_dir"></a> [install\_dir](#input\_install\_dir) | Directory where the hybrid configuration directory will be installed on the<br>on-premise controller. This updates the prefix path for the resume and<br>suspend scripts in the generated `cloud.conf` file. The value defaults to<br>output\_dir if not specified. | `string` | `null` | no |
 | <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | Storage to mounted on all instances.<br>- server\_ip     : Address of the storage server.<br>- remote\_mount  : The location in the remote instance filesystem to mount from.<br>- local\_mount   : The location on the instance filesystem to mount to.<br>- fs\_type       : Filesystem type (e.g. "nfs").<br>- mount\_options : Options to mount with. | <pre>list(object({<br>    server_ip     = string<br>    remote_mount  = string<br>    local_mount   = string<br>    fs_type       = string<br>    mount_options = string<br>  }))</pre> | `[]` | no |
-| <a name="input_output_dir"></a> [output\_dir](#input\_output\_dir) | Directory where this module will write its files to. These files include:<br>cloud.conf; cloud\_gres.conf; config.yaml; resume.py; suspend.py; and util.py. | `string` | `null` | no |
+| <a name="input_output_dir"></a> [output\_dir](#input\_output\_dir) | Directory where this module will write its files to. These files include:<br>cloud.conf; cloud\_gres.conf; config.yaml; resume.py; suspend.py; and util.py.<br>If not specified explicitly, this will also be used as the default value<br>for the `install_dir` variable. | `string` | `null` | no |
 | <a name="input_partition"></a> [partition](#input\_partition) | Cluster partitions as a list. | <pre>list(object({<br>    compute_list = list(string)<br>    partition = object({<br>      enable_job_exclusive    = bool<br>      enable_placement_groups = bool<br>      network_storage = list(object({<br>        server_ip     = string<br>        remote_mount  = string<br>        local_mount   = string<br>        fs_type       = string<br>        mount_options = string<br>      }))<br>      partition_conf = map(string)<br>      partition_name = string<br>      partition_nodes = map(object({<br>        bandwidth_tier         = string<br>        node_count_dynamic_max = number<br>        node_count_static      = number<br>        enable_spot_vm         = bool<br>        group_name             = string<br>        instance_template      = string<br>        node_conf              = map(string)<br>        spot_instance_config = object({<br>          termination_action = string<br>        })<br>      }))<br>      subnetwork        = string<br>      zone_policy_allow = list(string)<br>      zone_policy_deny  = list(string)<br>    })<br>  }))</pre> | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
 | <a name="input_prolog_scripts"></a> [prolog\_scripts](#input\_prolog\_scripts) | List of scripts to be used for Prolog. Programs for the slurmd to execute<br>whenever it is asked to run a job step from a new job allocation.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/variables.tf
@@ -244,7 +244,20 @@ variable "output_dir" {
   description = <<-EOD
     Directory where this module will write its files to. These files include:
     cloud.conf; cloud_gres.conf; config.yaml; resume.py; suspend.py; and util.py.
+    If not specified explicitly, this will also be used as the default value
+    for the `install_dir` variable.
     EOD
+  default     = null
+}
+
+variable "install_dir" {
+  description = <<-EOD
+    Directory where the hybrid configuration directory will be installed on the
+    on-premise controller. This updates the prefix path for the resume and
+    suspend scripts in the generated `cloud.conf` file. The value defaults to
+    output_dir if not specified.
+    EOD
+  type        = string
   default     = null
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/versions.tf
@@ -15,5 +15,11 @@
 */
 
 terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
   required_version = ">= 0.14.0"
 }

--- a/tools/validate_configs/test_configs/hpc-cluster-hybrid-v5.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-hybrid-v5.yaml
@@ -66,3 +66,4 @@ deployment_groups:
       output_dir: ./hybrid
       slurm_bin_dir: /usr/local/bin
       slurm_control_host: $(vars.on_prem_controller_host_name)
+      install_dir: /etc/slurm/hybrid


### PR DESCRIPTION
A workaround to simplify hybrid deployment off controller. Rather than
have the full absolute path of the output_dir as the resume/suspend
program paths in cloud.conf, update the file with a sed command
replacing the output_dir with a provided install_dir, which acts
essentially as the prefix variable for the installation.

Alternatives attempted: Using a local_file block to read the data from
the generated cloud.conf file, use replace to update the content and
place the context back into the same file. This does not work as the
file does not exist at plan time, therefore terraform will fail.

Longer term solution: Build this into the setup_hybrid.py script used by
slurm-gcp in the underlying hybrid module.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
