### PR TITLE
Refactor mount shell script to take args

### DIFF
--- a/modules/file-system/pre-existing-network-storage/scripts/mount.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SERVER_IP=$1
+REMOTE_MOUNT_WITH_SLASH=$2
+LOCAL_MOUNT=$3
+MOUNT_COMMAND=$4
+
+if ! findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" --target "${LOCAL_MOUNT}" &>/dev/null; then
+	echo "Mounting --source ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} --target ${LOCAL_MOUNT}"
+	mkdir -p "${LOCAL_MOUNT}"
+	${MOUNT_COMMAND}
+else
+	echo "Skipping mounting source: ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}, already mounted to target:${LOCAL_MOUNT}"
+fi

--- a/modules/file-system/pre-existing-network-storage/scripts/mount.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount.sh
@@ -16,12 +16,12 @@
 SERVER_IP=$1
 REMOTE_MOUNT_WITH_SLASH=$2
 LOCAL_MOUNT=$3
-MOUNT_COMMAND=$4
+FS_TYPE=$4
 
 if ! findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" --target "${LOCAL_MOUNT}" &>/dev/null; then
 	echo "Mounting --source ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} --target ${LOCAL_MOUNT}"
 	mkdir -p "${LOCAL_MOUNT}"
-	${MOUNT_COMMAND}
+	mount -t "${FS_TYPE}" "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" "${LOCAL_MOUNT}"
 else
 	echo "Skipping mounting source: ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}, already mounted to target:${LOCAL_MOUNT}"
 fi


### PR DESCRIPTION
This change:
- is a no-op
- refactors the pre-existing-network-storage mount command to be a shell script that takes args
- fixes complaints from shell linter

Rational: 
- The shell script is more portable than a templated string
- The shell script is now checked by pre-commit

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
