### PR TITLE
Fix Quantum AI example by pinning to g++ 10 instead of 11 (known failure)

### DIFF
--- a/community/examples/quantum-circuit-simulator.yaml
+++ b/community/examples/quantum-circuit-simulator.yaml
@@ -60,7 +60,7 @@ deployment_groups:
           conda config --system --add channels nvidia/label/cuquantum-22.07.1
           conda update -n base conda --yes
           conda create -n qsim python=3.9 --yes
-          conda install -n qsim cuda cuquantum make cmake cxx-compiler --yes
+          conda install -n qsim cuda cuquantum make cmake cxx-compiler=1.5.1 --yes
           echo "cuda ==11.5.*" > /opt/conda/envs/qsim/conda-meta/pinned
           conda clean -p -t --yes
           conda activate qsim


### PR DESCRIPTION
This fix was merged into develop but is also needed in release. 

Process to create this PR:
```
git checkout 27718f37bf28bcdad9dc5d6e65636806c9044e0d
git checkout -b quantum_build_hot_fix
git rebase --onto 4b57fc5a HEAD^
git push --set-upstream origin quantum_build_hot_fix
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
