### PR TITLE
OFE update 14/02/2023.

### DIFF
--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/spack_install/tasks/main.yaml
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/spack_install/tasks/main.yaml
@@ -25,7 +25,7 @@
   ansible.builtin.git:
     repo: https://github.com/spack/spack.git
     dest: "{{ spack_dir }}"
-    version: v0.17.1
+    version: v0.19.1
     depth: 1
 
 - name: Apply Global Spack configurations
@@ -45,7 +45,7 @@
 
 - name: Get Slurm Version
   ansible.builtin.set_fact:
-    slurm_version={{ slurm_version_cmd.stdout }}
+    slurm_version={{ slurm_version_cmd.stdout }}   
 - name: Write Slurm Package file
   ansible.builtin.copy:
     dest: /tmp/spack_pkg.yml

--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/spack_install/tasks/main.yaml
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/spack_install/tasks/main.yaml
@@ -45,7 +45,7 @@
 
 - name: Get Slurm Version
   ansible.builtin.set_fact:
-    slurm_version={{ slurm_version_cmd.stdout }}   
+    slurm_version={{ slurm_version_cmd.stdout }}
 - name: Write Slurm Package file
   ansible.builtin.copy:
     dest: /tmp/spack_pkg.yml

--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/spack_setup/tasks/main.yaml
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/spack_setup/tasks/main.yaml
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 ---
-- name: Spack config externals
-  ansible.builtin.shell: |
-    module load openmpi
-    {{ spack_dir }}/bin/spack external find --scope=system --not-buildable
+- name: Load openmpi module
+  ansible.builtin.shell: ". /usr/share/Modules/init/sh;module load openmpi"
+  when: True
+
+- name: Spack find system modules
+  ansible.builtin.command: "{{ spack_dir }}/bin/spack external find --scope=system --not-buildable"
+  ignore_errors: true
   when: True
 
 - name: Spack mark cmake as buildable

--- a/community/front-end/ofe/script/service_account.sh
+++ b/community/front-end/ofe/script/service_account.sh
@@ -57,7 +57,8 @@ SA_ROLES=('aiplatform.admin'
 	'iam.serviceAccountAdmin'
 	'iam.serviceAccountUser'
 	'notebooks.admin'
-	'resourcemanager.projectIamAdmin')
+	'resourcemanager.projectIamAdmin'
+        'monitoring.viewer')
 
 #
 #

--- a/community/front-end/ofe/script/service_account.sh
+++ b/community/front-end/ofe/script/service_account.sh
@@ -58,7 +58,7 @@ SA_ROLES=('aiplatform.admin'
 	'iam.serviceAccountUser'
 	'notebooks.admin'
 	'resourcemanager.projectIamAdmin'
-        'monitoring.viewer')
+	'monitoring.viewer')
 
 #
 #

--- a/community/front-end/ofe/website/ghpcfe/views/credentials.py
+++ b/community/front-end/ofe/website/ghpcfe/views/credentials.py
@@ -97,7 +97,6 @@ class CredentialUpdateView(SuperUserRequiredMixin, UpdateView):
         initial[ "detail" ] = ""
         return initial
 
-
 class CredentialDeleteView(SuperUserRequiredMixin, DeleteView):
     """Custom DeleteView for Credential model"""
 
@@ -110,10 +109,20 @@ class CredentialDeleteView(SuperUserRequiredMixin, DeleteView):
         return context
 
     def get_success_url(self):
-        credential = Credential.objects.get(pk=self.kwargs["pk"])
-        messages.success(self.request, f"Credential {credential.name} deleted.")
         return reverse("credentials")
-
+    
+    def post(self, request, *args, **kwargs):
+        try:
+            delete_request = super().delete(request, *args, **kwargs)
+            messages.success(self.request, f"Credential successfully deleted.")
+            return delete_request
+        except RestrictedError:
+            msg = """Credential deletion failed due to a foreign key constraint.
+            It is used by other objects such as clusters. In order to 
+            delete the credential, archived objects should be completely deleted.
+             """
+            messages.error(request, msg)
+            return HttpResponseRedirect(reverse('credentials'))
 
 # For APIs
 

--- a/community/front-end/ofe/website/nginx.conf
+++ b/community/front-end/ofe/website/nginx.conf
@@ -40,7 +40,7 @@ http {
         }
 
         location /static/ {
-            alias ../hpc-toolkit/community/front-end/ofe/website/static/;
+            alias ../hpc-toolkit/community/front-end/website/static/;
         }
 
         location / {


### PR DESCRIPTION
### **OFE cluster compute node provisioning issue**

I noticed an issue where OFE cluster compute nodes getting stuck in configuring state and jobs are not getting executed. Looking at the logs, I noticed that Slurm setup script fails at the Spack configuration Ansible playbook. It uses the following command `module load openmpi` to load `openmpi` module. However, when the command is executed the `module` command is not yet available, because the user profile is not loaded [1]. In my opinion, it looks like a race condition, and the only reason why it could have only happened now is the compute node image update.

[1] https://modules.readthedocs.io/en/latest/module.html#examples-of-initialization 

Error message:
```json
"message": "Feb 14 13:31:13 clusterb61-batch-ghpc-1 google_metadata_script_runner: startup-script: fatal: [localhost]: FAILED! => {\"changed\": true, \"cmd\": \"module load openmpi\\n/share/spack/bin/spack external find --scope=system --not-buildable\\n\", \"delta\": \"0:00:00.003791\", \"end\": \"2023-02-14 13:31:13.616607\", \"msg\": \"non-zero return code\", \"rc\": 127, \"start\": \"2023-02-14 13:31:13.612816\", \"stderr\": \"/bin/sh: module: command not found\\n/bin/sh: line 1: /share/spack/bin/spack: No such file or directory\", \"stderr_lines\": [\"/bin/sh: module: command not found\", \"/bin/sh: line 1: /share/spack/bin/spack: No such file or directory\"], \"stdout\": \"\", \"stdout_lines\": []}"
```

My pull request, updates Spack version and makes sure module command is available before it is called.

### **Improved OFE credential delete error handing.**
When attempting to delete a credential from OFE while there are foreign key constrains, it results in an internal Django error as in example below. In this scenario, user get unfriendly error 500 view in their browser. 

Error message:
```bash
django.db.models.deletion.RestrictedError: ("Cannot delete some instances of model 'Credential' because they are referenced through restricted foreign keys: 'CloudResource.cloud_credential'.", {<CloudResource: CloudResource object (65)>, <CloudResource: CloudResource object (66)>, <CloudResource: CloudResource object (9)>, <CloudResource: CloudResource object (10)>, <CloudResource: CloudResource object (47)>, <CloudResource: CloudResource object (48)>, <CloudResource: CloudResource object (49)>, <CloudResource: CloudResource object (50)>, <CloudResource: CloudResource object (53)>, <CloudResource: CloudResource object (54)>, <CloudResource: CloudResource object (57)>, <CloudResource: CloudResource object (58)>, <CloudResource: CloudResource object (27)>, <CloudResource: CloudResource object (28)>, <CloudResource: CloudResource object (61)>, <CloudResource: CloudResource object (62)>})
```
This pull request improves error handing for that particular function and displays the following error instead:
![image](https://user-images.githubusercontent.com/117852832/218819909-1df9f41c-d097-4fa7-9284-9ad1dcb1f159.png)

### Adding extra role for OFE service account
Adding extra role for OFE service account so it can access monitoring and present and view dashboards in Grafana.
It looks like the access policy change on GCP, so that's why additional role is required.

### Fixing OFE broken static content path.
In my previous nginx security patch, I changed a path to the static content in the nginx.conf.
I did not anticipate that the startup scripts take content out from /front-end/ofe/ and put into /front-end/ and as a result static content ends up in the directory that is not expected by nginx. Changing that back to what it was.
.p.s. it was showing up fine during my testing when I was patching a security issue, the static content was in my browser cache that's why I did not spot the issue.



### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
