### PR TITLE
Add Windows Remote Desktop IAP firewall rule

### DIFF
--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -161,6 +161,7 @@ No resources.
 | <a name="input_default_primary_subnetwork_size"></a> [default\_primary\_subnetwork\_size](#input\_default\_primary\_subnetwork\_size) | The size, in CIDR bits, of the default primary subnetwork unless explicitly defined in var.subnetworks | `number` | `15` | no |
 | <a name="input_delete_default_internet_gateway_routes"></a> [delete\_default\_internet\_gateway\_routes](#input\_delete\_default\_internet\_gateway\_routes) | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
+| <a name="input_enable_iap_rdp_ingress"></a> [enable\_iap\_rdp\_ingress](#input\_enable\_iap\_rdp\_ingress) | Enable a firewall rule to allow Windows Remote Desktop Protocol access using IAP tunnels | `bool` | `false` | no |
 | <a name="input_enable_iap_ssh_ingress"></a> [enable\_iap\_ssh\_ingress](#input\_enable\_iap\_ssh\_ingress) | Enable a firewall rule to allow SSH access using IAP tunnels | `bool` | `true` | no |
 | <a name="input_enable_internal_traffic"></a> [enable\_internal\_traffic](#input\_enable\_internal\_traffic) | Enable a firewall rule to allow all internal TCP, UDP, and ICMP traffic within the network | `bool` | `true` | no |
 | <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | List of firewall rules | `any` | `[]` | no |

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -77,7 +77,7 @@ locals {
 
   allow_iap_ssh_ingress = {
     name                    = "${local.network_name}-fw-allow-iap-ssh-ingress"
-    description             = "allow console SSH access"
+    description             = "allow SSH access via Identity-Aware Proxy"
     direction               = "INGRESS"
     priority                = null
     ranges                  = ["35.235.240.0/20"]
@@ -94,6 +94,27 @@ locals {
       metadata = "INCLUDE_ALL_METADATA"
     }
   }
+
+  allow_iap_rdp_ingress = {
+    name                    = "${local.network_name}-fw-allow-iap-rdp-ingress"
+    description             = "allow Windows remote desktop access via Identity-Aware Proxy"
+    direction               = "INGRESS"
+    priority                = null
+    ranges                  = ["35.235.240.0/20"]
+    source_tags             = null
+    source_service_accounts = null
+    target_tags             = null
+    target_service_accounts = null
+    allow = [{
+      protocol = "tcp"
+      ports    = ["3389"]
+    }]
+    deny = []
+    log_config = {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+
 
   allow_internal_traffic = {
     name                    = "${local.network_name}-fw-allow-internal-traffic"
@@ -124,7 +145,8 @@ locals {
 
   firewall_rules = concat(var.firewall_rules,
     var.enable_internal_traffic ? [local.allow_internal_traffic] : [],
-    var.enable_iap_ssh_ingress ? [local.allow_iap_ssh_ingress] : []
+    var.enable_iap_rdp_ingress ? [local.allow_iap_rdp_ingress] : [],
+    var.enable_iap_ssh_ingress ? [local.allow_iap_ssh_ingress] : [],
   )
 }
 

--- a/modules/network/vpc/variables.tf
+++ b/modules/network/vpc/variables.tf
@@ -200,6 +200,12 @@ variable "enable_iap_ssh_ingress" {
   default     = true
 }
 
+variable "enable_iap_rdp_ingress" {
+  type        = bool
+  description = "Enable a firewall rule to allow Windows Remote Desktop Protocol access using IAP tunnels"
+  default     = false
+}
+
 variable "enable_internal_traffic" {
   type        = bool
   description = "Enable a firewall rule to allow all internal TCP, UDP, and ICMP traffic within the network"


### PR DESCRIPTION
Add knob to enable a firewall rule that allows Windows Remote Desktop connections through an IAP tunnel. I suggest leaving it off by default due to likelihood that Windows platforms are a secondary use case.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?