### PR TITLE
Install Slurm on GCP dependencies in testing docker image

### DIFF
--- a/tools/cloud-build/Dockerfile
+++ b/tools/cloud-build/Dockerfile
@@ -31,8 +31,6 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     apt-get -y update && apt-get -y install google-cloud-sdk && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN pip install pre-commit ansible && rm -rf ~/.cache/pip/*
-
 RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
 
 RUN go install github.com/terraform-docs/terraform-docs@latest      && \
@@ -46,6 +44,10 @@ RUN go install github.com/terraform-docs/terraform-docs@latest      && \
 # Setting GHPC dependencies
 WORKDIR /ghpc-tmp
 COPY ./ ./
+
+RUN pip install -r https://raw.githubusercontent.com/SchedMD/slurm-gcp/5.2.0/scripts/requirements.txt && \
+    pip install -r tools/cloud-build/requirements.txt && \
+    rm -rf ~/.cache/pip/*
 
 RUN make ghpc
 

--- a/tools/cloud-build/requirements.txt
+++ b/tools/cloud-build/requirements.txt
@@ -1,0 +1,2 @@
+pre-commit
+ansible


### PR DESCRIPTION
### Description
Installs the dependencies for Slurm on GCP to run null resources locally in integration tests (ex - enable_reconfig).

Pip installation was moved below setting the workdir so that the repo files are available (needed for requirements.txt)

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
