### PR TITLE
Fix filestore peering network cleanup script

### DIFF
--- a/tools/clean-filestore-limit.sh
+++ b/tools/clean-filestore-limit.sh
@@ -29,10 +29,17 @@ if [[ -z "$ACTIVE_BUILDS" && -z "$ACTIVE_FILESTORE" ]]; then
 	gcloud services disable file.googleapis.com --force --project "${PROJECT_ID}"
 
 	echo "Deleting all Filestore peering networks"
+	# the output of this command matches
+	# filestore-peer-426414172628;filestore-peer-646290499454 default
 	peerings=$(gcloud compute networks peerings list --project "${PROJECT_ID}" --format="value(peerings.name,name)")
 	while read -r peering; do
-		parr=("$peering")
+		# split the output into:
+		# 0: a semi-colon separated list of peerings
+		# 1: the name of a VPC network
+		read -ra parr <<<"$peering"
+		# split the list of peerings into an array
 		IFS=";" read -ra peers <<<"${parr[0]}"
+		# capture the VPC network
 		network=${parr[1]}
 
 		for peer in "${peers[@]}"; do


### PR DESCRIPTION
The filestore network peering script failed over the weekend due to an apparent parsing error. The solution worked for me locally before submitting, but I am providing what is likely a more portable fix by explicitly reading in a bash array using `read -ra`. The commenting is also improved to guide future developers understanding the solution.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?