### PR TITLE
Set minimal scopes for HTCondor IDTOKENs

### DIFF
--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -14,8 +14,16 @@
 
 ---
 - name: Configure HTCondor Role
-  become: true
   hosts: localhost
+  become: true
+  vars:
+    condor_config_root: /etc/condor
+    role_file: 00-role
+    pool_file: 01-pool
+    cm_config_file: 02-central-manager
+    cm_ha_config_file: 02-central-manager-high-availability
+    schedd_config_file: 02-schedd
+    execute_config_file: 02-execute
   tasks:
   - name: User must supply HTCondor role
     ansible.builtin.assert:
@@ -24,98 +32,141 @@
       - htcondor_role is defined
       - password_id is defined
       - project_id is defined
-  - name: Remove default HTCondor configuration
-    ansible.builtin.file:
-      name: /etc/condor/config.d/00-htcondor-9.0.config
-      state: absent
-    notify:
-    - Reload HTCondor
-  - name: Set HTCondor role
-    ansible.builtin.copy:
-      dest: /etc/condor/config.d/00-role
-      mode: 0644
-      content: |
-        use role:{{ htcondor_role }}
-    notify:
-    - Reload HTCondor
-  - name: Set HTCondor Central Manager and Trust Domain
-    ansible.builtin.copy:
-      dest: /etc/condor/config.d/01-central-manager
-      mode: 0644
-      content: |
-        CONDOR_HOST={{ htcondor_central_manager_ips }}
-        UID_DOMAIN=c.{{ project_id }}.internal
-        TRUST_DOMAIN=c.{{ project_id }}.internal
-    notify:
-    - Reload HTCondor
-  - name: Generate list of Central Managers
+  - name: Set Trust Domain
     ansible.builtin.set_fact:
-      central_manager_list: "{{ htcondor_central_manager_ips | split(',') }}"
-  - name: Set HTCondor Central Manager High Availability
-    when: htcondor_role == 'get_htcondor_central_manager' and central_manager_list | length > 1
-    ansible.builtin.copy:
-      dest: /etc/condor/config.d/01-central-manager-high-availability
-      mode: 0644
-      content: |
-        # following https://htcondor.readthedocs.io/en/latest/admin-manual/high-availability.html#high-availability-of-the-central-manager
-        CM_LIST = \
-          {{ central_manager_list[0] }}:$(SHARED_PORT_PORT), \
-          {{ central_manager_list[1] }}:$(SHARED_PORT_PORT)
-
-        HAD_USE_SHARED_PORT = TRUE
-        HAD_LIST = $(CM_LIST)
-
-        REPLICATION_USE_SHARED_PORT = TRUE
-        REPLICATION_LIST = $(CM_LIST)
-
-        HAD_USE_PRIMARY = TRUE
-        HAD_CONTROLLEE = NEGOTIATOR
-        MASTER_NEGOTIATOR_CONTROLLER = HAD
-
-        DAEMON_LIST = $(DAEMON_LIST), HAD, REPLICATION
-        HAD_USE_REPLICATION = TRUE
-        MASTER_HAD_BACKOFF_CONSTANT = 360
-    notify:
-    - Reload HTCondor
-  - name: Configure HTCondor SchedD
-    when: htcondor_role == 'get_htcondor_submit'
-    block:
-    - name: Create SchedD configuration file
-      ansible.builtin.copy:
-        dest: /etc/condor/config.d/02-schedd
-        mode: 0644
-        content: |
-          SCHEDD_INTERVAL=15
-          TRUST_UID_DOMAIN = True
-          SUBMIT_ATTRS = RunAsOwner
-          RunAsOwner = True
-      notify:
-      - Reload HTCondor
-  - name: Configure HTCondor StartD
-    when: htcondor_role == 'get_htcondor_execute'
-    block:
-    - name: Create StartD configuration file
-      ansible.builtin.copy:
-        dest: /etc/condor/config.d/02-startd
-        mode: 0644
-        content: |
-          use feature:PartitionableSlot
-          use feature:CommonCloudAttributesGoogle("-c created-by")
-          TRUST_UID_DOMAIN = True
-          STARTER_ALLOW_RUNAS_OWNER = True
-      notify:
-      - Reload HTCondor
-  - name: Set HTCondor credentials
+      trust_domain: c.{{ project_id }}.internal
+  - name: Set HTCondor Pool password (token signing key)
     ansible.builtin.shell: |
       set -e -o pipefail
       export CLOUDSDK_PYTHON=/usr/bin/python
       POOL_PASSWORD=$(gcloud secrets versions access latest --secret={{ password_id }})
       echo -n "$POOL_PASSWORD" | sh -c "condor_store_cred add -c -i -"
-      umask 0077
-      TRUST_DOMAIN=$(condor_config_val TRUST_DOMAIN)
-      condor_token_create -identity condor@$TRUST_DOMAIN > /etc/condor/tokens.d/condor@$TRUST_DOMAIN
     args:
-      creates: /etc/condor/passwords.d/POOL
+      creates: "{{ condor_config_root }}/passwords.d/POOL"
+  - name: Remove default HTCondor configuration
+    ansible.builtin.file:
+      path: "{{ condor_config_root }}/config.d/00-htcondor-9.0.config"
+      state: absent
+    notify:
+    - Reload HTCondor
+  - name: Set HTCondor role on all hosts
+    ansible.builtin.copy:
+      dest: "{{ condor_config_root }}/config.d/{{ role_file }}"
+      mode: 0644
+      content: |
+        use role:{{ htcondor_role }}
+    notify:
+    - Reload HTCondor
+  - name: Set HTCondor Central Manager and trust domain on all hosts
+    ansible.builtin.copy:
+      dest: "{{ condor_config_root }}/config.d/{{ pool_file }}"
+      mode: 0644
+      content: |
+        CONDOR_HOST={{ htcondor_central_manager_ips }}
+        UID_DOMAIN={{ trust_domain }}
+        TRUST_DOMAIN={{ trust_domain }}
+    notify:
+    - Reload HTCondor
+  - name: Configure HTCondor Central Manager
+    when: htcondor_role == 'get_htcondor_central_manager'
+    block:
+    - name: Create IDTOKEN for Central Manager
+      ansible.builtin.shell: |
+        umask 0077
+        TRUST_DOMAIN=$(condor_config_val TRUST_DOMAIN)
+        # do not restrict Central Manager authz scopes!
+        condor_token_create -identity condor@{{ trust_domain }} \
+          -token condor@{{ trust_domain }}
+      args:
+        creates: "{{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}"
+    - name: Generate list of Central Managers
+      ansible.builtin.set_fact:
+        central_manager_list: "{{ htcondor_central_manager_ips | split(',') }}"
+    - name: Create Central Manager standard configuration file
+      when: central_manager_list | length > 1
+      ansible.builtin.copy:
+        dest: "{{ condor_config_root }}/config.d/{{ cm_config_file }}"
+        mode: 0644
+        content: |
+          COLLECTOR_UPDATE_INTERVAL=60
+          NEGOTIATOR_UPDATE_INTERVAL=60
+    - name: Create Central Manager HA configuration file
+      when: central_manager_list | length > 1
+      ansible.builtin.copy:
+        dest: "{{ condor_config_root }}/config.d/{{ cm_ha_config_file }}"
+        mode: 0644
+        content: |
+          # following https://htcondor.readthedocs.io/en/latest/admin-manual/high-availability.html#high-availability-of-the-central-manager
+          CM_LIST = \
+            {{ central_manager_list[0] }}:$(SHARED_PORT_PORT), \
+            {{ central_manager_list[1] }}:$(SHARED_PORT_PORT)
+
+          HAD_USE_SHARED_PORT=True
+          HAD_LIST=$(CM_LIST)
+
+          REPLICATION_USE_SHARED_PORT=True
+          REPLICATION_LIST=$(CM_LIST)
+
+          HAD_USE_PRIMARY=True
+          HAD_CONTROLLEE=NEGOTIATOR
+          MASTER_NEGOTIATOR_CONTROLLER=HAD
+
+          DAEMON_LIST=$(DAEMON_LIST), HAD, REPLICATION
+          HAD_USE_REPLICATION=True
+          MASTER_HAD_BACKOFF_CONSTANT=360
+      notify:
+      - Reload HTCondor
+    - name: Remove Central Manager HA configuration file
+      when: central_manager_list | length == 1
+      ansible.builtin.file:
+        path: "{{ condor_config_root }}/config.d/{{ cm_ha_config_file }}"
+        state: absent
+      notify:
+      - Reload HTCondor
+  - name: Configure HTCondor SchedD
+    when: htcondor_role == 'get_htcondor_submit'
+    block:
+    - name: Create SchedD configuration file
+      ansible.builtin.copy:
+        dest: "{{ condor_config_root }}/config.d/{{ schedd_config_file }}"
+        mode: 0644
+        content: |
+          SCHEDD_INTERVAL=30
+          TRUST_UID_DOMAIN=True
+          SUBMIT_ATTRS=RunAsOwner
+          RunAsOwner=True
+      notify:
+      - Reload HTCondor
+    - name: Create IDTOKEN to advertise access point
+      ansible.builtin.shell: |
+        umask 0077
+        condor_token_create -authz READ -authz ADVERTISE_MASTER \
+          -authz ADVERTISE_SCHEDD -identity condor@{{ trust_domain }} \
+          -token condor@{{ trust_domain }}
+      args:
+        creates: "{{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}"
+  - name: Configure HTCondor StartD
+    when: htcondor_role == 'get_htcondor_execute'
+    block:
+    - name: Create StartD configuration file
+      ansible.builtin.copy:
+        dest: "{{ condor_config_root }}/config.d/{{ execute_config_file }}"
+        mode: 0644
+        content: |
+          use feature:PartitionableSlot
+          use feature:CommonCloudAttributesGoogle("-c created-by")
+          TRUST_UID_DOMAIN=True
+          STARTER_ALLOW_RUNAS_OWNER=True
+      notify:
+      - Reload HTCondor
+    - name: Create IDTOKEN to advertise execute point
+      ansible.builtin.shell: |
+        umask 0077
+        condor_token_create -authz READ -authz ADVERTISE_MASTER \
+          -authz ADVERTISE_STARTD -identity condor@{{ trust_domain }} \
+          -token condor@{{ trust_domain }}
+      args:
+        creates: "{{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}"
   - name: Start HTCondor
     ansible.builtin.service:
       name: condor


### PR DESCRIPTION
The current HTCondor modules creates IDTOKENs with full authorizations on each node within the HTCondor pool. An IDTOKEN is a [JWT](jwt.io) implementing OpenID Connect Standards much like Google Cloud authorizations. This PR reduces the scopes of the token on each node to the values recommended by the HTCondor team.

This PR continues to share the POOL signing key with each node (more or less the "root password" for the pool). It is anticipated that future work will eliminate the dependency on a local copy of the POOL signing key on each node. In the meantime, using the minimally scoped tokens for authentication will be a better practice and hopefully detect any problems.

We will not be able to share the POOL signing key to Windows execute points as we do for Linux execute points. So this change will help us better support Windows on equal footing with Linux.

Additionally, use some top-level variables to set destination filenames, with understanding that the lexical order matters when HTCondor reads its configuration.

- https://github.com/htcondor/htcondor/blob/8bcd2442756564ebbfdb6955fb16483806fda236/build/docker/services/README.md#using-the-execute-node-container
- https://github.com/htcondor/htcondor/blob/8bcd2442756564ebbfdb6955fb16483806fda236/build/docker/services/README.md#using-the-submit-access-point-container

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?