### PR TITLE
Fix remove default urls

### DIFF
--- a/docs/tutorials/gromacs/spack-gromacs.yaml
+++ b/docs/tutorials/gromacs/spack-gromacs.yaml
@@ -37,7 +37,6 @@ deployment_groups:
     source: community/modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
       spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -37,7 +37,6 @@ deployment_groups:
     source: community/modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
       spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:

--- a/docs/tutorials/wrfv3/spack-wrfv3.yaml
+++ b/docs/tutorials/wrfv3/spack-wrfv3.yaml
@@ -37,7 +37,6 @@ deployment_groups:
     source: community/modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
       spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:


### PR DESCRIPTION
@heyealex recently (correctly) advised removing default Spack URLs from a submission and I am picking off a few examples here of the same issue

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
