### PR TITLE
Always include a startup script with a predetermined name even if script is empty string

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
@@ -15,11 +15,11 @@
 */
 
 locals {
-  ghpc_startup_script_controller = var.controller_startup_script == "" ? [] : [{
+  ghpc_startup_script_controller = [{
     filename = "ghpc_startup.sh"
     content  = var.controller_startup_script
   }]
-  ghpc_startup_script_compute = var.compute_startup_script == "" ? [] : [{
+  ghpc_startup_script_compute = [{
     filename = "ghpc_startup.sh"
     content  = var.compute_startup_script
   }]

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/main.tf
@@ -15,7 +15,7 @@
 */
 
 locals {
-  ghpc_startup_script_compute = var.compute_startup_script == "" ? [] : [{
+  ghpc_startup_script_compute = [{
     filename = "ghpc_startup.sh"
     content  = var.compute_startup_script
   }]

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  ghpc_startup_script = var.startup_script == "" ? [] : [{
+  ghpc_startup_script = [{
     filename = "ghpc_startup.sh"
     content  = var.startup_script
   }]


### PR DESCRIPTION
My making the list a variable size we cause the filename to be only known at apply time and Slurm fails to deploy.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
