### PR TITLE
Add node group module as a helper function for partitions

### DIFF
--- a/community/modules/README.md
+++ b/community/modules/README.md
@@ -6,8 +6,17 @@ module documentation](../../modules/README.md).
 ## Compute
 
 * [**SchedMD-slurm-on-gcp-partition**](compute/SchedMD-slurm-on-gcp-partition/README.md):
-  Creates a SLURM partition that can be used by the
+  Creates a Slurm partition that can be used by the
   SchedMD-slurm_on_gcp_controller.
+* [**schedmd-slurm-gcp-v5-partition**](compute/schedmd-slurm-gcp-v5-partition/README.md):
+  Creates a Slurm partition that can be used by the
+  [schedmd-slurm-gcp-v5-controller] module.
+* [**schedmd-slurm-gcp-v5-node-group**](compute/schedmd-slurm-gcp-v5-node-group/README.md):
+  Defines a node group that can be used as input to the
+  [schedmd-slurm-gcp-v5-partition] module.
+
+[schedmd-slurm-gcp-v5-controller]: scheduler/schedmd-slurm-gcp-v5-controller/README.md
+[schedmd-slurm-gcp-v5-partition]: compute/schedmd-slurm-gcp-v5-partition/README.md
 
 ## Database
 
@@ -51,15 +60,23 @@ module documentation](../../modules/README.md).
 ## Scheduler
 
 * [**SchedMD-slurm-on-gcp-controller**](scheduler/SchedMD-slurm-on-gcp-controller/README.md):
-  Creates a SLURM controller node using
+  Creates a Slurm controller node using
   [slurm-gcp](https://github.com/SchedMD/slurm-gcp/tree/master/tf/modules/controller)
 
 * [**SchedMD-slurm-on-gcp-login-node**](scheduler/SchedMD-slurm-on-gcp-login-node/README.md):
-  Creates a SLURM login node using
+  Creates a Slurm login node using
   [slurm-gcp](https://github.com/SchedMD/slurm-gcp/tree/master/tf/modules/login)
+
+* [**schedmd-slurm-gcp-v5-login**](scheduler/schedmd-slurm-gcp-v5-login/README.md):
+  Creates a Slurm login node using [slurm-gcp] version 5.
+
+* [**schedmd-slurm-gcp-v5-controller**](scheduler/schedmd-slurm-gcp-v5-controller/README.md):
+  Creates a Slurm controller using [slurm-gcp] version 5.
 
 * [**schedmd-slurm-gcp-v5-hybrid**](scheduler/schedmd-slurm-gcp-v5-hybrid/README.md):
   Creates configurations for hybrid partitions that can be used with an
   on-premise Slurm cluster. This module uses the
   [slurm-controller-hybrid](https://github.com/SchedMD/slurm-gcp/tree/v5.1.0/terraform/slurm_cluster/modules/slurm_controller_hybrid)
   from the slurm-gcp project.
+
+[slurm-gcp]: https://github.com/SchedMD/slurm-gcp/tree/v5.1.0

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
@@ -1,0 +1,175 @@
+## Description
+
+> **_WARNING:_** This module is in active development and is therefore not
+> guaranteed to work consistently. Expect the interface to change rapidly while
+> warning exists.
+
+This module creates a node group data structure intended to be input to the
+[schedmd-slurm-gcp-v5-partition](../schedmd-slurm-gcp-v5-partition/) module.
+
+### Example
+
+The following code snippet creates a partition module using the `node-group`
+module as input with:
+
+* a max node count of 200
+* VM machine type of `c2-standard-30`
+* partition name of "compute"
+* default group name of "ghpc"
+* connected to the `network1` module via `use`
+* nodes mounted to homefs via `use`
+
+```yaml
+- id: node_group
+  source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+  use:
+  - network1
+  - homefs
+  settings:
+    node_count_dynamic_max: 200
+    machine_type: c2-standard-30
+
+- id: compute_partition
+  source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+  use:
+  - node_group
+  settings:
+    partition_name: compute
+```
+
+### Compute VM Zone Policies
+
+> **_WARNING:_** Lenient zone policies can lead to additional egress costs when
+> moving data between Google Cloud resources in different zones in the same
+> region, such as between filestore and other VM instances. For more information
+> on egress fees, see the [Network Pricing][networkpricing] Google Cloud
+> documentation.
+>
+> To avoid egress charges, ensure your compute nodes are created in the same
+> zone as the other resources that share data with them by setting
+> `zone_policy_deny` to all other zones in the region.
+
+The node group module and the underlying modules provided by Slurm on GCP
+provide the option to set policies regarding
+which zone the compute VM instances will be created in through the
+`zone_policy_allow` and `zone_policy_deny` variables.
+
+As an example, see the the following module:
+
+```yaml
+- id: node-group-with-zone-policy
+  source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+  settings:
+    zone_policy_allow:
+    - us-central1-a
+    - us-central1-b
+    zone_policy_deny: [us-central1-f]
+```
+
+In this module, the following is defined:
+
+* `us-central1-a` and `us-central1-b` zones have been explicitly allowed.
+* `us-central1-f` has been explicitly denied, therefore no nodes in this
+  node group will be created in that zone.
+* Since `us-central1-c` was not included in the zone policy, it will default to
+  "Allow", which means the node group has the same likelihood of creating a node in
+  that zone as the zones explicitly listed under `zone_policy_allow`.
+
+> **_NOTE:_** `zone_policy_allow` does not guarantee the use of specified zones
+> because zones are allowed by default. Configure `zone_policy_deny` to ensure
+> that zones outside the allowed list are not used.
+
+[networkpricing]: https://cloud.google.com/vpc/network-pricing
+
+## Support
+The HPC Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
+modules. For support with the underlying modules, see the instructions in the
+[slurm-gcp README][slurm-gcp-readme].
+
+[slurm-on-gcp]: https://github.com/SchedMD/slurm-gcp
+[slurm-gcp-readme]: https://github.com/SchedMD/slurm-gcp#slurm-on-google-cloud-platform
+
+## License
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_disks"></a> [additional\_disks](#input\_additional\_disks) | Configurations of additional disks to be included on the partition nodes. | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    disk_size_gb = number<br>    disk_type    = string<br>    disk_labels  = map(string)<br>    auto_delete  = bool<br>    boot         = bool<br>  }))</pre> | `[]` | no |
+| <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Configures the network interface card and the maximum egress bandwidth for VMs.<br>  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.<br>  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.<br>  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).<br>  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.<br>  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.<br>  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details. | `string` | `"platform_default"` | no |
+| <a name="input_can_ip_forward"></a> [can\_ip\_forward](#input\_can\_ip\_forward) | Enable IP forwarding, for NAT instances for example. | `bool` | `false` | no |
+| <a name="input_disable_smt"></a> [disable\_smt](#input\_disable\_smt) | Disables Simultaneous Multi-Threading (SMT) on instance. | `bool` | `true` | no |
+| <a name="input_disk_auto_delete"></a> [disk\_auto\_delete](#input\_disk\_auto\_delete) | Whether or not the boot disk should be auto-deleted. | `bool` | `true` | no |
+| <a name="input_disk_labels"></a> [disk\_labels](#input\_disk\_labels) | Labels specific to the boot disk. These will be merged with var.labels. | `map(string)` | `{}` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of boot disk to create for the partition compute nodes. | `number` | `50` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard. | `string` | `"pd-standard"` | no |
+| <a name="input_enable_confidential_vm"></a> [enable\_confidential\_vm](#input\_enable\_confidential\_vm) | Enable the Confidential VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables Google Cloud os-login for user login and authentication for VMs.<br>See https://cloud.google.com/compute/docs/oslogin | `bool` | `true` | no |
+| <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_spot_vm"></a> [enable\_spot\_vm](#input\_enable\_spot\_vm) | Enable the partition to use spot VMs (https://cloud.google.com/spot-vms). | `bool` | `false` | no |
+| <a name="input_gpu"></a> [gpu](#input\_gpu) | Definition of requested GPU resources. | <pre>object({<br>    count = number,<br>    type  = string<br>  })</pre> | `null` | no |
+| <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Self link to a custom instance template, used in place of other VM instance definition variables. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to partition compute instances. List of key key, value pairs. | `any` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes. | `string` | `"c2-standard-60"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the node group. | `string` | `"ghpc"` | no |
+| <a name="input_node_conf"></a> [node\_conf](#input\_node\_conf) | Map of Slurm node line configuration. | `map(any)` | `{}` | no |
+| <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of nodes allowed in this partition. | `number` | `10` | no |
+| <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |
+| <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Instance availability Policy.<br><br>Note: Placement groups are not supported when on\_host\_maintenance is set to<br>"MIGRATE" and will be deactivated regardless of the value of<br>enable\_placement. To support enable\_placement, ensure on\_host\_maintenance is<br>set to "TERMINATE". | `string` | `"TERMINATE"` | no |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Should use preemptibles to burst. | `string` | `false` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the compute instances. If not set, the<br>default compute service account for the given project will be used with the<br>"https://www.googleapis.com/auth/cloud-platform" scope. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>* enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>* enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>* enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
+| <a name="input_source_image"></a> [source\_image](#input\_source\_image) | Source disk image. By default, the image used will be the hpc-centos7<br>version of the slurm-gcp public images. More information can be found in the<br>slurm-gcp docs:<br>https://github.com/SchedMD/slurm-gcp/blob/v5.1.0/docs/images.md#public-image | `string` | `null` | no |
+| <a name="input_source_image_family"></a> [source\_image\_family](#input\_source\_image\_family) | Source image family. If not provided, the default image family name for the<br>hpc-centos-7 version of the slurm-gcp public images will be used. More<br>information can be found in the slurm-gcp docs:<br>https://github.com/SchedMD/slurm-gcp/blob/v5.1.0/docs/images.md#public-image | `string` | `null` | no |
+| <a name="input_source_image_project"></a> [source\_image\_project](#input\_source\_image\_project) | Project path where the source image comes from. If not provided, this value<br>will default to the project hosting the slurm-gcp public images. More<br>information can be found in the slurm-gcp docs:<br>https://github.com/SchedMD/slurm-gcp/blob/v5.1.0/docs/images.md#public-image. | `string` | `null` | no |
+| <a name="input_spot_instance_config"></a> [spot\_instance\_config](#input\_spot\_instance\_config) | Configuration for spot VMs. | <pre>object({<br>    termination_action = string<br>  })</pre> | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
+| <a name="input_zone_policy_allow"></a> [zone\_policy\_allow](#input\_zone\_policy\_allow) | Partition nodes will prefer to be created in the listed zones. If a zone appears<br>in both zone\_policy\_allow and zone\_policy\_deny, then zone\_policy\_deny will take<br>priority for that zone. | `set(string)` | `[]` | no |
+| <a name="input_zone_policy_deny"></a> [zone\_policy\_deny](#input\_zone\_policy\_deny) | Partition nodes will not be created in the listed zones. If a zone appears in<br>both zone\_policy\_allow and zone\_policy\_deny, then zone\_policy\_deny will take<br>priority for that zone. | `set(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_partition_nodes"></a> [partition\_nodes](#output\_partition\_nodes) | Details of the node group. Typically used as input to `schedmd-slurm-gcp-v5-partition`. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
@@ -151,7 +151,7 @@ No modules.
 | <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the node group. | `string` | `"ghpc"` | no |
 | <a name="input_node_conf"></a> [node\_conf](#input\_node\_conf) | Map of Slurm node line configuration. | `map(any)` | `{}` | no |
-| <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of nodes allowed in this partition. | `number` | `10` | no |
+| <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of dynamic nodes allowed in this partition. | `number` | `10` | no |
 | <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Instance availability Policy.<br><br>Note: Placement groups are not supported when on\_host\_maintenance is set to<br>"MIGRATE" and will be deactivated regardless of the value of<br>enable\_placement. To support enable\_placement, ensure on\_host\_maintenance is<br>set to "TERMINATE". | `string` | `"TERMINATE"` | no |
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Should use preemptibles to burst. | `string` | `false` | no |

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
@@ -22,9 +22,6 @@ module as input with:
 ```yaml
 - id: node_group
   source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
-  use:
-  - network1
-  - homefs
   settings:
     node_count_dynamic_max: 200
     machine_type: c2-standard-30
@@ -32,6 +29,8 @@ module as input with:
 - id: compute_partition
   source: community/modules/compute/schedmd-slurm-gcp-v5-partition
   use:
+  - network1
+  - homefs
   - node_group
   settings:
     partition_name: compute
@@ -171,5 +170,5 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_partition_nodes"></a> [partition\_nodes](#output\_partition\_nodes) | Details of the node group. Typically used as input to `schedmd-slurm-gcp-v5-partition`. |
+| <a name="output_node_groups"></a> [node\_groups](#output\_node\_groups) | Details of the node group. Typically used as input to `schedmd-slurm-gcp-v5-partition`. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/main.tf
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+
+  node_group = {
+    # Group Definition
+    group_name             = var.name
+    node_count_dynamic_max = var.node_count_dynamic_max
+    node_count_static      = var.node_count_static
+    node_conf              = var.node_conf
+
+    # Template By Definition
+    additional_disks         = var.additional_disks
+    bandwidth_tier           = var.bandwidth_tier
+    can_ip_forward           = var.can_ip_forward
+    disable_smt              = var.disable_smt
+    disk_auto_delete         = var.disk_auto_delete
+    disk_labels              = merge(var.labels, var.disk_labels)
+    disk_size_gb             = var.disk_size_gb
+    disk_type                = var.disk_type
+    enable_confidential_vm   = var.enable_confidential_vm
+    enable_oslogin           = var.enable_oslogin
+    enable_shielded_vm       = var.enable_shielded_vm
+    gpu                      = var.gpu
+    labels                   = var.labels
+    machine_type             = var.machine_type
+    metadata                 = var.metadata
+    min_cpu_platform         = var.min_cpu_platform
+    on_host_maintenance      = var.on_host_maintenance
+    preemptible              = var.preemptible
+    shielded_instance_config = var.shielded_instance_config
+    source_image_family      = var.source_image_family == null ? "" : var.source_image_family
+    source_image_project     = var.source_image_project == null ? "" : var.source_image_project
+    source_image             = var.source_image == null ? "" : var.source_image
+    tags                     = var.tags
+    service_account = var.service_account != null ? var.service_account : {
+      email  = data.google_compute_default_service_account.default.email
+      scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+    }
+
+    # Spot VM settings
+    enable_spot_vm       = var.enable_spot_vm
+    spot_instance_config = var.spot_instance_config
+
+    # Template By Source
+    instance_template = var.instance_template
+  }
+}
+
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "partition_nodes" {
+  description = "Details of the node group. Typically used as input to `schedmd-slurm-gcp-v5-partition`."
+  value       = local.node_group
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/outputs.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-output "partition_nodes" {
+output "node_groups" {
   description = "Details of the node group. Typically used as input to `schedmd-slurm-gcp-v5-partition`."
   value       = local.node_group
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
@@ -42,7 +42,7 @@ variable "node_conf" {
 }
 
 variable "node_count_dynamic_max" {
-  description = "Maximum number of nodes allowed in this partition."
+  description = "Maximum number of dynamic nodes allowed in this partition."
   type        = number
   default     = 10
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
@@ -1,0 +1,334 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Most variables have been sourced and modified from the SchedMD/slurm-gcp
+# github repository: https://github.com/SchedMD/slurm-gcp/tree/v5.1.0
+
+variable "project_id" {
+  description = "Project in which the HPC deployment will be created."
+  type        = string
+}
+
+## Node Group Definition
+
+variable "name" {
+  description = "Name of the node group."
+  type        = string
+  default     = "ghpc"
+
+  validation {
+    condition     = can(regex("^[a-z](?:[a-z0-9]{0,5})$", var.name))
+    error_message = "Node group name (var.name) must begin with a letter, be fully alphanumeric and be 6 characters or less. Regexp: '^[a-z](?:[a-z0-9]{0,5})$'."
+  }
+}
+
+variable "node_conf" {
+  description = "Map of Slurm node line configuration."
+  type        = map(any)
+  default     = {}
+}
+
+variable "node_count_dynamic_max" {
+  description = "Maximum number of nodes allowed in this partition."
+  type        = number
+  default     = 10
+}
+
+variable "node_count_static" {
+  description = "Number of nodes to be statically created."
+  type        = number
+  default     = 0
+}
+
+## VM Definition
+
+variable "instance_template" {
+  description = "Self link to a custom instance template, used in place of other VM instance definition variables."
+  type        = string
+  default     = null
+}
+
+variable "machine_type" {
+  description = "Compute Platform machine type to use for this partition compute nodes."
+  type        = string
+  default     = "c2-standard-60"
+}
+
+variable "metadata" {
+  type        = map(string)
+  description = "Metadata, provided as a map."
+  default     = {}
+}
+
+variable "source_image_project" {
+  type        = string
+  description = <<-EOD
+    Project path where the source image comes from. If not provided, this value
+    will default to the project hosting the slurm-gcp public images. More
+    information can be found in the slurm-gcp docs:
+    https://github.com/SchedMD/slurm-gcp/blob/v5.1.0/docs/images.md#public-image.
+    EOD
+  default     = null
+}
+
+variable "source_image_family" {
+  type        = string
+  description = <<-EOD
+    Source image family. If not provided, the default image family name for the
+    hpc-centos-7 version of the slurm-gcp public images will be used. More
+    information can be found in the slurm-gcp docs:
+    https://github.com/SchedMD/slurm-gcp/blob/v5.1.0/docs/images.md#public-image
+    EOD
+  default     = null
+}
+
+variable "source_image" {
+  type        = string
+  description = <<-EOD
+    Source disk image. By default, the image used will be the hpc-centos7
+    version of the slurm-gcp public images. More information can be found in the
+    slurm-gcp docs:
+    https://github.com/SchedMD/slurm-gcp/blob/v5.1.0/docs/images.md#public-image
+    EOD
+  default     = null
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "Network tag list."
+  default     = []
+}
+
+variable "disk_type" {
+  description = "Boot disk type, can be either pd-ssd, local-ssd, or pd-standard."
+  type        = string
+  default     = "pd-standard"
+
+  validation {
+    condition     = contains(["pd-ssd", "local-ssd", "pd-standard"], var.disk_type)
+    error_message = "Variable disk_type must be one of pd-ssd, local-ssd, or pd-standard."
+  }
+}
+
+variable "disk_size_gb" {
+  description = "Size of boot disk to create for the partition compute nodes."
+  type        = number
+  default     = 50
+}
+
+variable "disk_auto_delete" {
+  type        = bool
+  description = "Whether or not the boot disk should be auto-deleted."
+  default     = true
+}
+
+variable "disk_labels" {
+  description = "Labels specific to the boot disk. These will be merged with var.labels."
+  type        = map(string)
+  default     = {}
+}
+
+variable "additional_disks" {
+  description = "Configurations of additional disks to be included on the partition nodes."
+  type = list(object({
+    disk_name    = string
+    device_name  = string
+    disk_size_gb = number
+    disk_type    = string
+    disk_labels  = map(string)
+    auto_delete  = bool
+    boot         = bool
+  }))
+  default = []
+}
+
+variable "enable_confidential_vm" {
+  type        = bool
+  description = "Enable the Confidential VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_shielded_vm" {
+  type        = bool
+  description = "Enable the Shielded VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_oslogin" {
+  type        = bool
+  description = <<-EOD
+    Enables Google Cloud os-login for user login and authentication for VMs.
+    See https://cloud.google.com/compute/docs/oslogin
+    EOD
+  default     = true
+}
+
+variable "can_ip_forward" {
+  description = "Enable IP forwarding, for NAT instances for example."
+  type        = bool
+  default     = false
+}
+
+variable "disable_smt" {
+  type        = bool
+  description = "Disables Simultaneous Multi-Threading (SMT) on instance."
+  default     = true
+}
+
+variable "labels" {
+  description = "Labels to add to partition compute instances. List of key key, value pairs."
+  type        = any
+  default     = {}
+}
+
+variable "min_cpu_platform" {
+  description = "The name of the minimum CPU platform that you want the instance to use."
+  type        = string
+  default     = null
+}
+
+variable "on_host_maintenance" {
+  type        = string
+  description = <<-EOD
+    Instance availability Policy.
+
+    Note: Placement groups are not supported when on_host_maintenance is set to
+    "MIGRATE" and will be deactivated regardless of the value of
+    enable_placement. To support enable_placement, ensure on_host_maintenance is
+    set to "TERMINATE".
+    EOD
+  default     = "TERMINATE"
+}
+
+variable "gpu" {
+  description = "Definition of requested GPU resources."
+  type = object({
+    count = number,
+    type  = string
+  })
+  default = null
+}
+
+variable "preemptible" {
+  description = "Should use preemptibles to burst."
+  type        = string
+  default     = false
+}
+
+variable "service_account" {
+  type = object({
+    email  = string
+    scopes = set(string)
+  })
+  description = <<-EOD
+    Service account to attach to the compute instances. If not set, the
+    default compute service account for the given project will be used with the
+    "https://www.googleapis.com/auth/cloud-platform" scope.
+    EOD
+  default     = null
+}
+
+variable "shielded_instance_config" {
+  type = object({
+    enable_integrity_monitoring = bool
+    enable_secure_boot          = bool
+    enable_vtpm                 = bool
+  })
+  description = <<-EOD
+    Shielded VM configuration for the instance. Note: not used unless
+    enable_shielded_vm is 'true'.
+    * enable_integrity_monitoring : Compare the most recent boot measurements to the
+      integrity policy baseline and return a pair of pass/fail results depending on
+      whether they match or not.
+    * enable_secure_boot : Verify the digital signature of all boot components, and
+      halt the boot process if signature verification fails.
+    * enable_vtpm : Use a virtualized trusted platform module, which is a
+      specialized computer chip you can use to encrypt objects like keys and
+      certificates.
+    EOD
+  default = {
+    enable_integrity_monitoring = true
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+  }
+}
+
+variable "enable_spot_vm" {
+  description = "Enable the partition to use spot VMs (https://cloud.google.com/spot-vms)."
+  type        = bool
+  default     = false
+}
+
+variable "spot_instance_config" {
+  description = "Configuration for spot VMs."
+  type = object({
+    termination_action = string
+  })
+  default = null
+}
+
+variable "bandwidth_tier" {
+  description = <<EOT
+  Configures the network interface card and the maximum egress bandwidth for VMs.
+  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.
+  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.
+  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).
+  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.
+  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.
+  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details.
+  EOT
+  type        = string
+  default     = "platform_default"
+
+  validation {
+    condition     = contains(["platform_default", "virtio_enabled", "gvnic_enabled", "tier_1_enabled"], var.bandwidth_tier)
+    error_message = "Allowed values for bandwidth_tier are 'platform_default', 'virtio_enabled', 'gvnic_enabled', or 'tier_1_enabled'."
+  }
+}
+
+variable "zone_policy_allow" {
+  description = <<-EOD
+    Partition nodes will prefer to be created in the listed zones. If a zone appears
+    in both zone_policy_allow and zone_policy_deny, then zone_policy_deny will take
+    priority for that zone.
+    EOD
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for x in var.zone_policy_allow : length(regexall("^[a-z]+-[a-z]+[0-9]-[a-z]$", x)) > 0
+    ])
+    error_message = "A provided zone in zone_policy_allow is not a valid zone (Regexp: '^[a-z]+-[a-z]+[0-9]-[a-z]$')."
+  }
+}
+
+variable "zone_policy_deny" {
+  description = <<-EOD
+    Partition nodes will not be created in the listed zones. If a zone appears in
+    both zone_policy_allow and zone_policy_deny, then zone_policy_deny will take
+    priority for that zone.
+    EOD
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for x in var.zone_policy_deny : length(regexall("^[a-z]+-[a-z]+[0-9]-[a-z]$", x)) > 0
+    ])
+    error_message = "A provided zone in zone_policy_deny is not a valid zone (Regexp '^[a-z]+-[a-z]+[0-9]-[a-z]$')."
+  }
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.7.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.8.0"
   }
   required_version = ">= 0.13.0"
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.7.0"
+  }
+  required_version = ">= 0.13.0"
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.6.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.8.0"
   }
   required_version = ">= 0.13.0"
 }

--- a/modules/README.md
+++ b/modules/README.md
@@ -35,6 +35,8 @@ Modules that are still in development and less stable are labeled with the
   to be used by a [slurm-controller][schedmd-slurm-on-gcp-controller].
 * **[schedmd-slurm-gcp-v5-partition]** ![community-badge] ![experimental-badge] :
   Creates a partition to be used by a [slurm-controller][schedmd-slurm-gcp-v5-controller].
+* **[schedmd-slurm-gcp-v5-node-group]** ![community-badge] ![experimental-badge] :
+  Creates a node group to be used by the [schedmd-slurm-gcp-v5-partition] module.
 * **[htcondor-execute-point]** ![community-badge] ![experimental-badge] :
   Manages a group of execute points for use in an [HTCondor
   pool][htcondor-configure].
@@ -42,6 +44,7 @@ Modules that are still in development and less stable are labeled with the
 [vm-instance]: compute/vm-instance/README.md
 [schedmd-slurm-on-gcp-partition]: ../community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
 [schedmd-slurm-gcp-v5-partition]: ../community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
+[schedmd-slurm-gcp-v5-node-group]: ../community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
 [htcondor-execute-point]: ../community/modules/compute/htcondor-execute-point/README.md
 
 ### Database

--- a/tools/validate_configs/test_configs/node-groups.yaml
+++ b/tools/validate_configs/test_configs/node-groups.yaml
@@ -41,13 +41,75 @@ deployment_groups:
       local_mounts: [/home]
       auto_delete_disk: true
 
-  - id: debug_partition
+  ## Single node group, use defaults where appropriate
+  - id: default_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      name: simple
+
+  - id: one_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - homefs
+    - default_node_group
+    settings:
+      partition_name: simple
+
+  ## Complex partition using node groups
+  - id: node_group1
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      name: c30
+      machine_type: c2-standard-30
+
+  - id: node_group2
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      name: c60
+      machine_type: c2-standard-60
+
+  - id: node_group3
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      name: cd112
+      machine_type: c2d-standard-112
+
+  - id: node_group4
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      name: cd56
+      machine_type: c2d-standard-56
+
+  - id: multiple_node_groups
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - homefs
+    - node_group1
+    - node_group2
+    - node_group3
+    - node_group4
+    settings:
+      partition_name: multng
+
+  ## Simple partition, using the default node group only.
+  - id: default_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
     use:
     - network1
     - homefs
     settings:
-      partition_name: debug
+      partition_name: defng
+
+  ## Explicitly set node partition with one node group
+  - id: one_node_group_explicit
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - homefs
+    settings:
+      partition_name: explng
       node_count_dynamic_max: 4
       enable_placement: false
       machine_type: n2-standard-2
@@ -55,7 +117,7 @@ deployment_groups:
       node_groups:
       - node_count_static: 0
         node_count_dynamic_max: 4
-        group_name: custom
+        group_name: expl
         node_conf: {}
         additional_disks: []
         bandwidth_tier: null
@@ -85,21 +147,14 @@ deployment_groups:
         source_image: null
         tags: []
 
-  - id: compute_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
-    use:
-    - network1
-    - homefs
-    settings:
-      partition_name: compute
-      node_count_dynamic_max: 20
-
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
     use:
     - network1
-    - debug_partition
-    - compute_partition
+    - one_node_group
+    - multiple_node_groups
+    - default_partition
+    - one_node_group_explicit
     - homefs
     settings:
       disable_controller_public_ips: false


### PR DESCRIPTION
### Description
Add a node group module that is intended for use with the v5 partition module, useful for defining multiple node groups without explicitly setting all values.

The example config was updated as well, the partitions created look like this:
```
[...@slurmgcpv5-controller ~]$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
defng        up   infinite     10  idle~ slurmgcpv5-defng-ghpc-[0-9]
explng*      up   infinite      8  idle~ slurmgcpv5-explng-expl-[0-3],slurmgcpv5-explng-ghpc-[0-3]
multng       up   infinite     50  idle~ slurmgcpv5-multng-c30-[0-9],slurmgcpv5-multng-c60-[0-9],slurmgcpv5-multng-cd56-[0-9],slurmgcpv5-multng-cd112-[0-9],slurmgcpv5-multng-ghpc-[0-9]
simple       up   infinite     20  idle~ slurmgcpv5-simple-ghpc-[0-9],slurmgcpv5-simple-simple-[0-9]
```

Remaining tasks to support node-groups:
* Update variables to maintain consistency between slurm-gcp, the toolkit and other toolkit modules
* Document usage of node-groups as the default method in the partition README 
* Update all other examples and blueprints in the repo to use node groups
* Hard Deprecation of top-level node-group variables in partition
* Remove the default node-group along with it.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
