### PR TITLE
Eliminate warnings and align variable naming

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -213,17 +213,17 @@ func (dc *DeploymentConfig) applyUseModules() error {
 		grpModsInfo := dc.ModulesInfo[group.Name]
 		for iMod := range group.Modules {
 			fromMod := &group.Modules[iMod]
-			modInfo := grpModsInfo[fromMod.Source]
-			modInputs := getModuleInputMap(modInfo.Inputs)
+			fromModInfo := grpModsInfo[fromMod.Source]
+			fromModInputs := getModuleInputMap(fromModInfo.Inputs)
 			changedSettings := make(map[string]bool)
 			for _, toModID := range fromMod.Use {
 				toMod := group.getModuleByID(toModID)
-				useInfo := dc.ModulesInfo[group.Name][toMod.Source]
+				toModInfo := dc.ModulesInfo[group.Name][toMod.Source]
 				if toMod.ID == "" {
 					return fmt.Errorf("could not find module %s used by %s in group %s",
 						toModID, fromMod.ID, group.Name)
 				}
-				usedVars := useModule(fromMod, toMod, modInputs, useInfo.Outputs, changedSettings)
+				usedVars := useModule(fromMod, toMod, fromModInputs, toModInfo.Outputs, changedSettings)
 				connection := ModConnection{
 					toID:            toModID,
 					fromID:          fromMod.ID,

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -680,7 +680,7 @@ func expandSimpleVariable(
 		expandedVariable = fmt.Sprintf("((var.%s))", ref.Name)
 	} else {
 		if ref.FromGroupID != ref.ToGroupID {
-			expandedVariable = fmt.Sprintf("((var.%s_%s))", ref.Name, ref.ID)
+			// TODO: expandedVariable = fmt.Sprintf("((var.%s_%s))", ref.Name, ref.ID)
 			return "", fmt.Errorf("%s: %s is an intergroup reference",
 				errorMessages["varInAnotherGroup"], context.varString)
 		}

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -722,7 +722,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
 		"$(%s.%s.%s)", testBlueprint.DeploymentGroups[0].Name, testModule1.ID, existingOutput)
-	got, err = expandSimpleVariable(testVarContext1, testModToGrp)
+	_, err = expandSimpleVariable(testVarContext1, testModToGrp)
 	c.Assert(err, NotNil)
 
 	expectedErr = fmt.Sprintf("%s: %s.%s should be %s.%s",
@@ -739,7 +739,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule0.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
 		"$(%s.%s)", testModule0.ID, existingOutput)
-	got, err = expandSimpleVariable(testVarContext1, testModToGrp)
+	_, err = expandSimpleVariable(testVarContext1, testModToGrp)
 	expectedErr = fmt.Sprintf("%s: %s .*",
 		errorMessages["intergroupImplicit"], testModule0.ID)
 	c.Assert(err, ErrorMatches, expectedErr)
@@ -747,7 +747,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	// Intergroup variable: failure because explicit group and module does not exist
 	testVarContext1.varString = fmt.Sprintf("$(%s.%s.%s)",
 		testBlueprint.DeploymentGroups[0].Name, "bad_module", "bad_output")
-	got, err = expandSimpleVariable(testVarContext1, testModToGrp)
+	_, err = expandSimpleVariable(testVarContext1, testModToGrp)
 	expectedErr = fmt.Sprintf("%s: .*", errorMessages["varNotFound"])
 	c.Assert(err, ErrorMatches, expectedErr)
 
@@ -755,7 +755,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	fakeOutput = "bad_output"
 	testVarContext1.varString = fmt.Sprintf("$(%s.%s.%s)",
 		testBlueprint.DeploymentGroups[0].Name, testModule0.ID, fakeOutput)
-	got, err = expandSimpleVariable(testVarContext1, testModToGrp)
+	_, err = expandSimpleVariable(testVarContext1, testModToGrp)
 	expectedErr = fmt.Sprintf("%s: module %s did not have output %s",
 		errorMessages["noOutput"], testModule0.ID, fakeOutput)
 	c.Assert(err, ErrorMatches, expectedErr)
@@ -768,7 +768,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext0.varString = fmt.Sprintf(
 		"$(%s.%s.%s)", testBlueprint.DeploymentGroups[1].Name, testModule1.ID, existingOutput)
-	got, err = expandSimpleVariable(testVarContext0, testModToGrp)
+	_, err = expandSimpleVariable(testVarContext0, testModToGrp)
 	expectedErr = fmt.Sprintf("%s: %s .*",
 		errorMessages["intergroupOrder"], testModule1.ID)
 	c.Assert(err, ErrorMatches, expectedErr)
@@ -782,7 +782,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule0.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
 		"$(%s.%s.%s)", testBlueprint.DeploymentGroups[0].Name, testModule0.ID, existingOutput)
-	got, err = expandSimpleVariable(testVarContext1, testModToGrp)
+	_, err = expandSimpleVariable(testVarContext1, testModToGrp)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("%s: %s .*", errorMessages["varInAnotherGroup"], regexp.QuoteMeta(testVarContext1.varString)))
 }
 


### PR DESCRIPTION
- eliminate several unused variable warnings
- align naming of variables within `applyUseModules` to align with the ModConnection struct field names

This PR has no change in functionality.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?