### PR TITLE
Allow for DDN Lustre to be ready to install client

### DIFF
--- a/community/modules/file-system/DDN-EXAScaler/outputs.tf
+++ b/community/modules/file-system/DDN-EXAScaler/outputs.tf
@@ -73,4 +73,8 @@ output "network_storage" {
     fs_type       = "lustre"
     mount_options = ""
   }
+  depends_on = [
+    # do not release before ddn is ready to hand out client config script
+    module.ddn_exascaler.client_config,
+  ]
 }

--- a/modules/file-system/pre-existing-network-storage/templates/ddn_exascaler_luster_client_install.tftpl
+++ b/modules/file-system/pre-existing-network-storage/templates/ddn_exascaler_luster_client_install.tftpl
@@ -41,7 +41,7 @@ EOF
 
 for i in 1 2 3 4 5 6 7 8 9 10;
 do
-  echo $i
+  echo "Pulling client-setup-tool, try: $i"
   curl -fsSL http://${server_ip}/client-setup-tool -o /usr/sbin/esc-client && break || sleep 3;
 done
 chmod +x /usr/sbin/esc-client

--- a/tools/cloud-build/daily-tests/blueprints/lustre-with-new-vpc.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-with-new-vpc.yaml
@@ -49,6 +49,10 @@ deployment_groups:
     source: modules/scripts/startup-script
     settings:
       runners:
+      # TODO: remove this sleep once DDN implements retry logic
+      - type: shell
+        destination: "sleep.sh"
+        content: sleep 30
       - $(scratchfs.install_ddn_lustre_client_runner)
       - $(scratchfs.mount_runner)
 


### PR DESCRIPTION
Somehow in the tree of dependencies network_storage is released as soon as the msg ddn server is up while client_config waits until lustre is fully deployed. The pre-existing-network-storage install is trying execute before lustre is up, which I believe is causing issues. 

Also, the curl to download the client-setup-tool can fail when performed right after DDN EXAScaler finishes deploying or when multiple clients are trying to download simultaneously. I am working with DDN to try to add retry logic to this operation but for now the sleep in integration tests should improve congestion.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
