### PR TITLE
Add image to cloud batch example B/C default image gcloud version is lagging

### DIFF
--- a/community/examples/cloud-batch.yaml
+++ b/community/examples/cloud-batch.yaml
@@ -60,6 +60,9 @@ deployment_groups:
     settings:
       runnable: "cat /sw/hello.txt"
       machine_type: n2-standard-4
+      image:
+        family: rocky-linux-8-optimized-gcp
+        project: rocky-linux-cloud
 
   - id: batch-login
     source: community/modules/scheduler/cloud-batch-login-node


### PR DESCRIPTION
This will resolve the failing Batch integration test.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
