### PR TITLE
Fix `cmd/root_test.go` test runs from linked Git worktrees.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,7 +145,7 @@ func hpcToolkitRepo() (repo *git.Repository, dir string, err error) {
 			repo, err = git.PlainOpen(dir)
 
 			if err == nil && isHpcToolkitRepo(*repo) {
-				return
+				return repo, dir, nil
 			}
 		}
 	}
@@ -159,10 +159,10 @@ func hpcToolkitRepo() (repo *git.Repository, dir string, err error) {
 
 	repo, err = git.PlainOpen(dir)
 	if err != nil {
-		return
+		return nil, "", err
 	}
 	if isHpcToolkitRepo(*repo) {
-		return
+		return repo, dir, nil
 	}
 	return nil, "", errors.New("unable to find the hpc-toolkit git repo in the file system")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -164,7 +164,7 @@ func hpcToolkitRepo() (repo *git.Repository, dir string, err error) {
 	if isHpcToolkitRepo(*repo) {
 		return repo, dir, nil
 	}
-	return nil, "", errors.New("unable to find the hpc-toolkit git repo in the file system")
+	return nil, "", errors.New("ghpc executable found in a git repo other than the hpc-toolkit git repo")
 }
 
 // isHpcToolkitRepo will verify that the found git repository has a commit with

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -157,10 +158,13 @@ func hpcToolkitRepo() (repo *git.Repository, dir string, err error) {
 	dir = filepath.Dir(e)
 
 	repo, err = git.PlainOpen(dir)
-	if err == nil && isHpcToolkitRepo(*repo) {
-		return repo, dir, err
+	if err != nil {
+		return
 	}
-	return nil, "", err
+	if isHpcToolkitRepo(*repo) {
+		return
+	}
+	return nil, "", errors.New("Not the hpc-toolkit repo")
 }
 
 // isHpcToolkitRepo will verify that the found git repository has a commit with

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -164,7 +164,7 @@ func hpcToolkitRepo() (repo *git.Repository, dir string, err error) {
 	if isHpcToolkitRepo(*repo) {
 		return
 	}
-	return nil, "", errors.New("Not the hpc-toolkit repo")
+	return nil, "", errors.New("unable to find the hpc-toolkit git repo in the file system")
 }
 
 // isHpcToolkitRepo will verify that the found git repository has a commit with

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,11 +20,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	. "gopkg.in/check.v1"
 )
@@ -196,7 +198,13 @@ func initTestRepo(path string) (repo *git.Repository, initHash plumbing.Hash, er
 		f.Write([]byte(s + " @ " + path))
 		f.Close()
 		w.Add(n)
-		hash, err = w.Commit(s, &git.CommitOptions{})
+		hash, err = w.Commit(s, &git.CommitOptions{
+			Author: &object.Signature{
+				Name:  "T T",
+				Email: "t@t.io",
+				When:  time.Now(),
+			},
+		})
 		return
 	}
 


### PR DESCRIPTION
Fix `cmd/root_test.go` test runs from linked Git worktrees.
```
$git worktree add wt && cd wt
$make tests
...
PANIC: root_test.go:112: MySuite.TestCheckGitHashMismatch
```

- Don't use real repo as a subject for inspection, use test ones;
- Use `Check` instead of `Assert`.

**Testing**:
```
$ cd ~/wp/hpc-toolkit && git checkout wt
$ make tests
...
$ git checkout develop && git worktree add wt && cd wt
$ make tests
...
```

**NOTE**:
While running `make tests` from linked worktree, incorrect warning is shown:
```
WARNING: ghpc binary was built from a different commit (wt/7812ced) than the current git branch in ~/wp/hpc-toolkit (develop/edb0ce3). You can rebuild the binary by running 'make'
```
This issue should be addressed in separate PR.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
