### PR TITLE
Improve mounting for filestore and pre-existing-network-storage

### DIFF
--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -19,15 +19,21 @@ resource "random_id" "resource_name_suffix" {
 }
 
 locals {
-  timeouts = var.filestore_tier == "HIGH_SCALE_SSD" ? [1] : []
+  timeouts      = var.filestore_tier == "HIGH_SCALE_SSD" ? [1] : []
+  server_ip     = google_filestore_instance.filestore_instance.networks[0].ip_addresses[0]
+  remote_mount  = format("/%s", google_filestore_instance.filestore_instance.file_shares[0].name)
+  fs_type       = "nfs"
+  mount_options = "defaults,_netdev"
+
   install_nfs_client_runner = {
     "type"        = "shell"
     "source"      = "${path.module}/scripts/install-nfs-client.sh"
     "destination" = "install-nfs.sh"
   }
   mount_runner = {
-    "type"        = "ansible-local"
-    "source"      = "${path.module}/scripts/mount.yaml"
+    "type"        = "shell"
+    "source"      = "${path.module}/scripts/mount.sh"
+    "args"        = "\"${local.server_ip}\" \"${local.remote_mount}\" \"${var.local_mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
     "destination" = "mount.yaml"
   }
 }

--- a/modules/file-system/filestore/outputs.tf
+++ b/modules/file-system/filestore/outputs.tf
@@ -17,11 +17,11 @@
 output "network_storage" {
   description = "Describes a filestore instance."
   value = {
-    server_ip             = google_filestore_instance.filestore_instance.networks[0].ip_addresses[0]
-    remote_mount          = format("/%s", google_filestore_instance.filestore_instance.file_shares[0].name)
+    server_ip             = local.server_ip
+    remote_mount          = local.remote_mount
     local_mount           = var.local_mount
-    fs_type               = "nfs"
-    mount_options         = "defaults,_netdev"
+    fs_type               = local.fs_type
+    mount_options         = local.mount_options
     client_install_runner = local.install_nfs_client_runner
     mount_runner          = local.mount_runner
   }

--- a/modules/file-system/filestore/scripts/mount.sh
+++ b/modules/file-system/filestore/scripts/mount.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+SERVER_IP=$1
+REMOTE_MOUNT_WITH_SLASH=$2
+LOCAL_MOUNT=$3
+FS_TYPE=$4
+MOUNT_OPTIONS=$5
+[[ -z "${MOUNT_OPTIONS}" ]] && POPULATED_MOUNT_OPTIONS="defaults" || POPULATED_MOUNT_OPTIONS="${MOUNT_OPTIONS}"
+
+SAME_LOCAL_IDENTIFIER="^[^#].*[[:space:]]${LOCAL_MOUNT}"
+EXACT_MATCH_IDENTIFIER="${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}[[:space:]]${LOCAL_MOUNT}[[:space:]]${FS_TYPE}[[:space:]]${POPULATED_MOUNT_OPTIONS}[[:space:]]0[[:space:]]0"
+
+grep -q "${SAME_LOCAL_IDENTIFIER}" /etc/fstab && SAME_LOCAL_IN_FSTAB=true || SAME_LOCAL_IN_FSTAB=false
+grep -q "${EXACT_MATCH_IDENTIFIER}" /etc/fstab && EXACT_IN_FSTAB=true || EXACT_IN_FSTAB=false
+findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" --target "${LOCAL_MOUNT}" &>/dev/null && EXACT_MOUNTED=true || EXACT_MOUNTED=false
+
+# Do nothing and success if exact entry is already in fstab and mounted
+if [ "$EXACT_IN_FSTAB" = true ] && [ "${EXACT_MOUNTED}" = true ]; then
+	echo "Skipping mounting source: ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}, already mounted to target:${LOCAL_MOUNT}"
+	exit 0
+fi
+
+# Fail if previous fstab entry is using same local mount
+if [ "$SAME_LOCAL_IN_FSTAB" = true ] && [ "${EXACT_IN_FSTAB}" = false ]; then
+	echo "Mounting failed as local mount: ${LOCAL_MOUNT} was already in use in fstab"
+	exit 1
+fi
+
+# Add to fstab if entry is not already there
+if [ "${EXACT_IN_FSTAB}" = false ]; then
+	echo "Adding ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} -> ${LOCAL_MOUNT} to /etc/fstab"
+	echo "${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} ${LOCAL_MOUNT} ${FS_TYPE} ${POPULATED_MOUNT_OPTIONS} 0 0" >>/etc/fstab
+fi
+
+# Mount from fstab
+echo "Mounting --target ${LOCAL_MOUNT} from fstab"
+mkdir -p "${LOCAL_MOUNT}"
+mount --target "${LOCAL_MOUNT}"

--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -32,6 +32,7 @@ mount the network storage system.
 
 Supported `fs_type`:
 
+- nfs
 - lustre (DDN)
 
 [scripts/mount.sh](./scripts/mount.sh) is used as the contents of

--- a/modules/file-system/pre-existing-network-storage/outputs.tf
+++ b/modules/file-system/pre-existing-network-storage/outputs.tf
@@ -38,9 +38,11 @@ locals {
       local_mount  = var.local_mount
     }
   )
+  nfs_client_install_script = file("${path.module}/scripts/install-nfs-client.sh")
 
   install_scripts = {
     "lustre" = local.ddn_lustre_client_install_script
+    "nfs"    = local.nfs_client_install_script
   }
   client_install_runner = {
     "type"        = "shell"
@@ -48,7 +50,7 @@ locals {
     "destination" = "install_filesystem_client${replace(var.local_mount, "/", "_")}.sh"
   }
 
-  mount_supported_fstype = ["lustre"]
+  mount_supported_fstype = ["lustre", "nfs"]
   mount_runner = {
     "type"        = "shell"
     "destination" = "mount_filesystem${replace(var.local_mount, "/", "_")}.sh"

--- a/modules/file-system/pre-existing-network-storage/scripts/install-nfs-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-nfs-client.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ ! "$(which mount.nfs)" ]; then
+	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] ||
+		[ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
+		major_version=$(rpm -E "%{rhel}")
+		enable_repo=""
+		if [ "${major_version}" -eq "7" ]; then
+			enable_repo="base,epel"
+		elif [ "${major_version}" -eq "8" ]; then
+			enable_repo="baseos"
+		else
+			echo "Unsupported version of centos/RHEL/Rocky"
+			return 1
+		fi
+		yum install --disablerepo="*" --enablerepo=${enable_repo} -y nfs-utils
+	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
+		apt-get -y update
+		apt-get -y install nfs-common
+	else
+		echo 'Unsuported distribution'
+		return 1
+	fi
+fi


### PR DESCRIPTION
This change:
- Updates filestore to use shell mount runner, which removes the requirement to have Ansible installed saving time on startup.
- Updates pre-existing-network-storage to provide runners for fs_type nfs
- Adds pre-commit check that will keep duplicate files in sync

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
