### PR TITLE
Set unique script names for all mount points in nfs-server

### DIFF
--- a/community/modules/file-system/nfs-server/README.md
+++ b/community/modules/file-system/nfs-server/README.md
@@ -88,7 +88,7 @@ No modules.
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Storage size gb | `number` | `"100"` | no |
 | <a name="input_image"></a> [image](#input\_image) | the VM image used by the nfs server | `string` | `"cloud-hpc-image-public/hpc-centos-7"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NFS instance. List key, value pairs. | `any` | n/a | yes |
-| <a name="input_local_mounts"></a> [local\_mounts](#input\_local\_mounts) | Mountpoint for this NFS compute instance | `list(string)` | <pre>[<br>  "/tools",<br>  "/data"<br>]</pre> | no |
+| <a name="input_local_mounts"></a> [local\_mounts](#input\_local\_mounts) | Mountpoint for this NFS compute instance | `list(string)` | <pre>[<br>  "/data"<br>]</pre> | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Type of the VM instance to use | `string` | `"n2d-standard-2"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resource name of the instance. | `string` | `null` | no |

--- a/community/modules/file-system/nfs-server/main.tf
+++ b/community/modules/file-system/nfs-server/main.tf
@@ -23,19 +23,21 @@ locals {
   server_ip     = google_compute_instance.compute_instance.network_interface[0].network_ip
   fs_type       = "nfs"
   mount_options = "defaults,hard,intr"
-  install_nfs_client_runner = {
-    "type"        = "shell"
-    "source"      = "${path.module}/scripts/install-nfs-client.sh"
-    "destination" = "install-nfs.sh"
-  }
-  mount_runners = { for mount in var.local_mounts :
-    mount => {
+  install_nfs_client_runners = [for mount in var.local_mounts :
+    {
+      "type"        = "shell"
+      "source"      = "${path.module}/scripts/install-nfs-client.sh"
+      "destination" = "install-nfs${replace(mount, "/", "_")}.sh"
+    }
+  ]
+  mount_runners = [for mount in var.local_mounts :
+    {
       "type"        = "shell"
       "source"      = "${path.module}/scripts/mount.sh"
       "args"        = "\"${local.server_ip}\" \"/exports${mount}\" \"${mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
       "destination" = "mount${replace(mount, "/", "_")}.sh"
     }
-  }
+  ]
   ansible_mount_runner = {
     "type"        = "ansible-local"
     "source"      = "${path.module}/scripts/mount.yaml"

--- a/community/modules/file-system/nfs-server/outputs.tf
+++ b/community/modules/file-system/nfs-server/outputs.tf
@@ -16,14 +16,14 @@
 # render the content for each folder
 output "network_storage" {
   description = "export of all desired folder directories"
-  value = [for mount, mount_runner in local.mount_runners : {
+  value = [for i, mount in var.local_mounts : {
     remote_mount          = "/exports${mount}"
     local_mount           = mount
     fs_type               = local.fs_type
     mount_options         = local.mount_options
     server_ip             = local.server_ip
-    client_install_runner = local.install_nfs_client_runner
-    mount_runner          = mount_runner
+    client_install_runner = local.install_nfs_client_runners[i]
+    mount_runner          = local.mount_runners[i]
     }
   ]
 }
@@ -35,7 +35,7 @@ output "install_nfs_client" {
 
 output "install_nfs_client_runner" {
   description = "Runner to install NFS client using the startup-script module"
-  value       = local.install_nfs_client_runner
+  value       = local.install_nfs_client_runners[0]
 }
 
 output "mount_runner" {

--- a/community/modules/file-system/nfs-server/variables.tf
+++ b/community/modules/file-system/nfs-server/variables.tf
@@ -103,11 +103,16 @@ variable "scopes" {
 variable "local_mounts" {
   description = "Mountpoint for this NFS compute instance"
   type        = list(string)
+  default     = ["/tools", "/data"]
+
   validation {
     condition = alltrue([
       for m in var.local_mounts : substr(m, 0, 1) == "/"
     ])
     error_message = "Local mountpoints have to start with '/'."
   }
-  default = ["/tools", "/data"]
+  validation {
+    condition     = length(var.local_mounts) > 0
+    error_message = "At least one local mount must be specified in var.local_mounts."
+  }
 }

--- a/community/modules/file-system/nfs-server/variables.tf
+++ b/community/modules/file-system/nfs-server/variables.tf
@@ -103,7 +103,7 @@ variable "scopes" {
 variable "local_mounts" {
   description = "Mountpoint for this NFS compute instance"
   type        = list(string)
-  default     = ["/tools", "/data"]
+  default     = ["/data"]
 
   validation {
     condition = alltrue([

--- a/tools/validate_configs/test_configs/nfs-servers.yaml
+++ b/tools/validate_configs/test_configs/nfs-servers.yaml
@@ -14,11 +14,11 @@
 
 ---
 
-blueprint_name: 2-nfs-servers
+blueprint_name: nfs-servers
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: two-nfs-servers
+  deployment_name: nfs-servers
   region: us-central1
   zone: us-central1-a
 
@@ -42,4 +42,15 @@ deployment_groups:
     outputs: [network_storage]
     settings:
       local_mounts: ["/apps"]
+      auto_delete_disk: true
+
+  - id: multiple-local-mounts
+    source: ./community/modules/file-system/nfs-server
+    use: [network1]
+    outputs: [network_storage]
+    settings:
+      local_mounts:
+      - /mnt1
+      - /mnt2
+      - /mnt3
       auto_delete_disk: true


### PR DESCRIPTION
Solves an error when deploying with multiple mount points that share the same destination filenames (including the default value for local_mounts.

Tested against `tools/validate_configs/test_configs/hpc-centos-ss.yaml`

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
