### PR TITLE
Mount script also makes entry in /etc/fstab

### DIFF
--- a/modules/file-system/pre-existing-network-storage/outputs.tf
+++ b/modules/file-system/pre-existing-network-storage/outputs.tf
@@ -57,7 +57,7 @@ output "mount_runner" {
   value = {
     "type"        = "shell"
     "destination" = "mount_filesystem${replace(var.local_mount, "/", "_")}.sh"
-    "args"        = "\"${var.server_ip}\" \"${local.remote_mount_with_slash}\" \"${var.local_mount}\" \"${var.fs_type}\""
+    "args"        = "\"${var.server_ip}\" \"${local.remote_mount_with_slash}\" \"${var.local_mount}\" \"${var.fs_type}\" \"${var.mount_options}\""
     "content" = (
       contains(local.mount_supported_fstype, var.fs_type) ?
       file("${path.module}/scripts/mount.sh") :

--- a/modules/file-system/pre-existing-network-storage/scripts/mount.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount.sh
@@ -30,3 +30,13 @@ if ! findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" --target "${LO
 else
 	echo "Skipping mounting source: ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}, already mounted to target:${LOCAL_MOUNT}"
 fi
+
+MOUNT_IDENTIFIER="${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}[[:space:]]${LOCAL_MOUNT}"
+if ! grep -q "${MOUNT_IDENTIFIER}" /etc/fstab; then
+	echo "Adding ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} -> ${LOCAL_MOUNT} to /etc/fstab"
+
+	[[ -z "${MOUNT_OPTIONS}" ]] && POPULATED_MOUNT_OPTIONS="defaults" || POPULATED_MOUNT_OPTIONS="${MOUNT_OPTIONS}"
+	echo "${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} ${LOCAL_MOUNT} ${FS_TYPE} ${POPULATED_MOUNT_OPTIONS} 0 0" >>/etc/fstab
+else
+	echo "Skipping editing /etc/fstab as entry already exists"
+fi

--- a/modules/file-system/pre-existing-network-storage/scripts/mount.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount.sh
@@ -17,11 +17,16 @@ SERVER_IP=$1
 REMOTE_MOUNT_WITH_SLASH=$2
 LOCAL_MOUNT=$3
 FS_TYPE=$4
+MOUNT_OPTIONS=$5
 
 if ! findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" --target "${LOCAL_MOUNT}" &>/dev/null; then
 	echo "Mounting --source ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} --target ${LOCAL_MOUNT}"
 	mkdir -p "${LOCAL_MOUNT}"
-	mount -t "${FS_TYPE}" "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" "${LOCAL_MOUNT}"
+	if [ -z "${MOUNT_OPTIONS}" ]; then
+		mount -t "${FS_TYPE}" "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" "${LOCAL_MOUNT}"
+	else
+		mount -t "${FS_TYPE}" -o "${MOUNT_OPTIONS}" "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" "${LOCAL_MOUNT}"
+	fi
 else
 	echo "Skipping mounting source: ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}, already mounted to target:${LOCAL_MOUNT}"
 fi


### PR DESCRIPTION
This change:
- Adds functionality for mount options to mount.sh script
- Adds entry for mount in /etc/fstab

Tested:
- manually tested mounting and fstab entry with and without options

Note: ATM this script is only used for mounting lustre with pre-existing-network-storage but the intent is to make it more broadly used in follow on PR.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
