### PR TITLE
Update AMD blueprint with OpenFOAM application and test suite

### DIFF
--- a/community/examples/AMD/README.md
+++ b/community/examples/AMD/README.md
@@ -58,7 +58,19 @@ ghpc create --vars project_id=<<PROJECT_ID>> hpc-cluster-amd-slurmv5.yaml
 It will create a directory containing a Terraform module. Follow the printed
 instructions to execute Terraform.
 
-### Login to the cluster and complete installation of AOCC
+### Run an OpenFOAM test suite
+
+Browse to the [Cloud Console][console] and use the SSH feature to access the
+Slurm login node. A script has been provisioned which will activate your
+OpenFOAM environment and run a test suite of applications. The output of this
+test suite will appear in `openfoam_test` under your home directory. To execute
+the test suite, run:
+
+```shell
+bash /var/tmp/openfoam_test.sh
+```
+
+### Complete installation of AOCC
 
 Because AOCC requires acceptance of a license, we advise a manual step to
 install AOCC and OpenMPI compiled with AOCC. You can browse to the

--- a/community/examples/AMD/hpc-cluster-amd-slurmv5.yaml
+++ b/community/examples/AMD/hpc-cluster-amd-slurmv5.yaml
@@ -44,19 +44,70 @@ deployment_groups:
     settings:
       install_dir: /sw/spack
       spack_ref: v0.18.1
+      log_file: /var/log/spack.log
       configs:
+      - type: file
+        scope: defaults
+        content: |
+          config:
+            build_stage:
+              - /opt/spack_build_stage
+      - type: file
+        scope: defaults
+        content: |
+          modules:
+            default:
+              tcl:
+                hash_length: 0
+                all:
+                  conflict:
+                    - '{name}'
+                projections:
+                  all: '{name}/{version}-{compiler.name}-{compiler.version}'
       - type: file
         scope: site
         content: |
           packages:
             slurm:
               externals:
-                - spec: slurm@22-05-2
+                - spec: slurm@22-05-3
                   prefix: /usr/local
               buildable: False
-      log_file: /var/log/spack.log
-      compilers: []
-      packages: []
+      - type: file
+        scope: site
+        content: |
+          concretizer:
+            targets:
+              host_compatible: false
+      compilers:
+      - gcc@10.3.0 %gcc@4.8.5 target=x86_64
+      environments:
+      - name: openfoam
+        type: file
+        content: |
+          spack:
+            definitions:
+            - compilers:
+              - gcc@10.3.0
+            - mpis:
+              - openmpi@4.1.3+legacylaunchers+pmi fabrics=none schedulers=slurm
+            - packages:
+              - flex@2.6.4
+            - mpi_packages:
+              - openfoam-org@8 ^flex@2.6.4 target=zen3
+            specs:
+            - matrix:
+              - - $mpis
+              - - $%compilers
+            - matrix:
+              - - $packages
+              - - $%compilers
+            - matrix:
+              - - $mpi_packages
+              - - $%compilers
+              - - $^mpis
+            concretizer:
+              unify: when_possible
 
   - id: spack-startup
     source: modules/scripts/startup-script
@@ -70,8 +121,13 @@ deployment_groups:
       - $(spack.install_spack_deps_runner)
       - $(spack.install_spack_runner)
       - type: shell
-        content: "shutdown -h +1"
         destination: shutdown.sh
+        content: |
+          #!/bin/bash
+          if [ ! -f /etc/block_auto_shutdown ]; then
+                  touch /etc/block_auto_shutdown
+                  shutdown -h +1
+          fi
 
   - id: slurm_startup
     source: modules/scripts/startup-script
@@ -91,13 +147,19 @@ deployment_groups:
           spack compiler find --scope site
           spack -d install -v openmpi@4.1.3 %aocc@3.2.0 +legacylaunchers +pmi schedulers=slurm
 
-  # must restart vm to re-initiate subsequent installs
   - id: spack_builder
     source: modules/compute/vm-instance
     use: [network1, swfs, spack-startup]
     settings:
       name_prefix: spack-builder
       machine_type: c2d-standard-16
+      disable_public_ips: true
+      instance_image:
+        # these images must match the images used by Slurm modules below because
+        # we are building OpenMPI with PMI support in libaries contained in
+        # Slurm installation
+        family: schedmd-v5-slurm-22-05-3-hpc-centos-7
+        project: schedmd-slurm-public
 
   - id: low_cost_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition

--- a/community/examples/AMD/hpc-cluster-amd-slurmv5.yaml
+++ b/community/examples/AMD/hpc-cluster-amd-slurmv5.yaml
@@ -80,6 +80,8 @@ deployment_groups:
             targets:
               host_compatible: false
       compilers:
+      # gcc 12.1.0 is known to have runtime failures with OpenFOAM 8
+      # gcc 10.3.0 is the earliest copy of gcc with Zen 3 support
       - gcc@10.3.0 %gcc@4.8.5 target=x86_64
       environments:
       - name: openfoam
@@ -146,6 +148,20 @@ deployment_groups:
           spack load aocc@3.2.0
           spack compiler find --scope site
           spack -d install -v openmpi@4.1.3 %aocc@3.2.0 +legacylaunchers +pmi schedulers=slurm
+      - type: data
+        destination: /var/tmp/openfoam_test.sh
+        content: |
+          #!/bin/bash
+          # the following line works around a problem activating environments
+          # before directory is accessed
+          ls -lha /sw/spack/var/spack/environments/openfoam/ &>/dev/null
+          spack env activate openfoam
+          DIR=$HOME/openfoam_test
+          mkdir -p $DIR
+          cd $DIR
+          cp -fr $WM_PROJECT_DIR/tutorials/incompressible/simpleFoam/motorBike .
+          cd motorBike
+          ./Allrun
 
   - id: spack_builder
     source: modules/compute/vm-instance
@@ -202,4 +218,5 @@ deployment_groups:
     - slurm_controller
     - slurm_startup
     settings:
-      machine_type: c2d-standard-4
+      # need at least 8 physical cores to run OpenFOAM test
+      machine_type: c2d-standard-16


### PR DESCRIPTION
This PR updates the AMD-optimized blueprint to install an OpenFOAM application that has been compiled with gcc targeting the Zen 3 platform (C2D instances). It also includes and documents a simple mechanism by which to run a test suite.

AMD (and I) have observed runtime failures (`"error in IOstream"`) of the simpleFoam test when compiling OpenFOAM 8 with gcc 12.1. gcc 10.3 is the earliest release with support for AMD Zen 3 instructions.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?