### PR TITLE
Validate unique destinations startup-scripts

### DIFF
--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -64,6 +64,10 @@ EOT
     error_message = "All runners must declare a destination name (even without a path)."
   }
   validation {
+    condition     = length(distinct([for r in var.runners : r["destination"]])) == length(var.runners)
+    error_message = "All startup-script runners must have a unique destination."
+  }
+  validation {
     condition = alltrue([
       for r in var.runners : r["type"] == "ansible-local" || r["type"] == "shell" || r["type"] == "data"
     ])

--- a/tools/validate_configs/test_configs/instance-with-startup.yaml
+++ b/tools/validate_configs/test_configs/instance-with-startup.yaml
@@ -40,10 +40,10 @@ deployment_groups:
       runners:
       - type: shell
         content: $(homefs.install_nfs_client)
-        destination: "tmp.sh"
+        destination: "install_nfs.sh"
       - type: "ansible-local"
         source: "modules/startup-script/examples/mount.yaml"
-        destination: "tmp.sh"
+        destination: "mount.sh"
 
   - id: workstation
     source: modules/compute/vm-instance

--- a/tools/validate_configs/test_configs/slurm-two-partitions-workstation.yaml
+++ b/tools/validate_configs/test_configs/slurm-two-partitions-workstation.yaml
@@ -40,10 +40,10 @@ deployment_groups:
       runners:
       - type: shell
         content: $(homefs.install_nfs_client)
-        destination: "tmp.sh"
+        destination: "install_nfs.sh"
       - type: "ansible-local"
         source: "modules/startup-script/examples/mount.yaml"
-        destination: "tmp.sh"
+        destination: "mount.sh"
 
   - id: workstation
     source: modules/compute/vm-instance


### PR DESCRIPTION
### Description
Short term improvement for the duplicate destination issue in startup-scripts: Validate and have a clear error message for the user when it happens.

Longer term, startup scripts may be refactored to remove this requirement.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
