### PR TITLE
Fix: having the same share name and local mount caused slurm failure

### DIFF
--- a/docs/videos/healthcare-and-life-sciences/README.md
+++ b/docs/videos/healthcare-and-life-sciences/README.md
@@ -77,8 +77,8 @@
 
    Now that the file stores have been deployed we need to populate their IP
    addresses so subsequent deployment groups can use them. Look up the IP
-   addresses for the `apps` and `home` file system and populate them in the
-   command below.
+   addresses for the `appsshare` and `homeshare` file system and populate them
+   in the command below.
 
    > **Note**: You can use the following command to list information about
    > filestores, including their IP address.

--- a/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
+++ b/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
@@ -67,12 +67,12 @@ deployment_groups:
   - id: homefs-create
     source: modules/file-system/filestore
     use: [network-create]
-    settings: {filestore_share_name: home}
+    settings: {filestore_share_name: homeshare}
 
   - id: appsfs-create
     source: modules/file-system/filestore
     use: [network-create]
-    settings: {filestore_share_name: apps}
+    settings: {filestore_share_name: appsshare}
 
   - id: bucket-software-create
     source: ./community/modules/file-system/cloud-storage-bucket
@@ -99,7 +99,7 @@ deployment_groups:
     source: modules/file-system/pre-existing-network-storage
     settings:
       server_ip: $(vars.appsfs_server_ip)
-      remote_mount: apps
+      remote_mount: appsshare
       local_mount: /apps
       fs_type: nfs
 
@@ -233,7 +233,7 @@ deployment_groups:
     source: modules/file-system/pre-existing-network-storage
     settings:
       server_ip: $(vars.homefs_server_ip)
-      remote_mount: home
+      remote_mount: homeshare
       local_mount: /home
       fs_type: nfs
 
@@ -241,7 +241,7 @@ deployment_groups:
     source: modules/file-system/pre-existing-network-storage
     settings:
       server_ip: $(vars.appsfs_server_ip)
-      remote_mount: apps
+      remote_mount: appsshare
       local_mount: /apps
       fs_type: nfs
 


### PR DESCRIPTION
Slurm exhibits odd behavior and under some conditions failure when the share name and local mount of a filestore are the same (ex: share name: `apps`, local mount: `/apps`). 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
