### PR TITLE
Fix link to the hpc-cluster-localssd example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [spack-gromacs.yaml](#spack-gromacsyaml--)
   * [omnia-cluster.yaml](#omnia-clusteryaml--)
   * [hpc-cluster-small-sharedvpc.yaml](#hpc-cluster-small-sharedvpcyaml--)
-  * [hpc-cluster-localssd.yaml](#hpc-cluster-localssd--)
+  * [hpc-cluster-localssd.yaml](#hpc-cluster-localssdyaml--)
   * [htcondor-pool.yaml](#htcondor-poolyaml--)
   * [quantum-circuit-simulator.yaml](#quantum-circuit-simulatoryaml-)
 * [Blueprint Schema](#blueprint-schema)


### PR DESCRIPTION
The "yaml" characters were missing in the link, and are added back in this PR.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
