### PR TITLE
Remove Batch startup script workaround

### DIFF
--- a/community/modules/scheduler/cloud-batch-login-node/README.md
+++ b/community/modules/scheduler/cloud-batch-login-node/README.md
@@ -88,7 +88,7 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_login_startup_script"></a> [login\_startup\_script](#module\_login\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.0.0 |
+| <a name="module_login_startup_script"></a> [login\_startup\_script](#module\_login\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.6.0 |
 
 ## Resources
 

--- a/community/modules/scheduler/cloud-batch-login-node/main.tf
+++ b/community/modules/scheduler/cloud-batch-login-node/main.tf
@@ -33,7 +33,7 @@ locals {
 }
 
 module "login_startup_script" {
-  source          = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=v1.0.0"
+  source          = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=v1.6.0"
   labels          = var.labels
   project_id      = var.project_id
   deployment_name = var.deployment_name
@@ -41,12 +41,7 @@ module "login_startup_script" {
   runners = [
     {
       content     = local.batch_startup_script
-      destination = "/tmp/startup-scripts/batch_startup_script.sh"
-      type        = "data"
-    },
-    { # TODO: This workaround should be removed once startup-script supports Bash syntax
-      content     = "bash /tmp/startup-scripts/batch_startup_script.sh"
-      destination = "/tmp/startup-scripts/invoke_batch_startup_script.sh"
+      destination = "batch_startup_script.sh"
       type        = "shell"
     },
     {


### PR DESCRIPTION
Tested:
- manually tested with change against startup script version: 
  - 1.0.0: FAILED
  - 1.6.0: PASSED
- Integration tests will exercise but I don't think they are necessary for this PR as I tested manually. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
