### PR TITLE
Inject build id into Omnia test, drop to last build

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -81,10 +81,6 @@
         gcloud compute instances describe --zone={{ zone }} {{ remote_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
       when: '"*" not in remote_node'
-    - name: Set remote_ip variable - Exact name provided
-      ansible.builtin.set_fact:
-        remote_ip: "{{ get_remote_ip.stdout }}"
-      when: '"*" not in remote_node'
     - name: Get IP of the remote node - Name pattern provided
       changed_when: false
       register: get_remote_ip
@@ -93,13 +89,9 @@
           --format='get(networkInterfaces[0].accessConfigs[0].natIP)' --limit=1 \
           --filter=NAME:{{ remote_node }}
       when: '"*" in remote_node'
-    - name: Set remote_ip variable - Name pattern provided
-      ansible.builtin.set_fact:
-        remote_ip: "{{ get_remote_ip.stdout }}"
-      when: '"*" in remote_node'
     - name: Print remote node's public IP
       ansible.builtin.debug:
-        var: remote_node
+        var: get_remote_ip.stdout
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
@@ -140,7 +132,7 @@
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
     - name: Add Remote node as host
       ansible.builtin.add_host:
-        hostname: "{{ remote_ip }}"
+        hostname: "{{ get_remote_ip.stdout }}"
         groups: [remote_host]
     - name: Wait for cluster
       ansible.builtin.wait_for_connection:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -81,6 +81,13 @@
         gcloud compute instances describe --zone={{ zone }} {{ remote_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
       when: '"*" not in remote_node'
+    # Setting a fact is needed because the variable will overwrite itself even
+    # if a task is skipped, leading to an undefined variable when the exact name
+    # is provided.
+    - name: Set remote_ip variable - Exact name provided
+      ansible.builtin.set_fact:
+        remote_ip: "{{ get_remote_ip.stdout }}"
+      when: '"*" not in remote_node'
     - name: Get IP of the remote node - Name pattern provided
       changed_when: false
       register: get_remote_ip
@@ -89,9 +96,13 @@
           --format='get(networkInterfaces[0].accessConfigs[0].natIP)' --limit=1 \
           --filter=NAME:{{ remote_node }}
       when: '"*" in remote_node'
+    - name: Set remote_ip variable - Name pattern provided
+      ansible.builtin.set_fact:
+        remote_ip: "{{ get_remote_ip.stdout }}"
+      when: '"*" in remote_node'
     - name: Print remote node's public IP
       ansible.builtin.debug:
-        var: get_remote_ip.stdout
+        var: remote_ip
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
@@ -132,7 +143,7 @@
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
     - name: Add Remote node as host
       ansible.builtin.add_host:
-        hostname: "{{ get_remote_ip.stdout }}"
+        hostname: "{{ remote_ip }}"
         groups: [remote_host]
     - name: Wait for cluster
       ansible.builtin.wait_for_connection:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -74,12 +74,32 @@
     - name: Print instance information
       ansible.builtin.debug:
         var: instances_list.stdout_lines
-    - name: Get remote IP
+    - name: Get IP of the remote node - Exact name provided
       changed_when: false
-      register: remote_ip
+      register: get_remote_ip
       ansible.builtin.command: >-
         gcloud compute instances describe --zone={{ zone }} {{ remote_node }}
         --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+      when: '"*" not in remote_node'
+    - name: Set remote_ip variable - Exact name provided
+      ansible.builtin.set_fact:
+        remote_ip: "{{ get_remote_ip.stdout }}"
+      when: '"*" not in remote_node'
+    - name: Get IP of the remote node - Name pattern provided
+      changed_when: false
+      register: get_remote_ip
+      ansible.builtin.command: >-
+        gcloud compute instances list \
+          --format='get(networkInterfaces[0].accessConfigs[0].natIP)' --limit=1 \
+          --filter=NAME:{{ remote_node }}
+      when: '"*" in remote_node'
+    - name: Set remote_ip variable - Name pattern provided
+      ansible.builtin.set_fact:
+        remote_ip: "{{ get_remote_ip.stdout }}"
+      when: '"*" in remote_node'
+    - name: Print remote node's public IP
+      ansible.builtin.debug:
+        var: remote_node
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
@@ -120,7 +140,7 @@
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
     - name: Add Remote node as host
       ansible.builtin.add_host:
-        hostname: "{{ remote_ip.stdout }}"
+        hostname: "{{ remote_ip }}"
         groups: [remote_host]
     - name: Wait for cluster
       ansible.builtin.wait_for_connection:

--- a/tools/cloud-build/daily-tests/integration-group-3.yaml
+++ b/tools/cloud-build/daily-tests/integration-group-3.yaml
@@ -17,9 +17,9 @@
 # ├── build_ghpc
 # └── fetch_builder
 #    └── monitoring  (group 3)
-#        └── omnia
-#            └── lustre-new-vpc
-#                └── packer
+#        └── lustre-new-vpc
+#            └── packer
+#                └── omnia
 
 
 timeout: 14400s  # 4hr
@@ -65,31 +65,10 @@ steps:
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/monitoring.yml"
 
-## Test Omnia Example
-- id: omnia
-  waitFor:
-  - monitoring
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  env:
-  - "ANSIBLE_HOST_KEY_CHECKING=false"
-  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
-  args:
-  - -c
-  - |
-    set -x -e
-    BUILD_ID_FULL=$BUILD_ID
-    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
-
-    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
-      --extra-vars="@tools/cloud-build/daily-tests/tests/omnia.yml"
-
 ## Test DDN Lustre with new VPC
 - id: lustre-new-vpc
   waitFor:
-  - omnia
+  - monitoring
   name: >-
     us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash
@@ -127,3 +106,28 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/packer.yml"
+
+## Test Omnia Example
+- id: omnia
+  waitFor:
+  - packer
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    OMNIA_EXAMPLE=community/examples/omnia-cluster.yaml
+
+    # Inject the build ID into the name prefix of the vm-instance modules to avoid naming collisions
+    sed -i "s/name_prefix: \(.*\)/name_prefix: \1-$${BUILD_ID_SHORT}/" $${OMNIA_EXAMPLE}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/omnia.yml"

--- a/tools/cloud-build/daily-tests/tests/omnia.yml
+++ b/tools/cloud-build/daily-tests/tests/omnia.yml
@@ -20,5 +20,5 @@ zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/omnia-cluster.yaml"
 network: "default"
-remote_node: "omnia-manager-0"
+remote_node: "omnia-manager-*-0"
 post_deploy_tests: []


### PR DESCRIPTION
There have been known issues with the naming of the resources created by the omnia example in automated testing. In order to allow parallel builds, this PR injects the build ID into the name prefix before running the test.

More thorough fixes are possible, but are not a priority for now. In addition, the test has been dropped to last in the group to ensure that all other tests can run if Omnia fails due to changes outside of our teams control.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
