### PR TITLE
Manage HTCondor yum repo configuration directly

### DIFF
--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -2,7 +2,11 @@
 
 This module creates a Toolkit runner that will install HTCondor on RedHat 7 or
 derivative operating systems such as the CentOS 7 release in the [HPC VM
-Image][hpcvmimage].
+Image][hpcvmimage]. It should also function on RedHat or Rocky Linux releases 8
+and 9, however it is not yet supported. Please report any [issues] on these
+platforms.
+
+[issues]: https://github.com/GoogleCloudPlatform/hpc-toolkit/issues
 
 It also exports a list of Google Cloud APIs which must be enabled prior to
 provisioning an HTCondor Pool.

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The instructions for installing HTCondor may change with time, although we
+# anticipate that they will stay fixed for the 10.x releases. Find up-to-date
+# recommendations at:
+## https://htcondor.readthedocs.io/en/latest/getting-htcondor/from-our-repositories.html
+
 ---
 - name: Ensure HTCondor is installed
   hosts: all
@@ -19,13 +24,32 @@
     enable_docker: true
   become: true
   tasks:
-  - name: Setup HTCondor yum repository
-    ansible.builtin.yum:
+  - name: Enable EPEL repository
+    ansible.builtin.package:
       name:
       - epel-release
-      - https://research.cs.wisc.edu/htcondor/repo/10.x/htcondor-release-current.el7.noarch.rpm
+  - name: Enable HTCondor Feature Release repository
+    ansible.builtin.yum_repository:
+      name: htcondor-feature
+      description: HTCondor Feature Releases (10.x.0)
+      file: htcondor
+      baseurl: https://research.cs.wisc.edu/htcondor/repo/10.x/el$releasever/$basearch/release
+      gpgkey: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key
+      gpgcheck: true
+      repo_gpgcheck: true
+      priority: "90"
+  - name: Enable HTCondor Feature Release Updates repository
+    ansible.builtin.yum_repository:
+      name: htcondor-feature-update
+      description: HTCondor Feature Release Updates (10.x.y)
+      file: htcondor
+      baseurl: https://research.cs.wisc.edu/htcondor/repo/10.x/el$releasever/$basearch/update
+      gpgkey: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key
+      gpgcheck: true
+      repo_gpgcheck: true
+      priority: "90"
   - name: Install HTCondor
-    ansible.builtin.yum:
+    ansible.builtin.package:
       name: condor
       state: present
   - name: Ensure token directory
@@ -46,7 +70,7 @@
         gpgcheck: yes
         gpgkey: https://download.docker.com/linux/centos/gpg
     - name: Install Docker
-      ansible.builtin.yum:
+      ansible.builtin.package:
         name:
         - docker-ce
         - docker-ce-cli


### PR DESCRIPTION
This PR updates the HTCondor installation runner

- enable a 2nd HTCondor "feature update" repo which contains patch releases (X.Y.Z) to the feature/development releases (X.Y.0)
- manage yum repo configurations directly rather than using yum to download and install a package
    - this is a minor efficiency improvement because Ansible is fast at rendering files while running yum can take a long time for simple operations
- changing instances of ansible.builtin.yum to ansible.builtin.package anticipating the need to support this module on more recent RedHat and derivative operating systems (8 + 9 use `dnf` rather than `yum`)
- update the README to indicate potential functionality, but not support, for releases of RedHat/derivatives above 7

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?