### PR TITLE
Default to the compute engine service account if null is provided

### DIFF
--- a/community/examples/slurm-gcp-v5-hpc-centos7.yaml
+++ b/community/examples/slurm-gcp-v5-hpc-centos7.yaml
@@ -70,6 +70,7 @@ deployment_groups:
     - homefs
     settings:
       disable_controller_public_ips: false
+      enable_reconfigure: true
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-login

--- a/community/examples/slurm-gcp-v5-hpc-centos7.yaml
+++ b/community/examples/slurm-gcp-v5-hpc-centos7.yaml
@@ -70,7 +70,6 @@ deployment_groups:
     - homefs
     settings:
       disable_controller_public_ips: false
-      enable_reconfigure: true
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-login

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
@@ -61,10 +61,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 
@@ -74,7 +77,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 
 ## Inputs
 
@@ -110,7 +115,7 @@ No resources.
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Should use preemptibles to burst. | `string` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The default region for Cloud resources. | `string` | n/a | yes |
-| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instances. See<br>'main.tf:local.service\_account' for the default. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": "default",<br>  "scopes": [<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the compute instances. If not set, the<br>default compute service account for the given project will be used with the<br>"https://www.googleapis.com/auth/cloud-platform" scope. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
 | <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>* enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>* enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>* enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
 | <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Cluster name, used for resource naming and slurm accounting. If not provided it will default to the first 8 characters of the deployment name (removing any invalid characters). | `string` | `null` | no |
 | <a name="input_source_image"></a> [source\_image](#input\_source\_image) | Source disk image. By default, the image used will be the hpc-centos7<br>version of the slurm-gcp public images. More information can be found in the<br>slurm-gcp docs:<br>https://github.com/SchedMD/slurm-gcp/blob/v5.0.2/docs/images.md#public-image | `string` | `null` | no |

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
@@ -28,25 +28,28 @@ locals {
       node_conf              = var.node_conf
 
       # Template By Definition
-      additional_disks         = var.additional_disks
-      bandwidth_tier           = var.bandwidth_tier
-      can_ip_forward           = var.can_ip_forward
-      disable_smt              = var.disable_smt
-      disk_auto_delete         = var.disk_auto_delete
-      disk_labels              = var.labels
-      disk_size_gb             = var.disk_size_gb
-      disk_type                = var.disk_type
-      enable_confidential_vm   = var.enable_confidential_vm
-      enable_oslogin           = var.enable_oslogin
-      enable_shielded_vm       = var.enable_shielded_vm
-      gpu                      = var.gpu
-      labels                   = var.labels
-      machine_type             = var.machine_type
-      metadata                 = var.metadata
-      min_cpu_platform         = var.min_cpu_platform
-      on_host_maintenance      = var.on_host_maintenance
-      preemptible              = var.preemptible
-      service_account          = var.service_account
+      additional_disks       = var.additional_disks
+      bandwidth_tier         = var.bandwidth_tier
+      can_ip_forward         = var.can_ip_forward
+      disable_smt            = var.disable_smt
+      disk_auto_delete       = var.disk_auto_delete
+      disk_labels            = var.labels
+      disk_size_gb           = var.disk_size_gb
+      disk_type              = var.disk_type
+      enable_confidential_vm = var.enable_confidential_vm
+      enable_oslogin         = var.enable_oslogin
+      enable_shielded_vm     = var.enable_shielded_vm
+      gpu                    = var.gpu
+      labels                 = var.labels
+      machine_type           = var.machine_type
+      metadata               = var.metadata
+      min_cpu_platform       = var.min_cpu_platform
+      on_host_maintenance    = var.on_host_maintenance
+      preemptible            = var.preemptible
+      service_account = var.service_account != null ? var.service_account : {
+        email  = data.google_compute_default_service_account.default.email
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+      }
       shielded_instance_config = var.shielded_instance_config
       source_image_family      = var.source_image_family == null ? "" : var.source_image_family
       source_image_project     = var.source_image_project == null ? "" : var.source_image_project
@@ -68,6 +71,9 @@ locals {
   slurm_cluster_name = var.slurm_cluster_name != null ? var.slurm_cluster_name : local.tmp_cluster_name
 }
 
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}
 
 module "slurm_partition" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition?ref=v5.1.0"

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
@@ -28,33 +28,33 @@ locals {
       node_conf              = var.node_conf
 
       # Template By Definition
-      additional_disks       = var.additional_disks
-      bandwidth_tier         = var.bandwidth_tier
-      can_ip_forward         = var.can_ip_forward
-      disable_smt            = var.disable_smt
-      disk_auto_delete       = var.disk_auto_delete
-      disk_labels            = var.labels
-      disk_size_gb           = var.disk_size_gb
-      disk_type              = var.disk_type
-      enable_confidential_vm = var.enable_confidential_vm
-      enable_oslogin         = var.enable_oslogin
-      enable_shielded_vm     = var.enable_shielded_vm
-      gpu                    = var.gpu
-      labels                 = var.labels
-      machine_type           = var.machine_type
-      metadata               = var.metadata
-      min_cpu_platform       = var.min_cpu_platform
-      on_host_maintenance    = var.on_host_maintenance
-      preemptible            = var.preemptible
-      service_account = var.service_account != null ? var.service_account : {
-        email  = data.google_compute_default_service_account.default.email
-        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-      }
+      additional_disks         = var.additional_disks
+      bandwidth_tier           = var.bandwidth_tier
+      can_ip_forward           = var.can_ip_forward
+      disable_smt              = var.disable_smt
+      disk_auto_delete         = var.disk_auto_delete
+      disk_labels              = var.labels
+      disk_size_gb             = var.disk_size_gb
+      disk_type                = var.disk_type
+      enable_confidential_vm   = var.enable_confidential_vm
+      enable_oslogin           = var.enable_oslogin
+      enable_shielded_vm       = var.enable_shielded_vm
+      gpu                      = var.gpu
+      labels                   = var.labels
+      machine_type             = var.machine_type
+      metadata                 = var.metadata
+      min_cpu_platform         = var.min_cpu_platform
+      on_host_maintenance      = var.on_host_maintenance
+      preemptible              = var.preemptible
       shielded_instance_config = var.shielded_instance_config
       source_image_family      = var.source_image_family == null ? "" : var.source_image_family
       source_image_project     = var.source_image_project == null ? "" : var.source_image_project
       source_image             = var.source_image == null ? "" : var.source_image
       tags                     = var.tags
+      service_account = var.service_account != null ? var.service_account : {
+        email  = data.google_compute_default_service_account.default.email
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+      }
 
       # Spot VM settings
       enable_spot_vm       = var.enable_spot_vm

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
@@ -292,15 +292,11 @@ variable "service_account" {
     scopes = set(string)
   })
   description = <<-EOD
-    Service account to attach to the instances. See
-    'main.tf:local.service_account' for the default.
+    Service account to attach to the compute instances. If not set, the
+    default compute service account for the given project will be used with the
+    "https://www.googleapis.com/auth/cloud-platform" scope.
     EOD
-  default = {
-    email = "default"
-    scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-    ]
-  }
+  default     = null
 }
 
 variable "shielded_instance_config" {

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
@@ -15,5 +15,14 @@
 */
 
 terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.6.0"
+  }
   required_version = ">= 0.13.0"
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
@@ -80,10 +80,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 
@@ -94,7 +97,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 
 ## Inputs
 
@@ -138,7 +143,7 @@ No resources.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
 | <a name="input_prolog_scripts"></a> [prolog\_scripts](#input\_prolog\_scripts) | List of scripts to be used for Prolog. Programs for the slurmd to execute<br>whenever it is asked to run a job step from a new job allocation.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the instances should be created. | `string` | `null` | no |
-| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instances. See<br>'main.tf:local.service\_account' for the default. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the controller instance. If not set, the<br>default compute service account for the given project will be used with the<br>"https://www.googleapis.com/auth/cloud-platform" scope. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
 | <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>  enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>  enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>  enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
 | <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Cluster name, used for resource naming and slurm accounting. If not provided it will default to the first 8 characters of the deployment name (removing any invalid characters). | `string` | `null` | no |
 | <a name="input_slurm_conf_tpl"></a> [slurm\_conf\_tpl](#input\_slurm\_conf\_tpl) | Slurm slurm.conf template file path. | `string` | `null` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
@@ -33,6 +33,10 @@ locals {
 
 }
 
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}
+
 module "slurm_controller_instance" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_instance?ref=v5.1.0"
 
@@ -69,28 +73,31 @@ module "slurm_controller_instance" {
 module "slurm_controller_template" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=v5.1.0"
 
-  additional_disks         = var.additional_disks
-  can_ip_forward           = var.can_ip_forward
-  slurm_cluster_name       = local.slurm_cluster_name
-  disable_smt              = var.disable_smt
-  disk_auto_delete         = var.disk_auto_delete
-  disk_labels              = var.labels
-  disk_size_gb             = var.disk_size_gb
-  disk_type                = var.disk_type
-  enable_confidential_vm   = var.enable_confidential_vm
-  enable_oslogin           = var.enable_oslogin
-  enable_shielded_vm       = var.enable_shielded_vm
-  gpu                      = var.gpu
-  labels                   = var.labels
-  machine_type             = var.machine_type
-  metadata                 = var.metadata
-  min_cpu_platform         = var.min_cpu_platform
-  network_ip               = var.network_ip != null ? var.network_ip : ""
-  on_host_maintenance      = var.on_host_maintenance
-  preemptible              = var.preemptible
-  project_id               = var.project_id
-  region                   = var.region
-  service_account          = var.service_account
+  additional_disks       = var.additional_disks
+  can_ip_forward         = var.can_ip_forward
+  slurm_cluster_name     = local.slurm_cluster_name
+  disable_smt            = var.disable_smt
+  disk_auto_delete       = var.disk_auto_delete
+  disk_labels            = var.labels
+  disk_size_gb           = var.disk_size_gb
+  disk_type              = var.disk_type
+  enable_confidential_vm = var.enable_confidential_vm
+  enable_oslogin         = var.enable_oslogin
+  enable_shielded_vm     = var.enable_shielded_vm
+  gpu                    = var.gpu
+  labels                 = var.labels
+  machine_type           = var.machine_type
+  metadata               = var.metadata
+  min_cpu_platform       = var.min_cpu_platform
+  network_ip             = var.network_ip != null ? var.network_ip : ""
+  on_host_maintenance    = var.on_host_maintenance
+  preemptible            = var.preemptible
+  project_id             = var.project_id
+  region                 = var.region
+  service_account = var.service_account != null ? var.service_account : {
+    email  = data.google_compute_default_service_account.default.email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
   shielded_instance_config = var.shielded_instance_config
   slurm_instance_role      = "controller"
   source_image_family      = var.source_image_family

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
@@ -73,31 +73,27 @@ module "slurm_controller_instance" {
 module "slurm_controller_template" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=v5.1.0"
 
-  additional_disks       = var.additional_disks
-  can_ip_forward         = var.can_ip_forward
-  slurm_cluster_name     = local.slurm_cluster_name
-  disable_smt            = var.disable_smt
-  disk_auto_delete       = var.disk_auto_delete
-  disk_labels            = var.labels
-  disk_size_gb           = var.disk_size_gb
-  disk_type              = var.disk_type
-  enable_confidential_vm = var.enable_confidential_vm
-  enable_oslogin         = var.enable_oslogin
-  enable_shielded_vm     = var.enable_shielded_vm
-  gpu                    = var.gpu
-  labels                 = var.labels
-  machine_type           = var.machine_type
-  metadata               = var.metadata
-  min_cpu_platform       = var.min_cpu_platform
-  network_ip             = var.network_ip != null ? var.network_ip : ""
-  on_host_maintenance    = var.on_host_maintenance
-  preemptible            = var.preemptible
-  project_id             = var.project_id
-  region                 = var.region
-  service_account = var.service_account != null ? var.service_account : {
-    email  = data.google_compute_default_service_account.default.email
-    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-  }
+  additional_disks         = var.additional_disks
+  can_ip_forward           = var.can_ip_forward
+  slurm_cluster_name       = local.slurm_cluster_name
+  disable_smt              = var.disable_smt
+  disk_auto_delete         = var.disk_auto_delete
+  disk_labels              = var.labels
+  disk_size_gb             = var.disk_size_gb
+  disk_type                = var.disk_type
+  enable_confidential_vm   = var.enable_confidential_vm
+  enable_oslogin           = var.enable_oslogin
+  enable_shielded_vm       = var.enable_shielded_vm
+  gpu                      = var.gpu
+  labels                   = var.labels
+  machine_type             = var.machine_type
+  metadata                 = var.metadata
+  min_cpu_platform         = var.min_cpu_platform
+  network_ip               = var.network_ip != null ? var.network_ip : ""
+  on_host_maintenance      = var.on_host_maintenance
+  preemptible              = var.preemptible
+  project_id               = var.project_id
+  region                   = var.region
   shielded_instance_config = var.shielded_instance_config
   slurm_instance_role      = "controller"
   source_image_family      = var.source_image_family
@@ -107,4 +103,8 @@ module "slurm_controller_template" {
   subnetwork_project       = var.subnetwork_project == null ? "" : var.subnetwork_project
   subnetwork               = var.subnetwork_self_link == null ? "" : var.subnetwork_self_link
   tags                     = concat([local.slurm_cluster_name], var.tags)
+  service_account = var.service_account != null ? var.service_account : {
+    email  = data.google_compute_default_service_account.default.email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
@@ -392,10 +392,11 @@ variable "service_account" {
     email  = string
     scopes = set(string)
   })
-  description = <<EOD
-Service account to attach to the instances. See
-'main.tf:local.service_account' for the default.
-EOD
+  description = <<-EOD
+    Service account to attach to the controller instance. If not set, the
+    default compute service account for the given project will be used with the
+    "https://www.googleapis.com/auth/cloud-platform" scope.
+    EOD
   default     = null
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/versions.tf
@@ -15,5 +15,14 @@
 */
 
 terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-controller/v1.6.0"
+  }
   required_version = ">= 0.14.0"
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
@@ -62,10 +62,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 
@@ -76,7 +79,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 
 ## Inputs
 
@@ -107,7 +112,7 @@ No resources.
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Allow the instance to be preempted. | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Region where the instances should be created.<br>Note: region will be ignored if it can be extracted from subnetwork. | `string` | `null` | no |
-| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instances. See<br>'main.tf:local.service\_account' for the default. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the login instance. If not set, the<br>default compute service account for the given project will be used with the<br>"https://www.googleapis.com/auth/cloud-platform" scope. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
 | <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>* enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>* enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>* enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
 | <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Cluster name, used for resource naming and slurm accounting. If not provided it will default to the first 8 characters of the deployment name (removing any invalid characters). | `string` | `null` | no |
 | <a name="input_source_image"></a> [source\_image](#input\_source\_image) | Source disk image. By default, the image used will be the hpc-centos7<br>version of the slurm-gcp public images. More information can be found in the<br>slurm-gcp docs:<br>https://github.com/SchedMD/slurm-gcp/blob/v5.0.2/docs/images.md#public-image | `string` | `null` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
@@ -28,32 +28,39 @@ locals {
   access_config                  = length(var.access_config) == 0 ? local.enable_public_ip_access_config : var.access_config
 }
 
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}
+
 module "slurm_login_template" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=v5.1.0"
 
-  additional_disks         = var.additional_disks
-  bandwidth_tier           = "platform_default"
-  can_ip_forward           = var.can_ip_forward
-  slurm_cluster_name       = local.slurm_cluster_name
-  disable_smt              = var.disable_smt
-  disk_auto_delete         = var.disk_auto_delete
-  disk_labels              = var.labels
-  disk_size_gb             = var.disk_size_gb
-  disk_type                = var.disk_type
-  enable_confidential_vm   = var.enable_confidential_vm
-  enable_oslogin           = var.enable_oslogin
-  enable_shielded_vm       = var.enable_shielded_vm
-  gpu                      = var.gpu
-  labels                   = var.labels
-  machine_type             = var.machine_type
-  metadata                 = var.metadata
-  min_cpu_platform         = var.min_cpu_platform
-  network_ip               = var.network_ip != null ? var.network_ip : ""
-  on_host_maintenance      = var.on_host_maintenance
-  preemptible              = var.preemptible
-  project_id               = var.project_id
-  region                   = var.region
-  service_account          = var.service_account
+  additional_disks       = var.additional_disks
+  bandwidth_tier         = "platform_default"
+  can_ip_forward         = var.can_ip_forward
+  slurm_cluster_name     = local.slurm_cluster_name
+  disable_smt            = var.disable_smt
+  disk_auto_delete       = var.disk_auto_delete
+  disk_labels            = var.labels
+  disk_size_gb           = var.disk_size_gb
+  disk_type              = var.disk_type
+  enable_confidential_vm = var.enable_confidential_vm
+  enable_oslogin         = var.enable_oslogin
+  enable_shielded_vm     = var.enable_shielded_vm
+  gpu                    = var.gpu
+  labels                 = var.labels
+  machine_type           = var.machine_type
+  metadata               = var.metadata
+  min_cpu_platform       = var.min_cpu_platform
+  network_ip             = var.network_ip != null ? var.network_ip : ""
+  on_host_maintenance    = var.on_host_maintenance
+  preemptible            = var.preemptible
+  project_id             = var.project_id
+  region                 = var.region
+  service_account = var.service_account != null ? var.service_account : {
+    email  = data.google_compute_default_service_account.default.email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
   shielded_instance_config = var.shielded_instance_config
   slurm_instance_role      = "login"
   source_image_family      = var.source_image_family

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
@@ -35,32 +35,28 @@ data "google_compute_default_service_account" "default" {
 module "slurm_login_template" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=v5.1.0"
 
-  additional_disks       = var.additional_disks
-  bandwidth_tier         = "platform_default"
-  can_ip_forward         = var.can_ip_forward
-  slurm_cluster_name     = local.slurm_cluster_name
-  disable_smt            = var.disable_smt
-  disk_auto_delete       = var.disk_auto_delete
-  disk_labels            = var.labels
-  disk_size_gb           = var.disk_size_gb
-  disk_type              = var.disk_type
-  enable_confidential_vm = var.enable_confidential_vm
-  enable_oslogin         = var.enable_oslogin
-  enable_shielded_vm     = var.enable_shielded_vm
-  gpu                    = var.gpu
-  labels                 = var.labels
-  machine_type           = var.machine_type
-  metadata               = var.metadata
-  min_cpu_platform       = var.min_cpu_platform
-  network_ip             = var.network_ip != null ? var.network_ip : ""
-  on_host_maintenance    = var.on_host_maintenance
-  preemptible            = var.preemptible
-  project_id             = var.project_id
-  region                 = var.region
-  service_account = var.service_account != null ? var.service_account : {
-    email  = data.google_compute_default_service_account.default.email
-    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-  }
+  additional_disks         = var.additional_disks
+  bandwidth_tier           = "platform_default"
+  can_ip_forward           = var.can_ip_forward
+  slurm_cluster_name       = local.slurm_cluster_name
+  disable_smt              = var.disable_smt
+  disk_auto_delete         = var.disk_auto_delete
+  disk_labels              = var.labels
+  disk_size_gb             = var.disk_size_gb
+  disk_type                = var.disk_type
+  enable_confidential_vm   = var.enable_confidential_vm
+  enable_oslogin           = var.enable_oslogin
+  enable_shielded_vm       = var.enable_shielded_vm
+  gpu                      = var.gpu
+  labels                   = var.labels
+  machine_type             = var.machine_type
+  metadata                 = var.metadata
+  min_cpu_platform         = var.min_cpu_platform
+  network_ip               = var.network_ip != null ? var.network_ip : ""
+  on_host_maintenance      = var.on_host_maintenance
+  preemptible              = var.preemptible
+  project_id               = var.project_id
+  region                   = var.region
   shielded_instance_config = var.shielded_instance_config
   slurm_instance_role      = "login"
   source_image_family      = var.source_image_family
@@ -70,6 +66,10 @@ module "slurm_login_template" {
   subnetwork_project       = var.subnetwork_project == null ? "" : var.subnetwork_project
   subnetwork               = var.subnetwork_self_link == null ? "" : var.subnetwork_self_link
   tags                     = concat([local.slurm_cluster_name], var.tags)
+  service_account = var.service_account != null ? var.service_account : {
+    email  = data.google_compute_default_service_account.default.email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
 }
 
 module "slurm_login_instance" {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
@@ -170,8 +170,9 @@ variable "service_account" {
     scopes = set(string)
   })
   description = <<-EOD
-    Service account to attach to the instances. See
-    'main.tf:local.service_account' for the default.
+    Service account to attach to the login instance. If not set, the
+    default compute service account for the given project will be used with the
+    "https://www.googleapis.com/auth/cloud-platform" scope.
     EOD
   default     = null
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/versions.tf
@@ -15,5 +15,14 @@
  */
 
 terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-login/v1.6.0"
+  }
   required_version = ">= 0.14.0"
 }


### PR DESCRIPTION
### Description
Get and set the service account to the default compute engine service account if it was not provided. 

The enable_reconfigure setting of the controller currently requires an explicit service_account to be defined, as the default email set in the underlying modules is still just "default", which is not accepted when running the reconfig scripts. This is a temporary workaround until the underlying modules handle this situation in a similar way.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
