### PR TITLE
Merge v1.7.0 release into develop

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ HPC deployments on the Google Cloud Platform.`,
 				log.Fatalf("cmd.Help function failed: %s", err)
 			}
 		},
-		Version:     "v1.6.0",
+		Version:     "v1.7.0",
 		Annotations: annotation,
 	}
 )

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/versions.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-partition/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-partition/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -30,10 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.7.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.7.0"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/cloud-batch-login-node/versions.tf
+++ b/community/modules/scheduler/cloud-batch-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-batch-login-node/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-batch-login-node/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/htcondor-configure/versions.tf
+++ b/community/modules/scheduler/htcondor-configure/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-configure/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-configure/v1.7.0"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [starccm-tutorial.yaml](#starccm-tutorialyaml--)
 * [Blueprint Schema](#blueprint-schema)
 * [Writing an HPC Blueprint](#writing-an-hpc-blueprint)
+  * [Blueprint Boilerplate](#blueprint-boilerplate)
   * [Top Level Parameters](#top-level-parameters)
   * [Deployment Variables](#deployment-variables)
   * [Deployment Groups](#deployment-groups)
@@ -638,6 +639,28 @@ deployment_groups:
 The blueprint file is composed of 3 primary parts, top-level parameters,
 deployment variables and deployment groups. These are described in more detail
 below.
+
+### Blueprint Boilerplate
+
+The following is a template that can be used to start writing a blueprint from
+scratch.
+
+```yaml
+---
+blueprint_name: # boilerplate-blueprint
+
+vars:
+  project_id: # my-project-id
+  deployment_name: # boilerplate-001
+  region: us-central1
+  zone: us-central1-a
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: # network1
+    source: # modules/network/vpc
+```
 
 ### Top Level Parameters
 

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -27,10 +27,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.7.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.7.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.7.0"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.7.0"
   }
 
   required_version = ">= 0.14.0"


### PR DESCRIPTION
This PR merges the v1.7.0 release from main into the develop branch via the intermediary of a short-lived branch that was used to resolve merge conflicts likely introduced by backporting work into the 1.7.0 release.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?