### PR TITLE
Update documentation to reflect gcloud batch is now available on hpc image

### DIFF
--- a/community/examples/cloud-batch.yaml
+++ b/community/examples/cloud-batch.yaml
@@ -60,9 +60,6 @@ deployment_groups:
     settings:
       runnable: "cat /sw/hello.txt"
       machine_type: n2-standard-4
-      image:
-        family: centos-7
-        project: centos-cloud
 
   - id: batch-login
     source: community/modules/scheduler/cloud-batch-login-node

--- a/community/modules/scheduler/cloud-batch-login-node/README.md
+++ b/community/modules/scheduler/cloud-batch-login-node/README.md
@@ -56,10 +56,6 @@ Google Cloud Batch cli is not available it can generally be mitigated by either
 updating `gcloud` by running `gcloud components update`, or using an image that
 contains a more recent version of `gcloud`.
 
-> _**WARNING:**_ It is a known issue that the version of `gcloud` on the
-> [HPC VM image](https://cloud.google.com/compute/docs/instances/create-hpc-vm)
-> does not contain the Google Cloud Batch cli.
-
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
Tested:
- Manually confirmed gcloud alpha batch is available on hpc image
- Tests will now use hpc image (default for example)

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
