### PR TITLE
Update nfs-server network_storage to use shell mount script

### DIFF
--- a/community/modules/file-system/nfs-server/outputs.tf
+++ b/community/modules/file-system/nfs-server/outputs.tf
@@ -16,14 +16,14 @@
 # render the content for each folder
 output "network_storage" {
   description = "export of all desired folder directories"
-  value = [for mount in var.local_mounts : {
+  value = [for mount, mount_runner in local.mount_runners : {
     remote_mount          = "/exports${mount}"
     local_mount           = mount
-    fs_type               = "nfs"
-    mount_options         = "defaults,hard,intr"
-    server_ip             = google_compute_instance.compute_instance.network_interface[0].network_ip
+    fs_type               = local.fs_type
+    mount_options         = local.mount_options
+    server_ip             = local.server_ip
     client_install_runner = local.install_nfs_client_runner
-    mount_runner          = local.mount_runner
+    mount_runner          = mount_runner
     }
   ]
 }
@@ -49,5 +49,5 @@ output "mount_runner" {
       - $(your-fs-id.mount_runner)
   ...
   EOT
-  value       = local.mount_runner
+  value       = local.ansible_mount_runner
 }

--- a/community/modules/file-system/nfs-server/scripts/mount.sh
+++ b/community/modules/file-system/nfs-server/scripts/mount.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+SERVER_IP=$1
+REMOTE_MOUNT_WITH_SLASH=$2
+LOCAL_MOUNT=$3
+FS_TYPE=$4
+MOUNT_OPTIONS=$5
+[[ -z "${MOUNT_OPTIONS}" ]] && POPULATED_MOUNT_OPTIONS="defaults" || POPULATED_MOUNT_OPTIONS="${MOUNT_OPTIONS}"
+
+SAME_LOCAL_IDENTIFIER="^[^#].*[[:space:]]${LOCAL_MOUNT}"
+EXACT_MATCH_IDENTIFIER="${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}[[:space:]]${LOCAL_MOUNT}[[:space:]]${FS_TYPE}[[:space:]]${POPULATED_MOUNT_OPTIONS}[[:space:]]0[[:space:]]0"
+
+grep -q "${SAME_LOCAL_IDENTIFIER}" /etc/fstab && SAME_LOCAL_IN_FSTAB=true || SAME_LOCAL_IN_FSTAB=false
+grep -q "${EXACT_MATCH_IDENTIFIER}" /etc/fstab && EXACT_IN_FSTAB=true || EXACT_IN_FSTAB=false
+findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT_WITH_SLASH}" --target "${LOCAL_MOUNT}" &>/dev/null && EXACT_MOUNTED=true || EXACT_MOUNTED=false
+
+# Do nothing and success if exact entry is already in fstab and mounted
+if [ "$EXACT_IN_FSTAB" = true ] && [ "${EXACT_MOUNTED}" = true ]; then
+	echo "Skipping mounting source: ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH}, already mounted to target:${LOCAL_MOUNT}"
+	exit 0
+fi
+
+# Fail if previous fstab entry is using same local mount
+if [ "$SAME_LOCAL_IN_FSTAB" = true ] && [ "${EXACT_IN_FSTAB}" = false ]; then
+	echo "Mounting failed as local mount: ${LOCAL_MOUNT} was already in use in fstab"
+	exit 1
+fi
+
+# Add to fstab if entry is not already there
+if [ "${EXACT_IN_FSTAB}" = false ]; then
+	echo "Adding ${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} -> ${LOCAL_MOUNT} to /etc/fstab"
+	echo "${SERVER_IP}:${REMOTE_MOUNT_WITH_SLASH} ${LOCAL_MOUNT} ${FS_TYPE} ${POPULATED_MOUNT_OPTIONS} 0 0" >>/etc/fstab
+fi
+
+# Mount from fstab
+echo "Mounting --target ${LOCAL_MOUNT} from fstab"
+mkdir -p "${LOCAL_MOUNT}"
+mount --target "${LOCAL_MOUNT}"

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -17,6 +17,7 @@ import sys
 
 duplicates = [
     [
+        "community/modules/file-system/nfs-server/scripts/mount.sh",
         "modules/file-system/filestore/scripts/mount.sh",
         "modules/file-system/pre-existing-network-storage/scripts/mount.sh",
     ],


### PR DESCRIPTION
This change swaps out the ansible runner for shell runners in the `nfs-server` `network_storage` variable. This removes the requirement for ansible to be installed when mounting with the `use` field. It also makes it possible to mount both a `nfs-server` alongside a DDN lustre network file system. 

Note: `nfs-server` differs from other file systems in that it takes multiple local mount points. A mount script is generated for each mount point. Since the `mount_runner` output only provides a single runner we must still use a runner that can mount to all locations. The simple fix here is to continue to use the ansible runner for this output. We may want to consider rewriting the mount script to take multiple local mount points.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
