### PR TITLE
Enable tests on ./cmd and enforce lower (40%) coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,7 @@ MIN_GOLANG_VERSION=1.18 # for building ghpc
         terraform-format packer-format \
         check-tflint check-pre-commit
 
-# TODO: push cmd test coverage above 80% and re-enable.
-# ENG = ./cmd/... ./pkg/...
-ENG = ./pkg/...
+ENG = ./cmd/... ./pkg/...
 TERRAFORM_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.tf" -not -path '*/\.*' -exec dirname "{}" \; | sort -u)
 PACKER_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.pkr.hcl" -not -path '*/\.*' -exec dirname "{}" \; | sort -u)
 

--- a/tools/cloud-build/hpc-toolkit-pr-validation.yaml
+++ b/tools/cloud-build/hpc-toolkit-pr-validation.yaml
@@ -40,6 +40,7 @@ steps:
 - id: make-tests
   waitFor:
   - pre-commits-setup
+  - git-fetch-unshallow
   name: >-
     us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash

--- a/tools/cloud-build/hpc-toolkit-pr-validation.yaml
+++ b/tools/cloud-build/hpc-toolkit-pr-validation.yaml
@@ -15,6 +15,9 @@
 ---
 
 steps:
+- id: git-fetch-unshallow
+  name: gcr.io/cloud-builders/git
+  args: ['fetch', '--unshallow']
 - id: pre-commits-setup
   name: >-
     us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder

--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -16,13 +16,17 @@
 use strict;
 use warnings;
 
+# TODO: raise ./cmd min coverage to 80% after tests are written
 my $min = 80;
+my $cmdmin = 40;
 my $failed_coverage = 0;
 my $failed_tests = 0;
 
 while (<>){
   print $_;
-  if ( $_ =~ /coverage: (\d+\.\d)%/ ) {
+  if ( $_ =~ /hpc-toolkit\/cmd.*coverage: (\d+\.\d)%/) {
+    $failed_coverage++ if ($1 < $cmdmin);
+  } elsif ( $_ =~ /coverage: (\d+\.\d)%/ ) {
     $failed_coverage++ if ($1 < $min);
   }
   if ($_ =~ /\d+ passed, (\d+) FAILED/){
@@ -34,6 +38,6 @@ if ($failed_tests > 0) {
    exit 1
 }
 if ($failed_coverage > 0) {
-   print STDERR "Coverage must be above $min%, $failed_coverage packages were below that.\n";
+   print STDERR "Coverage must be above $cmdmin% for ./cmd and $min% for other packages, $failed_coverage packages were below that.\n";
    exit 1
 }


### PR DESCRIPTION
I've started writing unit tests for `./cmd` and I'm lowering the threshold to 40% prevent `enforce_coverage.pl` from failing due to insufficient coverage. I'll increase it as coverage of `./cmd` improves.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
