### PR TITLE
Reorder validator list to test blueprint correctness first

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -919,8 +919,14 @@ func (dc *DeploymentConfig) addDefaultValidators() error {
 	_, regionExists := dc.Config.Vars["region"]
 	_, zoneExists := dc.Config.Vars["zone"]
 
-	// always add the project ID validator first; remaining validators can only
-	// succeed if credentials can access the project
+	dc.Config.Validators = append(dc.Config.Validators, validatorConfig{
+		Validator: testModuleNotUsedName.String(),
+		Inputs:    map[string]interface{}{},
+	})
+
+	// always add the project ID validator before subsequent validators that can
+	// only succeed if credentials can access the project. If the project ID
+	// validator fails, all remaining validators are not executed.
 	if projectIDExists {
 		v := validatorConfig{
 			Validator: testProjectExistsName.String(),
@@ -972,11 +978,6 @@ func (dc *DeploymentConfig) addDefaultValidators() error {
 		}
 		dc.Config.Validators = append(dc.Config.Validators, v)
 	}
-
-	dc.Config.Validators = append(dc.Config.Validators, validatorConfig{
-		Validator: testModuleNotUsedName.String(),
-		Inputs:    map[string]interface{}{},
-	})
 
 	return nil
 }


### PR DESCRIPTION
The test for a valid project ID had been set first, which would exit before running other validators that depend on it.

This PR simply moves the one current validator that only check for correctness of the blueprint ahead of the project ID validator to ensure it runs even if the project ID is incorrect or credentials have not been setup correctly yet.

Further efforts to update and/or refine the validator package may be needed, but this works around the current issue for the time being.

When run against an example blueprint with a bad project ID and an unused module, both validators print warnings now:

```
$ ghpc create test-blueprint.yaml
module workstation uses module spack, but matching setting and outputs were not found. This may be because the value is set explicitly or set by a prior used module
One or more used modules could not have their settings and outputs linked.
warning: validator test_module_not_used failed

project ID **Omitted** does not exist or your credentials do not have permission to access it
warning: validator test_project_exists failed

One or more blueprint validators has failed. See messages above for suggested
actions. General troubleshooting guidance and instructions for configuring
validators are shown below.

- https://goo.gle/hpc-toolkit-troubleshooting
- https://goo.gle/hpc-toolkit-validation

Validators can be silenced or treated as warnings or errors:

- https://goo.gle/hpc-toolkit-validation-levels

Validation failures were treated as a warning, continuing to create blueprint.

Terraform group 'primary' was successfully created in directory spack-01/primary
To deploy, run the following commands:
  terraform -chdir=spack-01/primary init
  terraform -chdir=spack-01/primary validate
  terraform -chdir=spack-01/primary apply
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
