### PR TITLE
Remove deployment_name var from vpc example as it is passed implicitly

### DIFF
--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -109,16 +109,10 @@ compact set of subnetworks possible.
 - id: network1
   source: modules/network/vpc
   settings:
-  - deployment_name: $(vars.deployment_name)
+    network_name: cluster-net
 ```
 
-This creates a new VPC network named based on the `deployment_name` variable
-with `_net` appended. `network_name` can be set manually as well as part of the
-settings.
-
-> **_NOTE:_** `deployment_name` does not need to be set explicitly here. It
-> would typically be inferred from the deployment variable of the same name. It
-> is included here for clarity.
+This creates a new VPC network named `cluster-net`.
 
 ## License
 


### PR DESCRIPTION
### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
