### PR TITLE
Allow generic git sources

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -259,6 +259,14 @@ Toolkit vpc module, use:
 [tfsubdir]: https://www.terraform.io/language/modules/sources#modules-in-package-sub-directories
 [daos-cluster.yaml]: ../community/examples/intel/daos-cluster.yaml
 
+#### Generic Git Modules
+To use a Terraform module available in a non-GitHub git repository such as
+gitlab, set the source to a path starting `git::`. Two Standard git protocols
+are supported, `git::https://` for HTTPS or `git::git@github.com` for SSH.
+
+Additional formatting and features after `git::` are identical to that of the
+[GitHub Modules](#github-modules) described above.
+
 ### Kind (May be Required)
 
 `kind` refers to the way in which a module is deployed. Currently, `kind` can be

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -115,7 +115,7 @@ func WriteDeployment(blueprint *config.Blueprint, outputDir string, overwriteFla
 func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGroup) {
 	for iGrp, grp := range *deploymentGroups {
 		for iMod, module := range grp.Modules {
-			if sourcereader.IsGitHubPath(module.Source) {
+			if sourcereader.IsGitPath(module.Source) {
 				continue
 			}
 

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -225,6 +225,64 @@ func (s *MySuite) TestWriteDeployment(c *C) {
 	c.Check(err, IsNil)
 }
 
+func (s *MySuite) TestCreateGroupDirs(c *C) {
+	// Setup
+	testDeployDir := filepath.Join(testDir, "test_createGroupDirs")
+	if err := os.Mkdir(testDeployDir, 0755); err != nil {
+		log.Fatal("Failed to create test deployment directory for createGroupDirs")
+	}
+	groupNames := []string{"group0", "group1", "group2"}
+
+	// No deployment groups
+	testDepGroups := []config.DeploymentGroup{}
+	err := createGroupDirs(testDeployDir, &testDepGroups)
+	c.Check(err, IsNil)
+
+	// Single deployment group
+	testDepGroups = []config.DeploymentGroup{{Name: groupNames[0]}}
+	err = createGroupDirs(testDeployDir, &testDepGroups)
+	c.Check(err, IsNil)
+	grp0Path := filepath.Join(testDeployDir, groupNames[0])
+	_, err = os.Stat(grp0Path)
+	c.Check(errors.Is(err, os.ErrNotExist), Equals, false)
+	c.Check(err, IsNil)
+	err = os.Remove(grp0Path)
+	c.Check(err, IsNil)
+
+	// Multiple deployment groups
+	testDepGroups = []config.DeploymentGroup{
+		{Name: groupNames[0]},
+		{Name: groupNames[1]},
+		{Name: groupNames[2]},
+	}
+	err = createGroupDirs(testDeployDir, &testDepGroups)
+	c.Check(err, IsNil)
+	// Check for group 0
+	_, err = os.Stat(grp0Path)
+	c.Check(errors.Is(err, os.ErrNotExist), Equals, false)
+	c.Check(err, IsNil)
+	err = os.Remove(grp0Path)
+	c.Check(err, IsNil)
+	// Check for group 1
+	grp1Path := filepath.Join(testDeployDir, groupNames[1])
+	_, err = os.Stat(grp1Path)
+	c.Check(errors.Is(err, os.ErrNotExist), Equals, false)
+	c.Check(err, IsNil)
+	err = os.Remove(grp1Path)
+	c.Check(err, IsNil)
+	// Check for group 2
+	grp2Path := filepath.Join(testDeployDir, groupNames[2])
+	_, err = os.Stat(grp2Path)
+	c.Check(errors.Is(err, os.ErrNotExist), Equals, false)
+	c.Check(err, IsNil)
+	err = os.Remove(grp2Path)
+	c.Check(err, IsNil)
+
+	// deployment group(s) already exists
+	err = createGroupDirs(testDeployDir, &testDepGroups)
+	c.Check(err, IsNil)
+}
+
 func (s *MySuite) TestWriteDeployment_BadDeploymentName(c *C) {
 	testBlueprint := getBlueprintForTest()
 	var e *config.InputValueError

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -236,7 +236,7 @@ func writeMain(
 
 		// Add source attribute
 		var moduleSource cty.Value
-		if sourcereader.IsGitHubPath(mod.Source) {
+		if sourcereader.IsGitPath(mod.Source) {
 			moduleSource = cty.StringVal(mod.Source)
 		} else {
 			moduleSource = cty.StringVal(fmt.Sprintf("./modules/%s", mod.ModuleName))

--- a/pkg/sourcereader/git.go
+++ b/pkg/sourcereader/git.go
@@ -37,10 +37,10 @@ var goGetterGetters = map[string]getter.Getter{
 
 var goGetterDecompressors = map[string]getter.Decompressor{}
 
-// GitHubSourceReader reads modules from a GitHub repository
-type GitHubSourceReader struct{}
+// GitSourceReader reads modules from a git repository
+type GitSourceReader struct{}
 
-func copyGitHubModules(srcPath string, destPath string) error {
+func copyGitModules(srcPath string, destPath string) error {
 	client := getter.Client{
 		Src: srcPath,
 		Dst: destPath,
@@ -57,9 +57,9 @@ func copyGitHubModules(srcPath string, destPath string) error {
 	return err
 }
 
-// GetModuleInfo gets modulereader.ModuleInfo for the given kind from the GitHub source
-func (r GitHubSourceReader) GetModuleInfo(modPath string, kind string) (modulereader.ModuleInfo, error) {
-	if !IsGitHubPath(modPath) {
+// GetModuleInfo gets modulereader.ModuleInfo for the given kind from the git source
+func (r GitSourceReader) GetModuleInfo(modPath string, kind string) (modulereader.ModuleInfo, error) {
+	if !IsGitPath(modPath) {
 		return modulereader.ModuleInfo{}, fmt.Errorf("Source is not valid: %s", modPath)
 	}
 
@@ -70,8 +70,8 @@ func (r GitHubSourceReader) GetModuleInfo(modPath string, kind string) (modulere
 		return modulereader.ModuleInfo{}, err
 	}
 
-	if err := copyGitHubModules(modPath, writeDir); err != nil {
-		return modulereader.ModuleInfo{}, fmt.Errorf("failed to clone GitHub module at %s to tmp dir %s: %v",
+	if err := copyGitModules(modPath, writeDir); err != nil {
+		return modulereader.ModuleInfo{}, fmt.Errorf("failed to clone git module at %s to tmp dir %s: %v",
 			modPath, writeDir, err)
 	}
 
@@ -79,9 +79,9 @@ func (r GitHubSourceReader) GetModuleInfo(modPath string, kind string) (modulere
 	return reader.GetInfo(writeDir)
 }
 
-// GetModule copies the GitHub source to a provided destination (the deployment directory)
-func (r GitHubSourceReader) GetModule(modPath string, copyPath string) error {
-	if !IsGitHubPath(modPath) {
+// GetModule copies the git source to a provided destination (the deployment directory)
+func (r GitSourceReader) GetModule(modPath string, copyPath string) error {
+	if !IsGitPath(modPath) {
 		return fmt.Errorf("Source is not valid: %s", modPath)
 	}
 
@@ -92,8 +92,8 @@ func (r GitHubSourceReader) GetModule(modPath string, copyPath string) error {
 		return err
 	}
 
-	if err := copyGitHubModules(modPath, writeDir); err != nil {
-		return fmt.Errorf("failed to clone GitHub module at %s to tmp dir %s: %v",
+	if err := copyGitModules(modPath, writeDir); err != nil {
+		return fmt.Errorf("failed to clone git module at %s to tmp dir %s: %v",
 			modPath, writeDir, err)
 	}
 

--- a/pkg/sourcereader/git_test.go
+++ b/pkg/sourcereader/git_test.go
@@ -22,16 +22,16 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *MySuite) TestCopyGitHubModules(c *C) {
+func (s *MySuite) TestCopyGitModules(c *C) {
 	// Setup
-	destDir := filepath.Join(testDir, "TestCopyGitHubRepository")
+	destDir := filepath.Join(testDir, "TestCopyGitRepository")
 	if err := os.Mkdir(destDir, 0755); err != nil {
 		log.Fatal(err)
 	}
 
 	// Success via HTTPS
 	destDirForHTTPS := filepath.Join(destDir, "https")
-	err := copyGitHubModules("github.com/terraform-google-modules/terraform-google-project-factory//helpers", destDirForHTTPS)
+	err := copyGitModules("github.com/terraform-google-modules/terraform-google-project-factory//helpers", destDirForHTTPS)
 	c.Assert(err, IsNil)
 	fInfo, err := os.Stat(filepath.Join(destDirForHTTPS, "terraform_validate"))
 	c.Assert(err, IsNil)
@@ -41,7 +41,7 @@ func (s *MySuite) TestCopyGitHubModules(c *C) {
 
 	// Success via HTTPS (Root directory)
 	destDirForHTTPSRootDir := filepath.Join(destDir, "https-rootdir")
-	err = copyGitHubModules("github.com/terraform-google-modules/terraform-google-service-accounts.git?ref=v4.1.1", destDirForHTTPSRootDir)
+	err = copyGitModules("github.com/terraform-google-modules/terraform-google-service-accounts.git?ref=v4.1.1", destDirForHTTPSRootDir)
 	c.Assert(err, IsNil)
 	fInfo, err = os.Stat(filepath.Join(destDirForHTTPSRootDir, "main.tf"))
 	c.Assert(err, IsNil)
@@ -50,13 +50,13 @@ func (s *MySuite) TestCopyGitHubModules(c *C) {
 	c.Assert(fInfo.IsDir(), Equals, false)
 }
 
-func (s *MySuite) TestGetModuleInfo_GitHub(c *C) {
-	reader := GitHubSourceReader{}
+func (s *MySuite) TestGetModuleInfo_Git(c *C) {
+	reader := GitSourceReader{}
 
-	// Invalid GitHub repository - path does not exists
+	// Invalid git repository - path does not exists
 	badGitRepo := "github.com:not/exist.git"
 	_, err := reader.GetModuleInfo(badGitRepo, tfKindString)
-	expectedErr := "failed to clone GitHub module at .*"
+	expectedErr := "failed to clone git module at .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Invalid: Unsupported Module Source
@@ -66,13 +66,13 @@ func (s *MySuite) TestGetModuleInfo_GitHub(c *C) {
 	c.Assert(err, ErrorMatches, expectedErr)
 }
 
-func (s *MySuite) TestGetModule_GitHub(c *C) {
-	reader := GitHubSourceReader{}
+func (s *MySuite) TestGetModule_Git(c *C) {
+	reader := GitSourceReader{}
 
-	// Invalid GitHub repository - path does not exists
+	// Invalid git repository - path does not exists
 	badGitRepo := "github.com:not/exist.git"
 	err := reader.GetModule(badGitRepo, tfKindString)
-	expectedErr := "failed to clone GitHub module at .*"
+	expectedErr := "failed to clone git module at .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Invalid: Unsupported Module Source

--- a/pkg/sourcereader/sourcereader.go
+++ b/pkg/sourcereader/sourcereader.go
@@ -58,7 +58,9 @@ func IsEmbeddedPath(source string) bool {
 
 // IsGitHubPath checks if a source path points to GitHub
 func IsGitHubPath(source string) bool {
-	return strings.HasPrefix(source, "github.com") || strings.HasPrefix(source, "git@github.com")
+	return strings.HasPrefix(source, "github.com") ||
+		strings.HasPrefix(source, "git@github.com") ||
+		strings.HasPrefix(source, "git::")
 }
 
 // Factory returns a SourceReader of module path

--- a/pkg/sourcereader/sourcereader.go
+++ b/pkg/sourcereader/sourcereader.go
@@ -41,7 +41,7 @@ type SourceReader interface {
 var readers = map[int]SourceReader{
 	local:    LocalSourceReader{},
 	embedded: EmbeddedSourceReader{},
-	github:   GitHubSourceReader{},
+	github:   GitSourceReader{},
 }
 
 // IsLocalPath checks if a source path is a local FS path
@@ -56,8 +56,8 @@ func IsEmbeddedPath(source string) bool {
 	return strings.HasPrefix(source, "modules/") || strings.HasPrefix(source, "community/modules/")
 }
 
-// IsGitHubPath checks if a source path points to GitHub
-func IsGitHubPath(source string) bool {
+// IsGitPath checks if a source path points to GitHub or has the git:: prefix
+func IsGitPath(source string) bool {
 	return strings.HasPrefix(source, "github.com") ||
 		strings.HasPrefix(source, "git@github.com") ||
 		strings.HasPrefix(source, "git::")
@@ -75,7 +75,7 @@ func Factory(modPath string) SourceReader {
 		return readers[local]
 	case IsEmbeddedPath(modPath):
 		return readers[embedded]
-	case IsGitHubPath(modPath):
+	case IsGitPath(modPath):
 		return readers[github]
 	default:
 		log.Fatalf(

--- a/pkg/sourcereader/sourcereader_test.go
+++ b/pkg/sourcereader/sourcereader_test.go
@@ -127,6 +127,10 @@ func (s *MySuite) TestIsGitHubRepository(c *C) {
 	// True, other
 	ret = IsGitHubPath("github.com/modules")
 	c.Assert(ret, Equals, true)
+
+	// True, genetic git repository
+	ret = IsGitHubPath("git::https://gitlab.com/modules")
+	c.Assert(ret, Equals, true)
 }
 
 func (s *MySuite) TestFactory(c *C) {
@@ -141,6 +145,10 @@ func (s *MySuite) TestFactory(c *C) {
 	// GitHub modules
 	ghSrcString := Factory("github.com/modules")
 	c.Assert(reflect.TypeOf(ghSrcString), Equals, reflect.TypeOf(GitHubSourceReader{}))
+
+	// Git modules
+	gitSrcString := Factory("git::https://gitlab.com/modules")
+	c.Assert(reflect.TypeOf(gitSrcString), Equals, reflect.TypeOf(GitHubSourceReader{}))
 }
 
 func (s *MySuite) TestCopyFromPath(c *C) {

--- a/pkg/sourcereader/sourcereader_test.go
+++ b/pkg/sourcereader/sourcereader_test.go
@@ -109,27 +109,27 @@ func (s *MySuite) TestIsLocalPath(c *C) {
 	c.Assert(ret, Equals, false)
 }
 
-func (s *MySuite) TestIsGitHubRepository(c *C) {
+func (s *MySuite) TestIsGitRepository(c *C) {
 	// False: Is an embedded path
-	ret := IsGitHubPath("modules/anything/else")
+	ret := IsGitPath("modules/anything/else")
 	c.Assert(ret, Equals, false)
 
 	// False: Local path
-	ret = IsGitHubPath("./anything/else")
+	ret = IsGitPath("./anything/else")
 	c.Assert(ret, Equals, false)
 
-	ret = IsGitHubPath("./modules")
+	ret = IsGitPath("./modules")
 	c.Assert(ret, Equals, false)
 
-	ret = IsGitHubPath("../modules/")
+	ret = IsGitPath("../modules/")
 	c.Assert(ret, Equals, false)
 
 	// True, other
-	ret = IsGitHubPath("github.com/modules")
+	ret = IsGitPath("github.com/modules")
 	c.Assert(ret, Equals, true)
 
 	// True, genetic git repository
-	ret = IsGitHubPath("git::https://gitlab.com/modules")
+	ret = IsGitPath("git::https://gitlab.com/modules")
 	c.Assert(ret, Equals, true)
 }
 
@@ -144,11 +144,11 @@ func (s *MySuite) TestFactory(c *C) {
 
 	// GitHub modules
 	ghSrcString := Factory("github.com/modules")
-	c.Assert(reflect.TypeOf(ghSrcString), Equals, reflect.TypeOf(GitHubSourceReader{}))
+	c.Assert(reflect.TypeOf(ghSrcString), Equals, reflect.TypeOf(GitSourceReader{}))
 
 	// Git modules
 	gitSrcString := Factory("git::https://gitlab.com/modules")
-	c.Assert(reflect.TypeOf(gitSrcString), Equals, reflect.TypeOf(GitHubSourceReader{}))
+	c.Assert(reflect.TypeOf(gitSrcString), Equals, reflect.TypeOf(GitSourceReader{}))
 }
 
 func (s *MySuite) TestCopyFromPath(c *C) {


### PR DESCRIPTION
This PR allows generic git repos to be sourced as modules using the `git::` prefix. The underlying implementation is identical to the github source, so the same sourcereader is being used. 

This has been tested against a git repo hosted outside of github or gitlab and the hpc-cluster-small.yaml example (all modules were converted to pull from that git repo instead of from the binary or locally).

A bug also had to be fixed, the group directory was not always created when all modules are sourced from git, so now a directory is created explicitly for all groups, rather than depending on the writer.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
