### PR TITLE
Add support for highly available HTCondor Central Managers

### DIFF
--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -71,7 +71,7 @@ deployment_groups:
       - network: null
         subnetwork: $(network1.subnetwork_self_link)
         subnetwork_project: $(vars.project_id)
-        network_ip: ((module.htcondor_configure.central_manager_internal_ips[0]))
+        network_ip: $(htcondor_configure.central_manager_internal_ip)
         stack_type: null
         access_config: []
         ipv6_access_config: []

--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -44,6 +44,8 @@ deployment_groups:
 
   - id: htcondor_configure
     source: community/modules/scheduler/htcondor-configure
+    use:
+    - network1
 
   - id: htcondor_configure_central_manager
     source: modules/scripts/startup-script
@@ -65,6 +67,17 @@ deployment_groups:
         email: $(htcondor_configure.central_manager_service_account)
         scopes:
         - cloud-platform
+      network_interfaces:
+      - network: null
+        subnetwork: $(network1.subnetwork_self_link)
+        subnetwork_project: $(vars.project_id)
+        network_ip: ((module.htcondor_configure.central_manager_internal_ips[0]))
+        stack_type: null
+        access_config: []
+        ipv6_access_config: []
+        alias_ip_range: []
+        nic_type: VIRTIO_NET
+        queue_count: null
     outputs:
     - internal_ip
 
@@ -83,7 +96,6 @@ deployment_groups:
     settings:
       metadata:
         enable-oslogin: "TRUE"
-        central-manager: ((module.htcondor_cm.internal_ip[0]))
       service_account:
         email: $(htcondor_configure.execute_point_service_account)
         scopes:
@@ -118,8 +130,6 @@ deployment_groups:
     settings:
       name_prefix: access-point
       machine_type: c2-standard-4
-      metadata:
-        central-manager: ((module.htcondor_cm.internal_ip[0]))
       service_account:
         email: $(htcondor_configure.access_point_service_account)
         scopes:

--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -97,6 +97,7 @@ limitations under the License.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_point_service_account"></a> [access\_point\_service\_account](#module\_access\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
+| <a name="module_address"></a> [address](#module\_address) | terraform-google-modules/address/google | ~> 3.0 |
 | <a name="module_central_manager_service_account"></a> [central\_manager\_service\_account](#module\_central\_manager\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
 | <a name="module_execute_point_service_account"></a> [execute\_point\_service\_account](#module\_execute\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
 
@@ -116,11 +117,15 @@ limitations under the License.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_point_roles"></a> [access\_point\_roles](#input\_access\_point\_roles) | Project-wide roles for HTCondor Access Point service account | `list(string)` | <pre>[<br>  "roles/compute.instanceAdmin",<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_central_manager_high_availability"></a> [central\_manager\_high\_availability](#input\_central\_manager\_high\_availability) | Provision HTCondor central manager in high availability mode | `bool` | `false` | no |
 | <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_execute_point_roles"></a> [execute\_point\_roles](#input\_execute\_point\_roles) | Project-wide roles for HTCondor Execute Point service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to resources. List key, value pairs. | `map(string)` | n/a | yes |
 | <a name="input_pool_password"></a> [pool\_password](#input\_pool\_password) | HTCondor Pool Password | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Default region for creating resources | `string` | n/a | yes |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork in which Central Managers will be placed. | `string` | `null` | no |
 
 ## Outputs
 
@@ -128,6 +133,7 @@ limitations under the License.
 |------|-------------|
 | <a name="output_access_point_runner"></a> [access\_point\_runner](#output\_access\_point\_runner) | Toolkit Runner to configure an HTCondor Access Point |
 | <a name="output_access_point_service_account"></a> [access\_point\_service\_account](#output\_access\_point\_service\_account) | HTCondor Access Point Service Account (e-mail format) |
+| <a name="output_central_manager_internal_ips"></a> [central\_manager\_internal\_ips](#output\_central\_manager\_internal\_ips) | Reserved internal IP addresses for use by Central Managers |
 | <a name="output_central_manager_runner"></a> [central\_manager\_runner](#output\_central\_manager\_runner) | Toolkit Runner to configure an HTCondor Central Manager |
 | <a name="output_central_manager_service_account"></a> [central\_manager\_service\_account](#output\_central\_manager\_service\_account) | HTCondor Central Manager Service Account (e-mail format) |
 | <a name="output_execute_point_runner"></a> [execute\_point\_runner](#output\_execute\_point\_runner) | Toolkit Runner to configure an HTCondor Execute Point |

--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -125,7 +125,7 @@ limitations under the License.
 | <a name="input_pool_password"></a> [pool\_password](#input\_pool\_password) | HTCondor Pool Password | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Default region for creating resources | `string` | n/a | yes |
-| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork in which Central Managers will be placed. | `string` | `null` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork in which Central Managers will be placed. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -133,7 +133,8 @@ limitations under the License.
 |------|-------------|
 | <a name="output_access_point_runner"></a> [access\_point\_runner](#output\_access\_point\_runner) | Toolkit Runner to configure an HTCondor Access Point |
 | <a name="output_access_point_service_account"></a> [access\_point\_service\_account](#output\_access\_point\_service\_account) | HTCondor Access Point Service Account (e-mail format) |
-| <a name="output_central_manager_internal_ips"></a> [central\_manager\_internal\_ips](#output\_central\_manager\_internal\_ips) | Reserved internal IP addresses for use by Central Managers |
+| <a name="output_central_manager_internal_ip"></a> [central\_manager\_internal\_ip](#output\_central\_manager\_internal\_ip) | Reserved internal IP address for use by Central Manager |
+| <a name="output_central_manager_internal_ips"></a> [central\_manager\_internal\_ips](#output\_central\_manager\_internal\_ips) | Reserved internal IP addresses for use by 2 Central Managers in HA mode |
 | <a name="output_central_manager_runner"></a> [central\_manager\_runner](#output\_central\_manager\_runner) | Toolkit Runner to configure an HTCondor Central Manager |
 | <a name="output_central_manager_service_account"></a> [central\_manager\_service\_account](#output\_central\_manager\_service\_account) | HTCondor Central Manager Service Account (e-mail format) |
 | <a name="output_execute_point_runner"></a> [execute\_point\_runner](#output\_execute\_point\_runner) | Toolkit Runner to configure an HTCondor Execute Point |

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -20,6 +20,7 @@
   - name: User must supply HTCondor role
     ansible.builtin.assert:
       that:
+      - htcondor_central_manager_ips is defined
       - htcondor_role is defined
       - password_id is defined
       - project_id is defined
@@ -27,37 +28,55 @@
     ansible.builtin.file:
       name: /etc/condor/config.d/00-htcondor-9.0.config
       state: absent
+    notify:
+    - Reload HTCondor
   - name: Set HTCondor role
     ansible.builtin.copy:
-      dest: /etc/condor/config.d/01-role
+      dest: /etc/condor/config.d/00-role
       mode: 0644
       content: |
         use role:{{ htcondor_role }}
-  - name: Configure VM to be HTCondor Central Manager
-    when: htcondor_role == 'get_htcondor_central_manager'
-    block:
-    - name: Set HTCondor Central Manager
-      ansible.builtin.copy:
-        dest: /etc/condor/config.d/00-central-manager
-        mode: 0644
-        content: |
-          CONDOR_HOST={{ ansible_default_ipv4.address }}
-  - name: Read HTCondor Central Manager from metadata
-    when: htcondor_role != 'get_htcondor_central_manager'
-    block:
-    - name: Read metadata central-manager
-      ansible.builtin.uri:
-        url: http://metadata.google.internal/computeMetadata/v1/instance/attributes/central-manager
-        return_content: true
-        headers:
-          Metadata-Flavor: "Google"
-      register: cm
-    - name: Set HTCondor Central Manager
-      ansible.builtin.copy:
-        dest: /etc/condor/config.d/00-central-manager
-        mode: 0644
-        content: |
-          CONDOR_HOST={{ cm.content }}
+    notify:
+    - Reload HTCondor
+  - name: Set HTCondor Central Manager and Trust Domain
+    ansible.builtin.copy:
+      dest: /etc/condor/config.d/01-central-manager
+      mode: 0644
+      content: |
+        CONDOR_HOST={{ htcondor_central_manager_ips }}
+        UID_DOMAIN=c.{{ project_id }}.internal
+        TRUST_DOMAIN=c.{{ project_id }}.internal
+    notify:
+    - Reload HTCondor
+  - name: Generate list of Central Managers
+    ansible.builtin.set_fact:
+      central_manager_list: "{{ htcondor_central_manager_ips | split(',') }}"
+  - name: Set HTCondor Central Manager High Availability
+    when: htcondor_role == 'get_htcondor_central_manager' and central_manager_list | length > 1
+    ansible.builtin.copy:
+      dest: /etc/condor/config.d/01-central-manager-high-availability
+      mode: 0644
+      content: |
+        # following https://htcondor.readthedocs.io/en/latest/admin-manual/high-availability.html#high-availability-of-the-central-manager
+        CM_LIST = \
+          {{ central_manager_list[0] }}:$(SHARED_PORT_PORT), \
+          {{ central_manager_list[1] }}:$(SHARED_PORT_PORT)
+
+        HAD_USE_SHARED_PORT = TRUE
+        HAD_LIST = $(CM_LIST)
+
+        REPLICATION_USE_SHARED_PORT = TRUE
+        REPLICATION_LIST = $(CM_LIST)
+
+        HAD_USE_PRIMARY = TRUE
+        HAD_CONTROLLEE = NEGOTIATOR
+        MASTER_NEGOTIATOR_CONTROLLER = HAD
+
+        DAEMON_LIST = $(DAEMON_LIST), HAD, REPLICATION
+        HAD_USE_REPLICATION = TRUE
+        MASTER_HAD_BACKOFF_CONSTANT = 360
+    notify:
+    - Reload HTCondor
   - name: Configure HTCondor SchedD
     when: htcondor_role == 'get_htcondor_submit'
     block:
@@ -67,10 +86,11 @@
         mode: 0644
         content: |
           SCHEDD_INTERVAL=15
-          UID_DOMAIN = c.{{ project_id }}.internal
           TRUST_UID_DOMAIN = True
           SUBMIT_ATTRS = RunAsOwner
           RunAsOwner = True
+      notify:
+      - Reload HTCondor
   - name: Configure HTCondor StartD
     when: htcondor_role == 'get_htcondor_execute'
     block:
@@ -81,9 +101,10 @@
         content: |
           use feature:PartitionableSlot
           use feature:CommonCloudAttributesGoogle("-c created-by")
-          UID_DOMAIN = c.{{ project_id }}.internal
           TRUST_UID_DOMAIN = True
           STARTER_ALLOW_RUNAS_OWNER = True
+      notify:
+      - Reload HTCondor
   - name: Set HTCondor credentials
     ansible.builtin.shell: |
       set -e -o pipefail
@@ -105,3 +126,8 @@
     ansible.builtin.shell: |
       set -e -o pipefail
       wall "******* HTCondor system configuration complete ********"
+  handlers:
+  - name: Reload HTCondor
+    ansible.builtin.service:
+      name: condor
+      state: reloaded

--- a/community/modules/scheduler/htcondor-configure/main.tf
+++ b/community/modules/scheduler/htcondor-configure/main.tf
@@ -22,6 +22,9 @@ locals {
   central_manager_display_name = "HTCondor Central Manager (${var.deployment_name})"
   central_manager_roles        = [for role in var.central_manager_roles : "${var.project_id}=>${role}"]
 
+  central_manager_count    = var.central_manager_high_availability ? 2 : 1
+  central_manager_ip_names = [for i in range(local.central_manager_count) : "${var.deployment_name}-cm-ip-${i}"]
+
   pool_password = var.pool_password == null ? random_password.pool.result : var.pool_password
 
   runner_cm_role = {
@@ -30,6 +33,7 @@ locals {
     "destination" = "htcondor_configure.yml"
     "args" = join(" ", [
       "-e htcondor_role=get_htcondor_central_manager",
+      "-e htcondor_central_manager_ips=${join(",", module.address.addresses)}",
       "-e password_id=${google_secret_manager_secret.pool_password.secret_id}",
       "-e project_id=${var.project_id}",
     ])
@@ -41,6 +45,7 @@ locals {
     "destination" = "htcondor_configure.yml"
     "args" = join(" ", [
       "-e htcondor_role=get_htcondor_submit",
+      "-e htcondor_central_manager_ips=${join(",", module.address.addresses)}",
       "-e password_id=${google_secret_manager_secret.pool_password.secret_id}",
       "-e project_id=${var.project_id}",
     ])
@@ -52,6 +57,7 @@ locals {
     "destination" = "htcondor_configure.yml"
     "args" = join(" ", [
       "-e htcondor_role=get_htcondor_execute",
+      "-e htcondor_central_manager_ips=${join(",", module.address.addresses)}",
       "-e password_id=${google_secret_manager_secret.pool_password.secret_id}",
       "-e project_id=${var.project_id}",
     ])
@@ -100,9 +106,7 @@ resource "random_password" "pool" {
 resource "google_secret_manager_secret" "pool_password" {
   secret_id = "${var.deployment_name}-pool-password"
 
-  labels = {
-    label = var.deployment_name
-  }
+  labels = var.labels
 
   replication {
     automatic = true
@@ -130,4 +134,13 @@ resource "google_secret_manager_secret_iam_member" "execute_point" {
   secret_id = google_secret_manager_secret.pool_password.id
   role      = "roles/secretmanager.secretAccessor"
   member    = module.execute_point_service_account.iam_email
+}
+
+module "address" {
+  source     = "terraform-google-modules/address/google"
+  version    = "~> 3.0"
+  project_id = var.project_id
+  region     = var.region
+  subnetwork = var.subnetwork_self_link
+  names      = local.central_manager_ip_names
 }

--- a/community/modules/scheduler/htcondor-configure/outputs.tf
+++ b/community/modules/scheduler/htcondor-configure/outputs.tf
@@ -59,7 +59,12 @@ output "execute_point_runner" {
   value       = local.runner_execute_role
 }
 
+output "central_manager_internal_ip" {
+  description = "Reserved internal IP address for use by Central Manager"
+  value       = try(module.address.addresses[0], null)
+}
+
 output "central_manager_internal_ips" {
-  description = "Reserved internal IP addresses for use by Central Managers"
+  description = "Reserved internal IP addresses for use by 2 Central Managers in HA mode"
   value       = module.address.addresses
 }

--- a/community/modules/scheduler/htcondor-configure/outputs.tf
+++ b/community/modules/scheduler/htcondor-configure/outputs.tf
@@ -58,3 +58,8 @@ output "execute_point_runner" {
   description = "Toolkit Runner to configure an HTCondor Execute Point"
   value       = local.runner_execute_role
 }
+
+output "central_manager_internal_ips" {
+  description = "Reserved internal IP addresses for use by Central Managers"
+  value       = module.address.addresses
+}

--- a/community/modules/scheduler/htcondor-configure/variables.tf
+++ b/community/modules/scheduler/htcondor-configure/variables.tf
@@ -37,7 +37,6 @@ variable "region" {
 variable "subnetwork_self_link" {
   description = "The self link of the subnetwork in which Central Managers will be placed."
   type        = string
-  default     = null
 }
 
 variable "access_point_roles" {

--- a/community/modules/scheduler/htcondor-configure/variables.tf
+++ b/community/modules/scheduler/htcondor-configure/variables.tf
@@ -24,6 +24,22 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "labels" {
+  description = "Labels to add to resources. List key, value pairs."
+  type        = map(string)
+}
+
+variable "region" {
+  description = "Default region for creating resources"
+  type        = string
+}
+
+variable "subnetwork_self_link" {
+  description = "The self link of the subnetwork in which Central Managers will be placed."
+  type        = string
+  default     = null
+}
+
 variable "access_point_roles" {
   description = "Project-wide roles for HTCondor Access Point service account"
   type        = list(string)
@@ -60,4 +76,10 @@ variable "pool_password" {
   type        = string
   sensitive   = true
   default     = null
+}
+
+variable "central_manager_high_availability" {
+  description = "Provision HTCondor central manager in high availability mode"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
This PR adds support to the Toolkit for highly available HTCondor Central Managers.

- use reserved IP address(es) so that central managers are in a robust "location" and supply them as variables directly to Ansible runner instead of as metadata to pool VMs
- modify blueprint to ensure that vm-instance modules use reserved IP
- update Ansible playbook to ensure that HTCondor will reload its configuration when updates are made

The example blueprint does not demonstrate HA mode yet. Forthcoming work to support HA job queues can add that.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?