### PR TITLE
Eliminate 1 git checkout during Spack install

### DIFF
--- a/community/modules/scripts/spack-install/templates/install_spack.tpl
+++ b/community/modules/scripts/spack-install/templates/install_spack.tpl
@@ -24,7 +24,7 @@ if [ ! -d ${INSTALL_DIR} ]; then
   chmod a+rwx ${INSTALL_DIR};
   chmod a+s ${INSTALL_DIR};
   cd ${INSTALL_DIR};
-  git clone ${SPACK_URL} .
+  git clone --no-checkout ${SPACK_URL} .
   } &>> ${LOG_FILE}
   echo "$PREFIX Checking out ${SPACK_REF}..."
   git checkout ${SPACK_REF} >> ${LOG_FILE} 2>&1


### PR DESCRIPTION
Empirically, git checkout can take several minutes when performed over NFS. The automatic checkout performed during git clone is undesirable because we are going to immediately switch to another git reference. This commit eliminates that checkout.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?