### PR TITLE
Cap TF Google provider version at latest stable (4.43)

### DIFF
--- a/pkg/modulewriter/tfversions.go
+++ b/pkg/modulewriter/tfversions.go
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.83, < 5.0"
+      version = ">= 3.83, <= 4.43"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.83, < 5.0"
+      version = ">= 3.83, <= 4.43"
     }
   }
 }


### PR DESCRIPTION
This is a workaround for the plugin panic error (https://github.com/hashicorp/terraform-provider-google/issues/13097), but is also a good practice to ensure breaking changes don't affect our deployments without us being able to test beforehand.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
