### PR TITLE
Update HTCondor release to current 10.x series

### DIFF
--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -24,7 +24,7 @@
     ansible.builtin.yum:
       name:
       - epel-release
-      - https://research.cs.wisc.edu/htcondor/repo/9.x/htcondor-release-current.el7.noarch.rpm
+      - https://research.cs.wisc.edu/htcondor/repo/10.x/htcondor-release-current.el7.noarch.rpm
   - name: Install HTCondor
     ansible.builtin.yum:
       name: condor


### PR DESCRIPTION
This commit updates the version of HTCondor we are installing to the 10.x series (X>0). The 10.0 series is the Long Term Support release which contains developed along the 9.x series.

We are better off tracking the new feature development releases (10.x), which may contain updates based upon our partnership with the HTCondor team.

This change requires no blueprint changes (tested manually).

https://htcondor.org/htcondor/release-highlights/

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?