### PR TITLE
Bump TFLint version in image to latest

### DIFF
--- a/tools/cloud-build/hpc-toolkit-builder.yaml
+++ b/tools/cloud-build/hpc-toolkit-builder.yaml
@@ -24,7 +24,7 @@ steps:
   - '--cache-from'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder:latest'
   - '--build-arg'
-  - 'TFLINT_VERSION=v0.40.0'
+  - 'TFLINT_VERSION=v0.45.0'
   - '-f'
   - 'tools/cloud-build/Dockerfile'
   - '.'


### PR DESCRIPTION
This PR updates the release of TFLint in the base builder image to the latest release. I use it regularly in my development environment and do not anticipate problems. Based on experience, we should stay close to the latest release but keep the version fixed until we choose to upgrade (as we are now).

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?