### PR TITLE
Minor fixes to PBS Pro modules and required APIs

### DIFF
--- a/community/modules/scripts/pbspro-preinstall/outputs.tf
+++ b/community/modules/scripts/pbspro-preinstall/outputs.tf
@@ -22,16 +22,25 @@ output "bucket_name" {
 output "pbs_client_rpm_url" {
   description = "gsutil URL of PBS client RPM package"
   value       = "gs://${module.pbspro_bucket.bucket.name}/${google_storage_bucket_object.client_rpm.name}"
+  depends_on = [
+    google_storage_bucket_object.client_rpm,
+  ]
 }
 
 output "pbs_execution_rpm_url" {
   description = "gsutil URL of PBS execution host RPM package"
   value       = "gs://${module.pbspro_bucket.bucket.name}/${google_storage_bucket_object.execution_rpm.name}"
+  depends_on = [
+    google_storage_bucket_object.execution_rpm,
+  ]
 }
 
 output "pbs_server_rpm_url" {
   description = "gsutil URL of PBS server host RPM package"
   value       = "gs://${module.pbspro_bucket.bucket.name}/${google_storage_bucket_object.server_rpm.name}"
+  depends_on = [
+    google_storage_bucket_object.server_rpm,
+  ]
 }
 
 output "pbs_license_file_url" {

--- a/pkg/sourcereader/embedded.go
+++ b/pkg/sourcereader/embedded.go
@@ -171,11 +171,11 @@ func defaultAPIList(source string) []string {
 			"iam.googleapis.com",
 			"secretmanager.googleapis.com",
 		},
-		"community/modules/scripts/pbspro-client": {
+		"community/modules/scheduler/pbspro-client": {
 			"compute.googleapis.com",
 			"storage.googleapis.com",
 		},
-		"community/modules/scripts/pbspro-server": {
+		"community/modules/scheduler/pbspro-server": {
 			"compute.googleapis.com",
 			"storage.googleapis.com",
 		},


### PR DESCRIPTION
- ensure PBS modules fail if RPM objects are not created (the RPM URLs are rendered from values that do not depend upon the object creation)
- fix paths to modules in embedded required_apis listing

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
