### PR TITLE
Improve startup-script validation

### DIFF
--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -69,13 +69,23 @@ EOT
     ])
     error_message = "The 'type' must be 'ansible-local', 'shell' or 'data'."
   }
+  # this validation tests that exactly 1 or other of source/content have been
+  # set to anything (including null)
   validation {
     condition = alltrue([
       for r in var.runners :
-      (contains(keys(r), "content") && !contains(keys(r), "source")) ||
-      (!contains(keys(r), "content") && contains(keys(r), "source"))
+      can(r["content"]) != can(r["source"])
     ])
-    error_message = "A runner must specify one of 'content' or 'source file', but not both."
+    error_message = "A runner must specify either 'content' or 'source', but never both."
+  }
+  # this validation tests that at least 1 of source/content are non-null
+  # can fail either by not having been set all or by being set to null
+  validation {
+    condition = alltrue([
+      for r in var.runners :
+      lookup(r, "content", lookup(r, "source", null)) != null
+    ])
+    error_message = "A runner must specify a non-null 'content' or 'source'."
   }
   default = []
 }

--- a/tools/validate_configs/test_configs/spack-buildcache.yaml
+++ b/tools/validate_configs/test_configs/spack-buildcache.yaml
@@ -56,7 +56,7 @@ deployment_groups:
     settings:
       runners:
       - type: data
-        source:  ##  Add path to GPG key here ##
+        source: /local/path/to/spack/key.gpg
         destination: /tmp/spack_key.gpg
       - type: shell
         content: |

--- a/tools/validate_configs/test_configs/spack-environments.yaml
+++ b/tools/validate_configs/test_configs/spack-environments.yaml
@@ -84,7 +84,7 @@ deployment_groups:
     settings:
       runners:
       - type: data
-        source:  ##  Add path to GPG key here ##
+        source: /local/path/to/spack/key.gpg
         destination: /tmp/spack_key.gpg
       - type: shell
         content: |


### PR DESCRIPTION
Handle case that user has supplied an explicit null value to either the startup script content (string) or source (filepath). Modules will accept null values by default, while resources will treat these as values that have not been supplied by the user.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?