### PR TITLE
Switch to GA provider v4.19.0 and above

### DIFF
--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -95,14 +95,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.4 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.19 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.4 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.19 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -113,7 +113,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google-beta_google_filestore_instance.filestore_instance](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_filestore_instance) | resource |
+| [google_filestore_instance.filestore_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance) | resource |
 | [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -39,9 +39,7 @@ locals {
 }
 
 resource "google_filestore_instance" "filestore_instance" {
-  project    = var.project_id
-  provider   = google-beta
-  depends_on = [var.network_name]
+  project = var.project_id
 
   name     = var.name != null ? var.name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
   location = var.filestore_tier == "ENTERPRISE" ? var.region : var.zone

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -16,9 +16,9 @@
 
 terraform {
   required_providers {
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = ">= 4.4"
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.19"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Filestore enterprise tier is supported in [v4.19.0](https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#4190-april-25-2022) and latest (v4.43.1) documentation has no notes about use of beta provider at all.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?