### PR TITLE
Ensure Open Front End dependabot updates target develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
     time: "03:00"
     timezone: America/Los_Angeles
   target-branch: develop
+- package-ecosystem: pip
+  directory: /community/front-end/ofe/
+  schedule:
+    interval: weekly
+    day: monday
+    time: "03:00"
+    timezone: America/Los_Angeles
+  target-branch: develop


### PR DESCRIPTION
The choice to restrict this change to the Open Front End code is deliberate as I think it's the only instance of Python code with a properly curated requirements.txt file. There are 2 other instances:

- /tools/cloud-build/requirements.txt
- /docs/hybrid-slurm-cluster/requirements.txt

The cloud-build requirements.txt contains no version constraints at all while the Slurm docs appear to be more of a tutorial without any integration testing. So, for now, I think we are better off configuring what we test.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?