### PR TITLE
Use keyword must be explicit across groups

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	expectedVarFormat string = "$(vars.var_name) or $(module_id.output_name)"
+	expectedModFormat string = "$(module_id) or $(group_id.module_id)"
 	matchLabelExp     string = `^[\p{Ll}\p{Lo}\p{N}_-]{1,63}$`
 )
 
@@ -52,6 +53,7 @@ var errorMessages = map[string]string{
 	"globalLabelType":      "deployment variable 'labels' are not a map",
 	"settingsLabelType":    "labels in module settings are not a map",
 	"invalidVar":           "invalid variable definition in",
+	"invalidMod":           "invalid module reference",
 	"invalidDeploymentRef": "invalid deployment-wide reference (only \"vars\") is supported)",
 	"varNotFound":          "Could not find source of variable",
 	"varInAnotherGroup":    "References to other groups are not yet supported",
@@ -60,6 +62,7 @@ var errorMessages = map[string]string{
 	"referenceWrongGroup":  "Reference specified the wrong group for the module",
 	"noOutput":             "Output not found for a variable",
 	"varWithinStrings":     "variables \"$(...)\" within strings are not yet implemented. remove them or add a backslash to render literally.",
+	"groupNotFound":        "The group ID was not found",
 	// validator
 	"emptyID":            "a module id cannot be empty",
 	"emptySource":        "a module source cannot be empty",
@@ -482,17 +485,22 @@ func checkModuleAndGroupNames(
 // are in the correct group
 func checkUsedModuleNames(
 	depGroups []DeploymentGroup, idToGroup map[string]int) error {
-	for iGrp, grp := range depGroups {
+	for _, grp := range depGroups {
 		for _, mod := range grp.Modules {
 			for _, usedMod := range mod.Use {
-				// Check if module even exists
-				if _, ok := idToGroup[usedMod]; !ok {
-					return fmt.Errorf("used module ID %s does not exist", usedMod)
+				ref, err := identifyModuleByReference(usedMod, grp)
+				if err != nil {
+					return err
 				}
-				// Ensure module is from the correct group
-				if idToGroup[usedMod] != iGrp {
-					return fmt.Errorf(
-						"used module ID %s not found in this Deployment Group", usedMod)
+				err = ref.validate(depGroups, idToGroup)
+				if err != nil {
+					return err
+				}
+
+				// TODO: remove this when support is added!
+				if ref.FromGroupID != ref.ToGroupID {
+					return fmt.Errorf("%s: %s is an intergroup reference",
+						errorMessages["varInAnotherGroup"], usedMod)
 				}
 			}
 		}


### PR DESCRIPTION
This commit adds the infrastructure to enforce intergroup constraints upon module references made by the `use` keyword:

- references across groups must be explicit and correct about group ID
- references can only be within a group or to earlier groups

Unit test coverage for the `hpc-toolkit/pkg/config` package remains unchanged (85.3%) by this commit.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?
