### PR TITLE
Add links to hybrid docs from other modules

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
@@ -93,6 +93,13 @@ page.
 More information on GPU support in Slurm on GCP and other HPC Toolkit modules
 can be found at [docs/gpu-support.md](../../../../docs/gpu-support.md)
 
+## Hybrid Slurm Clusters
+For more information on how to configure an on premise slurm cluster with hybrid
+cloud partitions, see the [schedmd-slurm-gcp-v5-hybrid] module and our
+extended instructions in our [docs](../../../../docs/hybrid-slurm-cluster/).
+
+[schedmd-slurm-gcp-v5-hybrid]: ../schedmd-slurm-gcp-v5-hybrid/README.md
+
 ## Support
 The HPC Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
 modules. For support with the underlying modules, see the instructions in the

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
@@ -8,7 +8,7 @@ used, in the same way as the [schedmd-slurm-gcp-v5-controller] module
 auto-scales VMs.
 
 Further documentation on how to use this module when deploying a hybrid Slurm
-cluster in our [docs](../../../../docs/hybrid-slurm-cluster/). There, you can
+cluster can be found in our [docs](../../../../docs/hybrid-slurm-cluster/). There, you can
 find two tutorials. The [first] tutorial walks you through deploying a test
 environment entirely in GCP that is designed to demonstrate the capabilities
 without needing to make any changes to your local slurm cluster. The [second]

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
@@ -7,6 +7,14 @@ requested nodes in a GCP project on-demand and scale after a period of not being
 used, in the same way as the [schedmd-slurm-gcp-v5-controller] module
 auto-scales VMs.
 
+Further documentation on how to use this module when deploying a hybrid Slurm
+cluster in our [docs](../../../../docs/hybrid-slurm-cluster/). There, you can
+find two tutorials. The [first] tutorial walks you through deploying a test
+environment entirely in GCP that is designed to demonstrate the capabilities
+without needing to make any changes to your local slurm cluster. The [second]
+tutorial goes through the process of deploying the hybrid configuration onto a
+on-premise slurm cluster.
+
 > **_NOTE:_** This is an experimental module and the functionality and
 > documentation will likely be updated in the near future. This module has only
 > been tested in limited capacity with the HPC Toolkit. On Premise
@@ -14,6 +22,8 @@ auto-scales VMs.
 > be used as a starting point, not a complete solution.
 
 [schedmd-slurm-gcp-v5-controller]: ../schedmd-slurm-gcp-v5-controller/
+[first]: ../../../../docs/hybrid-slurm-cluster/README.md#demo-with-cloud-controller-instructionsmd
+[second]: ../../../../docs/hybrid-slurm-cluster/README.md#on-prem-instructionsmd
 
 ### Usage
 The [slurm-controller-hybrid] is intended to be run on the controller of the on


### PR DESCRIPTION
### Description
The goal is to improve find-ability of these docs, as currently they are not referenced anywhere else in the repo.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
