### PR TITLE
Fix spack setup scripts in tutorials.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ HPC deployments on the Google Cloud Platform.`,
 				log.Fatalf("cmd.Help function failed: %s", err)
 			}
 		},
-		Version: "v1.4.0",
+		Version: "v1.4.1",
 	}
 )
 

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/versions.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-partition/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-partition/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -30,10 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.4.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.4.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/cloud-batch-login-node/versions.tf
+++ b/community/modules/scheduler/cloud-batch-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-batch-login-node/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-batch-login-node/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/htcondor-configure/versions.tf
+++ b/community/modules/scheduler/htcondor-configure/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-configure/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-configure/v1.4.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/docs/tutorials/gromacs/spack-gromacs.yaml
+++ b/docs/tutorials/gromacs/spack-gromacs.yaml
@@ -113,7 +113,6 @@ deployment_groups:
           #!/bin/bash
           source /apps/spack/share/spack/setup-env.sh
           spack env activate gromacs
-          spack env loads -r
           chmod -R a+rwX /apps/spack/var/spack/environments/gromacs
           mkdir -p /apps/gromacs
           chmod a+rwx /apps/gromacs

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -120,7 +120,6 @@ deployment_groups:
           #!/bin/bash
           source /apps/spack/share/spack/setup-env.sh
           spack env activate openfoam
-          spack env loads -r
           chmod -R a+rwX /apps/spack/var/spack/environments/openfoam
           mkdir -p /apps/openfoam
           chmod a+rwx /apps/openfoam

--- a/docs/tutorials/wrfv3/spack-wrfv3.yaml
+++ b/docs/tutorials/wrfv3/spack-wrfv3.yaml
@@ -113,7 +113,6 @@ deployment_groups:
           #!/bin/bash
           source /apps/spack/share/spack/setup-env.sh
           spack env activate wrfv3
-          spack env loads -r
           chmod -R a+rwX /apps/spack/var/spack/environments/wrfv3
           mkdir -p /apps/wrfv3
           chmod a+rwx /apps/wrfv3

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -27,10 +27,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.4.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.4.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.4.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.4.0"
+    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.4.1"
   }
 
   required_version = ">= 0.14.0"


### PR DESCRIPTION
The `spack env loads -r` line was causing `Error: No module available for package hdf5@1.12.2%gcc@8.2.0~cxx+fortran+hl~ipo~java+mpi+shared~szip~threadsafe+tools`. The error halts the startup script so the wget for the input deck never takes place and submit_gromacs.sh never gets loaded onto the machine. The result is that the sbatch command fails.

From reading the [spack docs](https://spack.readthedocs.io/en/latest/environments.html#loading) it seems like this load command is unnecessary for our tutorial. 

I have conferred with @douglasjacobsen, and they agree it is fine to remove it.

I have manually tested this and the tutorial succeeds.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
