### PR TITLE
Automate gpu guest accelerator in vm-instance if not set

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -120,7 +120,7 @@ Use the following settings for spread placement:
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-Copyright 2022 Google LLC
+Copyright 2023 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/compute/vm-instance/gpu_definition.tf
+++ b/modules/compute/vm-instance/gpu_definition.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+locals {
+  #
+  # if a machine type is a2-*-?g it will automatically fill in the guest_accelerator structure.
+  #
+  is_a2_vm = length(regexall("a2-[a-z]+-\\d+g", var.machine_type)) > 0
+  accelerator_types = {
+    "highgpu"  = "nvidia-tesla-a100"
+    "megagpu"  = "nvidia-tesla-a100"
+    "ultragpu" = "nvidia-a100-80gb"
+  }
+  generated_guest_accelerator = try([{
+    type  = lookup(local.accelerator_types, regex("a2-([A-Za-z]+)-", var.machine_type)[0], ""),
+    count = one(regex("a2-[A-Za-z]+-(\\d+)", var.machine_type)),
+  }], [])
+  guest_accelerator = local.is_a2_vm ? coalescelist(
+    var.guest_accelerator,
+    local.generated_guest_accelerator,
+  ) : var.guest_accelerator
+}

--- a/modules/compute/vm-instance/gpu_definition.tf
+++ b/modules/compute/vm-instance/gpu_definition.tf
@@ -15,10 +15,10 @@
 */
 
 locals {
-  #
   # if a machine type is a2-*-?g it will automatically fill in the guest_accelerator structure.
-  #
   is_a2_vm = length(regexall("a2-[a-z]+-\\d+g", var.machine_type)) > 0
+
+  # If the machine type indicates a GPU is used, gather the count and type information
   accelerator_types = {
     "highgpu"  = "nvidia-tesla-a100"
     "megagpu"  = "nvidia-tesla-a100"
@@ -28,6 +28,9 @@ locals {
     type  = lookup(local.accelerator_types, regex("a2-([A-Za-z]+)-", var.machine_type)[0], ""),
     count = one(regex("a2-[A-Za-z]+-(\\d+)", var.machine_type)),
   }], [])
+
+  # Set the guest_accelerator to the user defined value if supplied, otherwise
+  # use the locally generated accelerator list.
   guest_accelerator = local.is_a2_vm ? coalescelist(
     var.guest_accelerator,
     local.generated_guest_accelerator,

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -32,7 +32,7 @@ locals {
   # compact_placement : true when placement policy is provided and collocation set; false if unset
   compact_placement = try(var.placement_policy.collocation, null) != null
 
-  gpu_attached = contains(["a2"], local.machine_family) || var.guest_accelerator != null
+  gpu_attached = contains(["a2"], local.machine_family) || local.guest_accelerator != null
 
   # both of these must be false if either compact placement or preemptible/spot instances are used
   # automatic restart is tolerant of GPUs while on host maintenance is not

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,7 @@ resource "google_compute_disk" "boot_disk" {
   type   = var.disk_type
   size   = var.disk_size_gb
   labels = var.labels
+  zone   = var.zone
 }
 
 resource "google_compute_resource_policy" "placement_policy" {
@@ -192,7 +193,7 @@ resource "google_compute_instance" "compute_vm" {
     }
   }
 
-  guest_accelerator = var.guest_accelerator
+  guest_accelerator = local.guest_accelerator
   scheduling {
     on_host_maintenance = local.on_host_maintenance
     automatic_restart   = local.automatic_restart

--- a/tools/validate_configs/test_configs/README.md
+++ b/tools/validate_configs/test_configs/README.md
@@ -13,6 +13,10 @@ but otherwise the same variables. This test exists to ensure there will be no
 naming collisions when more than one NFS server is created in a projects with
 the same deployment name.
 
+**gpu.yaml**: Deploys a set of VM instances (`vm-instance`) with different GPU
+configurations attached. Both automatic (via `gpu_definition.yaml`) and manually
+supplied guest accelerators are adding to the VM instances.
+
 **hpc-cluster-simple.yaml**: Creates a simple cluster with a single compute VM,
 filestore as a /home directory and a network. This has been used as a demo
 blueprint when presenting the toolkit.

--- a/tools/validate_configs/test_configs/gpu.yaml
+++ b/tools/validate_configs/test_configs/gpu.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,9 +21,42 @@ vars:
   deployment_name: gpu-vm
   region: us-central1
   zone: us-central1-c
+  instance_image:
+    family: common-dl-gpu-debian-10
+    project: ml-images
 
+# Broken into 3 groups to better manage GPU quotas
 deployment_groups:
-- group: primary
+- group: high-count-auto
+  modules:
+  - id: network-hca
+    source: modules/network/pre-existing-vpc
+
+  - id: auto-megagpu
+    source: modules/compute/vm-instance
+    use:
+    - network-hca
+    settings:
+      name_prefix: auto-megagpu
+      machine_type: a2-megagpu-16g
+
+- group: high-count-manual
+  modules:
+  - id: network-hcm
+    source: modules/network/pre-existing-vpc
+
+  - id: manual-megagpu
+    source: modules/compute/vm-instance
+    use:
+    - network-hcm
+    settings:
+      name_prefix: manual-megagpu
+      machine_type: a2-megagpu-16g
+      guest_accelerator:
+      - type: nvidia-tesla-a100
+        count: 16
+
+- group: low-count
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
@@ -31,13 +64,52 @@ deployment_groups:
   - id: network1
     source: modules/network/pre-existing-vpc
 
-  - id: workstation
+  - id: manual-n1
     source: ./modules/compute/vm-instance
     use:
     - network1
     settings:
+      name_prefix: manual-n1
       machine_type: n1-standard-32
       on_host_maintenance: TERMINATE
       guest_accelerator:
       - type: nvidia-tesla-t4
         count: 1
+
+  - id: auto-highgpu
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    settings:
+      name_prefix: auto-highgpu
+      machine_type: a2-highgpu-1g
+
+  - id: manual-highgpu
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    settings:
+      name_prefix: manual-highgpu
+      machine_type: a2-highgpu-2g
+      guest_accelerator:
+      - type: nvidia-tesla-a100
+        count: 2
+
+  - id: auto-ultragpu
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    settings:
+      name_prefix: auto-ultragpu
+      machine_type: a2-ultragpu-2g
+
+  - id: manual-ultragpu
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    settings:
+      name_prefix: manual-ultragpu
+      machine_type: a2-ultragpu-2g
+      guest_accelerator:
+      - type: nvidia-a100-80gb
+        count: 2


### PR DESCRIPTION
Adds a boilerplate file "gpu_definition.tf" that handled populating the guest_accelerator field when not set by the user and when the machine type indicates GPUs are available.

The same format will be applied to slurm modules and any other module using "guest_accelerator" in follow-on PRs.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
