### PR TITLE
Improve and document mount.sh

### DIFF
--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -24,6 +24,22 @@ This creates a pre-existing-network-storage module in terraform at the
 provided IP in `server_ip` of type nfs that will be mounted at `/home`. Note
 that the `server_ip` must be known before deployment.
 
+### Mounting
+
+For some `fs_type`, this module will provide `client_install_runner` and
+`mount_runner` outputs. These can be used to create a startup script to mount
+the network storage system.
+
+Supported `fs_type`:
+
+- lustre (DDN)
+
+[scripts/mount.sh](./scripts/mount.sh) is used as the contents of
+`mount_runner`. This script will update `/etc/fstab` and mount the
+network storage. Behavior is undefined if:
+
+- System already has an entry in `/etc/fstab` for `local_mount`.
+
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/file-system/pre-existing-network-storage/scripts/mount.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount.sh
@@ -19,18 +19,6 @@ LOCAL_MOUNT=$3
 FS_TYPE=$4
 MOUNT_OPTIONS=$5
 
-if ! findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" --target "${LOCAL_MOUNT}" &>/dev/null; then
-	echo "Mounting --source ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} --target ${LOCAL_MOUNT}"
-	mkdir -p "${LOCAL_MOUNT}"
-	if [ -z "${MOUNT_OPTIONS}" ]; then
-		mount -t "${FS_TYPE}" "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" "${LOCAL_MOUNT}"
-	else
-		mount -t "${FS_TYPE}" -o "${MOUNT_OPTIONS}" "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" "${LOCAL_MOUNT}"
-	fi
-else
-	echo "Skipping mounting source: ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}, already mounted to target:${LOCAL_MOUNT}"
-fi
-
 MOUNT_IDENTIFIER="${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}[[:space:]]${LOCAL_MOUNT}"
 if ! grep -q "${MOUNT_IDENTIFIER}" /etc/fstab; then
 	echo "Adding ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} -> ${LOCAL_MOUNT} to /etc/fstab"
@@ -39,4 +27,12 @@ if ! grep -q "${MOUNT_IDENTIFIER}" /etc/fstab; then
 	echo "${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} ${LOCAL_MOUNT} ${FS_TYPE} ${POPULATED_MOUNT_OPTIONS} 0 0" >>/etc/fstab
 else
 	echo "Skipping editing /etc/fstab as entry already exists"
+fi
+
+if ! findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" --target "${LOCAL_MOUNT}" &>/dev/null; then
+	echo "Mounting --target ${LOCAL_MOUNT} from fstab"
+	mkdir -p "${LOCAL_MOUNT}"
+	mount --target "${LOCAL_MOUNT}"
+else
+	echo "Skipping mounting source: ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}, already mounted to target:${LOCAL_MOUNT}"
 fi

--- a/modules/file-system/pre-existing-network-storage/templates/ddn_exascaler_luster_client_install.tftpl
+++ b/modules/file-system/pre-existing-network-storage/templates/ddn_exascaler_luster_client_install.tftpl
@@ -46,3 +46,5 @@ do
 done
 chmod +x /usr/sbin/esc-client
 esc-client auto setup --config /etc/esc-client.conf
+esc-client unmount -m "${local_mount}"
+mv /etc/fstab.last /etc/fstab


### PR DESCRIPTION
This change:
- makes edit in fstab first then mounts from fstab
- documents undefined behavior when local mount already exists
- undoes mounting and fstab entry automatically added by DDN client auto installation (more discussion below)

The DDN lustre client installer does a host of things, including making an entry in fstab and mounting the lustre. The issue here is that:
- the installer is slow, even when called a second time
- there is no way to set mount options for these steps

For these reasons we really want install and mount to be separate. The two lines added to undo the fstab entry and mounting done by the auto installer while leaving the client in place.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
