### PR TITLE
Add slurm v5 HPC Centos example to integration tests

### DIFF
--- a/community/examples/slurm-gcp-v5-hpc-centos7.yaml
+++ b/community/examples/slurm-gcp-v5-hpc-centos7.yaml
@@ -68,6 +68,8 @@ deployment_groups:
     - debug_partition
     - compute_partition
     - homefs
+    settings:
+      disable_controller_public_ips: false
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
@@ -76,3 +78,4 @@ deployment_groups:
     - slurm_controller
     settings:
       machine_type: n2-standard-4
+      disable_login_public_ips: false

--- a/tools/cloud-build/daily-tests/README.md
+++ b/tools/cloud-build/daily-tests/README.md
@@ -33,3 +33,75 @@ This example consists of 3 files:
   - The post deploy test (tasks) that is called by the playbook
 - tools/cloud-build/daily-tests/tests/hello-world-vars.yml
   - The variables passed into the playbook
+
+## Nightly Test Groups
+
+Each test group can be run concurrently, and some tests within test groups run
+currently with each other as well. Each group begins with 2 steps for
+initializing the environment:
+
+- `build_ghpc`: Build `ghpc` in a golang builder container, verifying that no
+  additional dependencies are required for a simple build.
+- `fetch_builder`: Simply pulls the `hpc-toolkit-builder` image to the local
+  environment to decrease the overhead in subsequent steps.
+
+The tests in each group are listed below:
+
+### Group 1
+
+Config: [integration-group-1.yaml](./integration-group-1.yaml)
+
+Contents:
+
+- `hpc-high-io`: Tests the [hpc-cluster-high-io.yaml] example blueprint.
+
+[hpc-cluster-high-io.yaml]: ../../../examples/hpc-cluster-high-io.yaml
+
+### Group 2
+
+Config: [integration-group-2.yaml](./integration-group-2.yaml)
+
+Contents:
+
+- `spack-gromacs`: Tests the [spack-gromacs.yaml] example blueprint.
+- `slurm-gcp-v5-hpc-centos7`: Tests the [slurm-gcp-v5-hpc-centos7.yaml] example
+  blueprint.
+
+Notes:
+
+- This test pulls a secret from the hpc-toolkit-dev project which contains the
+  path to the internal Spack build cache.
+
+[spack-gromacs.yaml]: ../../../community/examples/spack-gromacs.yaml
+[slurm-gcp-v5-hpc-centos7.yaml]: ../../../community/examples/slurm-gcp-v5-hpc-centos7.yaml
+
+### Group 3
+
+Config: [integration-group-3.yaml](./integration-group-3.yaml)
+
+Contents:
+
+- `monitoring`: Tests a blueprint with a monitoring dashboard.
+- `omnia`: Tests the [omnia-cluster.yaml] example blueprint.
+- `lustre-new-vpc`: Tests the `lustre-with-new-vpc.yaml` blueprint, which
+  includes testing DDN lustre with a newly created VPC network as well as other
+  unique configurations not tested elsewhere.
+- `packer`: Tests the [image-builder.yaml] example blueprint.
+- `quantum-circuit`: Tests the [quantum-circuit-simulator.yaml] example
+  blueprint.
+
+[omnia-cluster.yaml]: ../../../community/examples/omnia-cluster.yaml
+[image-builder.yaml]: ../../../examples/image-builder.yaml
+[quantum-circuit-simulator.yaml]: ../../../community/examples/quantum-circuit-simulator.yaml
+
+### Group 4
+
+Config: [integration-group-4.yaml](./integration-group-4.yaml)
+
+Contents:
+
+- `htcondor`: Tests the [htcondor-pool.yaml] example blueprint.
+- `cloud-batch`: Tests the [cloud-batch.yaml] example blueprint.
+
+[htcondor-pool.yaml]: ../../../community/examples/htcondor-pool.yaml
+[cloud-batch.yaml]: ../../../community/examples/cloud-batch.yaml

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -41,6 +41,10 @@
       NETWORK: "{{ network }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
+    register: create_output
+  - name: Print ghpc blueprint information
+    ansible.builtin.debug:
+      var: create_output.stdout_lines
   - name: Create Infrastructure and test
     block:
     - name: Create Cluster with Terraform
@@ -59,6 +63,9 @@
       changed_when: false
       delegate_to: localhost
       register: instances_list
+      retries: 2
+      delay: 60
+      until: instances_list.rc == 0
       command: >-
         gcloud compute instances list
         --filter="labels.ghpc_deployment={{ deployment_name }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -40,6 +40,10 @@
       NETWORK: "{{ network }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
+    register: create_output
+  - name: Print ghpc blueprint information
+    ansible.builtin.debug:
+      var: create_output.stdout_lines
   - name: Create Infrastructure and test
     block:
     - name: Setup network and HTCondor install scripts

--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -31,6 +31,10 @@
       NETWORK: "{{ network }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
+    register: create_output
+  - name: Print ghpc blueprint information
+    ansible.builtin.debug:
+      var: create_output.stdout_lines
   - name: Create Infrastructure and test
     block:
     - name: Create Network with Terraform

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -76,26 +76,34 @@
         var: instances_list.stdout_lines
     - name: Get IP of a login node - Exact name provided
       changed_when: false
-      register: login_ip
-      command: >-
+      register: get_login_ip
+      ansible.builtin.command: >-
         gcloud compute instances describe --zone={{ zone }} {{ login_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
       when: '"*" not in login_node'
+    - name: Set login_ip variable - Exact name provided
+      ansible.builtin.set_fact:
+        login_ip: "{{ get_login_ip.stdout }}"
+      when: '"*" not in login_node'
     - name: Get IP of a login node - Name pattern provided
       changed_when: false
-      register: login_ip
-      command: >-
+      register: get_login_ip
+      ansible.builtin.command: >-
         gcloud compute instances list \
           --format='get(networkInterfaces[0].accessConfigs[0].natIP)' --limit=1 \
           --filter=NAME:{{ login_node }}
       when: '"*" in login_node'
+    - name: Set login_ip variable - Name pattern provided
+      ansible.builtin.set_fact:
+        login_ip: "{{ get_login_ip.stdout }}"
+      when: '"*" in login_node'
     - name: Print login public IP
       ansible.builtin.debug:
-        var: login_ip.stdout_lines
+        var: login_ip
     - name: Get Controller IP
       changed_when: false
       register: controller_ip
-      command: >-
+      ansible.builtin.command: >-
         gcloud compute instances describe --zone={{ zone }} {{ controller_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
     - name: Print controller public IP
@@ -141,7 +149,7 @@
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
     - name: Add Login node as host
       add_host:
-        hostname: "{{ login_ip.stdout }}"
+        hostname: "{{ login_ip }}"
         groups: [remote_host]
 
     ## Cleanup and fail gracefully
@@ -161,7 +169,7 @@
   - name: Slurm Test Block
     vars:
       ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
-      ansible_remote_tmp: /tmp/ghpc/
+      ansible_remote_tmp: "/tmp/ghpc/"
     block:
     - name: Wait until host is reachable
       ansible.builtin.wait_for_connection:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -42,6 +42,10 @@
       NETWORK: "{{ network }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
+    register: create_output
+  - name: Print ghpc blueprint information
+    ansible.builtin.debug:
+      var: create_output.stdout_lines
   - name: Create Infrastructure and test
     block:
     - name: Create Cluster with Terraform
@@ -60,6 +64,9 @@
       changed_when: false
       delegate_to: localhost
       register: instances_list
+      retries: 2
+      delay: 60
+      until: instances_list.rc == 0
       command: >-
         gcloud compute instances list
         --filter="labels.ghpc_deployment={{ deployment_name }}"
@@ -67,18 +74,33 @@
     - name: Print instance information
       ansible.builtin.debug:
         var: instances_list.stdout_lines
-    - name: Get login IP
+    - name: Get IP of a login node - Exact name provided
       changed_when: false
       register: login_ip
       command: >-
         gcloud compute instances describe --zone={{ zone }} {{ login_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+      when: '"*" not in login_node'
+    - name: Get IP of a login node - Name pattern provided
+      changed_when: false
+      register: login_ip
+      command: >-
+        gcloud compute instances list \
+          --format='get(networkInterfaces[0].accessConfigs[0].natIP)' --limit=1 \
+          --filter=NAME:{{ login_node }}
+      when: '"*" in login_node'
+    - name: Print login public IP
+      ansible.builtin.debug:
+        var: login_ip.stdout_lines
     - name: Get Controller IP
       changed_when: false
       register: controller_ip
       command: >-
         gcloud compute instances describe --zone={{ zone }} {{ controller_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+    - name: Print controller public IP
+      ansible.builtin.debug:
+        var: controller_ip.stdout_lines
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
@@ -139,6 +161,7 @@
   - name: Slurm Test Block
     vars:
       ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
+      ansible_remote_tmp: /tmp/ghpc/
     block:
     - name: Wait until host is reachable
       ansible.builtin.wait_for_connection:

--- a/tools/cloud-build/daily-tests/integration-group-2.yaml
+++ b/tools/cloud-build/daily-tests/integration-group-2.yaml
@@ -16,7 +16,8 @@
 # Current parallel execution tree, built to minimize total execution time and faster tests first.
 # ├── build_ghpc
 # └── fetch_builder
-#    ├── spack-gromacks (group 2)
+#    ├── spack-gromacs (group 2)
+#    ├── slurm-gcp-v5-hpc-centos7 (group 2)
 
 
 timeout: 14400s  # 4hr
@@ -71,3 +72,25 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/spack-gromacs.yml"
+
+## Test Slurm v5 HPC Centos7 Example
+- id: slurm-gcp-v5-hpc-centos7
+  waitFor:
+  - fetch_builder
+  - build_ghpc
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v5.yml"

--- a/tools/cloud-build/daily-tests/integration-group-2.yaml
+++ b/tools/cloud-build/daily-tests/integration-group-2.yaml
@@ -93,4 +93,4 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
-      --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v5.yml"
+      --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml"

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
@@ -14,15 +14,18 @@
 
 ---
 
-deployment_name: "slurm-gcp-v5-{{ build }}"
+deployment_name: "cent-v5-{{ build }}"
+# Manually adding the slurm_cluster_name for use in node names, which filters
+# non-alphanumeric chars and is capped at 10 chars.
+slurm_cluster_name: "centv5{{ build[0:4] }}"
 zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/slurm-gcp-v5-hpc-centos7.yaml"
-blueprint_dir: not-needed
 network: "{{ deployment_name }}-net"
 max_nodes: 5
-login_node: "slurmgcpv5-login-*"
-controller_node: "slurmgcpv5-controller"
+# Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
+login_node: "{{ slurm_cluster_name }}-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-mounts.yml
 - test-partitions.yml

--- a/tools/cloud-build/daily-tests/tests/slurm-v5.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5.yml
@@ -1,0 +1,34 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+deployment_name: "slurm-gcp-v5-{{ build }}"
+zone: us-central1-c
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/community/examples/slurm-gcp-v5-hpc-centos7.yaml"
+blueprint_dir: not-needed
+network: "{{ deployment_name }}-net"
+max_nodes: 5
+login_node: "slurmgcpv5-login-*"
+controller_node: "slurmgcpv5-controller"
+post_deploy_tests:
+- test-mounts.yml
+- test-partitions.yml
+custom_vars:
+  partitions:
+  - compute
+  - debug
+  mounts:
+  - /home


### PR DESCRIPTION
Building off of [#502](https://github.com/GoogleCloudPlatform/hpc-toolkit/pull/502), this PR implements changes needed to support a Slurm v5 integration test. Additional documentation was added to list our current integration test groups.

Changes made:
* Expose public IPs of login and controller
* Print output of `create_deployment.sh`
* Add retries for gathering instance info
* Get login node IP using a pattern rather than the exact name
* Change ansible tmp directory to avoid conflict with packer based images

DRAFT: Opened to verify all tests.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
