### PR TITLE
Improve Batch output instructions and add README to login node

### DIFF
--- a/community/modules/scheduler/cloud-batch-job/README.md
+++ b/community/modules/scheduler/cloud-batch-job/README.md
@@ -172,9 +172,9 @@ limitations under the License.
 | Name | Description |
 |------|-------------|
 | <a name="output_gcloud_version"></a> [gcloud\_version](#output\_gcloud\_version) | The version of gcloud to be used. |
-| <a name="output_instance_template"></a> [instance\_template](#output\_instance\_template) | Instance template used by the Google Cloud Batch job. |
-| <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions for submitting Google Cloud Batch job. |
-| <a name="output_job_filename"></a> [job\_filename](#output\_job\_filename) | The filename of the generated Google Cloud Batch job template. |
-| <a name="output_job_id"></a> [job\_id](#output\_job\_id) | The Google Cloud Batch job id. |
-| <a name="output_job_template_contents"></a> [job\_template\_contents](#output\_job\_template\_contents) | The generated Google Cloud Batch job template. |
+| <a name="output_instance_template"></a> [instance\_template](#output\_instance\_template) | Instance template used by the Batch job. |
+| <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions for submitting the Batch job. |
+| <a name="output_job_filename"></a> [job\_filename](#output\_job\_filename) | The filename of the generated Batch job template. |
+| <a name="output_job_id"></a> [job\_id](#output\_job\_id) | The Batch job id. |
+| <a name="output_job_template_contents"></a> [job\_template\_contents](#output\_job\_template\_contents) | The generated Batch job template. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/cloud-batch-job/outputs.tf
+++ b/community/modules/scheduler/cloud-batch-job/outputs.tf
@@ -15,8 +15,8 @@
  */
 
 locals {
-  provided_instance_tpl_msg  = "An instance template was provided to be used by your Batch job"
-  generated_instance_tpl_msg = "An instance template was created for your Batch job"
+  provided_instance_tpl_msg  = "The Batch job template uses the existing VM instance template:"
+  generated_instance_tpl_msg = "The Batch job template uses a new VM instance template created matching the provided settings:"
 }
 
 output "instructions" {
@@ -26,9 +26,8 @@ output "instructions" {
   A Batch job template file has been created locally at:
     ${abspath(local.job_template_output_path)}
 
-  ${var.instance_template == null ? local.generated_instance_tpl_msg : local.provided_instance_tpl_msg} & referenced in the above file:
+  ${var.instance_template == null ? local.generated_instance_tpl_msg : local.provided_instance_tpl_msg}
     ${local.instance_template}
-
 
   Use the following commands to:
   Submit your job:

--- a/community/modules/scheduler/cloud-batch-job/outputs.tf
+++ b/community/modules/scheduler/cloud-batch-job/outputs.tf
@@ -14,11 +14,23 @@
  * limitations under the License.
  */
 
+locals {
+  provided_instance_tpl_msg  = "An instance template was provided to be used by your Batch job"
+  generated_instance_tpl_msg = "An instance template was created for your Batch job"
+}
+
 output "instructions" {
-  description = "Instructions for submitting Google Cloud Batch job."
+  description = "Instructions for submitting the Batch job."
   value       = <<-EOT
+
+  A Batch job template file has been created locally at:
+    ${abspath(local.job_template_output_path)}
+
+  ${var.instance_template == null ? local.generated_instance_tpl_msg : local.provided_instance_tpl_msg} & referenced in the above file:
+    ${local.instance_template}
+
+
   Use the following commands to:
-  
   Submit your job:
     gcloud ${var.gcloud_version} batch jobs submit ${local.job_id} --config=${abspath(local.job_template_output_path)} --location=${var.region} --project=${var.project_id}
   
@@ -28,28 +40,28 @@ output "instructions" {
   Delete job:
     gcloud ${var.gcloud_version} batch jobs delete ${local.job_id} --location=${var.region} --project=${var.project_id}
 
-  List all jobs in region:
+  List all jobs:
     gcloud ${var.gcloud_version} batch jobs list --project=${var.project_id}
   EOT
 }
 
 output "instance_template" {
-  description = "Instance template used by the Google Cloud Batch job."
+  description = "Instance template used by the Batch job."
   value       = local.instance_template
 }
 
 output "job_template_contents" {
-  description = "The generated Google Cloud Batch job template."
+  description = "The generated Batch job template."
   value       = local.job_template_contents
 }
 
 output "job_filename" {
-  description = "The filename of the generated Google Cloud Batch job template."
+  description = "The filename of the generated Batch job template."
   value       = local.job_filename
 }
 
 output "job_id" {
-  description = "The Google Cloud Batch job id."
+  description = "The Batch job id."
   value       = local.job_id
 }
 

--- a/community/modules/scheduler/cloud-batch-login-node/outputs.tf
+++ b/community/modules/scheduler/cloud-batch-login-node/outputs.tf
@@ -22,21 +22,15 @@ output "login_node_name" {
 output "instructions" {
   description = "Instructions for accessing the login node and submitting Google Cloud Batch jobs"
   value       = <<-EOT
-  Use the following commands to:
 
+  A Batch job template file will be placed on the Batch login node at:
+    ${local.job_template_destination}
+
+
+  Use the following commands to:
   SSH into the login node:
     gcloud compute ssh --zone ${google_compute_instance_from_template.batch_login.zone} ${google_compute_instance_from_template.batch_login.name}  --project ${google_compute_instance_from_template.batch_login.project}
   
-  Submit your job from login node:
-    gcloud ${var.gcloud_version} batch jobs submit ${var.job_id} --config=${var.batch_job_directory}/${var.job_filename} --location=${var.region} --project=${var.project_id}
-  
-  Check status:
-    gcloud ${var.gcloud_version} batch jobs describe ${var.job_id} --location=${var.region} --project=${var.project_id} | grep state:
-  
-  Delete job:
-    gcloud ${var.gcloud_version} batch jobs delete ${var.job_id} --location=${var.region} --project=${var.project_id}
-
-  List all jobs in region:
-    gcloud ${var.gcloud_version} batch jobs list --project=${var.project_id}
+  ${local.batch_command_instructions}
   EOT
 }

--- a/community/modules/scheduler/cloud-batch-login-node/outputs.tf
+++ b/community/modules/scheduler/cloud-batch-login-node/outputs.tf
@@ -26,7 +26,6 @@ output "instructions" {
   A Batch job template file will be placed on the Batch login node at:
     ${local.job_template_destination}
 
-
   Use the following commands to:
   SSH into the login node:
     gcloud compute ssh --zone ${google_compute_instance_from_template.batch_login.zone} ${google_compute_instance_from_template.batch_login.name}  --project ${google_compute_instance_from_template.batch_login.project}


### PR DESCRIPTION
This change:
- Adds more explicit instructions about created Batch job template and instance template
- Adds a README.md file to the folder generated on the login node
- Renames Google Cloud Batch to Batch in documentation

Example output:
```
instructions_batch-job = <<EOT

A Batch job template file has been created locally at:
  /***/hpc-toolkit/simple-batch/primary/cloud-batch-simple-batch.json

An instance template was created for your Batch job & referenced in the above file:
  https://www.googleapis.com/compute/v1/projects/***/global/instanceTemplates/simple-batch-instance-template-20221011005718936600000001


Use the following commands to:
Submit your job:
  gcloud alpha batch jobs submit simple-batch --config=/***/hpc-toolkit/simple-batch/primary/cloud-batch-simple-batch.json --location=us-central1 --project=***
  
Check status:
  gcloud alpha batch jobs describe simple-batch --location=us-central1 --project=*** | grep state:
  
Delete job:
  gcloud alpha batch jobs delete simple-batch --location=us-central1 --project=***

List all jobs:
  gcloud alpha batch jobs list --project=***

EOT
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
