### PR TITLE
Eliminate risky-file-permissions warning on PBS qmgr Ansible tasks

### DIFF
--- a/community/modules/scripts/pbspro-qmgr/scripts/pbs_qmgr.yml
+++ b/community/modules/scripts/pbspro-qmgr/scripts/pbs_qmgr.yml
@@ -63,6 +63,7 @@
     ansible.builtin.lineinfile:
       create: true
       path: /etc/hosts.equiv
+      mode: 0644
       line: "{{ client_hostname_prefix }}-{{ idx }}"
     loop: "{{ range(0, client_host_count | int) | list }}"
     loop_control:


### PR DESCRIPTION
### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?