### PR TITLE
Push test deployment directory to GCS

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -39,6 +39,7 @@
       ROOT_DIR: "{{ workspace }}"
       DEPLOYMENT_NAME: "{{ deployment_name }}"
       NETWORK: "{{ network }}"
+      TEST_NAME: "{{ test_name }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
     register: create_output

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -38,6 +38,7 @@
       ROOT_DIR: "{{ workspace }}"
       DEPLOYMENT_NAME: "{{ deployment_name }}"
       NETWORK: "{{ network }}"
+      TEST_NAME: "{{ test_name }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
     register: create_output

--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -29,6 +29,7 @@
       ROOT_DIR: "{{ workspace }}"
       DEPLOYMENT_NAME: "{{ deployment_name }}"
       NETWORK: "{{ network }}"
+      TEST_NAME: "{{ test_name }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
     register: create_output

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -40,6 +40,7 @@
       ROOT_DIR: "{{ workspace }}"
       DEPLOYMENT_NAME: "{{ deployment_name }}"
       NETWORK: "{{ network }}"
+      TEST_NAME: "{{ test_name }}"
     args:
       creates: "{{ workspace }}/{{ deployment_name }}.tgz"
     register: create_output

--- a/tools/cloud-build/daily-tests/create_deployment.sh
+++ b/tools/cloud-build/daily-tests/create_deployment.sh
@@ -21,18 +21,19 @@ NETWORK=${NETWORK:-missing-network-name}
 MAX_NODES=${MAX_NODES:-2}
 TEST_NAME=${TEST_NAME:unnamed_test}
 ALWAYS_RECOMPILE=${ALWAYS_RECOMPILE:-yes}
+GHPC_DEV_BUCKET=${GHPC_DEV_BUCKET:-daily-tests-tf-state}
 
 echo "Creating blueprint from ${EXAMPLE_YAML} in project ${PROJECT} for test ${TEST_NAME}"
 
 ## Add GCS Backend to example
-echo "Adding GCS Backend to the yaml (bucket: daily-tests-tf-state)"
+echo "Adding GCS Backend to the yaml (bucket: ${GHPC_DEV_BUCKET})"
 if ! grep -Fxq terraform_backend_defaults: "${EXAMPLE_YAML}"; then
 	cat <<EOT >>"${EXAMPLE_YAML}"
 
 terraform_backend_defaults:
   type: gcs
   configuration:
-    bucket: daily-tests-tf-state
+    bucket: ${GHPC_DEV_BUCKET}
 EOT
 fi
 
@@ -74,5 +75,5 @@ tar -czf "${DEPLOYMENT_NAME}.tgz" "${DEPLOYMENT_NAME}" ||
 		exit 1
 	}
 
-echo "Copying ${DEPLOYMENT_NAME}.tgz to gs://daily-tests-tf-state/${TEST_NAME}/"
-gsutil cp "${DEPLOYMENT_NAME}.tgz" "gs://daily-tests-tf-state/${TEST_NAME}/"
+echo "Copying ${DEPLOYMENT_NAME}.tgz to gs://${GHPC_DEV_BUCKET}/${TEST_NAME}/"
+gsutil cp "${DEPLOYMENT_NAME}.tgz" "gs://${GHPC_DEV_BUCKET}/${TEST_NAME}/"

--- a/tools/cloud-build/daily-tests/tests/cloud-batch.yml
+++ b/tools/cloud-build/daily-tests/tests/cloud-batch.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+test_name: cloud-batch
 deployment_name: cloud-batch-{{ build }}
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/hello-world-vars.yml
+++ b/tools/cloud-build/daily-tests/tests/hello-world-vars.yml
@@ -14,6 +14,7 @@
 
 # The hello world integration test exists to demonstrate the test interaction between test files
 ---
+test_name: hello-world
 top_level_var: "top level var"
 post_deploy_tests: [test-hello-world.yml]
 custom_vars:

--- a/tools/cloud-build/daily-tests/tests/hpc-high-io.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-high-io.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: hpc-high-io
 deployment_name: "hpc-high-io-{{ build }}"
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/htcondor.yml
+++ b/tools/cloud-build/daily-tests/tests/htcondor.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: htcondor
 deployment_name: "htcondor-{{ build }}"
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/lustre-new-vpc.yml
+++ b/tools/cloud-build/daily-tests/tests/lustre-new-vpc.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: lustre-new-vpc
 deployment_name: "lustre-new-vpc-{{ build }}"
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/monitoring.yml
+++ b/tools/cloud-build/daily-tests/tests/monitoring.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: monitoring
 deployment_name: monitoring-{{ build }}
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/omnia.yml
+++ b/tools/cloud-build/daily-tests/tests/omnia.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: omnia
 deployment_name: "omnia-{{ build }}"
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/packer.yml
+++ b/tools/cloud-build/daily-tests/tests/packer.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: packer
 deployment_name: packer-image-{{ build }}
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/qsim.yml
+++ b/tools/cloud-build/daily-tests/tests/qsim.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: qsim
 deployment_name: "qsim-{{ build }}"
 zone: us-west4-b
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: slurm-gcp-v5-hpc-centos7
 deployment_name: "cent-v5-{{ build }}"
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: slurm-gcp-v5-ubuntu2004
 deployment_name: "ubun-v5-{{ build }}"
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.

--- a/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
+++ b/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
@@ -14,6 +14,7 @@
 
 ---
 
+test_name: spack-gromacs
 deployment_name: "spack-gromacs-{{ build }}"
 zone: us-central1-c
 workspace: /workspace


### PR DESCRIPTION
Remains a draft until https://github.com/GoogleCloudPlatform/hpc-toolkit/pull/587 is merged so this branch can rebase and run tests.

Update create_deployment.sh in the daily integration tests to push the deployment directory (tar'd) into a GCS bucket for later debugging.

Co-authored-by: Carlos Boneti <carlosboneti@google.com>

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
