### PR TITLE
Changed DAOS community examples to use v0.3.0 terraform modules

### DIFF
--- a/community/examples/intel/README.md
+++ b/community/examples/intel/README.md
@@ -261,7 +261,7 @@ Follow `ghpc` instructions to deploy the environment
 
 The `community/examples/intel/daos-cluster.yaml` blueprint does not contain configuration for DAOS pools and containers. Therefore, pools and containers will need to be created manually.
 
-Before pools and containers can be created the storage system must be formatted. Formatting the storage is done automatically by the startup script that runs on the *daos-server-0001* instance. The startup script will run the [dmg storage format](https://docs.daos.io/v2.0/admin/deployment/?h=dmg+storage#storage-formatting) command. It may take a few minutes for all daos server instances to join.
+Before pools and containers can be created the storage system must be formatted. Formatting the storage is done automatically by the startup script that runs on the *daos-server-0001* instance. The startup script will run the [dmg storage format](https://docs.daos.io/v2.2/admin/deployment/?h=dmg+storage#storage-formatting) command. It may take a few minutes for all daos server instances to join.
 
 Verify that the storage system has been formatted and that the daos-server instances have joined.
 
@@ -286,9 +286,9 @@ Both daos-server instances should show a state of *Joined*.
 
 #### About the DAOS Command Line Tools
 
-The DAOS Management tool `dmg` is used by System Administrators to manange the DAOS storage [system](https://docs.daos.io/v2.0/overview/architecture/#daos-system) and DAOS [pools](https://docs.daos.io/v2.0/overview/storage/#daos-pool). Therefore, `sudo` must be used when running `dmg`.
+The DAOS Management tool `dmg` is used by System Administrators to manange the DAOS storage [system](https://docs.daos.io/v2.2/overview/architecture/#daos-system) and DAOS [pools](https://docs.daos.io/v2.2/overview/storage/#daos-pool). Therefore, `sudo` must be used when running `dmg`.
 
-The DAOS CLI `daos` is used by both users and System Administrators to create and manage [containers](https://docs.daos.io/v2.0/overview/storage/#daos-container). It is not necessary to use `sudo` with the `daos` command.
+The DAOS CLI `daos` is used by both users and System Administrators to create and manage [containers](https://docs.daos.io/v2.2/overview/storage/#daos-container). It is not necessary to use `sudo` with the `daos` command.
 
 #### Determine Free Space
 
@@ -323,7 +323,7 @@ Set ACLs to allow any user to create a container in *pool1*.
 sudo dmg pool update-acl -e A::EVERYONE@:rcta pool1
 ```
 
-See the [Pool Operations](https://docs.daos.io/v2.0/admin/pool_operations) section of the of the DAOS Administration Guide for more information about creating pools.
+See the [Pool Operations](https://docs.daos.io/v2.2/admin/pool_operations) section of the of the DAOS Administration Guide for more information about creating pools.
 
 #### Create a Container
 
@@ -336,10 +336,10 @@ For the purpose of this demo create the container without specifying ACLs. The c
 daos cont create pool1 \
   --label cont1 \
   --type POSIX \
-  --properties rf:1
+  --properties rf:0
 ```
 
-See the [Container Management](https://docs.daos.io/v2.0/user/container) section of the of the DAOS User Guide for more information about creating containers.
+See the [Container Management](https://docs.daos.io/v2.2/user/container) section of the of the DAOS User Guide for more information about creating containers.
 
 #### Mount the DAOS Container
 
@@ -371,7 +371,7 @@ time LD_PRELOAD=/usr/lib64/libioil.so \
 dd if=/dev/zero of=./test20GiB.img iflag=fullblock bs=1G count=20
 ```
 
-See the [File System](https://docs.daos.io/v2.0/user/filesystem/) section of the DAOS User Guide for more information about DFuse.
+See the [File System](https://docs.daos.io/v2.2/user/filesystem/) section of the DAOS User Guide for more information about DFuse.
 
 ### Unmount the DAOS Container
 
@@ -387,7 +387,7 @@ Verify that the container is unmounted
 df -h -t fuse.daos
 ```
 
-See the [DFuse (DAOS FUSE)](https://docs.daos.io/v2.0/user/filesystem/?h=dfuse#dfuse-daos-fuse) section of the DAOS User Guide for more information about mounting POSIX containers.
+See the [DFuse (DAOS FUSE)](https://docs.daos.io/v2.2/user/filesystem/?h=dfuse#dfuse-daos-fuse) section of the DAOS User Guide for more information about mounting POSIX containers.
 
 ### Delete the DAOS infrastructure when not in use
 
@@ -596,7 +596,7 @@ Verify that the container is unmounted
 df -h -t fuse.daos
 ```
 
-See the [DFuse (DAOS FUSE)](https://docs.daos.io/v2.0/user/filesystem/?h=dfuse#dfuse-daos-fuse) section of the DAOS User Guide for more information about mounting POSIX containers.
+See the [DFuse (DAOS FUSE)](https://docs.daos.io/v2.2/user/filesystem/?h=dfuse#dfuse-daos-fuse) section of the DAOS User Guide for more information about mounting POSIX containers.
 
 ### Delete the DAOS/Slurm Cluster infrastructure when not in use
 

--- a/community/examples/intel/daos-cluster.yaml
+++ b/community/examples/intel/daos-cluster.yaml
@@ -35,7 +35,7 @@ deployment_groups:
   # https://github.com/daos-stack/google-cloud-daos/tree/main/images
   # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server
   - id: daos-server
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.2.1
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.3.0
     use: [network1]
     settings:
       number_of_instances: 2
@@ -45,7 +45,7 @@ deployment_groups:
   # https://github.com/daos-stack/google-cloud-daos/tree/main/images
   # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_client
   - id: daos-client
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_client?ref=v0.2.1
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_client?ref=v0.3.0
     use: [network1, daos-server]
     settings:
       number_of_instances: 2

--- a/community/examples/intel/daos-slurm.yaml
+++ b/community/examples/intel/daos-slurm.yaml
@@ -41,7 +41,7 @@ deployment_groups:
   # https://github.com/daos-stack/google-cloud-daos/tree/main/images
   # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server
   - id: daos
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.2.1
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.3.0
     use: [network1]
     settings:
       labels: {ghpc_role: file-system}


### PR DESCRIPTION
https://daosio.atlassian.net/browse/DAOSGCP-145

The community/examples/intel/daos*.yaml blueprints use the Terraform modules in the https://github.com/daos-stack/google-cloud-daos repo.

Changed the version tag of the modules referenced in the daos*.yaml blueprints to v0.3.0 in order to use the latest terraform modules that work with the DAOS v2.2 (the current release at this time).

Updated DAOS v2.0 references in the README.md to DAOS v2.2

Fixed incorrect replication factor setting in the README.md. The Replication Factor used in the 'daos cont create' command was set to 'rf:1'. That setting requires erasure coding which is not enabled in the example deployment. As a result, the container will be created successfully but an error will occur when attempting to create a file in the container. Therefore, the 'rf:1' setting was changed to 'rf:0' to prevent errors when following the instructions in the README.md

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
