### PR TITLE
Filestore cleanup fails on existing instances

### DIFF
--- a/tools/clean-filestore-limit.sh
+++ b/tools/clean-filestore-limit.sh
@@ -57,6 +57,9 @@ elif [[ -n "$ACTIVE_BUILDS" ]]; then
 	echo "There are active Cloud Build jobs. Refusing to disable/enable Filestore to reset internal limit."
 elif [[ -n "$ACTIVE_FILESTORE" ]]; then
 	echo "There are active Filestore instances. These may require manual cleanup."
+	# Fail if there are active filestore instances. This triggers an alert to the
+	# team, ensuring leftover resources are cleaned up if needed.
+	exit 1
 fi
 
 exit 0

--- a/tools/cloud-build/README.md
+++ b/tools/cloud-build/README.md
@@ -1,0 +1,18 @@
+# Cloud Build Tools
+
+## Contents
+
+* `daily-tests`: The daily-tests directory contains cloud build configs and
+  support files for running the daily test suite
+* `dependency-checks`: Verifies the `ghpc` build in limited depedency
+  environments.
+* `ansible.cfg`: Ansible config used to set common ansible setting for running
+  the test suite.
+* `Dockerfile`: Defines the HPC Toolkit docker image used in testing.
+* `hpc-toolkit-builder.yaml`: Cloud build config for running regular builds of
+  the HPC Toolkit docker image.
+* `hpc-toolkit-pr-validation.yaml`: Cloud build config for the PR validition
+  tests. The PR validation run `make tests` and validates against all
+  pre-commits on all files.
+* `project-cleanup.yaml`: Cloud build config that performs a regular cleanup of
+  resources in the test project.


### PR DESCRIPTION
### Description
This PR ensures a failure will occur in the daily-project-cleanup.yaml cloud config that notifies the team when the test project has pre-existing filestore instances that have not been cleaned up. The trigger will not fail if there are active cloud builds, assuming that any active builds should be prioritized, are intentional and do not imply any invalid state.

A README was added to the cloud-build directory as well to document the purpose of the cloud-build tools in the repo.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
