### PR TITLE
Add unshallow git fetch to weekly builds

### DIFF
--- a/tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml
+++ b/tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml
@@ -16,6 +16,10 @@
 
 timeout: 3600s
 steps:
+# Make tests requires full history. Perform deep fetch.
+- id: git-fetch-unshallow
+  name: gcr.io/cloud-builders/git
+  args: ['fetch', '--unshallow']
 - name: golang:bullseye
   entrypoint: /bin/bash
   args:

--- a/tools/cloud-build/hpc-toolkit-builder.yaml
+++ b/tools/cloud-build/hpc-toolkit-builder.yaml
@@ -40,8 +40,13 @@ steps:
     pre-commit install --install-hooks
     time tflint --init
     SKIP=go-unit-tests pre-commit run --all-files
+# Make tests requires full history. Perform deep fetch.
+- id: git-fetch-unshallow
+  waitFor: ["-"]
+  name: gcr.io/cloud-builders/git
+  args: ['fetch', '--unshallow']
 - id: make-tests
-  waitFor: [builder]
+  waitFor: [builder, git-fetch-unshallow]
   name: >-
     us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash


### PR DESCRIPTION
Follow up that was missed in #695. `make tests` assumes it is running from the git repository. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
