### PR TITLE
Faster project number lookup in tutorials

### DIFF
--- a/docs/tutorials/basic.md
+++ b/docs/tutorials/basic.md
@@ -32,7 +32,7 @@ the slurm controller can perform actions such as auto-scaling.
 <!-- Tried getting PROJECT_NUMBER using <walkthrough-project-number/> but returns empty string. -->
 
 ```bash
-PROJECT_NUMBER=$(gcloud projects list --filter=<walkthrough-project-id/> --format='value(PROJECT_NUMBER)')
+PROJECT_NUMBER=$(gcloud projects describe <walkthrough-project-id/> --format='value(projectNumber)')
 
 echo "granting roles/editor to $PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 

--- a/docs/tutorials/gromacs/spack-gromacs.md
+++ b/docs/tutorials/gromacs/spack-gromacs.md
@@ -42,7 +42,7 @@ the slurm controller can perform actions such as auto-scaling.
 <!-- Tried getting PROJECT_NUMBER using <walkthrough-project-number/> but returns empty string. -->
 
 ```bash
-PROJECT_NUMBER=$(gcloud projects list --filter=<walkthrough-project-id/> --format='value(PROJECT_NUMBER)')
+PROJECT_NUMBER=$(gcloud projects describe <walkthrough-project-id/> --format='value(projectNumber)')
 
 echo "granting roles/editor to $PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 

--- a/docs/tutorials/intel-select/intel-select.md
+++ b/docs/tutorials/intel-select/intel-select.md
@@ -33,7 +33,7 @@ the slurm controller can perform actions such as auto-scaling.
 <!-- Tried getting PROJECT_NUMBER using <walkthrough-project-number/> but returns empty string. -->
 
 ```bash
-PROJECT_NUMBER=$(gcloud projects list --filter=<walkthrough-project-id/> --format='value(PROJECT_NUMBER)')
+PROJECT_NUMBER=$(gcloud projects describe <walkthrough-project-id/> --format='value(projectNumber)')
 
 echo "granting roles/editor to $PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 

--- a/docs/tutorials/wrfv3/spack-wrfv3.md
+++ b/docs/tutorials/wrfv3/spack-wrfv3.md
@@ -42,7 +42,7 @@ the slurm controller can perform actions such as auto-scaling.
 <!-- Tried getting PROJECT_NUMBER using <walkthrough-project-number/> but returns empty string. -->
 
 ```bash
-PROJECT_NUMBER=$(gcloud projects list --filter=<walkthrough-project-id/> --format='value(PROJECT_NUMBER)')
+PROJECT_NUMBER=$(gcloud projects describe <walkthrough-project-id/> --format='value(projectNumber)')
 
 echo "granting roles/editor to $PROJECT_NUMBER-compute@developer.gserviceaccount.com"
 


### PR DESCRIPTION
Tested:
- Loaded the open in cloud shell (using `teachme` cmd) and verified new command works.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
