### PR TITLE
Add partition level startup script variables

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
@@ -198,6 +198,7 @@ limitations under the License.
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Deprecated: Use the schedmd-slurm-gcp-v5-node-group module for defining node groups instead. | `string` | `null` | no |
 | <a name="input_partition_conf"></a> [partition\_conf](#input\_partition\_conf) | Slurm partition configuration as a map.<br>See https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION | `map(string)` | `{}` | no |
 | <a name="input_partition_name"></a> [partition\_name](#input\_partition\_name) | The name of the slurm partition. | `string` | n/a | yes |
+| <a name="input_partition_startup_scripts_timeout"></a> [partition\_startup\_scripts\_timeout](#input\_partition\_startup\_scripts\_timeout) | The timeout (seconds) applied to the partition startup script. If<br>any script exceeds this timeout, then the instance setup process is considered<br>failed and handled accordingly.<br><br>NOTE: When set to 0, the timeout is considered infinite and thus disabled. | `number` | `300` | no |
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Deprecated: Use the schedmd-slurm-gcp-v5-node-group module for defining node groups instead. | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The default region for Cloud resources. | `string` | n/a | yes |
@@ -208,6 +209,7 @@ limitations under the License.
 | <a name="input_source_image_family"></a> [source\_image\_family](#input\_source\_image\_family) | Deprecated: Use the schedmd-slurm-gcp-v5-node-group module for defining node groups instead. | `string` | `null` | no |
 | <a name="input_source_image_project"></a> [source\_image\_project](#input\_source\_image\_project) | Deprecated: Use the schedmd-slurm-gcp-v5-node-group module for defining node groups instead. | `string` | `null` | no |
 | <a name="input_spot_instance_config"></a> [spot\_instance\_config](#input\_spot\_instance\_config) | Deprecated: Use the schedmd-slurm-gcp-v5-node-group module for defining node groups instead. | <pre>object({<br>    termination_action = string<br>  })</pre> | `null` | no |
+| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script that will be used by the partition VMs. | `string` | `""` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The project the subnetwork belongs to. | `string` | `""` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Deprecated: Use the schedmd-slurm-gcp-v5-node-group module for defining node groups instead. | `list(string)` | `null` | no |

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  ghpc_startup_script = var.startup_script == "" ? [] : [{
+  ghpc_startup_script = [{
     filename = "ghpc_startup.sh"
     content  = var.startup_script
   }]

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
@@ -97,6 +97,24 @@ variable "partition_conf" {
   default     = {}
 }
 
+variable "startup_script" {
+  description = "Startup script that will be used by the partition VMs."
+  type        = string
+  default     = ""
+}
+
+variable "partition_startup_scripts_timeout" {
+  description = <<-EOD
+    The timeout (seconds) applied to the partition startup script. If
+    any script exceeds this timeout, then the instance setup process is considered
+    failed and handled accordingly.
+
+    NOTE: When set to 0, the timeout is considered infinite and thus disabled.
+    EOD
+  type        = number
+  default     = 300
+}
+
 variable "is_default" {
   description = <<-EOD
     Sets this partition as the default partition by updating the partition_conf.

--- a/tools/validate_configs/test_configs/hpc-cluster-small-slurm-v5.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-small-slurm-v5.yaml
@@ -68,6 +68,10 @@ deployment_groups:
     - compute_node_group
     settings:
       partition_name: compute
+      startup_script: |
+        #!/bin/bash
+        set -ex
+        echo "hello compute_partition"
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller

--- a/tools/validate_configs/test_configs/hpc-cluster-small-slurm-v5.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-small-slurm-v5.yaml
@@ -82,10 +82,6 @@ deployment_groups:
     - startup-partition
     settings:
       partition_name: compute
-      startup_script: |
-        #!/bin/bash
-        set -ex
-        echo "hello compute_partition"
 
   # Used by the login and controller, the controller applies it to all partitions as well.
   - id: startup-all
@@ -93,7 +89,7 @@ deployment_groups:
     settings:
       runners:
       - type: shell
-        destination: startup-test-partition.sh
+        destination: startup-test-all.sh
         content: |
           #!/bin/bash
           set -ex

--- a/tools/validate_configs/test_configs/hpc-cluster-small-slurm-v5.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-small-slurm-v5.yaml
@@ -38,6 +38,18 @@ deployment_groups:
     settings:
       local_mount: /home
 
+  # Used by the partitions, this tests startup scripts that are partition specific
+  - id: startup-partition
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: shell
+        destination: startup-test-partition.sh
+        content: |
+          #!/bin/bash
+          set -ex
+          echo "Hello partition! Hostname: \$(hostname)"
+
   - id: debug_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
@@ -50,6 +62,7 @@ deployment_groups:
     - network1
     - homefs
     - debug_node_group
+    - startup-partition
     settings:
       partition_name: debug
       enable_placement: false
@@ -66,12 +79,25 @@ deployment_groups:
     - network1
     - homefs
     - compute_node_group
+    - startup-partition
     settings:
       partition_name: compute
       startup_script: |
         #!/bin/bash
         set -ex
         echo "hello compute_partition"
+
+  # Used by the login and controller, the controller applies it to all partitions as well.
+  - id: startup-all
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: shell
+        destination: startup-test-partition.sh
+        content: |
+          #!/bin/bash
+          set -ex
+          echo "Hello world! Hostname: \$(hostname)"
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
@@ -80,9 +106,11 @@ deployment_groups:
     - debug_partition
     - compute_partition
     - homefs
+    - startup-all
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
     use:
     - network1
     - slurm_controller
+    - startup-all


### PR DESCRIPTION
Fixes a bug with the slurm_cluster_name in the partition module that prevented the partition setup from recognizing custom startup scripts in the metadata.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
