### PR TITLE
Address dependency checker timeout failure

### DIFF
--- a/tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml
+++ b/tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml
@@ -14,7 +14,7 @@
 
 ---
 
-timeout: 1800s
+timeout: 3600s
 steps:
 - name: golang:bullseye
   entrypoint: /bin/bash


### PR DESCRIPTION
A weekly run of the dependency checker test failed on the last stage of the test because it hit the 1800s timeout. There were no other failures. This commit increases the timeout to ensure failures are meaningful.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?