### PR TITLE
Move directory check to after embedded checks

### DIFF
--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -34,23 +34,25 @@ func getHCLInfo(source string) (ModuleInfo, error) {
 	var module *tfconfig.Module
 	ret := ModuleInfo{}
 
-	fileInfo, err := os.Stat(source)
-	if os.IsNotExist(err) {
-		return ret, fmt.Errorf("Source to module does not exist: %s", source)
-	}
-	if err != nil {
-		return ret, fmt.Errorf("Failed to read source of module: %s", source)
-	}
-	if !fileInfo.IsDir() {
-		return ret, fmt.Errorf("Source of module must be a directory: %s", source)
-	}
-	if !tfconfig.IsModuleDir(source) {
-		return ret, fmt.Errorf("Source is not a terraform or packer module: %s", source)
-	}
-
 	if isEmbeddedPath(source) {
+		if !tfconfig.IsModuleDirOnFilesystem(tfconfig.WrapFS(ModuleFS), source) {
+			return ret, fmt.Errorf("Source is not a terraform or packer module: %s", source)
+		}
 		module, _ = tfconfig.LoadModuleFromFilesystem(tfconfig.WrapFS(ModuleFS), source)
 	} else {
+		fileInfo, err := os.Stat(source)
+		if os.IsNotExist(err) {
+			return ret, fmt.Errorf("Source to module does not exist: %s", source)
+		}
+		if err != nil {
+			return ret, fmt.Errorf("Failed to read source of module: %s", source)
+		}
+		if !fileInfo.IsDir() {
+			return ret, fmt.Errorf("Source of module must be a directory: %s", source)
+		}
+		if !tfconfig.IsModuleDir(source) {
+			return ret, fmt.Errorf("Source is not a terraform or packer module: %s", source)
+		}
 		module, _ = tfconfig.LoadModule(source)
 	}
 


### PR DESCRIPTION
Fixes a bug caused when not running in the same directory as the HPC Toolkit.

The check for whether the local file exists passes when running in the repo, even if an embedded resource is used, but fails outside of the repo since the path doesn't exist.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
