### PR TITLE
Remove singularity install to avoid failed package install

### DIFF
--- a/community/modules/scripts/omnia-install/templates/install_omnia.tpl
+++ b/community/modules/scripts/omnia-install/templates/install_omnia.tpl
@@ -78,6 +78,14 @@
       path: "{{ omnia_dir }}/roles/slurm_common/vars/main.yml"
       regexp: '^slurm_uid: ".*"'
       line: 'slurm_uid: "{{ slurm_uid }}"'
+  # Temporary workaround for singularity (3.8) being removed from epel-release in
+  # favor of singularity-ce (3.10) which causes downstream failures. An upgrade
+  # to version 1.4 may fix this.
+  - name: Remove installation of the "singularity" package in centos
+    ansible.builtin.lineinfile:
+      path: "{{ omnia_dir }}/roles/common/vars/main.yml"
+      regexp: '\s*\- singularity?'
+      state: absent
 
 - name: Run the Omnia installation once all nodes are ready
   hosts: localhost


### PR DESCRIPTION
With a recent update of epel-release, the singularity package has been replaced with singularity-ce at version 3.10 (vs 3.8 before). Installing 3.10 causes downstream failures that should be investigated further.

For now as a temporary workaround, this optional package will be removed to allow the omnia example and tests to succeed again. Without singularity, Omnia still deploys a functional slurm cluster.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
