### PR TITLE
Add default Spack log file

### DIFF
--- a/community/modules/scripts/spack-install/README.md
+++ b/community/modules/scripts/spack-install/README.md
@@ -199,7 +199,7 @@ No resources.
 | <a name="input_install_dir"></a> [install\_dir](#input\_install\_dir) | Directory to install spack into. | `string` | `"/sw/spack"` | no |
 | <a name="input_install_flags"></a> [install\_flags](#input\_install\_flags) | Defines the flags to pass into `spack install` | `string` | `""` | no |
 | <a name="input_licenses"></a> [licenses](#input\_licenses) | List of software licenses to install within spack. | <pre>list(object({<br>    source = string<br>    dest   = string<br>  }))</pre> | `null` | no |
-| <a name="input_log_file"></a> [log\_file](#input\_log\_file) | Defines the logfile that script output will be written to | `string` | `"/dev/null"` | no |
+| <a name="input_log_file"></a> [log\_file](#input\_log\_file) | Defines the logfile that script output will be written to | `string` | `"/var/log/spack.log"` | no |
 | <a name="input_packages"></a> [packages](#input\_packages) | Defines root packages for spack to install (in order). | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
 | <a name="input_spack_cache_url"></a> [spack\_cache\_url](#input\_spack\_cache\_url) | List of buildcaches for spack. | <pre>list(object({<br>    mirror_name = string<br>    mirror_url  = string<br>  }))</pre> | `null` | no |

--- a/community/modules/scripts/spack-install/variables.tf
+++ b/community/modules/scripts/spack-install/variables.tf
@@ -224,6 +224,6 @@ EOT
 
 variable "log_file" {
   description = "Defines the logfile that script output will be written to"
-  default     = "/dev/null"
+  default     = "/var/log/spack.log"
   type        = string
 }


### PR DESCRIPTION
We often want this information for debugging. I had thought this was the default but realized it is only because we set it similarly in our of our examples. I discussed with @douglasjacobsen, who agreed this would be fine to change.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
