### PR TITLE
Fix TFLint version in builder image

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,10 @@ Follow these steps to install and setup pre-commit in your cloned repository:
    > **_NOTE:_** The version of TFLint must be compatible with the Google plugin
    > version identified in [tflint.hcl](.tflint.hcl). Versions of the plugin
    > `>=0.20.0` should use `tflint>=0.40.0`. These versions are readily
-   > available available via GitHub or package managers.
+   > available via GitHub or package managers. Please review the [TFLint Ruleset
+   > for Google Release Notes][tflint-google] for up-to-date requirements.
+
+[tflint-google]: https://github.com/terraform-linters/tflint-ruleset-google/releases
 
 1. Install ShellCheck using the instructions from
    [the ShellCheck documentation](https://github.com/koalaman/shellcheck#installing)

--- a/tools/cloud-build/Dockerfile
+++ b/tools/cloud-build/Dockerfile
@@ -14,6 +14,8 @@
 
 # Getting Terraform and Packer
 FROM golang:bullseye
+ARG TFLINT_VERSION
+
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     apt-get -y update && apt-get -y install \
     software-properties-common \

--- a/tools/cloud-build/hpc-toolkit-builder.yaml
+++ b/tools/cloud-build/hpc-toolkit-builder.yaml
@@ -23,6 +23,8 @@ steps:
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder:latest'
   - '--cache-from'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder:latest'
+  - '--build-arg'
+  - 'TFLINT_VERSION=v0.40.0'
   - '-f'
   - 'tools/cloud-build/Dockerfile'
   - '.'


### PR DESCRIPTION
Our CI tests frequently run into an incompatibility between the [TFLint Ruleset Google Plugin version](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/.tflint.hcl) and [TFLint itself](https://github.com/terraform-linters/tflint). We already fix the plugin version in the first link above. This PR implements a fixed version of TFLint to install in our CI images.

When we want to upgrade, we should update these files in unison:

- .tflint.hcl
- tools/cloud-build/hpc-toolkit-builder.yaml

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?