### PR TITLE
Eliminate unnecessary guard around map access warning (S1036)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -283,11 +283,7 @@ func (dc *DeploymentConfig) listUnusedModules() map[string][]string {
 	unusedModules := make(map[string][]string)
 	for _, conn := range dc.moduleConnections {
 		if conn.isEmpty() {
-			if _, exists := unusedModules[conn.fromID]; exists {
-				unusedModules[conn.fromID] = append(unusedModules[conn.fromID], conn.toID)
-			} else {
-				unusedModules[conn.fromID] = []string{conn.toID}
-			}
+			unusedModules[conn.fromID] = append(unusedModules[conn.fromID], conn.toID)
 		}
 	}
 	return unusedModules


### PR DESCRIPTION
This PR eliminates a "harmless" warning reported by VS Code. We can rely on the behavior of Go to return zero values when accessing elements of a map that do not yet exist.

https://staticcheck.io/docs/checks#S1036

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?