### PR TITLE
Improve readability of useModule

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -171,7 +171,8 @@ func useModule(
 	for _, useOutput := range useOutputs {
 		settingName := useOutput.Name
 		_, isAlreadySet := mod.Settings[settingName]
-		_, hasChanged := changedSettings[settingName]
+		// if key is not present, this will return false
+		hasChanged := changedSettings[settingName]
 
 		// Skip settings explicitly defined by users
 		if isAlreadySet && !hasChanged {

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -24,6 +24,7 @@ import (
 
 	"hpc-toolkit/pkg/modulereader"
 
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
 
@@ -165,19 +166,20 @@ func useModule(
 	useMod Module,
 	modInputs map[string]string,
 	useOutputs []modulereader.VarInfo,
-	changedSettings map[string]bool,
+	settingsInBlueprint []string,
 ) (usedVars []string) {
 	usedVars = []string{}
 	for _, useOutput := range useOutputs {
 		settingName := useOutput.Name
-		_, isAlreadySet := mod.Settings[settingName]
-		// if key is not present, this will return false
-		hasChanged := changedSettings[settingName]
-
 		// Skip settings explicitly defined by users
-		if isAlreadySet && !hasChanged {
+		if slices.Contains(settingsInBlueprint, settingName) {
 			continue
 		}
+
+		// track whether setting already has a value; important when
+		// ensuring that the first used module takes precedence and also
+		// when flattening multiple values for settings that are lists
+		_, isAlreadySet := mod.Settings[settingName]
 
 		// This output corresponds to an input that was not explicitly set by the user
 		if inputType, ok := modInputs[settingName]; ok {
@@ -187,7 +189,6 @@ func useModule(
 				if !isAlreadySet {
 					// Input is a list, create an outer list for it
 					mod.Settings[settingName] = []interface{}{}
-					changedSettings[settingName] = true
 					mod.createWrapSettingsWith()
 					mod.WrapSettingsWith[settingName] = []string{"flatten(", ")"}
 				}
@@ -198,7 +199,6 @@ func useModule(
 			} else if !isAlreadySet {
 				// If input is not a list, set value if not already set and continue
 				mod.Settings[settingName] = modVarName
-				changedSettings[settingName] = true
 				usedVars = append(usedVars, settingName)
 			}
 		}
@@ -216,7 +216,7 @@ func (dc *DeploymentConfig) applyUseModules() error {
 			fromMod := &group.Modules[iMod]
 			fromModInfo := grpModsInfo[fromMod.Source]
 			fromModInputs := getModuleInputMap(fromModInfo.Inputs)
-			changedSettings := make(map[string]bool)
+			settingsInBlueprint := maps.Keys(fromMod.Settings)
 			for _, toModID := range fromMod.Use {
 				toMod := group.getModuleByID(toModID)
 				toModInfo := dc.ModulesInfo[group.Name][toMod.Source]
@@ -224,7 +224,7 @@ func (dc *DeploymentConfig) applyUseModules() error {
 					return fmt.Errorf("could not find module %s used by %s in group %s",
 						toModID, fromMod.ID, group.Name)
 				}
-				usedVars := useModule(fromMod, toMod, fromModInputs, toModInfo.Outputs, changedSettings)
+				usedVars := useModule(fromMod, toMod, fromModInputs, toModInfo.Outputs, settingsInBlueprint)
 				connection := ModConnection{
 					toID:            toModID,
 					fromID:          fromMod.ID,


### PR DESCRIPTION
No changes in user-facing functionality are contained in this PR. While implementing future functionality, I found `useModule` to be difficult to follow and it contained a bug in its implementation that worked by happy accident. This PR combines two commits. Unit test coverage is unaltered (85.2%).

- fix a "happy accident" bug (for posterity of git history)
- alter the implementation to avoid the bug by to accepting a list of module inputs not to modify to indicate that they were explicitly set by the user in the blueprint

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
