### PR TITLE
Support local module required APIs

### DIFF
--- a/pkg/sourcereader/local.go
+++ b/pkg/sourcereader/local.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"hpc-toolkit/pkg/modulereader"
 	"os"
+	"strings"
 )
 
 // LocalSourceReader reads modules from a local directory
@@ -30,7 +31,13 @@ func (r LocalSourceReader) GetModuleInfo(modPath string, kind string) (modulerea
 	}
 
 	reader := modulereader.Factory(kind)
-	return reader.GetInfo(modPath)
+	mi, err := reader.GetInfo(modPath)
+	if idx := strings.Index(modPath, "/community/modules/"); idx != -1 {
+		mi.RequiredApis = defaultAPIList(modPath[idx+1:])
+	} else if idx := strings.Index(modPath, "/modules/"); idx != -1 {
+		mi.RequiredApis = defaultAPIList(modPath[idx+1:])
+	}
+	return mi, err
 }
 
 // GetModule copies the local source to a provided destination (the deployment directory)


### PR DESCRIPTION
If a local resource could plausibly be a local development copy of an embedded module, then ensure that its required API list defaults to that of the embedded module. This also provides a pathway for development to change and test the default value while modifying the embedded module.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?