### PR TITLE
Default enable reconfig high io

### DIFF
--- a/community/examples/slurm-gcp-v5-high-io.yaml
+++ b/community/examples/slurm-gcp-v5-high-io.yaml
@@ -26,7 +26,7 @@ vars:
   disable_public_ips: false
   # Set to true for active cluster reconfiguration. Note that setting this
   # option requires additional dependencies to be installed locally.
-  enable_reconfigure: false
+  enable_reconfigure: true
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md


### PR DESCRIPTION
### Description
With the update to the build in #733, enable_reconfigure will be able to
run without failing at a python dependency, so we are setting active
cluster configuration by default in the high io blueprint.

### Dependent PRs

* #730 
* #733 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
