### PR TITLE
Modify Packer instructions to user

### DIFF
--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -46,6 +46,7 @@ func printPackerInstructions(modPath string) {
 	fmt.Println("  packer init .")
 	fmt.Println("  packer validate .")
 	fmt.Println("  packer build .")
+	fmt.Println("  cd -")
 }
 
 func writePackerAutovars(vars map[string]cty.Value, dst string) error {


### PR DESCRIPTION
Packer does not have the equivalent of -chdir in Terraform. So we advise the user to cd to the directory of the Packer deployment group. But we do not advise them to return to the original working directory before printing out Terraform instructions that assume one is in the original working directory. Resolve by adding "cd -" to end of Packer output.


This matters when a Terraform group comes after a Packer group.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?