### PR TITLE
release-candidate - Handle case that cloud-batch-job does not have startup script in metadata

### DIFF
--- a/community/modules/scheduler/cloud-batch-login-node/main.tf
+++ b/community/modules/scheduler/cloud-batch-login-node/main.tf
@@ -20,7 +20,7 @@ data "google_compute_instance_template" "batch_instance_template" {
 
 locals {
   instance_template_metadata = data.google_compute_instance_template.batch_instance_template.metadata
-  batch_startup_script       = local.instance_template_metadata["startup-script"]
+  batch_startup_script       = lookup(local.instance_template_metadata, "startup-script", "echo 'Batch job template had no startup script'")
   startup_metadata           = { startup-script = module.login_startup_script.startup_script }
 
   oslogin_api_values = {


### PR DESCRIPTION
`cloud-batch-login` tries to lookup the startup script from the `cloud-batch-job` but did not handle the case that there is none. 

Tested:
- Manuall tested with  blueprint below. Fails before change, succeeds after change.

```
deployment_groups:
- group: primary
  modules:
  - id: network1
    source: modules/network/pre-existing-vpc

  - id: batch-job
    source: community/modules/scheduler/cloud-batch-job
    # use: [network1, startup]
    use: [network1]
    settings:
      runnable: "echo 'hello world'"
      machine_type: n2-standard-2

  - id: batch-login
    source: community/modules/scheduler/cloud-batch-login-node
    use: [batch-job]
    outputs: [instructions]
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
