### PR TITLE
Update default spack version to v0.19.0

### DIFF
--- a/community/examples/spack-gromacs.yaml
+++ b/community/examples/spack-gromacs.yaml
@@ -49,8 +49,6 @@ deployment_groups:
     source: community/modules/scripts/spack-install
     settings:
       install_dir: /sw/spack
-      spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:
       - type: single-config

--- a/community/modules/scripts/spack-install/README.md
+++ b/community/modules/scripts/spack-install/README.md
@@ -35,7 +35,7 @@ see this module used in a full blueprint, see the [spack-gromacs.yaml] example.
     settings:
       install_dir: /sw/spack
       spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
+      spack_ref: v0.19.0
       spack_cache_url:
       - mirror_name: 'gcs_cache'
         mirror_url: gs://example-buildcache/linux-centos7
@@ -203,7 +203,7 @@ No resources.
 | <a name="input_packages"></a> [packages](#input\_packages) | Defines root packages for spack to install (in order). | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
 | <a name="input_spack_cache_url"></a> [spack\_cache\_url](#input\_spack\_cache\_url) | List of buildcaches for spack. | <pre>list(object({<br>    mirror_name = string<br>    mirror_url  = string<br>  }))</pre> | `null` | no |
-| <a name="input_spack_ref"></a> [spack\_ref](#input\_spack\_ref) | Git ref to checkout for spack. | `string` | `"v0.18.0"` | no |
+| <a name="input_spack_ref"></a> [spack\_ref](#input\_spack\_ref) | Git ref to checkout for spack. | `string` | `"v0.19.0"` | no |
 | <a name="input_spack_url"></a> [spack\_url](#input\_spack\_url) | URL to clone the spack repo from. | `string` | `"https://github.com/spack/spack"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone where the instance is running. | `string` | n/a | yes |
 

--- a/community/modules/scripts/spack-install/variables.tf
+++ b/community/modules/scripts/spack-install/variables.tf
@@ -39,7 +39,7 @@ variable "spack_url" {
 variable "spack_ref" {
   description = "Git ref to checkout for spack."
   type        = string
-  default     = "v0.18.0"
+  default     = "v0.19.0"
 }
 
 variable "spack_cache_url" {

--- a/docs/tutorials/gromacs/spack-gromacs.yaml
+++ b/docs/tutorials/gromacs/spack-gromacs.yaml
@@ -36,7 +36,6 @@ deployment_groups:
     source: community/modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:
       - type: file

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -36,7 +36,6 @@ deployment_groups:
     source: community/modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:
       - type: file

--- a/docs/tutorials/wrfv3/spack-wrfv3.yaml
+++ b/docs/tutorials/wrfv3/spack-wrfv3.yaml
@@ -36,7 +36,6 @@ deployment_groups:
     source: community/modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:
       - type: file

--- a/tools/validate_configs/test_configs/centos8-ss.yaml
+++ b/tools/validate_configs/test_configs/centos8-ss.yaml
@@ -45,8 +45,6 @@ deployment_groups:
     source: ./community//modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:

--- a/tools/validate_configs/test_configs/debian-ss.yaml
+++ b/tools/validate_configs/test_configs/debian-ss.yaml
@@ -45,8 +45,6 @@ deployment_groups:
     source: ./community//modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:

--- a/tools/validate_configs/test_configs/hpc-centos-ss.yaml
+++ b/tools/validate_configs/test_configs/hpc-centos-ss.yaml
@@ -45,8 +45,6 @@ deployment_groups:
     source: ./community//modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
       compilers:
       - gcc@10.3.0 target=x86_64
       packages:

--- a/tools/validate_configs/test_configs/rocky-ss.yaml
+++ b/tools/validate_configs/test_configs/rocky-ss.yaml
@@ -46,8 +46,6 @@ deployment_groups:
     source: ./community//modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
       spack_cache_url:
       compilers:
       - gcc@10.3.0 target=x86_64

--- a/tools/validate_configs/test_configs/spack-buildcache.yaml
+++ b/tools/validate_configs/test_configs/spack-buildcache.yaml
@@ -32,8 +32,6 @@ deployment_groups:
     source: ./community/modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
       log_file: /var/log/spack.log
       configs:
       - type: 'single-config'

--- a/tools/validate_configs/test_configs/ubuntu-ss.yaml
+++ b/tools/validate_configs/test_configs/ubuntu-ss.yaml
@@ -45,8 +45,6 @@ deployment_groups:
     source: ./community//modules/scripts/spack-install
     settings:
       install_dir: /apps/spack
-      spack_url: https://github.com/spack/spack
-      spack_ref: v0.18.0
       spack_cache_url:
       compilers:
       - gcc@10.3.0 target=x86_64


### PR DESCRIPTION
This merge updates the default spack version used from v0.18.0 to v0.19.0.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?
