### PR TITLE
Initial support for intergroup variable references

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -417,7 +417,9 @@ type varContext struct {
 A variable reference has the following fields
   - ID: a module ID or "vars" if referring to a deployment variable
   - GroupID: if ID is a module ID, GroupID must be the deployment group in
-    which the module is *expected* to be found.
+    which the module is *expected* to be found. If ID is "vars", then it
+    should be set to "deployment" to indicate that the reference belongs
+    to the entire blueprint, rather than a deployment group.
   - Name: the name of the module output or deployment variable
   - Explicit: a boolean value indicating whether the user made an explicit
     reference to GroupID or whether it was automatically assigned the GroupID

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -407,6 +407,38 @@ func (s *MySuite) TestHasVariable(c *C) {
 	c.Assert(got, Equals, false)
 }
 
+func (s *MySuite) TestIdentifySimpleVariable(c *C) {
+	var ref varReference
+	var err error
+
+	ref, err = identifySimpleVariable("group_id.module_id.output_name")
+	c.Assert(err, IsNil)
+	c.Assert(ref.Group, Equals, "group_id")
+	c.Assert(ref.Source, Equals, "module_id")
+	c.Assert(ref.Name, Equals, "output_name")
+
+	ref, err = identifySimpleVariable("module_id.output_name")
+	c.Assert(err, IsNil)
+	c.Assert(ref.Group, Equals, "")
+	c.Assert(ref.Source, Equals, "module_id")
+	c.Assert(ref.Name, Equals, "output_name")
+
+	ref, err = identifySimpleVariable("foo")
+	c.Assert(err, NotNil)
+
+	ref, err = identifySimpleVariable("foo.bar.baz.qux")
+	c.Assert(err, NotNil)
+
+	ref, err = identifySimpleVariable("foo..bar")
+	c.Assert(err, NotNil)
+
+	ref, err = identifySimpleVariable("foo.bar.")
+	c.Assert(err, NotNil)
+
+	ref, err = identifySimpleVariable("foo..")
+	c.Assert(err, NotNil)
+}
+
 func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	// Setup
 	testModID := "existingModule"

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -423,19 +423,25 @@ func (s *MySuite) TestIdentifySimpleVariable(c *C) {
 	c.Assert(ref.ID, Equals, "module_id")
 	c.Assert(ref.Name, Equals, "output_name")
 
+	ref, err = identifySimpleVariable("vars.variable_name")
+	c.Assert(err, IsNil)
+	c.Assert(ref.GroupID, Equals, "deployment")
+	c.Assert(ref.ID, Equals, "vars")
+	c.Assert(ref.Name, Equals, "variable_name")
+
 	ref, err = identifySimpleVariable("foo")
 	c.Assert(err, NotNil)
-
 	ref, err = identifySimpleVariable("foo.bar.baz.qux")
 	c.Assert(err, NotNil)
-
 	ref, err = identifySimpleVariable("foo..bar")
 	c.Assert(err, NotNil)
-
 	ref, err = identifySimpleVariable("foo.bar.")
 	c.Assert(err, NotNil)
-
 	ref, err = identifySimpleVariable("foo..")
+	c.Assert(err, NotNil)
+	ref, err = identifySimpleVariable(".foo")
+	c.Assert(err, NotNil)
+	ref, err = identifySimpleVariable("..foo")
 	c.Assert(err, NotNil)
 }
 

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -413,14 +413,14 @@ func (s *MySuite) TestIdentifySimpleVariable(c *C) {
 
 	ref, err = identifySimpleVariable("group_id.module_id.output_name")
 	c.Assert(err, IsNil)
-	c.Assert(ref.Group, Equals, "group_id")
-	c.Assert(ref.Source, Equals, "module_id")
+	c.Assert(ref.GroupID, Equals, "group_id")
+	c.Assert(ref.ID, Equals, "module_id")
 	c.Assert(ref.Name, Equals, "output_name")
 
 	ref, err = identifySimpleVariable("module_id.output_name")
 	c.Assert(err, IsNil)
-	c.Assert(ref.Group, Equals, "")
-	c.Assert(ref.Source, Equals, "module_id")
+	c.Assert(ref.GroupID, Equals, "")
+	c.Assert(ref.ID, Equals, "module_id")
 	c.Assert(ref.Name, Equals, "output_name")
 
 	ref, err = identifySimpleVariable("foo")

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -411,37 +411,37 @@ func (s *MySuite) TestIdentifySimpleVariable(c *C) {
 	var ref varReference
 	var err error
 
-	ref, err = identifySimpleVariable("group_id.module_id.output_name")
+	ref, err = identifySimpleVariable("group_id.module_id.output_name", "other_group_id")
 	c.Assert(err, IsNil)
 	c.Assert(ref.GroupID, Equals, "group_id")
 	c.Assert(ref.ID, Equals, "module_id")
 	c.Assert(ref.Name, Equals, "output_name")
 
-	ref, err = identifySimpleVariable("module_id.output_name")
+	ref, err = identifySimpleVariable("module_id.output_name", "group_id")
 	c.Assert(err, IsNil)
-	c.Assert(ref.GroupID, Equals, "")
+	c.Assert(ref.GroupID, Equals, "group_id")
 	c.Assert(ref.ID, Equals, "module_id")
 	c.Assert(ref.Name, Equals, "output_name")
 
-	ref, err = identifySimpleVariable("vars.variable_name")
+	ref, err = identifySimpleVariable("vars.variable_name", "group_id")
 	c.Assert(err, IsNil)
 	c.Assert(ref.GroupID, Equals, "deployment")
 	c.Assert(ref.ID, Equals, "vars")
 	c.Assert(ref.Name, Equals, "variable_name")
 
-	ref, err = identifySimpleVariable("foo")
+	ref, err = identifySimpleVariable("foo", "group_id")
 	c.Assert(err, NotNil)
-	ref, err = identifySimpleVariable("foo.bar.baz.qux")
+	ref, err = identifySimpleVariable("foo.bar.baz.qux", "group_id")
 	c.Assert(err, NotNil)
-	ref, err = identifySimpleVariable("foo..bar")
+	ref, err = identifySimpleVariable("foo..bar", "group_id")
 	c.Assert(err, NotNil)
-	ref, err = identifySimpleVariable("foo.bar.")
+	ref, err = identifySimpleVariable("foo.bar.", "group_id")
 	c.Assert(err, NotNil)
-	ref, err = identifySimpleVariable("foo..")
+	ref, err = identifySimpleVariable("foo..", "group_id")
 	c.Assert(err, NotNil)
-	ref, err = identifySimpleVariable(".foo")
+	ref, err = identifySimpleVariable(".foo", "group_id")
 	c.Assert(err, NotNil)
-	ref, err = identifySimpleVariable("..foo")
+	ref, err = identifySimpleVariable("..foo", "group_id")
 	c.Assert(err, NotNil)
 }
 


### PR DESCRIPTION
This PR adds the following:

- a new struct defining a "variable reference" to deployment variables or to the output values of other modules
- unit tests for a function introduced in #828 

The unit test increases coverage by 0.1% and serves to enforce the syntax of variable references.

This PR anticipates future work adding functionality to `expandSimpleVariable` which will allow it to properly resolve intergroup references. [Current feature branch (link may not live forever)](https://github.com/tpdownes/hpc-toolkit/commit/f591fa13592a9a8fa617550f5dfe173110c7c931).

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?
