### PR TITLE
Update HTCondor modules

### DIFF
--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -134,8 +134,8 @@ limitations under the License.
 | <a name="output_access_point_runner"></a> [access\_point\_runner](#output\_access\_point\_runner) | Toolkit Runner to configure an HTCondor Access Point |
 | <a name="output_access_point_service_account"></a> [access\_point\_service\_account](#output\_access\_point\_service\_account) | HTCondor Access Point Service Account (e-mail format) |
 | <a name="output_central_manager_internal_ip"></a> [central\_manager\_internal\_ip](#output\_central\_manager\_internal\_ip) | Reserved internal IP address for use by Central Manager |
-| <a name="output_central_manager_internal_ips"></a> [central\_manager\_internal\_ips](#output\_central\_manager\_internal\_ips) | Reserved internal IP addresses for use by 2 Central Managers in HA mode |
 | <a name="output_central_manager_runner"></a> [central\_manager\_runner](#output\_central\_manager\_runner) | Toolkit Runner to configure an HTCondor Central Manager |
+| <a name="output_central_manager_secondary_internal_ip"></a> [central\_manager\_secondary\_internal\_ip](#output\_central\_manager\_secondary\_internal\_ip) | Reserved internal IP address for use by failover Central Manager |
 | <a name="output_central_manager_service_account"></a> [central\_manager\_service\_account](#output\_central\_manager\_service\_account) | HTCondor Central Manager Service Account (e-mail format) |
 | <a name="output_execute_point_runner"></a> [execute\_point\_runner](#output\_execute\_point\_runner) | Toolkit Runner to configure an HTCondor Execute Point |
 | <a name="output_execute_point_service_account"></a> [execute\_point\_service\_account](#output\_execute\_point\_service\_account) | HTCondor Execute Point Service Account (e-mail format) |

--- a/community/modules/scheduler/htcondor-configure/outputs.tf
+++ b/community/modules/scheduler/htcondor-configure/outputs.tf
@@ -64,7 +64,7 @@ output "central_manager_internal_ip" {
   value       = try(module.address.addresses[0], null)
 }
 
-output "central_manager_internal_ips" {
-  description = "Reserved internal IP addresses for use by 2 Central Managers in HA mode"
-  value       = module.address.addresses
+output "central_manager_secondary_internal_ip" {
+  description = "Reserved internal IP address for use by failover Central Manager"
+  value       = try(module.address.addresses[1], null)
 }

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -48,11 +48,27 @@ A full example can be found in the [examples README][htc-example].
 
 ## Important note
 
-This module enables Linux firewall rules that block access to the instance
-metadata server for any POSIX user that is not `root` or `condor`. This prevents
-user jobs from being able to escalate privileges to act as the VM. System
-services and HTCondor itself can continue to do so, such as writing to Cloud
-Logging. This [feature can be disabled](#input_block_metadata_server).
+All POSIX users and HTCondor jobs can act as the service account attached to
+VMs within the pool. This enables the use of IAM restrictions via service
+accounts but also allows users to access services to which system daemons need
+access (e.g. to create Cloud Logging entries). If this is undesirable, one can
+restrict access to the instance metadata server to the `root` and `condor`
+users. This will allow system services to use the service account, but not
+other POSIX users or HTCondor jobs. The firewall example below is appropriate
+for CentOS 7.
+
+```shell
+firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 1 \
+    -m owner --uid-owner root -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
+firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 2 \
+    -m owner --uid-owner condor -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
+firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 3 \
+    -p tcp -d metadata.google.internal --dport 80 -j DROP
+firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 4 \
+    -p tcp -d metadata.google.internal --dport 8080 -j DROP
+firewall-cmd --permanent --zone=public --add-port=9618/tcp
+firewall-cmd --reload
+```
 
 ## Support
 
@@ -104,7 +120,6 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_block_metadata_server"></a> [block\_metadata\_server](#input\_block\_metadata\_server) | Use Linux firewall to block the instance metadata server for users other than root and HTCondor daemons | `bool` | `true` | no |
 | <a name="input_enable_docker"></a> [enable\_docker](#input\_enable\_docker) | Install and enable docker daemon alongside HTCondor | `bool` | `true` | no |
 
 ## Outputs

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -16,7 +16,6 @@
 - name: Ensure HTCondor is installed
   hosts: all
   vars:
-    block_metadata_server: true
     enable_docker: true
   become: true
   tasks:
@@ -35,12 +34,6 @@
       mode: 0700
       owner: root
       group: root
-  - name: Ensure that firewall is started and enabled
-    ansible.builtin.systemd:
-      name: firewalld
-      enabled: true
-      state: started
-      masked: no
   - name: Install Docker and configure HTCondor to use it
     when: enable_docker | bool  # allows string to be passed at CLI
     block:
@@ -69,16 +62,3 @@
         name: condor
         groups: docker
         append: yes
-  - name: Ensure that only root and condor users can access service account
-    when: block_metadata_server | bool # allows string to be passed at CLI
-    ansible.builtin.shell: |
-      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 1 \
-          -m owner --uid-owner root -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
-      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 2 \
-          -m owner --uid-owner condor -p tcp -d metadata.google.internal --dport 80 -j ACCEPT
-      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 3 \
-          -p tcp -d metadata.google.internal --dport 80 -j DROP
-      firewall-cmd --direct --permanent --add-rule ipv4 filter OUTPUT_direct 4 \
-          -p tcp -d metadata.google.internal --dport 8080 -j DROP
-      firewall-cmd --permanent --zone=public --add-port=9618/tcp
-      firewall-cmd --reload

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -19,10 +19,7 @@ locals {
     "type"        = "ansible-local"
     "source"      = "${path.module}/files/install-htcondor.yaml"
     "destination" = "install-htcondor.yaml"
-    "args" = join(" ", [
-      "-e block_metadata_server=${var.block_metadata_server}",
-      "-e enable_docker=${var.enable_docker}"
-    ])
+    "args"        = "-e enable_docker=${var.enable_docker}"
   }
 
   runner_install_autoscaler_deps = {

--- a/community/modules/scripts/htcondor-install/variables.tf
+++ b/community/modules/scripts/htcondor-install/variables.tf
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-variable "block_metadata_server" {
-  description = "Use Linux firewall to block the instance metadata server for users other than root and HTCondor daemons"
-  type        = bool
-  default     = true
-}
-
 variable "enable_docker" {
   description = "Install and enable docker daemon alongside HTCondor"
   type        = bool


### PR DESCRIPTION
- Implement suggestion from #892 to avoid use of Toolkit literals in blueprint after review of documentation indicates that, in fact, we are using HTCondor HA in a primary/secondary configuration
- The goal of managing the firewall on HTCondor pools is to avoid regular POSIX users escalating to use the service account needed by HTCondor daemons. That is a reasonable objective, but is probably more confusing for users than helpful. The solution is also not idempotent or cross-platform friendly. We will return to this upon user demand. In the meantime, I've documented the concern in the README and offered the existing solution as one the user can manually implement.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?