### PR TITLE
Add shared task for recover from terraform failure

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -119,30 +119,11 @@
 
     ## Cleanup and fail gracefully
     rescue:
-    - name: Delete Firewall Rule
-      register: fw_deleted
-      changed_when: fw_deleted.rc == 0
-      failed_when: false
-      command:
-        argv:
-        - gcloud
-        - compute
-        - firewall-rules
-        - delete
-        - "{{ deployment_name }}"
-    - name: Tear Down Cluster
-      run_once: true
-      changed_when: true # assume something got destroyed
-      delegate_to: localhost
-      environment:
-        TF_IN_AUTOMATION: "TRUE"
-      command:
-        cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
-    - name: Fail Out
-      fail:
-        msg: "Failed while setting up test infrastructure"
-      when: true
+    - name: Include rescue from terraform failure
+      ansible.builtin.include_tasks: "tasks/rescue_terraform_failure.yml"
+      vars:
+        deployment_name: "{{ deployment_name }}"
+        workspace: "{{ workspace }}"
 
 - name: Run Integration Tests
   hosts: remote_host

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -124,30 +124,11 @@
 
     ## Cleanup and fail gracefully
     rescue:
-    - name: Delete Firewall Rule
-      register: fw_deleted
-      changed_when: fw_deleted.rc == 0
-      failed_when: false  # keep cleaning up
-      command:
-        argv:
-        - gcloud
-        - compute
-        - firewall-rules
-        - delete
-        - "{{ deployment_name }}"
-    - name: Tear Down Cluster
-      changed_when: true  # assume something destroyed
-      run_once: true
-      delegate_to: localhost
-      environment:
-        TF_IN_AUTOMATION: "TRUE"
-      command:
-        cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
-    - name: Fail Out
-      fail:
-        msg: "Failed while setting up test infrastructure"
-      when: true
+    - name: Include rescue from terraform failure
+      ansible.builtin.include_tasks: "tasks/rescue_terraform_failure.yml"
+      vars:
+        deployment_name: "{{ deployment_name }}"
+        workspace: "{{ workspace }}"
 
 - name: Run Integration Tests
   hosts: remote_host

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - deployment_name is defined
+    - workspace is defined
+
+- name: Delete Firewall Rule
+  register: fw_deleted
+  changed_when: fw_deleted.rc == 0
+  failed_when: false  # keep cleaning up
+  command:
+    argv:
+    - gcloud
+    - compute
+    - firewall-rules
+    - delete
+    - "{{ deployment_name }}"
+- name: Tear Down Cluster
+  changed_when: true  # assume something destroyed
+  run_once: true
+  delegate_to: localhost
+  environment:
+    TF_IN_AUTOMATION: "TRUE"
+  command:
+    cmd: terraform destroy -auto-approve
+    chdir: "{{ workspace }}/{{ deployment_name }}/primary"
+- name: Fail Out
+  fail:
+    msg: "Failed while setting up test infrastructure"
+  when: true


### PR DESCRIPTION
Initially I refactored this so I could add a wait for startup script logging to all tests. That effort did not end up working but I think this refactor is still value added on its own. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
