### PR TITLE
Increasing default login node disk size on the ofe

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/models.py
+++ b/community/front-end/ofe/website/ghpcfe/models.py
@@ -643,10 +643,10 @@ class Cluster(CloudResource):
     )
     login_node_disk_size = models.PositiveIntegerField(
         # login node disk must be large enough to hold the SlurmGCP
-        # image: >=30GB
-        validators=[MinValueValidator(30)],
+        # image: >=50GB
+        validators=[MinValueValidator(50)],
         help_text="Boot disk size (in GB)",
-        default=30,
+        default=50,
         blank=True,
     )
     grafana_dashboard_url = models.CharField(


### PR DESCRIPTION
The `schedmd-v5-slurm-22-05-6-hpc-centos-7` image is now 32GB in size. However, the default login node disk size value in the "ofe" is 30GB. If the user keeps the default value when provisioning a cluster, the creation will fail because the disk will be smaller than the image.
![image](https://user-images.githubusercontent.com/117852832/213667917-afb545f2-36b9-4940-8ce5-7ca74027fb38.png)

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
