### PR TITLE
HTCondor job track machine information

### DIFF
--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -135,6 +135,10 @@
           TRUST_UID_DOMAIN=True
           SUBMIT_ATTRS=RunAsOwner
           RunAsOwner=True
+          use feature:JobsHaveInstanceIDs
+          SYSTEM_JOB_MACHINE_ATTRS=$(SYSTEM_JOB_MACHINE_ATTRS) \
+            CloudMachineType CloudZone CloudInterruptible
+          SYSTEM_JOB_MACHINE_ATTRS_HISTORY_LENGTH=10
       notify:
       - Reload HTCondor
     - name: Create IDTOKEN to advertise access point


### PR DESCRIPTION
This commit will ensure that Machine ClassAd attributes for Instance ID, Machine Type, Zone, and Spot ("interruptible") pricing configuration are added to job ClassAd attributes and made available when querying the scheduler and the history file for completed jobs.

For example, the history of a job that lands on the same machine twice (due to a retry) looks like:

```
MachineAttrCloudInstanceID0 = "5718041327577390030"
MachineAttrCloudInstanceID1 = "5718041327577390030"
MachineAttrCloudInterruptible0 = false
MachineAttrCloudInterruptible1 = false
MachineAttrCloudMachineType0 = "n2-standard-4"
MachineAttrCloudMachineType1 = "n2-standard-4"
MachineAttrCloudZone0 = "us-central1-b"
MachineAttrCloudZone1 = "us-central1-b"
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
