### PR TITLE
Update hybrid docs to conform to 5.3.0

### DIFF
--- a/docs/hybrid-slurm-cluster/blueprints/hybrid-configuration.yaml
+++ b/docs/hybrid-slurm-cluster/blueprints/hybrid-configuration.yaml
@@ -22,6 +22,7 @@ vars:
   region: us-central1
   zone: us-central1-c
   static_controller_hostname:  ## <<instance name>>.c.<<Project_A>>.internal
+  static_controller_addr: null ## IP Address of the controller
   network_name: compute-vpc-network
   subnetwork_name: primary-subnet
 
@@ -77,6 +78,7 @@ deployment_groups:
     - scratchfs
     settings:
       output_dir: ./hybrid
-      slurm_bin_dir: /usr/bin
+      slurm_bin_dir: /usr/local/bin
       slurm_control_host: $(vars.static_controller_hostname)
+      slurm_control_addr: $(vars.static_controller_addr)
       install_dir: /etc/slurm/hybrid


### PR DESCRIPTION
### Description
Some options have changed with the update to Slurm on GCP 5.3.0 that require changes to the hybrid deployment instructions. This has been tested as a demo/all GCP deployment.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
