### PR TITLE
Fix Ansible module for upgrading setuptools in HTCondor autoscaler

### DIFF
--- a/community/modules/scripts/htcondor-install/files/install-htcondor-autoscaler-deps.yml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor-autoscaler-deps.yml
@@ -24,13 +24,13 @@
   - name: Create virtual environment for HTCondor autoscaler
     ansible.builtin.pip:
       name: pip
-      version: 21.3.1  # last Python 2.7-compatible release
+      version: 21.3.1  # last Python 3.6-compatible release
       virtualenv: /usr/local/htcondor
       virtualenv_command: /usr/bin/python3 -m venv
   - name: Install latest setuptools
     ansible.builtin.pip:
       name: setuptools
-      state: 44.1.1  # last Python 2.7-compatible release
+      version: 59.6.0  # last Python 3.6-compatible release
       virtualenv: /usr/local/htcondor
       virtualenv_command: /usr/bin/python3 -m venv
   - name: Install HTCondor autoscaler dependencies


### PR DESCRIPTION
The Ansible module for installing the HTCondor autoscaler has a bug in which the version number is being supplied to the `state` parameter rather than the `version` parameter. I suspect this is a behavioral change in the pip module above ansible 2.9. The consequence of the bug is that the virtual environment for the HTCondor autoscaler fails to install and the  the HTCondor pool community example stops mid-way through its configuration. This has the user-facing consequence that the access point ("login node") fails to join the pool and users cannot submit jobs.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?