### PR TITLE
make overwrite error exit with rc=1

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -23,6 +23,7 @@ import (
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/modulewriter"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -98,6 +99,7 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 		var target *modulewriter.OverwriteDeniedError
 		if errors.As(err, &target) {
 			fmt.Printf("\n%s\n", err.Error())
+			os.Exit(1)
 		} else {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Fixing a bug where an overwrite error causes `ghpc` to exit with an error but with with rc=0 instead of rc=1

```
$ ./ghpc create examples/hpc-cluster-small.yaml --vars project_id=project-id 

Failed to overwrite existing deployment.

Use the -w command line argument to enable overwrite.
If overwrite is already enabled then this may be because you are attempting to remove a deployment group, which is not supported.
original error: The directory already exists: hpc-small
$ echo $?
0
```

After fix:
```
$ ./ghpc create examples/hpc-cluster-small.yaml --vars project_id=project-id 

Failed to overwrite existing deployment.

Use the -w command line argument to enable overwrite.
If overwrite is already enabled then this may be because you are attempting to remove a deployment group, which is not supported.
original error: The directory already exists: hpc-small
$ echo $?
1
```



### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
