### PR TITLE
Address an idempotency in Spack install script

### DIFF
--- a/community/modules/scripts/spack-install/templates/install_spack.tpl
+++ b/community/modules/scripts/spack-install/templates/install_spack.tpl
@@ -152,7 +152,9 @@ echo "$PREFIX Populating defined buildcaches"
   %{endif ~}
 %{endfor ~}
 
-echo "source ${INSTALL_DIR}/share/spack/setup-env.sh" >> /etc/profile.d/spack.sh
-chmod a+rx /etc/profile.d/spack.sh
+if [ ! -f /etc/profile.d/spack.sh ]; then
+        echo "source ${INSTALL_DIR}/share/spack/setup-env.sh" > /etc/profile.d/spack.sh
+        chmod a+rx /etc/profile.d/spack.sh
+fi
 
 echo "$PREFIX Setup complete..."


### PR DESCRIPTION
Spack installation script adds environment setup command each time the machine boots. This change resolves that by using overwrite stdout redirection rather than append redirection and only creating the appropriate /etc/profile.d script if it does not already exist.

Tested on a vm-instance module. Script observed to read:

```
if [ ! -f /etc/profile.d/spack.sh ]; then
        echo "source /sw/spack/share/spack/setup-env.sh" > /etc/profile.d/spack.sh
        chmod a+rx /etc/profile.d/spack.sh
fi
```

After a few restart cycles, it still showed only 1 instance of the environment setup:

```
$ cat /etc/profile.d/spack.sh 
source /sw/spack/share/spack/setup-env.sh
```

I do not believe this constitutes resolving idempotency problems with Spack installation generally, but it is an easy step in the right direction.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?