### PR TITLE
Fix: passing non-existent cache was causing failures in some projects

### DIFF
--- a/docs/tutorials/gromacs/spack-gromacs.yaml
+++ b/docs/tutorials/gromacs/spack-gromacs.yaml
@@ -21,7 +21,6 @@ vars:
   deployment_name: spack-gromacs
   region: us-central1
   zone: us-central1-c
-  spack_cache_mirror_url: gs://optionally_set_spack_cache_bucket
 
 deployment_groups:
 - group: primary
@@ -89,9 +88,10 @@ deployment_groups:
               - - $mpi_packages
               - - $%compilers
               - - $^mpis
-      spack_cache_url:
-      - mirror_name: gcs_cache
-        mirror_url: $(vars.spack_cache_mirror_url)
+      # Un-comment and update mirror_url to install from spack cache
+      # spack_cache_url:
+      # - mirror_name: gcs_cache
+      #   mirror_url: gs://optionally_set_spack_cache_bucket
 
   - id: controller-setup
     source: modules/scripts/startup-script

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -21,7 +21,6 @@ vars:
   deployment_name: spack-openfoam
   region: us-central1
   zone: us-central1-c
-  spack_cache_mirror_url: gs://optionally_set_spack_cache_bucket
 
 deployment_groups:
 - group: primary
@@ -96,9 +95,10 @@ deployment_groups:
               - - $^mpis
             concretizer:
               unify: when_possible
-      spack_cache_url:
-      - mirror_name: gcs_cache
-        mirror_url: $(vars.spack_cache_mirror_url)
+      # Un-comment and update mirror_url to install from spack cache
+      # spack_cache_url:
+      # - mirror_name: gcs_cache
+      #   mirror_url: gs://optionally_set_spack_cache_bucket
 
   - id: controller-setup
     source: modules/scripts/startup-script

--- a/docs/tutorials/wrfv3/spack-wrfv3.yaml
+++ b/docs/tutorials/wrfv3/spack-wrfv3.yaml
@@ -21,7 +21,6 @@ vars:
   deployment_name: spack-wrfv3
   region: us-central1
   zone: us-central1-c
-  spack_cache_mirror_url: gs://optionally_set_spack_cache_bucket
 
 deployment_groups:
 - group: primary
@@ -89,9 +88,10 @@ deployment_groups:
               - - $mpi_packages
               - - $%compilers
               - - $^mpis
-      spack_cache_url:
-      - mirror_name: gcs_cache
-        mirror_url: $(vars.spack_cache_mirror_url)
+      # Un-comment and update mirror_url to install from spack cache
+      # spack_cache_url:
+      # - mirror_name: gcs_cache
+      #   mirror_url: gs://optionally_set_spack_cache_bucket
 
   - id: controller-setup
     source: modules/scripts/startup-script


### PR DESCRIPTION
We (@douglasjacobsen and myself) have observed that some projects fail on `gs://optionally_set_spack_cache_bucket` while others do not. Root cause is not yet known, but until it is found I am changing the structure of the blueprint to eliminate the failure. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
