### PR TITLE
Fail integration tests on validation warnings.

### DIFF
--- a/tools/cloud-build/daily-tests/create_deployment.sh
+++ b/tools/cloud-build/daily-tests/create_deployment.sh
@@ -63,7 +63,7 @@ sed -i "s/max_node_count: .*/max_node_count: ${MAX_NODES}/" "${EXAMPLE_YAML}" ||
 VARS="project_id=${PROJECT_ID},deployment_name=${DEPLOYMENT_NAME}"
 
 ## Create blueprint and create artifact
-./ghpc create "${EXAMPLE_YAML}" \
+./ghpc create  -l ERROR "${EXAMPLE_YAML}" \
 	--vars "${VARS}" ||
 	{
 		echo "could not write blueprint"

--- a/tools/cloud-build/daily-tests/create_deployment.sh
+++ b/tools/cloud-build/daily-tests/create_deployment.sh
@@ -63,7 +63,7 @@ sed -i "s/max_node_count: .*/max_node_count: ${MAX_NODES}/" "${EXAMPLE_YAML}" ||
 VARS="project_id=${PROJECT_ID},deployment_name=${DEPLOYMENT_NAME}"
 
 ## Create blueprint and create artifact
-./ghpc create  -l ERROR "${EXAMPLE_YAML}" \
+./ghpc create -l ERROR "${EXAMPLE_YAML}" \
 	--vars "${VARS}" ||
 	{
 		echo "could not write blueprint"


### PR DESCRIPTION
Context:
A bug was introduced into Toolkit due to a bug in the Go Compute Engine package. Integration tests didn't catch it because validator warnings do not impact `ghpc` exit code.

Add flag `-l ERROR` to `ghpc create` run to fail on validation warnings.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
