### PR TITLE
Run shell runners as executable

### DIFF
--- a/community/examples/quantum-circuit-simulator.yaml
+++ b/community/examples/quantum-circuit-simulator.yaml
@@ -113,7 +113,8 @@ deployment_groups:
       - type: shell
         destination: run-qsim.sh
         content: |
-          #!/bin/bash
+          #!/bin/bash -i
+          # The -i above (for interactive) is required so that conda command will be accessible.
           # this script demonstrates how to run the qsim example application and
           # also "warms up" the GPU to give reliable performance metrics
           conda activate qsim

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -39,7 +39,7 @@ stdlib::runner() {
   stdlib::info "=== start executing runner: $object ==="
   case "$1" in
     ansible-local) stdlib::run_playbook "$destpath/$filename" "$args";;
-    shell) . $destpath/$filename $args;;
+    shell) chmod u+x /$destpath/$filename && ./$destpath/$filename $args;;
   esac
   
   exit_code=$?


### PR DESCRIPTION
Tested: 
- I ran some basic manual tests for validation including using args
- I tested against using a startup script as a runner ([example](https://github.com/nick-stroud/hpc-toolkit/blob/a5f1ffd86a9e2919567d9729d2b6e0188cac7da2/community/modules/scheduler/cloud-batch-login-node/main.tf#L43-L45))

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
