### PR TITLE
Improve Packer module

### DIFF
--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -225,7 +225,7 @@ No resources.
 | <a name="input_accelerator_count"></a> [accelerator\_count](#input\_accelerator\_count) | Number of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `number` | `null` | no |
 | <a name="input_accelerator_type"></a> [accelerator\_type](#input\_accelerator\_type) | Type of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `string` | `null` | no |
 | <a name="input_ansible_playbooks"></a> [ansible\_playbooks](#input\_ansible\_playbooks) | A list of Ansible playbook configurations that will be uploaded to customize the VM image | <pre>list(object({<br>    playbook_file   = string<br>    galaxy_file     = string<br>    extra_arguments = list(string)<br>  }))</pre> | `[]` | no |
-| <a name="input_communicator"></a> [communicator](#input\_communicator) | Communicator to use for provisioners that require access to VM (SSH, WinRM) | `string` | `null` | no |
+| <a name="input_communicator"></a> [communicator](#input\_communicator) | Communicator to use for provisioners that require access to VM ("ssh" or "winrm") | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name | `string` | n/a | yes |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
 | <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Defaults to `deployment_name` | `string` | `null` | no |

--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -230,6 +230,7 @@ No resources.
 | <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Image name will also be derived from this value. Defaults to `deployment_name` | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the short-lived VM | `map(string)` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2-standard-4"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Instance metadata to attach to the build VM (startup-script key overridden by var.startup\_script and var.startup\_script\_file if either is set) | `map(string)` | `{}` | no |
 | <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | Project ID of Shared VPC network | `string` | `null` | no |
 | <a name="input_omit_external_ip"></a> [omit\_external\_ip](#input\_omit\_external\_ip) | Provision the image building VM without a public IP address | `bool` | `true` | no |
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Describes maintenance behavior for the instance. If left blank this will default to `MIGRATE` except the use of GPUs requires it to be `TERMINATE` | `string` | `null` | no |
@@ -241,8 +242,8 @@ No resources.
 | <a name="input_source_image_family"></a> [source\_image\_family](#input\_source\_image\_family) | Alternative to source\_image. Specify image family to build from latest image in family | `string` | `"hpc-centos-7"` | no |
 | <a name="input_source_image_project_id"></a> [source\_image\_project\_id](#input\_source\_image\_project\_id) | A list of project IDs to search for the source image. Packer will search the<br>first project ID in the list first, and fall back to the next in the list,<br>until it finds the source image. | `list(string)` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username to use for SSH access to VM | `string` | `"packer"` | no |
-| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script (as raw string) used to build the custom VM image (overridden by var.startup\_script\_file if both are supplied) | `string` | `null` | no |
-| <a name="input_startup_script_file"></a> [startup\_script\_file](#input\_startup\_script\_file) | Path to local shell script that will be uploaded as a startup script to customize the VM image | `string` | `null` | no |
+| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script (as raw string) used to build the custom Linux VM image (overridden by var.startup\_script\_file if both are set) | `string` | `null` | no |
+| <a name="input_startup_script_file"></a> [startup\_script\_file](#input\_startup\_script\_file) | File path to local shell script that will be used to customize the Linux VM image (overrides var.startup\_script) | `string` | `null` | no |
 | <a name="input_state_timeout"></a> [state\_timeout](#input\_state\_timeout) | The time to wait for instance state changes, including image creation | `string` | `"10m"` | no |
 | <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of subnetwork in which to provision image building VM | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Assign network tags to apply firewall rules to VM instance | `list(string)` | `null` | no |

--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -227,7 +227,8 @@ No resources.
 | <a name="input_ansible_playbooks"></a> [ansible\_playbooks](#input\_ansible\_playbooks) | A list of Ansible playbook configurations that will be uploaded to customize the VM image | <pre>list(object({<br>    playbook_file   = string<br>    galaxy_file     = string<br>    extra_arguments = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name | `string` | n/a | yes |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
-| <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Image name will also be derived from this value. Defaults to `deployment_name` | `string` | `null` | no |
+| <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Defaults to `deployment_name` | `string` | `null` | no |
+| <a name="input_image_name"></a> [image\_name](#input\_image\_name) | The name of the image to be built. If not supplied, it will be set to image\_family-$ISO\_TIMESTAMP | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the short-lived VM | `map(string)` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2-standard-4"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Instance metadata to attach to the build VM (startup-script key overridden by var.startup\_script and var.startup\_script\_file if either is set) | `map(string)` | `{}` | no |

--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -225,6 +225,7 @@ No resources.
 | <a name="input_accelerator_count"></a> [accelerator\_count](#input\_accelerator\_count) | Number of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `number` | `null` | no |
 | <a name="input_accelerator_type"></a> [accelerator\_type](#input\_accelerator\_type) | Type of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `string` | `null` | no |
 | <a name="input_ansible_playbooks"></a> [ansible\_playbooks](#input\_ansible\_playbooks) | A list of Ansible playbook configurations that will be uploaded to customize the VM image | <pre>list(object({<br>    playbook_file   = string<br>    galaxy_file     = string<br>    extra_arguments = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_communicator"></a> [communicator](#input\_communicator) | Communicator to use for provisioners that require access to VM (SSH, WinRM) | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name | `string` | n/a | yes |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
 | <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Defaults to `deployment_name` | `string` | `null` | no |

--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -231,6 +231,7 @@ No resources.
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | The name of the image to be built. If not supplied, it will be set to image\_family-$ISO\_TIMESTAMP | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the short-lived VM | `map(string)` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2-standard-4"` | no |
+| <a name="input_manifest_file"></a> [manifest\_file](#input\_manifest\_file) | File to which to write Packer build manifest | `string` | `"packer-manifest.json"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Instance metadata to attach to the build VM (startup-script key overridden by var.startup\_script and var.startup\_script\_file if either is set) | `map(string)` | `{}` | no |
 | <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | Project ID of Shared VPC network | `string` | `null` | no |
 | <a name="input_omit_external_ip"></a> [omit\_external\_ip](#input\_omit\_external\_ip) | Provision the image building VM without a public IP address | `bool` | `true` | no |

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -102,5 +102,20 @@ build {
     }
   }
 
-  post-processor "manifest" {}
+  post-processor "manifest" {
+    output     = var.manifest_file
+    strip_path = true
+    custom_data = {
+      built-by = "cloud-hpc-toolkit"
+    }
+  }
+
+  # if the jq command is present, this will print the image name to stdout
+  # if jq is not present, this exits silently with code 0
+  post-processor "shell-local" {
+    inline = [
+      "command -v jq > /dev/null || exit 0",
+      "echo \"Image built: $(jq -r '.builds[-1].artifact_id' ${var.manifest_file} | cut -d ':' -f2)\"",
+    ]
+  }
 }

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 locals {
-  image_family = var.image_family != null ? var.image_family : var.deployment_name
+  # construct a unique image name from the image family
+  image_family       = var.image_family != null ? var.image_family : var.deployment_name
+  image_name_default = "${local.image_family}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
+  image_name         = var.image_name != null ? var.image_name : local.image_name_default
 
   # construct metadata from startup_script and metadata variables
   linux_startup_script_metadata = var.startup_script == null ? {} : { startup-script = var.startup_script }
@@ -41,7 +44,7 @@ locals {
 source "googlecompute" "toolkit_image" {
   communicator            = local.communicator
   project_id              = var.project_id
-  image_name              = "${local.image_family}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
+  image_name              = local.image_name
   image_family            = local.image_family
   machine_type            = var.machine_type
   accelerator_type        = var.accelerator_type

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -26,8 +26,9 @@ locals {
   no_shell_scripts     = length(var.shell_scripts) == 0
   no_ansible_playbooks = length(var.ansible_playbooks) == 0
   no_provisioners      = local.no_shell_scripts && local.no_ansible_playbooks
-  communicator         = local.no_provisioners ? "none" : "ssh"
-  use_iap              = local.no_provisioners ? false : var.use_iap
+  communicator_default = local.no_provisioners ? "none" : "ssh"
+  communicator         = var.communicator == null ? local.communicator_default : var.communicator
+  use_iap              = local.communicator == "none" ? false : var.use_iap
 
   # determine best value for on_host_maintenance if not supplied by user
   machine_vals                = split("-", var.machine_type)

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -46,6 +46,7 @@ source "googlecompute" "toolkit_image" {
   project_id              = var.project_id
   image_name              = local.image_name
   image_family            = local.image_family
+  image_labels            = var.labels
   machine_type            = var.machine_type
   accelerator_type        = var.accelerator_type
   accelerator_count       = var.accelerator_count

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -214,3 +214,13 @@ variable "manifest_file" {
   type        = string
   default     = "packer-manifest.json"
 }
+
+variable "communicator" {
+  description = "Communicator to use for provisioners that require access to VM (SSH, WinRM)"
+  type        = string
+  default     = null
+  validation {
+    condition     = var.communicator == null ? true : contains(["ssh", "winrm"], var.communicator)
+    error_message = "Set var.communicator to \"ssh\" or \"winrm\" or null."
+  }
+}

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -208,3 +208,9 @@ variable "metadata" {
   type        = map(string)
   default     = {}
 }
+
+variable "manifest_file" {
+  description = "File to which to write Packer build manifest"
+  type        = string
+  default     = "packer-manifest.json"
+}

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -216,11 +216,11 @@ variable "manifest_file" {
 }
 
 variable "communicator" {
-  description = "Communicator to use for provisioners that require access to VM (SSH, WinRM)"
+  description = "Communicator to use for provisioners that require access to VM (\"ssh\" or \"winrm\")"
   type        = string
   default     = null
   validation {
     condition     = var.communicator == null ? true : contains(["ssh", "winrm"], var.communicator)
-    error_message = "Set var.communicator to \"ssh\" or \"winrm\" or null."
+    error_message = "Set var.communicator to \"ssh\", \"winrm\", or null."
   }
 }

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -145,13 +145,13 @@ variable "shell_scripts" {
 }
 
 variable "startup_script" {
-  description = "Startup script (as raw string) used to build the custom VM image (overridden by var.startup_script_file if both are supplied)"
+  description = "Startup script (as raw string) used to build the custom Linux VM image (overridden by var.startup_script_file if both are set)"
   type        = string
   default     = null
 }
 
 variable "startup_script_file" {
-  description = "Path to local shell script that will be uploaded as a startup script to customize the VM image"
+  description = "File path to local shell script that will be used to customize the Linux VM image (overrides var.startup_script)"
   type        = string
   default     = null
 }
@@ -195,4 +195,10 @@ variable "state_timeout" {
   description = "The time to wait for instance state changes, including image creation"
   type        = string
   default     = "10m"
+}
+
+variable "metadata" {
+  description = "Instance metadata to attach to the build VM (startup-script key overridden by var.startup_script and var.startup_script_file if either is set)"
+  type        = map(string)
+  default     = {}
 }

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -63,7 +63,13 @@ variable "tags" {
 }
 
 variable "image_family" {
-  description = "The family name of the image to be built. Image name will also be derived from this value. Defaults to `deployment_name`"
+  description = "The family name of the image to be built. Defaults to `deployment_name`"
+  type        = string
+  default     = null
+}
+
+variable "image_name" {
+  description = "The name of the image to be built. If not supplied, it will be set to image_family-$ISO_TIMESTAMP"
   type        = string
   default     = null
 }


### PR DESCRIPTION
This PR combines a number of small commits (you might review commit-by-commit) that improve the overall Packer experience and put us in a better position to support building custom Windows images.

- allow user to set custom instance metadata (this is primary mechanism by which Packer supports building Windows images on GCP)
- allow user to explicitly identify the Packer communicator, although automatic detection is still enabled if left `null`. Primary use case is for the user to set the `winrm` communicator for an approach to Windows builds
- allow user to explicitly set the image name instead of only automating it from image_family and a timestamp
- allow user to select the manifest file destination
- improve stdout output to include the name of the image (when user has `jq` installed)
    ```
    ==> wimage.googlecompute.toolkit_image: Running post-processor:  (type manifest)
    ==> wimage.googlecompute.toolkit_image: Running post-processor:  (type shell-local)
    ==> wimage.googlecompute.toolkit_image (shell-local): Running local shell script: 
    /var/folders/0_/ms1tmdh54jq7qwwvgdydj20r00s9jb/T/packer-shell2223660212
        wimage.googlecompute.toolkit_image (shell-local): Image built: wimage-20230131t155739z
    ```
- add Toolkit labels to the image, not just the temporary build VM (presently only `ghpc_role : packer`)

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?