### PR TITLE
Implicitly add outputs to modules when they are being used across deployment groups

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	ctyJson "github.com/zclconf/go-cty/cty/json"
+	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 
 	"hpc-toolkit/pkg/modulereader"
@@ -96,14 +97,12 @@ type DeploymentGroup struct {
 	Kind             string
 }
 
-func (g DeploymentGroup) getModuleByID(modID string) Module {
-	for i := range g.Modules {
-		mod := g.Modules[i]
-		if g.Modules[i].ID == modID {
-			return mod
-		}
+func (g DeploymentGroup) getModuleByID(modID string) (Module, error) {
+	idx := slices.IndexFunc(g.Modules, func(m Module) bool { return m.ID == modID })
+	if idx == -1 {
+		return Module{}, fmt.Errorf("%s: %s", errorMessages["invalidMod"], modID)
 	}
-	return Module{}
+	return g.Modules[idx], nil
 }
 
 // TerraformBackend defines the configuration for the terraform state backend

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,7 @@ var errorMessages = map[string]string{
 	"noOutput":             "Output not found for a variable",
 	"varWithinStrings":     "variables \"$(...)\" within strings are not yet implemented. remove them or add a backslash to render literally.",
 	"groupNotFound":        "The group ID was not found",
+	"cannotUsePacker":      "Packer modules cannot be used by other modules",
 	// validator
 	"emptyID":            "a module id cannot be empty",
 	"emptySource":        "a module source cannot be empty",
@@ -103,6 +104,15 @@ func (g DeploymentGroup) getModuleByID(modID string) (Module, error) {
 		return Module{}, fmt.Errorf("%s: %s", errorMessages["invalidMod"], modID)
 	}
 	return g.Modules[idx], nil
+}
+
+func (dc DeploymentConfig) getGroupByID(groupID string) (DeploymentGroup, error) {
+	groupIndex := slices.IndexFunc(dc.Config.DeploymentGroups, func(d DeploymentGroup) bool { return d.Name == groupID })
+	if groupIndex == -1 {
+		return DeploymentGroup{}, fmt.Errorf("%s: %s", errorMessages["groupNotFound"], groupID)
+	}
+	group := dc.Config.DeploymentGroups[groupIndex]
+	return group, nil
 }
 
 // TerraformBackend defines the configuration for the terraform state backend

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -355,24 +355,25 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 func (s *MySuite) TestAddKindToModules(c *C) {
 	/* Test addKindToModules() works when nothing to do */
 	dc := getBasicDeploymentConfigWithTestModule()
-	expected := dc.Config.DeploymentGroups[0].getModuleByID("TestModule1").Kind
+	testMod, _ := dc.Config.DeploymentGroups[0].getModuleByID("TestModule1")
+	expected := testMod.Kind
 	dc.addKindToModules()
-	got := dc.Config.DeploymentGroups[0].getModuleByID("TestModule1").Kind
-	c.Assert(got, Equals, expected)
+	testMod, _ = dc.Config.DeploymentGroups[0].getModuleByID("TestModule1")
+	c.Assert(testMod.Kind, Equals, expected)
 
 	/* Test addKindToModules() works when kind is absent*/
 	dc = getDeploymentConfigWithTestModuleEmptyKind()
 	expected = "terraform"
 	dc.addKindToModules()
-	got = dc.Config.DeploymentGroups[0].getModuleByID("TestModule1").Kind
-	c.Assert(got, Equals, expected)
+	testMod, _ = dc.Config.DeploymentGroups[0].getModuleByID("TestModule1")
+	c.Assert(testMod.Kind, Equals, expected)
 
 	/* Test addKindToModules() works when kind is empty*/
 	dc = getDeploymentConfigWithTestModuleEmptyKind()
 	expected = "terraform"
 	dc.addKindToModules()
-	got = dc.Config.DeploymentGroups[0].getModuleByID("TestModule2").Kind
-	c.Assert(got, Equals, expected)
+	testMod, _ = dc.Config.DeploymentGroups[0].getModuleByID("TestModule1")
+	c.Assert(testMod.Kind, Equals, expected)
 
 	/* Test addKindToModules() does nothing to packer types*/
 	moduleID := "packerModule"
@@ -380,8 +381,8 @@ func (s *MySuite) TestAddKindToModules(c *C) {
 	dc = getDeploymentConfigWithTestModuleEmptyKind()
 	dc.Config.DeploymentGroups[0].Modules = append(dc.Config.DeploymentGroups[0].Modules, Module{ID: moduleID, Kind: expected})
 	dc.addKindToModules()
-	got = dc.Config.DeploymentGroups[0].getModuleByID(moduleID).Kind
-	c.Assert(got, Equals, expected)
+	testMod, _ = dc.Config.DeploymentGroups[0].getModuleByID(moduleID)
+	c.Assert(testMod.Kind, Equals, expected)
 
 	/* Test addKindToModules() does nothing to invalid types*/
 	moduleID = "funnyModule"
@@ -389,8 +390,8 @@ func (s *MySuite) TestAddKindToModules(c *C) {
 	dc = getDeploymentConfigWithTestModuleEmptyKind()
 	dc.Config.DeploymentGroups[0].Modules = append(dc.Config.DeploymentGroups[0].Modules, Module{ID: moduleID, Kind: expected})
 	dc.addKindToModules()
-	got = dc.Config.DeploymentGroups[0].getModuleByID(moduleID).Kind
-	c.Assert(got, Equals, expected)
+	testMod, _ = dc.Config.DeploymentGroups[0].getModuleByID(moduleID)
+	c.Assert(testMod.Kind, Equals, expected)
 }
 
 func (s *MySuite) TestSetModulesInfo(c *C) {
@@ -408,19 +409,22 @@ func (s *MySuite) TestGetResouceByID(c *C) {
 
 	// No Modules
 	rg := DeploymentGroup{}
-	got := rg.getModuleByID(testID)
+	got, err := rg.getModuleByID(testID)
 	c.Assert(got, DeepEquals, Module{})
+	c.Assert(err, NotNil)
 
 	// No Match
 	rg.Modules = []Module{{ID: "NoMatch"}}
-	got = rg.getModuleByID(testID)
+	got, _ = rg.getModuleByID(testID)
 	c.Assert(got, DeepEquals, Module{})
+	c.Assert(err, NotNil)
 
 	// Match
 	expected := Module{ID: testID}
 	rg.Modules = []Module{expected}
-	got = rg.getModuleByID(testID)
+	got, err = rg.getModuleByID(testID)
 	c.Assert(got, DeepEquals, expected)
+	c.Assert(err, IsNil)
 }
 
 func (s *MySuite) TestHasKind(c *C) {

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -218,12 +218,11 @@ func (dc *DeploymentConfig) applyUseModules() error {
 			fromModInputs := getModuleInputMap(fromModInfo.Inputs)
 			settingsInBlueprint := maps.Keys(fromMod.Settings)
 			for _, toModID := range fromMod.Use {
-				toMod := group.getModuleByID(toModID)
-				toModInfo := dc.ModulesInfo[group.Name][toMod.Source]
-				if toMod.ID == "" {
-					return fmt.Errorf("could not find module %s used by %s in group %s",
-						toModID, fromMod.ID, group.Name)
+				toMod, err := group.getModuleByID(toModID)
+				if err != nil {
+					return err
 				}
+				toModInfo := dc.ModulesInfo[group.Name][toMod.Source]
 				usedVars := useModule(fromMod, toMod, fromModInputs, toModInfo.Outputs, settingsInBlueprint)
 				connection := ModConnection{
 					toID:            toModID,

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -211,8 +211,7 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 	modLen := len(dc.Config.DeploymentGroups[0].Modules)
 	dc.Config.DeploymentGroups[0].Modules[modLen-1].ID = "wrongID"
 	err = dc.applyUseModules()
-	c.Assert(err, ErrorMatches, "could not find module .* used by .* in group .*")
-
+	c.Assert(err, ErrorMatches, fmt.Sprintf("%s: %s", errorMessages["invalidMod"], usedModuleID))
 }
 
 func (s *MySuite) TestUpdateVariableType(c *C) {

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -65,10 +65,11 @@ func (s *MySuite) TestExpandBackends(c *C) {
 }
 
 func (s *MySuite) TestGetModuleVarName(c *C) {
+	groupID := "groupID"
 	modID := "modID"
 	varName := "varName"
-	expected := fmt.Sprintf("$(%s.%s)", modID, varName)
-	got := getModuleVarName(modID, varName)
+	expected := fmt.Sprintf("$(%s.%s.%s)", groupID, modID, varName)
+	got := getModuleVarName(groupID, modID, varName)
 	c.Assert(got, Equals, expected)
 }
 
@@ -80,6 +81,8 @@ func (s *MySuite) TestUseModule(c *C) {
 		Source:   modSource,
 		Settings: make(map[string]interface{}),
 	}
+
+	usedModGroup := "group0"
 	usedModSource := "usedSource"
 	usedMod := Module{
 		ID:     "UsedModule",
@@ -90,7 +93,7 @@ func (s *MySuite) TestUseModule(c *C) {
 
 	// Pass: No Inputs, No Outputs
 	modInputs := getModuleInputMap(modInfo.Inputs)
-	usedVars := useModule(&mod, usedMod, modInputs, usedInfo.Outputs, []string{})
+	usedVars := useModule(&mod, usedMod, usedModGroup, modInputs, usedInfo.Outputs, []string{})
 	c.Assert(len(usedVars), Equals, 0)
 	c.Assert(len(mod.Settings), Equals, 0)
 
@@ -100,17 +103,17 @@ func (s *MySuite) TestUseModule(c *C) {
 		Type: "number",
 	}
 	usedInfo.Outputs = []modulereader.VarInfo{varInfoNumber}
-	usedVars = useModule(&mod, usedMod, modInputs, usedInfo.Outputs, []string{})
+	usedVars = useModule(&mod, usedMod, usedModGroup, modInputs, usedInfo.Outputs, []string{})
 	c.Assert(len(usedVars), Equals, 0)
 	c.Assert(len(mod.Settings), Equals, 0)
 
 	// Pass: Single Input/Output match - no lists
 	modInfo.Inputs = []modulereader.VarInfo{varInfoNumber}
 	modInputs = getModuleInputMap(modInfo.Inputs)
-	usedVars = useModule(&mod, usedMod, modInputs, usedInfo.Outputs, []string{})
+	usedVars = useModule(&mod, usedMod, usedModGroup, modInputs, usedInfo.Outputs, []string{})
 	c.Assert(len(usedVars), Equals, 1)
 	c.Assert(len(mod.Settings), Equals, 1)
-	expectedSetting := getModuleVarName("UsedModule", "val1")
+	expectedSetting := getModuleVarName(usedModGroup, usedMod.ID, varInfoNumber.Name)
 	c.Assert(mod.Settings["val1"], Equals, expectedSetting)
 
 	// Pass: Single Input/Output match - but setting was in blueprint so no-op
@@ -118,15 +121,15 @@ func (s *MySuite) TestUseModule(c *C) {
 	modInputs = getModuleInputMap(modInfo.Inputs)
 	mod.Settings = make(map[string]interface{})
 	mod.Settings["val1"] = expectedSetting
-	usedVars = useModule(&mod, usedMod, modInputs, usedInfo.Outputs, maps.Keys(mod.Settings))
+	usedVars = useModule(&mod, usedMod, usedModGroup, modInputs, usedInfo.Outputs, maps.Keys(mod.Settings))
 	c.Assert(len(usedVars), Equals, 0)
 	c.Assert(len(mod.Settings), Equals, 1)
-	expectedSetting = getModuleVarName("UsedModule", "val1")
+	expectedSetting = getModuleVarName(usedModGroup, "UsedModule", "val1")
 	c.Assert(mod.Settings["val1"], Equals, expectedSetting)
 
 	// Pass: re-apply used modules, should be a no-op
 	// Assume no settings were in blueprint
-	usedVars = useModule(&mod, usedMod, modInputs, usedInfo.Outputs, []string{})
+	usedVars = useModule(&mod, usedMod, usedModGroup, modInputs, usedInfo.Outputs, []string{})
 	c.Assert(len(usedVars), Equals, 0)
 	c.Assert(len(mod.Settings), Equals, 1)
 	c.Assert(mod.Settings["val1"], Equals, expectedSetting)
@@ -139,14 +142,14 @@ func (s *MySuite) TestUseModule(c *C) {
 	modInfo.Inputs = []modulereader.VarInfo{varInfoList}
 	modInputs = getModuleInputMap(modInfo.Inputs)
 	mod.Settings = make(map[string]interface{})
-	usedVars = useModule(&mod, usedMod, modInputs, usedInfo.Outputs, []string{})
+	usedVars = useModule(&mod, usedMod, usedModGroup, modInputs, usedInfo.Outputs, []string{})
 	c.Assert(len(usedVars), Equals, 1)
 	c.Assert(len(mod.Settings["val1"].([]interface{})), Equals, 1)
 	c.Assert(mod.Settings["val1"], DeepEquals, []interface{}{expectedSetting})
 
 	// Pass: Setting exists, Input is List, Output is not a list
 	// Assume setting was not set in blueprint
-	usedVars = useModule(&mod, usedMod, modInputs, usedInfo.Outputs, []string{})
+	usedVars = useModule(&mod, usedMod, usedModGroup, modInputs, usedInfo.Outputs, []string{})
 	c.Assert(len(usedVars), Equals, 1)
 	c.Assert(len(mod.Settings["val1"].([]interface{})), Equals, 2)
 	c.Assert(
@@ -158,7 +161,7 @@ func (s *MySuite) TestUseModule(c *C) {
 	// Assume setting was set in blueprint
 	mod.Settings = make(map[string]interface{})
 	mod.Settings["val1"] = []interface{}{expectedSetting}
-	usedVars = useModule(&mod, usedMod, modInputs, usedInfo.Outputs, maps.Keys(mod.Settings))
+	usedVars = useModule(&mod, usedMod, usedModGroup, modInputs, usedInfo.Outputs, maps.Keys(mod.Settings))
 	c.Assert(len(usedVars), Equals, 0)
 	c.Assert(len(mod.Settings["val1"].([]interface{})), Equals, 1)
 	c.Assert(
@@ -212,6 +215,30 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 	dc.Config.DeploymentGroups[0].Modules[modLen-1].ID = "wrongID"
 	err = dc.applyUseModules()
 	c.Assert(err, ErrorMatches, fmt.Sprintf("%s: %s", errorMessages["invalidMod"], usedModuleID))
+
+	// test multigroup deployment with config that has a known good match
+	dc = getMultiGroupDeploymentConfig()
+	c.Assert(len(dc.Config.DeploymentGroups[1].Modules[0].Settings), Equals, 0)
+	err = dc.applyUseModules()
+	c.Assert(err, IsNil)
+	c.Assert(len(dc.Config.DeploymentGroups[1].Modules[0].Settings), Equals, 1)
+
+	// Deliberately break the match and see that no settings are added
+	dc = getMultiGroupDeploymentConfig()
+	c.Assert(len(dc.Config.DeploymentGroups[1].Modules[0].Settings), Equals, 0)
+	groupName0 := dc.Config.DeploymentGroups[0].Name
+	moduleSource0 := dc.Config.DeploymentGroups[0].Modules[0].Source
+	// this eliminates the matching output from the used module
+	dc.ModulesInfo[groupName0][moduleSource0] = modulereader.ModuleInfo{}
+	err = dc.applyUseModules()
+	c.Assert(err, IsNil)
+	c.Assert(len(dc.Config.DeploymentGroups[1].Modules[0].Settings), Equals, 0)
+
+	// Use Packer module from group 0 (fail despite matching output/input)
+	dc = getMultiGroupDeploymentConfig()
+	dc.Config.DeploymentGroups[0].Modules[0].Kind = "packer"
+	err = dc.applyUseModules()
+	c.Assert(err, ErrorMatches, fmt.Sprintf("%s: %s", errorMessages["cannotUsePacker"], dc.Config.DeploymentGroups[0].Modules[0].ID))
 }
 
 func (s *MySuite) TestUpdateVariableType(c *C) {


### PR DESCRIPTION
This PR builds upon the same branch being merged in #877. The last 3 commits are the new additions. These commits...

- modify `getModuleByID` to explicitly error rather than rely upon the user to know how to detect an error in the output
- when intergroup references are made explicitly via module `settings` or `use` keywords, the used module's outputs are implicitly modified to include the targeted output (does not trigger when intragroup references are made)
- a final commit that enables blueprints to be written without generating warnings during `ghpc create`

This will ultimately faciliate the creation of blueprints with intergroup references via Toolkit variables and the `use` keyword.

```
---
blueprint_name: igc

vars:
  project_id: ####
  deployment_name: test
  region: us-east4
  zone: us-east4-c

deployment_groups:
- group: zero
  modules:
  - id: network0
    source: modules/network/vpc
  - id: homefs
    source: modules/file-system/filestore
    use: [network0]
    settings:
      local_mount: /home
  - id: projectsfs
    source: modules/file-system/filestore
    use: [network0]
    settings:
      local_mount: /projects
- group: one
  modules:
  - id: image
    source: modules/packer/custom-image
    kind: packer
    use:
    - zero.network0
- group: two
  modules:
  - id: network1
    source: modules/network/pre-existing-vpc
    use:
    - zero.network0
  - id: low_cost_partition
    source: community/modules/compute/SchedMD-slurm-on-gcp-partition
    use:
    - network1
    - zero.homefs
    - zero.projectsfs
    settings:
      partition_name: low_cost
      max_node_count: 10
      enable_placement: false
      exclusive: false
      machine_type: n2-standard-4
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
