### PR TITLE
Upgrade DDN-EXAScaler to v6.1.0

### DIFF
--- a/community/modules/file-system/DDN-EXAScaler/README.md
+++ b/community/modules/file-system/DDN-EXAScaler/README.md
@@ -61,7 +61,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ddn_exascaler"></a> [ddn\_exascaler](#module\_ddn\_exascaler) | github.com/DDNStorage/exascaler-cloud-terraform//gcp | 3eec46e |
+| <a name="module_ddn_exascaler"></a> [ddn\_exascaler](#module\_ddn\_exascaler) | github.com/DDNStorage/exascaler-cloud-terraform//gcp | 78deadb |
 
 ## Resources
 
@@ -71,11 +71,11 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_boot"></a> [boot](#input\_boot) | Boot disk properties | <pre>object({<br>    disk_type   = string<br>    auto_delete = bool<br>  })</pre> | <pre>{<br>  "auto_delete": true,<br>  "disk_type": "pd-standard"<br>}</pre> | no |
+| <a name="input_boot"></a> [boot](#input\_boot) | Boot disk properties | <pre>object({<br>    disk_type   = string<br>    auto_delete = bool<br>    script_url  = string<br>  })</pre> | <pre>{<br>  "auto_delete": true,<br>  "disk_type": "pd-standard",<br>  "script_url": null<br>}</pre> | no |
 | <a name="input_cls"></a> [cls](#input\_cls) | Compute client properties | <pre>object({<br>    node_type  = string<br>    node_cpu   = string<br>    nic_type   = string<br>    node_count = number<br>    public_ip  = bool<br>  })</pre> | <pre>{<br>  "nic_type": "GVNIC",<br>  "node_count": 0,<br>  "node_cpu": "Intel Cascade Lake",<br>  "node_type": "n2-standard-2",<br>  "public_ip": true<br>}</pre> | no |
 | <a name="input_clt"></a> [clt](#input\_clt) | Compute client target properties | <pre>object({<br>    disk_bus   = string<br>    disk_type  = string<br>    disk_size  = number<br>    disk_count = number<br>  })</pre> | <pre>{<br>  "disk_bus": "SCSI",<br>  "disk_count": 0,<br>  "disk_size": 256,<br>  "disk_type": "pd-standard"<br>}</pre> | no |
 | <a name="input_fsname"></a> [fsname](#input\_fsname) | EXAScaler filesystem name, only alphanumeric characters are allowed, and the value must be 1-8 characters long | `string` | `"exacloud"` | no |
-| <a name="input_image"></a> [image](#input\_image) | Source image properties | <pre>object({<br>    project = string<br>    name    = string<br>  })</pre> | <pre>{<br>  "name": "exascaler-cloud-v523-centos7",<br>  "project": "ddn-public"<br>}</pre> | no |
+| <a name="input_image"></a> [image](#input\_image) | Source image properties | <pre>object({<br>    project = string<br>    family  = string<br>  })</pre> | <pre>{<br>  "family": "exascaler-cloud-6-1-centos",<br>  "project": "ddn-public"<br>}</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to EXAScaler Cloud deployment. List of key key, value pairs. | `any` | `{}` | no |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint (at the client instances) for this EXAScaler system | `string` | `"/shared"` | no |
 | <a name="input_mds"></a> [mds](#input\_mds) | Metadata server properties | <pre>object({<br>    node_type  = string<br>    node_cpu   = string<br>    nic_type   = string<br>    node_count = number<br>    public_ip  = bool<br>  })</pre> | <pre>{<br>  "nic_type": "GVNIC",<br>  "node_count": 1,<br>  "node_cpu": "Intel Cascade Lake",<br>  "node_type": "n2-standard-32",<br>  "public_ip": true<br>}</pre> | no |

--- a/community/modules/file-system/DDN-EXAScaler/main.tf
+++ b/community/modules/file-system/DDN-EXAScaler/main.tf
@@ -36,7 +36,7 @@ locals {
 }
 
 module "ddn_exascaler" {
-  source          = "github.com/DDNStorage/exascaler-cloud-terraform//gcp?ref=3eec46e"
+  source          = "github.com/DDNStorage/exascaler-cloud-terraform//gcp?ref=78deadb"
   fsname          = var.fsname
   zone            = var.zone
   project         = var.project_id

--- a/community/modules/file-system/DDN-EXAScaler/variables.tf
+++ b/community/modules/file-system/DDN-EXAScaler/variables.tf
@@ -189,25 +189,27 @@ variable "boot" {
   type = object({
     disk_type   = string
     auto_delete = bool
+    script_url  = string
   })
   default = {
     disk_type   = "pd-standard"
     auto_delete = true
+    script_url  = null
   }
 }
 
 # Source image properties
 # project: project name
-# name: image name
+# family: image family name
 variable "image" {
   description = "Source image properties"
   type = object({
     project = string
-    name    = string
+    family  = string
   })
   default = {
     project = "ddn-public"
-    name    = "exascaler-cloud-v523-centos7"
+    family  = "exascaler-cloud-6-1-centos"
   }
 }
 


### PR DESCRIPTION
Upgraded needed to expose `ddn_exascaler.client_config` which will be added in subsequent PR.

DDN now only supports specifying image family (not name)

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
