### PR TITLE
Batch modules should require Batch API

### DIFF
--- a/pkg/sourcereader/embedded.go
+++ b/pkg/sourcereader/embedded.go
@@ -159,9 +159,11 @@ func defaultAPIList(source string) []string {
 			"compute.googleapis.com",
 		},
 		"community/modules/scheduler/cloud-batch-job": {
+			"batch.googleapis.com",
 			"compute.googleapis.com",
 		},
 		"community/modules/scheduler/cloud-batch-login-node": {
+			"batch.googleapis.com",
 			"compute.googleapis.com",
 			"storage.googleapis.com",
 		},


### PR DESCRIPTION
Although the Batch terraform modules do not strictly require the Batch API, we should help the user by testing whether it's enabled.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?