### PR TITLE
Replace Spack installation in AMD example with a builder VM

### DIFF
--- a/community/examples/AMD/README.md
+++ b/community/examples/AMD/README.md
@@ -75,7 +75,7 @@ remounted and that you should logout and login. Follow its instructions.
 Once configuration is complete, install AOCC by running:
 
 ```shell
-sudo -i bash /var/tmp/install_aocc.sh
+sudo bash /var/tmp/install_aocc.sh
 ```
 
 Spack will prompt you to accept the AOCC End User License Agreement by opening a
@@ -83,12 +83,7 @@ text file containing information about the license. Leave the file unmodified
 and write it to disk by typing `:q` as two characters in sequence
 ([VI help][vihelp]).
 
-Installation of AOCC and OpenMPI will take approximately 15 minutes. Once they
-are  installed, you can install additional packages such as `amdblis`:
-
-```shell
-sudo -i spack -d install -v amdblis %aocc@3.2.0
-```
+Installation of AOCC and OpenMPI will take approximately 15 minutes.
 
 Configure SSH user keys for access between cluster nodes:
 

--- a/community/examples/AMD/hpc-cluster-amd-slurmv5.yaml
+++ b/community/examples/AMD/hpc-cluster-amd-slurmv5.yaml
@@ -65,8 +65,25 @@ deployment_groups:
       - type: shell
         source: modules/startup-script/examples/install_ansible.sh
         destination: install_ansible.sh
+      - $(swfs.install_nfs_client_runner)
+      - $(swfs.mount_runner)
       - $(spack.install_spack_deps_runner)
       - $(spack.install_spack_runner)
+      - type: shell
+        content: "shutdown -h +1"
+        destination: shutdown.sh
+
+  - id: slurm_startup
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: data
+        destination: /etc/profile.d/spack.sh
+        content: |
+          #!/bin/sh
+          if [ -f /sw/spack/share/spack/setup-env.sh ]; then
+                  . /sw/spack/share/spack/setup-env.sh
+          fi
       # the following installation of AOCC may be automated in the future
       # with a clear direction to the user to read the EULA at
       # https://developer.amd.com/aocc-compiler-eula/
@@ -74,10 +91,19 @@ deployment_groups:
         destination: /var/tmp/install_aocc.sh
         content: |
           #!/bin/bash
+          source /sw/spack/share/spack/setup-env.sh
           spack install aocc@3.2.0 +license-agreed
           spack load aocc@3.2.0
           spack compiler find --scope site
           spack -d install -v openmpi@4.1.3 %aocc@3.2.0 +legacylaunchers +pmi schedulers=slurm
+
+  # must restart vm to re-initiate subsequent installs
+  - id: spack_builder
+    source: modules/compute/vm-instance
+    use: [network1, swfs, spack-startup]
+    settings:
+      name_prefix: spack-builder
+      machine_type: c2d-standard-16
 
   - id: low_cost_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -118,6 +144,6 @@ deployment_groups:
     use:
     - network1
     - slurm_controller
-    - spack-startup
+    - slurm_startup
     settings:
       machine_type: c2d-standard-4


### PR DESCRIPTION
This PR implements a builder VM on which Spack will be built and made available to a Slurm cluster via NFS.

It does not solve every problem (e.g. communicating to user clearly that Spack setup has complete) but does enable progress on provision clusters using `v5` of the Slurm-on-GCP solution.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?