### PR TITLE
Increase HTCondor installation timeout

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -155,7 +155,7 @@
       ansible.builtin.wait_for:
         port: 9618
         delay: 10
-        timeout: 300
+        timeout: 480
     - name: Run Integration tests for HPC toolkit
       ansible.builtin.include_tasks: "{{ test }}"
       run_once: true


### PR DESCRIPTION
Address an observed build failure that was due to combination of installation times for Ansible (~2min), HTCondor (~2min), and Docker (~1.5min). These installations were successful but need to be optimized by improved use of yum or alternative installation methods.

8 minutes was intentionally selected as a value that might still get triggered in exceptionally slow circumstances.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?