### PR TITLE
Disable OS Login in HTCondor example

### DIFF
--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -20,6 +20,7 @@ vars:
   deployment_name: htcondor-001
   region: us-central1
   zone: us-central1-c
+  enable_oslogin: "DISABLE"
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -37,11 +38,6 @@ deployment_groups:
 
   - id: htcondor_install
     source: community/modules/scripts/htcondor-install
-
-  - id: htcondor_services
-    source: community/modules/project/service-enablement
-    use:
-    - htcondor_install
 
   - id: htcondor_configure
     source: community/modules/scheduler/htcondor-configure
@@ -110,6 +106,7 @@ deployment_groups:
           request_cpus   = 1
           request_memory = 100MB
           queue
+
   - id: htcondor_access
     source: modules/compute/vm-instance
     use:

--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -95,6 +95,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with "ENABLE" or "DISABLE". Set to "INHERIT" to inherit project OS Login setting. | `string` | `"DISABLE"` | no |
 | <a name="input_image"></a> [image](#input\_image) | HTCondor execute point VM image | <pre>object({<br>    family  = string,<br>    project = string<br>  })</pre> | <pre>{<br>  "family": "hpc-centos-7",<br>  "project": "cloud-hpc-image-public"<br>}</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to HTConodr execute points | `map(string)` | n/a | yes |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to use for HTCondor execute points | `string` | `"n2-standard-4"` | no |

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -17,8 +17,14 @@
 
 locals {
   network_storage_metadata = var.network_storage == null ? {} : { network_storage = jsonencode(var.network_storage) }
-  metadata                 = merge(var.metadata, local.network_storage_metadata)
 
+  oslogin_api_values = {
+    "DISABLE" = "FALSE"
+    "ENABLE"  = "TRUE"
+  }
+  enable_oslogin = var.enable_oslogin == "INHERIT" ? {} : { enable-oslogin = lookup(local.oslogin_api_values, var.enable_oslogin, "") }
+
+  metadata = merge(var.metadata, local.network_storage_metadata, local.enable_oslogin)
 
   configure_autoscaler_role = {
     "type"        = "ansible-local"

--- a/community/modules/compute/htcondor-execute-point/variables.tf
+++ b/community/modules/compute/htcondor-execute-point/variables.tf
@@ -118,3 +118,13 @@ variable "metadata" {
   type        = map(string)
   default     = {}
 }
+
+# this default is deliberately the opposite of vm-instance because of observed
+# issues running HTCondor docker universe jobs with OS Login enabled and running
+# jobs as a user with uid>2^31; these uids occur when users outside the GCP
+# organization login to a VM and OS Login is enabled.
+variable "enable_oslogin" {
+  description = "Enable or Disable OS Login with \"ENABLE\" or \"DISABLE\". Set to \"INHERIT\" to inherit project OS Login setting."
+  type        = string
+  default     = "DISABLE"
+}


### PR DESCRIPTION
Although a UID mapping problem was resolved in htcondor/htcondor#780, some issues are still observed when running Docker jobs. This change disables OS Login in the HTCondor example until it is further diagnosed.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?