### PR TITLE
Automatically pull serial port 1 logs on startup script failure

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -52,6 +52,7 @@
         creates: "{{ workspace }}/{{ deployment_name }}/.terraform"
       environment:
         TF_IN_AUTOMATION: "TRUE"
+      register: terraform_output
       with_items:
       - "terraform init"
       - "terraform apply -auto-approve -no-color"
@@ -124,6 +125,7 @@
       vars:
         deployment_name: "{{ deployment_name }}"
         workspace: "{{ workspace }}"
+        terraform_apply_stderr: "{{ terraform_output.results.1.stderr }}"
 
 - name: Run Integration Tests
   hosts: remote_host

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -53,6 +53,7 @@
         creates: "{{ workspace }}/{{ deployment_name }}/.terraform"
       environment:
         TF_IN_AUTOMATION: "TRUE"
+      register: terraform_output
       with_items:
       - "terraform init"
       - "terraform apply -auto-approve -no-color"
@@ -129,6 +130,7 @@
       vars:
         deployment_name: "{{ deployment_name }}"
         workspace: "{{ workspace }}"
+        terraform_apply_stderr: "{{ terraform_output.results.1.stderr }}"
 
 - name: Run Integration Tests
   hosts: remote_host

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
@@ -17,6 +17,7 @@
     that:
     - deployment_name is defined
     - workspace is defined
+    - terraform_apply_stderr is defined
 
 - name: Delete Firewall Rule
   register: fw_deleted
@@ -29,6 +30,10 @@
     - firewall-rules
     - delete
     - "{{ deployment_name }}"
+- name: Wait for Startup Script Logs
+  ansible.builtin.pause:
+    minutes: 5
+  when: '"startup-script finished with errors" in terraform_apply_stderr'
 - name: Tear Down Cluster
   changed_when: true  # assume something destroyed
   run_once: true

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
@@ -23,24 +23,29 @@
   register: fw_deleted
   changed_when: fw_deleted.rc == 0
   failed_when: false  # keep cleaning up
-  command:
+  ansible.builtin.command:
     argv:
     - gcloud
     - compute
     - firewall-rules
     - delete
     - "{{ deployment_name }}"
-- name: Wait for Startup Script Logs
-  ansible.builtin.pause:
-    minutes: 5
+- name: Get Startup Script Logs
+  ansible.builtin.command: "{{ terraform_apply_stderr | replace('\n',' ') | regex_search('please run: (.+)', '\\1') | first }}"
+  register: serial_port_1_output
   when: '"startup-script finished with errors" in terraform_apply_stderr'
+  failed_when: false
+- name: Log Startup Script Failure
+  ansible.builtin.debug:
+    var: serial_port_1_output
+  when: serial_port_1_output is defined
 - name: Tear Down Cluster
   changed_when: true  # assume something destroyed
   run_once: true
   delegate_to: localhost
   environment:
     TF_IN_AUTOMATION: "TRUE"
-  command:
+  ansible.builtin.command:
     cmd: terraform destroy -auto-approve
     chdir: "{{ workspace }}/{{ deployment_name }}/primary"
 - name: Fail Out


### PR DESCRIPTION
When failure is detected in wait-for-startup we pull the serial port 1 logs (containing startup output). This is required because the last few seconds of logs are not making it to cloud logging in the case of failure.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
