### PR TITLE
Strip newlines chars before searching for startup failure

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_terraform_failure.yml
@@ -30,10 +30,13 @@
     - firewall-rules
     - delete
     - "{{ deployment_name }}"
+- name: Remove New Lines From Terraform Apply STDERR
+  ansible.builtin.set_fact:
+    terraform_apply_stderr_one_line: "{{ terraform_apply_stderr | replace('\n',' ') }}"
 - name: Get Startup Script Logs
-  ansible.builtin.command: "{{ terraform_apply_stderr | replace('\n',' ') | regex_search('please run: (.+)', '\\1') | first }}"
+  ansible.builtin.command: "{{ terraform_apply_stderr_one_line | regex_search('please run: (.+)', '\\1') | first }}"
   register: serial_port_1_output
-  when: '"to inspect the startup script output, please run:" in terraform_apply_stderr'
+  when: '"to inspect the startup script output, please run:" in terraform_apply_stderr_one_line'
   failed_when: false
 - name: Log Startup Script Failure
   ansible.builtin.debug:


### PR DESCRIPTION
For some reason ansible started adding new-line characters in STDERR logging. We use this logging to decide if there was a startup script failure. These new-lines were causing startup script logs to not be logged when they should be. 

Tested:
- Manually reproduceded failure and observed logging to could build

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
