### PR TITLE
Fix: Always generate Batch instance template to avoid known at apply time error

### DIFF
--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  instance_template = var.instance_template != null ? var.instance_template : one(module.instance_template[*].self_link)
+  instance_template = var.instance_template != null ? var.instance_template : module.instance_template.self_link
 
   tasks_per_node = var.task_count_per_node != null ? var.task_count_per_node : (var.mpi_mode ? 1 : null)
 
@@ -67,9 +67,8 @@ locals {
 module "instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
   version = "> 7.6.0"
-  count   = var.instance_template == null ? 1 : 0
 
-  name_prefix        = "${local.job_id}-instance-template"
+  name_prefix        = var.instance_template == null ? "${local.job_id}-instance-template" : "unused-template"
   project_id         = var.project_id
   subnetwork         = local.subnetwork_name
   subnetwork_project = local.subnetwork_project


### PR DESCRIPTION
The conditional creation of the Batch instance template causes "not known at apply time" errors. This change avoids those errors by always creating an instance template even when the user provides an instance template. In the case that the user provides an instance template, the created template will be unused. While this may not be optimal, instance templates do not have a cost to the end user and it is the best solution given the limitations of terraform.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
