### PR TITLE
Update SchedMD-slurm-on-gcp-* modules to 4.2.1

### DIFF
--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/README.md
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/README.md
@@ -75,8 +75,8 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_slurm_cluster_compute_node"></a> [slurm\_cluster\_compute\_node](#module\_slurm\_cluster\_compute\_node) | github.com/SchedMD/slurm-gcp//tf/modules/compute/ | v4.2.0 |
-| <a name="module_slurm_cluster_controller"></a> [slurm\_cluster\_controller](#module\_slurm\_cluster\_controller) | github.com/SchedMD/slurm-gcp//tf/modules/controller/ | v4.2.0 |
+| <a name="module_slurm_cluster_compute_node"></a> [slurm\_cluster\_compute\_node](#module\_slurm\_cluster\_compute\_node) | github.com/SchedMD/slurm-gcp//tf/modules/compute/ | v4.2.1 |
+| <a name="module_slurm_cluster_controller"></a> [slurm\_cluster\_controller](#module\_slurm\_cluster\_controller) | github.com/SchedMD/slurm-gcp//tf/modules/controller/ | v4.2.1 |
 
 ## Resources
 

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/main.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/main.tf
@@ -25,7 +25,7 @@ data "google_compute_image" "compute_image" {
 }
 
 module "slurm_cluster_controller" {
-  source                        = "github.com/SchedMD/slurm-gcp//tf/modules/controller/?ref=v4.2.0"
+  source                        = "github.com/SchedMD/slurm-gcp//tf/modules/controller/?ref=v4.2.1"
   boot_disk_size                = var.boot_disk_size
   boot_disk_type                = var.boot_disk_type
   image                         = data.google_compute_image.compute_image.self_link
@@ -61,7 +61,7 @@ module "slurm_cluster_controller" {
 }
 
 module "slurm_cluster_compute_node" {
-  source                     = "github.com/SchedMD/slurm-gcp//tf/modules/compute/?ref=v4.2.0"
+  source                     = "github.com/SchedMD/slurm-gcp//tf/modules/compute/?ref=v4.2.1"
   project                    = var.project_id
   cluster_name               = local.cluster_name
   region                     = var.region

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/README.md
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/README.md
@@ -77,7 +77,7 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_slurm_cluster_login_node"></a> [slurm\_cluster\_login\_node](#module\_slurm\_cluster\_login\_node) | github.com/SchedMD/slurm-gcp//tf/modules/login/ | v4.2.0 |
+| <a name="module_slurm_cluster_login_node"></a> [slurm\_cluster\_login\_node](#module\_slurm\_cluster\_login\_node) | github.com/SchedMD/slurm-gcp//tf/modules/login/ | v4.2.1 |
 
 ## Resources
 

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/main.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/main.tf
@@ -23,7 +23,7 @@ data "google_compute_image" "compute_image" {
 }
 
 module "slurm_cluster_login_node" {
-  source            = "github.com/SchedMD/slurm-gcp//tf/modules/login/?ref=v4.2.0"
+  source            = "github.com/SchedMD/slurm-gcp//tf/modules/login/?ref=v4.2.1"
   boot_disk_size    = var.boot_disk_size
   boot_disk_type    = var.boot_disk_type
   image             = data.google_compute_image.compute_image.self_link

--- a/tools/validate_configs/test_configs/test-gcs-fuse.yaml
+++ b/tools/validate_configs/test_configs/test-gcs-fuse.yaml
@@ -29,7 +29,7 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: modules/network/pre-existing-vpc
+    source: modules/network/vpc
 
   - id: gcs
     source: ./modules/file-system/pre-existing-network-storage
@@ -114,3 +114,33 @@ deployment_groups:
       instance_image:
         family: rocky-linux-8
         project: rocky-linux-cloud
+
+  - id: compute-partition
+    source: ./community/modules/compute/SchedMD-slurm-on-gcp-partition
+    use:
+    - gcs
+    - gcs2
+    - network1
+    settings:
+      partition_name: compute
+      machine_type: n2-standard-4
+
+  - id: slurm-controller
+    source: ./community/modules/scheduler/SchedMD-slurm-on-gcp-controller
+    use:
+    - gcs
+    - gcs2
+    - compute-partition
+    - network1
+    settings:
+      login_node_count: 1
+      compute_node_scopes:
+      - https://www.googleapis.com/auth/cloud-platform
+      - https://www.googleapis.com/auth/devstorage.read_only
+      disable_compute_public_ips: false
+
+  - id: slurm-login
+    source: ./community/modules/scheduler/SchedMD-slurm-on-gcp-login-node
+    use:
+    - slurm-controller
+    - network1


### PR DESCRIPTION
### Description
Updates the Slurm on GCP v4 modules to v4.2.1, providing support for gcsfuse.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
