### PR TITLE
Improve Ansible linting

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,15 @@
 skip_list:
 - yaml
+- jinja[invalid]
+
+exclude_paths:
+  - .cache/ # implicit unless exclude_paths is defined in config
+  - .github/
+  - cmd/
+  - docs/
+  - examples/
+  - community/examples/
+  - pkg/
 
 mock_roles:
 - googlecloudplatform.google_cloud_ops_agents

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,9 +57,14 @@ repos:
   - id: go-critic
     args: [-disable, "#experimental,sloppyTypeAssert"]
 - repo: https://github.com/ansible/ansible-lint.git
-  rev: v5.4.0
+  rev: v6.8.2
   hooks:
   - id: ansible-lint
+    always_run: false
+    exclude: '^(docs/|examples/|community/examples/)'
+    types: [yaml]
+    additional_dependencies:
+    - ansible==6.*
 - repo: https://github.com/adrienverge/yamllint.git
   rev: v1.28.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     name: terraform-readme
     entry: tools/autodoc/terraform_docs.sh
     language: script
-    types: ['terraform']
+    types: [terraform]
     exclude: \.terraform\/.*$
     pass_filenames: true
     require_serial: true

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -27,7 +27,7 @@
     ansible.builtin.file:
       name: /etc/condor/config.d/00-htcondor-9.0.config
       state: absent
-  - name: set HTCondor role
+  - name: Set HTCondor role
     ansible.builtin.copy:
       dest: /etc/condor/config.d/01-role
       mode: 0644
@@ -36,7 +36,7 @@
   - name: Configure VM to be HTCondor Central Manager
     when: htcondor_role == 'get_htcondor_central_manager'
     block:
-    - name: set HTCondor Central Manager
+    - name: Set HTCondor Central Manager
       ansible.builtin.copy:
         dest: /etc/condor/config.d/00-central-manager
         mode: 0644
@@ -52,7 +52,7 @@
         headers:
           Metadata-Flavor: "Google"
       register: cm
-    - name: set HTCondor Central Manager
+    - name: Set HTCondor Central Manager
       ansible.builtin.copy:
         dest: /etc/condor/config.d/00-central-manager
         mode: 0644
@@ -95,12 +95,12 @@
       condor_token_create -identity condor@$TRUST_DOMAIN > /etc/condor/tokens.d/condor@$TRUST_DOMAIN
     args:
       creates: /etc/condor/passwords.d/POOL
-  - name: start HTCondor
+  - name: Start HTCondor
     ansible.builtin.service:
       name: condor
       state: started
       enabled: true
-  - name: inform users
+  - name: Inform users
     changed_when: false
     ansible.builtin.shell: |
       set -e -o pipefail

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -13,23 +13,23 @@
 # limitations under the License.
 
 ---
-- name: ensure HTCondor is installed
+- name: Ensure HTCondor is installed
   hosts: all
   vars:
     block_metadata_server: true
     enable_docker: true
   become: true
   tasks:
-  - name: setup HTCondor yum repository
+  - name: Setup HTCondor yum repository
     ansible.builtin.yum:
       name:
       - epel-release
       - https://research.cs.wisc.edu/htcondor/repo/9.x/htcondor-release-current.el7.noarch.rpm
-  - name: install HTCondor
+  - name: Install HTCondor
     ansible.builtin.yum:
       name: condor
       state: present
-  - name: ensure token directory
+  - name: Ensure token directory
     ansible.builtin.file:
       path: /etc/condor/tokens.d
       mode: 0700

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -21,17 +21,17 @@
   tasks:
   ## Create SSH Keys
   - name: "Create .ssh folder"
-    file:
+    ansible.builtin.file:
       path: "/builder/home/.ssh"
       state: directory
       mode: 0700
   - name: Create SSH Key
-    openssh_keypair:
+    community.crypto.openssh_keypair:
       path: "/builder/home/.ssh/id_rsa"
 
   ## Create cluster
   - name: Create Deployment Directory
-    command: "{{ scripts_dir }}/create_deployment.sh"
+    ansible.builtin.command: "{{ scripts_dir }}/create_deployment.sh"
     environment:
       ALWAYS_RECOMPILE: "no"
       EXAMPLE_YAML: "{{ blueprint_yaml }}"
@@ -49,7 +49,7 @@
   - name: Create Infrastructure and test
     block:
     - name: Create Cluster with Terraform
-      command:
+      ansible.builtin.command:
         cmd: "{{ item }}"
         chdir: "{{ workspace }}/{{ deployment_name }}/primary"
       args:
@@ -67,7 +67,7 @@
       retries: 2
       delay: 60
       until: instances_list.rc == 0
-      command: >-
+      ansible.builtin.command: >-
         gcloud compute instances list
         --filter="labels.ghpc_deployment={{ deployment_name }}"
         --format='table(name,zone,id,status)'
@@ -77,21 +77,21 @@
     - name: Get remote IP
       changed_when: false
       register: remote_ip
-      command: >-
+      ansible.builtin.command: >-
         gcloud compute instances describe --zone={{ zone }} {{ remote_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
       changed_when: false
-      shell: >-
+      ansible.builtin.shell: >-
         dig TXT +short o-o.myaddr.l.google.com @ns1.google.com |
          awk -F'"' '{print $2}'
       register: build_ip
     - name: Create firewall rule
       register: fw_result
       changed_when: fw_result.rc == 0
-      command:
+      ansible.builtin.command:
         argv:
         - gcloud
         - compute
@@ -108,7 +108,7 @@
     - name: 'Add SSH Keys to OS-Login'
       register: key_result
       changed_when: key_result.rc == 0
-      command:
+      ansible.builtin.command:
         argv:
         - gcloud
         - compute
@@ -119,11 +119,11 @@
         - 2h
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
     - name: Add Remote node as host
-      add_host:
+      ansible.builtin.add_host:
         hostname: "{{ remote_ip.stdout }}"
         groups: [remote_host]
     - name: Wait for cluster
-      wait_for_connection:
+      ansible.builtin.wait_for_connection:
 
     ## Cleanup and fail gracefully
     rescue:
@@ -143,10 +143,10 @@
       ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
     block:
     - name: Pause for 2 minutes to allow cluster setup
-      pause:
+      ansible.builtin.pause:
         minutes: 2
     - name: Run Integration tests for HPC toolkit
-      include_tasks: "{{ test }}"
+      ansible.builtin.include_tasks: "{{ test }}"
       run_once: true
       vars:
         remote_node: "{{ remote_node }}"
@@ -164,7 +164,7 @@
       failed_when: false
       run_once: true
       delegate_to: localhost
-      command:
+      ansible.builtin.command:
         argv:
         - gcloud
         - compute
@@ -177,6 +177,6 @@
       delegate_to: localhost
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      command:
+      ansible.builtin.command:
         cmd: terraform destroy -auto-approve
         chdir: "{{ workspace }}/{{ deployment_name }}/primary"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/hello-world-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/hello-world-integration-test.yml
@@ -16,16 +16,16 @@
 # Run this locally with the following command:
 # ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/hello-world-integration-test.yml --extra-vars="@tools/cloud-build/daily-tests/tests/hello-world-vars.yml"
 ---
-- name: hello world integration tests
+- name: Hello world integration tests
   hosts: 127.0.0.1
   connection: local
 
   tasks:
   - name: Print Hello World
-    debug:
+    ansible.builtin.debug:
       msg: Hello world from the base integration test.
   - name: Run post_deploy_tests
-    include_tasks: "{{ test }}"
+    ansible.builtin.include_tasks: "{{ test }}"
     run_once: true
     vars:
       top_level_var: "{{ top_level_var }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -26,7 +26,7 @@
       state: directory
       mode: 0700
   - name: Create SSH Key
-    openssh_keypair:
+    community.crypto.openssh_keypair:
       path: "/builder/home/.ssh/id_rsa"
 
   ## Create cluster
@@ -157,7 +157,7 @@
         delay: 10
         timeout: 300
     - name: Run Integration tests for HPC toolkit
-      include_tasks: "{{ test }}"
+      ansible.builtin.include_tasks: "{{ test }}"
       run_once: true
       vars:
         access_point: "{{ access_point }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -21,7 +21,7 @@
   tasks:
   ## Create Deployment
   - name: Create Deployment Directory
-    command: "{{ scripts_dir }}/create_deployment.sh"
+    ansible.builtin.command: "{{ scripts_dir }}/create_deployment.sh"
     environment:
       ALWAYS_RECOMPILE: "no"
       EXAMPLE_YAML: "{{ blueprint_yaml }}"
@@ -39,7 +39,7 @@
   - name: Create Infrastructure and test
     block:
     - name: Create Network with Terraform
-      command:
+      ansible.builtin.command:
         cmd: "{{ item }}"
         chdir: "{{ workspace }}/{{ deployment_name }}/builder-env"
       args:
@@ -77,6 +77,6 @@
       delegate_to: localhost
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      command:
+      ansible.builtin.command:
         cmd: terraform destroy -auto-approve -no-color
         chdir: "{{ workspace }}/{{ deployment_name }}/builder-env"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -21,17 +21,17 @@
   tasks:
   ## Create SSH Keys
   - name: "Create .ssh folder"
-    file:
+    ansible.builtin.file:
       path: "/builder/home/.ssh"
       state: directory
       mode: 0700
   - name: Create SSH Key
-    openssh_keypair:
+    community.crypto.openssh_keypair:
       path: "/builder/home/.ssh/id_rsa"
 
   ## Create cluster
   - name: Create Deployment Directory
-    command: "{{ scripts_dir }}/create_deployment.sh"
+    ansible.builtin.command: "{{ scripts_dir }}/create_deployment.sh"
     environment:
       ALWAYS_RECOMPILE: "no"
       MAX_NODES: "{{ max_nodes }}"
@@ -50,7 +50,7 @@
   - name: Create Infrastructure and test
     block:
     - name: Create Cluster with Terraform
-      command:
+      ansible.builtin.command:
         cmd: "{{ item }}"
         chdir: "{{ workspace }}/{{ deployment_name }}/primary"
       args:
@@ -68,7 +68,7 @@
       retries: 2
       delay: 60
       until: instances_list.rc == 0
-      command: >-
+      ansible.builtin.command: >-
         gcloud compute instances list
         --filter="labels.ghpc_deployment={{ deployment_name }}"
         --format='table(name,zone,id,status)'
@@ -114,14 +114,14 @@
     ## Setup firewall for cloud build
     - name: Get Builder IP
       changed_when: false
-      shell: >-
+      ansible.builtin.shell: >-
         dig TXT +short o-o.myaddr.l.google.com @ns1.google.com |
          awk -F'"' '{print $2}'
       register: build_ip
     - name: Create firewall rule
       register: fw_created
       changed_when: fw_created.rc == 0
-      command:
+      ansible.builtin.command:
         argv:
         - gcloud
         - compute
@@ -138,7 +138,7 @@
     - name: 'Add SSH Keys to OS-Login'
       register: key_created
       changed_when: key_created.rc == 0
-      command:
+      ansible.builtin.command:
         argv:
         - gcloud
         - compute
@@ -149,7 +149,7 @@
         - 2h
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
     - name: Add Login node as host
-      add_host:
+      ansible.builtin.add_host:
         hostname: "{{ login_ip }}"
         groups: [remote_host]
 
@@ -183,7 +183,7 @@
         path: /var/run/munge/munge.socket.2
         timeout: 600
     - name: Run Integration tests for HPC toolkit
-      include_tasks: "{{ test }}"
+      ansible.builtin.include_tasks: "{{ test }}"
       run_once: true
       vars:
         login_node: "{{ login_node }}"
@@ -198,7 +198,7 @@
       changed_when: false
       failed_when: false
       delegate_to: "{{ hostvars['localhost']['controller_ip']['stdout'] }}"
-      command: cat /var/log/slurm/resume.log
+      ansible.builtin.command: cat /var/log/slurm/resume.log
       register: resume_output
     - name: Print Slurm resume.log
       ansible.builtin.debug:
@@ -207,7 +207,7 @@
       changed_when: false
       failed_when: false
       delegate_to: "{{ hostvars['localhost']['controller_ip']['stdout'] }}"
-      command: cat /var/log/slurm/suspend.log
+      ansible.builtin.command: cat /var/log/slurm/suspend.log
       register: suspend_output
     - name: Print Slurm suspend.log
       ansible.builtin.debug:
@@ -218,7 +218,7 @@
       failed_when: false  # keep cleaning up
       run_once: true
       delegate_to: localhost
-      command:
+      ansible.builtin.command:
         argv:
         - gcloud
         - compute
@@ -231,6 +231,6 @@
       delegate_to: localhost
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      command:
+      ansible.builtin.command:
         cmd: terraform destroy -auto-approve
         chdir: "{{ workspace }}/{{ deployment_name }}/primary"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
@@ -49,6 +49,6 @@
     cmd: terraform destroy -auto-approve
     chdir: "{{ workspace }}/{{ deployment_name }}/primary"
 - name: Fail Out
-  fail:
+  ansible.builtin.fail:
     msg: "Failed while setting up test infrastructure"
   when: true

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
@@ -26,6 +26,6 @@
     timeout: "{{ timeout_seconds }}"
   register: startup_status
 - name: Fail if startup script exited with a non-zero return code
-  fail:
+  ansible.builtin.fail:
     msg: There was a failure in the startup script
   when: startup_status['match_groups'][0] != "0"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-batch-submission.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-batch-submission.yml
@@ -36,7 +36,7 @@
     ansible.builtin.command: gcloud alpha batch jobs list --project={{ custom_vars.project }}
 
   always:
-  - name: delete job
+  - name: Delete job
     register: batch_deletion
     changed_when: batch_deletion.rc == 0
     ansible.builtin.command: gcloud alpha batch jobs delete {{ deployment_name }} --location=us-central1 --project={{ custom_vars.project }}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-hello-world.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-hello-world.yml
@@ -21,8 +21,8 @@
     - custom_vars.bar is defined
 
 - name: Print top_level_var
-  debug:
+  ansible.builtin.debug:
     msg: "{{ top_level_var }}"
 - name: Print item from custom_vars
-  debug:
+  ansible.builtin.debug:
     msg: "{{ custom_vars.bar }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-spack.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-spack.yml
@@ -20,10 +20,10 @@
     vm_name: "{{ login_node }}"
     timeout_seconds: 7200
 - name: Ensure spack is installed
-  command: spack --version
+  ansible.builtin.command: spack --version
   changed_when: False
 - name: Test gromacs is available on compute nodes
-  shell: |
+  ansible.builtin.shell: |
     spack load gromacs
     srun -N 1 gmx_mpi -version
     sleep 120


### PR DESCRIPTION
Most of the action in this PR is in ebb1daf3ffb5cdeee6fa106d59ffc79841970fb1. The theory here is that the ansible-lint pre-commit hook does not behave like typical hooks. This behavior is reasonable for a repo aimed at Ansible playbooks, but not our own.

The status quo:

- always trigger
- run ansible-lint on the entire directory structure and allow it to make smart decisions (e.g. differentiate between blueprint YAML and ansible YAML)

The change:

- trigger hook only when a commit includes YAML files
- BUT do not trigger on YAML files in blueprint directories
- configure ansible-lint so that it does not operate on files in blueprint directories (because it will run on the whole repo regardless of the trigger source)
- exclude jinja failures because we do not have default values / ansible directory structure for many of our templating variables

These changes combined with #435 enable better-targeted real world linting and also allow us to upgrade ansible-lint pre-commit hook itself. The linter now catches errors in our Ansible code and I have resolved approximately 40 failures along this PR branch.

You can test this by editing an Ansible code to use `command` instead of `ansible.builtin.command` under `tools` and it will properly report the FQCN violation. Meanwhile, editing a blueprint under `{community/}examples` doesn't trigger the hook at all.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?