### PR TITLE
Fix terraform validation in new PBS modules for older 1.x releases

### DIFF
--- a/community/modules/scripts/pbspro-install/variables.tf
+++ b/community/modules/scripts/pbspro-install/variables.tf
@@ -60,6 +60,6 @@ variable "pbs_role" {
   type        = string
   validation {
     condition     = contains(["server", "client", "execution"], var.pbs_role)
-    error_message = "var.pbs_role must be one of \"server\", \"client\", or \"execution\""
+    error_message = "Value for var.pbs_role must be one of \"server\", \"client\", or \"execution\"."
   }
 }

--- a/community/modules/scripts/pbspro-preinstall/variables.tf
+++ b/community/modules/scripts/pbspro-preinstall/variables.tf
@@ -33,8 +33,8 @@ variable "server_rpm" {
   description = "Absolute path to PBS Pro Server Host RPM file"
   type        = string
   validation {
-    condition     = startswith(var.server_rpm, "/")
-    error_message = "Path to RPM must be an absolute path beginning with \"/\""
+    condition     = can(regex("^/", var.server_rpm))
+    error_message = "Path to RPM must be an absolute path beginning with \"/\"."
   }
 }
 
@@ -42,8 +42,8 @@ variable "client_rpm" {
   description = "Absolute path to PBS Pro Client Host RPM file"
   type        = string
   validation {
-    condition     = startswith(var.client_rpm, "/")
-    error_message = "Path to RPM must be an absolute path beginning with \"/\""
+    condition     = can(regex("^/", var.client_rpm))
+    error_message = "Path to RPM must be an absolute path beginning with \"/\"."
   }
 }
 
@@ -51,8 +51,8 @@ variable "execution_rpm" {
   description = "Absolute path to PBS Pro Execution Host RPM file"
   type        = string
   validation {
-    condition     = startswith(var.execution_rpm, "/")
-    error_message = "Path to RPM must be an absolute path beginning with \"/\""
+    condition     = can(regex("^/", var.execution_rpm))
+    error_message = "Path to RPM must be an absolute path beginning with \"/\"."
   }
 }
 
@@ -132,10 +132,10 @@ variable "bucket_viewers" {
   default     = []
 
   validation {
-    error_message = "All bucket viewers must be in IAM style: user:user@example.com, serviceAccount:sa@example.com, or group:group@example.com"
+    error_message = "All bucket viewers must be in IAM style: user:user@example.com, serviceAccount:sa@example.com, or group:group@example.com."
     condition = alltrue([
-      for viewer in var.bucket_viewers : startswith(viewer, "user:") ||
-      startswith(viewer, "serviceAccount:") || startswith(viewer, "group:")
+      for viewer in var.bucket_viewers : regex("^user:", viewer) ||
+      regex("^serviceAccount:", viewer) || regex("^group:", viewer)
     ])
   }
 }

--- a/community/modules/scripts/pbspro-qmgr/variables.tf
+++ b/community/modules/scripts/pbspro-qmgr/variables.tf
@@ -42,6 +42,6 @@ variable "server_conf" {
 
   validation {
     condition     = var.server_conf != null && var.server_conf != ""
-    error_message = "server_conf must be set to a non-empty string"
+    error_message = "The value for var.server_conf must be set to a non-empty string."
   }
 }


### PR DESCRIPTION
Some errors were introduced in #681 for older releases of Terraform:

1. anything below 1.3 does not have `startswith` function
2. anything below 1.2 imposes formatting restriction on error_message

(1) is a fatal error while (2) is a `terraform validate` warning only

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?