### PR TITLE
Fix Quantum AI example by pinning to g++ 10 instead of 11

### DIFF
--- a/community/examples/quantum-circuit-simulator.yaml
+++ b/community/examples/quantum-circuit-simulator.yaml
@@ -60,7 +60,7 @@ deployment_groups:
           conda config --system --add channels nvidia/label/cuquantum-22.07.1
           conda update -n base conda --yes
           conda create -n qsim python=3.9 --yes
-          conda install -n qsim cuda cuquantum make cmake cxx-compiler --yes
+          conda install -n qsim cuda cuquantum make cmake cxx-compiler=1.5.1 --yes
           echo "cuda ==11.5.*" > /opt/conda/envs/qsim/conda-meta/pinned
           conda clean -p -t --yes
           conda activate qsim


### PR DESCRIPTION
There is an observed, repeatable failure in compilation of qsim with g++ 11.3. This commit fixes the `cxx-compiler` package to release 1.5.1 which, on Linux, points to g++ 10.4.

```
"Dec 14 18:50:27 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: nvcc cuda/pybind_main_cuda.cpp -o ../qsimcirq/qsim_cuda`python3-config --extension-suffix` -O3 -std=c++14 -x cu -Xcompiler \"-Wall -shared -fPIC `python3 -m pybind11 --includes`\"",
"Dec 14 18:50:29 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: cuda/../pybind_main.cpp(53): warning #177-D: handler parameter \"exp\" was declared but never referenced",
"Dec 14 18:50:29 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script:",
"Dec 14 18:50:29 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: cuda/../pybind_main.cpp(61): warning #177-D: handler parameter \"exp\" was declared but never referenced",
"Dec 14 18:50:29 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script:",
"Dec 14 18:50:29 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: cuda/../pybind_main.cpp(70): warning #177-D: handler parameter \"exp\" was declared but never referenced",
"Dec 14 18:50:29 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script:",
"Dec 14 18:50:42 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: /opt/conda/envs/qsim/x86_64-conda-linux-gnu/include/c++/11.3.0/bits/std_function.h:435:145: error: parameter packs not expanded with '...':",
"Dec 14 18:50:42 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script:   435 |         function(_Functor&& __f)",
"Dec 14 18:50:42 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script:       |                                                                                                                                                 ^",
"Dec 14 18:50:42 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: /opt/conda/envs/qsim/x86_64-conda-linux-gnu/include/c++/11.3.0/bits/std_function.h:435:145: note:         '_ArgTypes'",
"Dec 14 18:50:42 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: /opt/conda/envs/qsim/x86_64-conda-linux-gnu/include/c++/11.3.0/bits/std_function.h:530:146: error: parameter packs not expanded with '...':",
"Dec 14 18:50:42 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script:   530 |         operator=(_Functor&& __f)",
"Dec 14 18:50:42 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script:       |                                                                                                                                                  ^",
"Dec 14 18:50:42 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: /opt/conda/envs/qsim/x86_64-conda-linux-gnu/include/c++/11.3.0/bits/std_function.h:530:146: note:         '_ArgTypes'",
"Dec 14 18:50:47 qsim-1af4f5-0 google_metadata_script_runner[1618]: startup-script: make[1]: *** [Makefile:47: pybind-gpu] Error 1",
```

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?