### PR TITLE
Rolling google terraform provider version to 4.46.0

### DIFF
--- a/pkg/modulewriter/tfversions.go
+++ b/pkg/modulewriter/tfversions.go
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.83, <= 4.44.1"
+      version = ">= 3.83, <= 4.46.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.83, <= 4.44.1"
+      version = ">= 3.83, <= 4.46.0"
     }
   }
 }


### PR DESCRIPTION
Rolling provider version as part of release process.