### PR TITLE
Remove ansible install warning message in README

### DIFF
--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -21,11 +21,6 @@ Each runner receives the following attributes:
       --limit localhost <<DESTINATION>>
     ```
 
-    > **_NOTE:_** Ansible must already be installed in this VM. This can be
-    > done using another runner executed prior to this one. A pre-built ansible
-    > installation shell runner is available as part of the
-    > [startup-script module](./examples/install_ansible.sh).
-
   - `data`: The data or file specified will be copied to `<<DESTINATION>>`. No
     action will be performed after the data is staged. This data can be used by
     subsequent runners or simply made available on the VM for later use.
@@ -55,7 +50,7 @@ Each runner receives the following attributes:
 
 ### Runner dependencies
 
-`ansible-local` runners requires Ansible to be installed in the VM before
+`ansible-local` runners require Ansible to be installed in the VM before
 running. To support other playbook runners in the HPC Toolkit, we install
 version 2.11 of `ansible-core` as well as the larger package of collections
 found in `ansible` version 4.10.0.


### PR DESCRIPTION
The install_ansible script is now added automatically, we no longer need to warn the user to have ansible installed or define the runner themselves.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
