### PR TITLE
Update wait for startup for qsim example to 2400s

### DIFF
--- a/community/examples/quantum-circuit-simulator.yaml
+++ b/community/examples/quantum-circuit-simulator.yaml
@@ -133,3 +133,4 @@ deployment_groups:
     source: community/modules/scripts/wait-for-startup
     settings:
       instance_name: ((module.qsimvm.name[0]))
+      timeout: 2400


### PR DESCRIPTION
Doubles the wait for startup completion. With a typically runtime of 20min (1200s), the default implies that with any irregularity or delay in installing dependencies, a test could fail.

This PR updates the timeout to 40min, which should easily cover any likely inconsistencies day to day and ensure that any failure is an actual failure or relevant performance degradation.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
