### PR TITLE
Pass family through instead of looking up image to allow compute nodes to pick up new version within family

### DIFF
--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
@@ -1,4 +1,4 @@
-## Description
+git ## Description
 
 This module creates a compute partition that be can used as input to
 [SchedMD-slurm-on-gcp-controller](../../scheduler/SchedMD-slurm-on-gcp-controller/README.md).
@@ -41,13 +41,10 @@ modules. For support with the underlying modules, see the instructions in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+No providers.
 
 ## Modules
 
@@ -55,9 +52,7 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_compute_image.compute_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+No resources.
 
 ## Inputs
 

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/outputs.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/outputs.tf
@@ -13,11 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_compute_image" "compute_image" {
-  family  = var.instance_image.family
-  project = var.instance_image.project
-}
-
 output "partition" {
   description = "The partition structure containing all the set variables"
   value = {
@@ -26,7 +21,7 @@ output "partition" {
     static_node_count : var.static_node_count
     max_node_count : var.max_node_count
     zone : var.zone
-    image : data.google_compute_image.compute_image.self_link
+    image : "projects/${var.instance_image.project}/global/images/family/${var.instance_image.family}"
     image_hyperthreads : var.image_hyperthreads
     compute_disk_type : var.compute_disk_type
     compute_disk_size_gb : var.compute_disk_size_gb

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/versions.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/versions.tf
@@ -15,15 +15,5 @@
 */
 
 terraform {
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 3.83"
-    }
-  }
-  provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-partition/v1.10.1"
-  }
-
   required_version = ">= 0.14.0"
 }


### PR DESCRIPTION
By passing the family instead of the specific image we allow for the compute nodes to grab the latest version of the image without any updates to the cluster. 

Tested: 
- I have manually verified that compute nodes will grab the latest image in a family without applying any updates to the cluster. The testing was done by:
  - Deploy cluster using custom image family in my project
  - Run job to confirm version of image used
  - While cluster is up, create a new image in the same family
  - Run subsequent job and confirm that new image is used

Follow on work might include:
- Using this same methodology for the controller and login images
- Verifying behavior on Slurm V5

I have opted to submit this PR as stand alone the compute nodes are most critical and additional testing should be completed for other updates. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
