### PR TITLE
Add Epilog/Prolog scripts to install path in hybrid

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/main.tf
@@ -21,7 +21,7 @@ locals {
   }]
   install_dir         = var.install_dir != null ? var.install_dir : abspath(var.output_dir)
   install_dir_pattern = replace(local.install_dir, ".", "\\.")
-  install_path_cmd    = "sed -i -E 's|Program=/.*/(resume\\|suspend).py|Program=${local.install_dir_pattern}/\\1\\.py|g' cloud.conf"
+  install_path_cmd    = "sed -i -E 's|(Program\\|logSlurmctld)=/.*/(resume\\|suspend).py|\\1=${local.install_dir_pattern}/\\2\\.py|g' cloud.conf"
 
   # Since deployment name may be used to create a cluster name, we remove any invalid character from the beginning
   # Also, slurm imposed a lot of restrictions to this name, so we format it to an acceptable string

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/main.tf
@@ -19,9 +19,19 @@ locals {
     filename = "ghpc_startup.sh"
     content  = var.compute_startup_script
   }]
+
+  # Install Directory Variables
+  # In order to allow the hybrid module to run in a different environment than
+  # the controller, certain paths need to be updated to match the anticpated
+  # install directory on the controller. This is done with a sed command that
+  # find all matching variables with names ending in Program (SuspendProgram,
+  # etc) or logSlurmctld (EpilogSlurmctld, etc) and replaces the path before
+  # suspend.py or resume.py with the user provided install_dir.
   install_dir         = var.install_dir != null ? var.install_dir : abspath(var.output_dir)
   install_dir_pattern = replace(local.install_dir, ".", "\\.")
-  install_path_cmd    = "sed -i -E 's|(Program\\|logSlurmctld)=/.*/(resume\\|suspend).py|\\1=${local.install_dir_pattern}/\\2\\.py|g' cloud.conf"
+  match_pattern       = "(Program\\|logSlurmctld)=/.*/(resume\\|suspend).py"
+  replace_pattern     = "\\1=${local.install_dir_pattern}/\\2\\.py"
+  install_path_cmd    = "sed -i -E 's|${local.match_pattern}|${local.replace_pattern}|g' cloud.conf"
 
   # Since deployment name may be used to create a cluster name, we remove any invalid character from the beginning
   # Also, slurm imposed a lot of restrictions to this name, so we format it to an acceptable string
@@ -56,6 +66,8 @@ module "slurm_controller_instance" {
   disable_default_mounts       = var.disable_default_mounts
 }
 
+# Null resource that injects the installation path before the resume/suspend
+# scripts in the hybrid configuration files. 
 resource "null_resource" "set_prefix_cloud_conf" {
   depends_on = [
     module.slurm_controller_instance

--- a/tools/validate_configs/test_configs/hpc-cluster-hybrid-v5.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-hybrid-v5.yaml
@@ -29,14 +29,12 @@ deployment_groups:
   modules:
   - id: network1
     source: modules/network/pre-existing-vpc
-    kind: terraform
     settings:
       network_name: cloud-vpc-network
       subnetwork_name: primary-subnet
 
   - id: pre-existing-storage
     source: modules/file-system/pre-existing-network-storage
-    kind: terraform
     outputs:
     - network_storage
     settings:
@@ -45,22 +43,28 @@ deployment_groups:
       local_mount: /home
       fs_type: nfs
 
-  - id: compute-partition
+  - id: debug-partition
     source: ./community/modules/compute/schedmd-slurm-gcp-v5-partition
-    kind: terraform
     use: [network1]
     settings:
-      partition_name: cloud
+      partition_name: debug
       node_count_dynamic_max: 10
       exclusive: false
       machine_type: n2-standard-2
       partition_conf:
         Default: NO
 
+  - id: compute-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    settings:
+      partition_name: compute
+      node_count_dynamic_max: 20
+
   - id: slurm-controller
     source: ./community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid
-    kind: terraform
-    use: [compute-partition, pre-existing-storage]
+    use: [debug-partition, compute-partition, pre-existing-storage]
     settings:
       output_dir: ./hybrid
       slurm_bin_dir: /usr/local/bin


### PR DESCRIPTION
Updated the install path sed command to also catch EpilogSlurmctld and PrologSlurmctld when exclusive partitions are being used.

Updated the hybrid test config to include an exclusive partition and to reformat module definitions in line with recent improvements in the codebase.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
