### PR TITLE
Address terraform_unused_required_providers errors

### DIFF
--- a/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/README.md
+++ b/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/versions.tf
+++ b/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
   }
 
-  required_version = ">= 0.12.20"
+  required_version = ">= 0.12.31"
 }
 
 

--- a/community/modules/remote-desktop/chrome-remote-desktop/README.md
+++ b/community/modules/remote-desktop/chrome-remote-desktop/README.md
@@ -53,7 +53,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.12 |
 

--- a/community/modules/remote-desktop/chrome-remote-desktop/README.md
+++ b/community/modules/remote-desktop/chrome-remote-desktop/README.md
@@ -54,8 +54,6 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.12 |
 
 ## Providers
 

--- a/community/modules/remote-desktop/chrome-remote-desktop/versions.tf
+++ b/community/modules/remote-desktop/chrome-remote-desktop/versions.tf
@@ -26,5 +26,5 @@ terraform {
       version = ">= 4.12"
     }
   }
-  required_version = ">= 0.12.20"
+  required_version = ">= 0.12.31"
 }

--- a/community/modules/remote-desktop/chrome-remote-desktop/versions.tf
+++ b/community/modules/remote-desktop/chrome-remote-desktop/versions.tf
@@ -15,16 +15,5 @@
 */
 
 terraform {
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 3.83"
-    }
-
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = ">= 4.12"
-    }
-  }
   required_version = ">= 0.12.31"
 }


### PR DESCRIPTION
- remove unused providers in Chrome Remote Desktop module
- impose minimum Terraform version of 0.12.31 because versions below that are known to have a built-in GPG key that was revoked due to a security incident (HCSEC-2021-12)

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?