### PR TITLE
Remove category field from HPC dashboard json

### DIFF
--- a/modules/monitoring/dashboard/dashboards/HPC.json.tpl
+++ b/modules/monitoring/dashboard/dashboards/HPC.json.tpl
@@ -1,5 +1,4 @@
 {
-  "category": "CUSTOM",
   "displayName": "${title}: ${deployment_name}",
   "gridLayout": {
     "columns": 2,


### PR DESCRIPTION
Removes the category field from the json template for the HPC dashboard. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
