### PR TITLE
Update guidance to use incremental placement to avoid deadlock

### DIFF
--- a/community/examples/starccm-tutorial.yaml
+++ b/community/examples/starccm-tutorial.yaml
@@ -66,7 +66,7 @@ deployment_groups:
       machine_type: c2-standard-60
       instance_count: 4
       placement_policy:
-        vm_count: 4  # Note: should match instance count
+        vm_count: null
         collocation: "COLLOCATED"
         availability_domain_count: null
 

--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -80,10 +80,17 @@ Use the following settings for compact placement:
     instance_count: 4
     machine_type: c2-standard-60
     placement_policy:
-      vm_count: 4  # Note: should match instance count
+      vm_count: null
       collocation: "COLLOCATED"
       availability_domain_count: null
 ```
+
+When `vm_count` is not set, as shown in the example above, then the VMs will be
+added to the placement policy incrementally. This is the **recommended way** to
+use placement policies.
+
+If `vm_count` is specified then VMs will stay in pending state until the
+specified number of VMs are created. See the warning below if using this field.
 
 > **Warning** When creating a compact placement with more than 10 VMs, you must
 > add `-parallelism=<n>` argument on apply. For example if you have 15 VMs in a
@@ -132,14 +139,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.12 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.42 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.12 |
 
 ## Modules

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.83"
+      version = ">= 4.42"
     }
 
     google-beta = {


### PR DESCRIPTION
In v4.42 of the google terraform provider, `vm_count` became optional, allowing for the use of incremental placement. Using incremental placement avoids the deadlock between terraform and Google Cloud when creating placement groups larger than terraform's `parallelism` (10 by default).

This change updates guidance to not set `vm_count` and use incremental placement. 

Tested:
- Manually tested with `vm_count: null` with `instance_count` of 4, 21, and 30. No deadlock observed.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
