### PR TITLE
HTCondor Job Queue High Availability

### DIFF
--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -148,10 +148,12 @@ limitations under the License.
 | <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_execute_point_roles"></a> [execute\_point\_roles](#input\_execute\_point\_roles) | Project-wide roles for HTCondor Execute Point service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_job_queue_high_availability"></a> [job\_queue\_high\_availability](#input\_job\_queue\_high\_availability) | Provision HTCondor access points in high availability mode | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to resources. List key, value pairs. | `map(string)` | n/a | yes |
 | <a name="input_pool_password"></a> [pool\_password](#input\_pool\_password) | HTCondor Pool Password | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Default region for creating resources | `string` | n/a | yes |
+| <a name="input_spool_parent_dir"></a> [spool\_parent\_dir](#input\_spool\_parent\_dir) | HTCondor access point configuration SPOOL will be set to subdirectory named "spool" | `string` | `"/var/lib/condor"` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork in which Central Managers will be placed. | `string` | n/a | yes |
 
 ## Outputs

--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -72,9 +72,81 @@ example can be found in the [examples README][htc-example].
   - internal_ip
 ```
 
-A full example can be found in the [examples README][htc-example].
+## High Availability
 
-[htc-example]: ../../../../examples/README.md#htcondor-poolyaml--
+This module supports high availability modes of the HTCondor Central Manager and
+of the Access Points. In these modes, the services can be resiliant against
+zonal failures by distributing the services across two zones. To implement
+HA of the Central Manager service, apply the startup script in the example
+snipppet to 2 VMs. The 2 VMs should differ only by using the primary and
+secondary IP addresses created by this module.
+
+```yaml
+- id: htcondor_cm_primary
+  source: modules/compute/vm-instance
+  use:
+  - network1
+  - htcondor_central_manager_startup
+  settings:
+    name_prefix: cm0
+    machine_type: c2-standard-4
+    disable_public_ips: true
+    service_account:
+      email: $(htcondor_configure.central_manager_service_account)
+      scopes:
+      - cloud-platform
+    network_interfaces:
+    - network: null
+      subnetwork: $(cluster_network.subnetwork_self_link)
+      subnetwork_project: $(vars.project_id)
+      network_ip: $(htcondor_configure.central_manager_internal_ip)
+      stack_type: null
+      access_config: []
+      ipv6_access_config: []
+      alias_ip_range: []
+      nic_type: VIRTIO_NET
+      queue_count: null
+  outputs:
+  - internal_ip
+
+- id: htcondor_cm_secondary
+  source: modules/compute/vm-instance
+  use:
+  - network1
+  - htcondor_central_manager_startup
+  settings:
+    name_prefix: cm0
+    machine_type: c2-standard-4
+    disable_public_ips: true
+    service_account:
+      email: $(htcondor_configure.central_manager_service_account)
+      scopes:
+      - cloud-platform
+    network_interfaces:
+    - network: null
+      subnetwork: $(network1.subnetwork_self_link)
+      subnetwork_project: $(vars.project_id)
+      network_ip: $(htcondor_configure.central_manager_secondary_internal_ip)
+      stack_type: null
+      access_config: []
+      ipv6_access_config: []
+      alias_ip_range: []
+      nic_type: VIRTIO_NET
+      queue_count: null
+  outputs:
+  - internal_ip
+
+```
+
+Access Point high availability is impacted by known issues [HTCONDOR-1590] and
+[HTCONDOR-1594]. These are anticipated to be resolved in LTS release 10.0.3 and
+above or feature release 10.4 and above. Please see [HTCondor version
+numbering][htcver] and [release notes][htcnotes] for details.
+
+[htcver]: https://htcondor.readthedocs.io/en/latest/version-history/introduction-version-history.html#types-of-releases
+[htcnotes]: https://htcondor.readthedocs.io/en/latest/version-history/index.html
+[HTCONDOR-1590]: https://opensciencegrid.atlassian.net/jira/software/c/projects/HTCONDOR/issues/HTCONDOR-1590
+[HTCONDOR-1594]: https://opensciencegrid.atlassian.net/jira/software/c/projects/HTCONDOR/issues/HTCONDOR-1594
 
 ## Support
 
@@ -148,7 +220,7 @@ limitations under the License.
 | <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_execute_point_roles"></a> [execute\_point\_roles](#input\_execute\_point\_roles) | Project-wide roles for HTCondor Execute Point service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
-| <a name="input_job_queue_high_availability"></a> [job\_queue\_high\_availability](#input\_job\_queue\_high\_availability) | Provision HTCondor access points in high availability mode | `bool` | `false` | no |
+| <a name="input_job_queue_high_availability"></a> [job\_queue\_high\_availability](#input\_job\_queue\_high\_availability) | Provision HTCondor access points in high availability mode (experimental: see README) | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to resources. List key, value pairs. | `map(string)` | n/a | yes |
 | <a name="input_pool_password"></a> [pool\_password](#input\_pool\_password) | HTCondor Pool Password | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -25,6 +25,7 @@
     cm_config_file: 02-central-manager
     cm_ha_config_file: 02-central-manager-high-availability
     schedd_config_file: 02-schedd
+    schedd_ha_config_file: 02-schedd-high-availability
     execute_config_file: 02-execute
   tasks:
   - name: User must supply HTCondor role
@@ -171,8 +172,11 @@
             HA_LOCK_URL=file:{{ spool_dir }}
             VALID_SPOOL_FILES=$(VALID_SPOOL_FILES), SCHEDD.lock
             HA_POLL_PERIOD=30
+            SCHEDD_NAME=had-schedd@
         notify:
         - Restart HTCondor
+      # the need for this SystemD override will be eliminated in HTCondor 10.0.3
+      # (LTS) and 10.4 (feature release) by resolving HTCONDOR-1594
       - name: Create SystemD override directory for HTCondor
         ansible.builtin.file:
           path: /etc/systemd/system/condor.service.d

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -17,6 +17,8 @@
   hosts: localhost
   become: true
   vars:
+    job_queue_ha: false
+    spool_dir: /var/lib/condor/spool
     condor_config_root: /etc/condor
     role_file: 00-role
     pool_file: 01-pool
@@ -139,6 +141,7 @@
           SYSTEM_JOB_MACHINE_ATTRS=$(SYSTEM_JOB_MACHINE_ATTRS) \
             CloudMachineType CloudZone CloudInterruptible
           SYSTEM_JOB_MACHINE_ATTRS_HISTORY_LENGTH=10
+          SPOOL={{ spool_dir }}
       notify:
       - Reload HTCondor
     - name: Create IDTOKEN to advertise access point
@@ -149,6 +152,56 @@
           -token condor@{{ trust_domain }}
       args:
         creates: "{{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}"
+    - name: Enable SchedD high availability
+      when: job_queue_ha | bool
+      block:
+      - name: Setup HA Spool directory
+        ansible.builtin.file:
+          path: "{{ spool_dir }}"
+          state: directory
+          owner: condor
+          group: condor
+          mode: 0700
+      - name: Set SchedD HA configuration (requires restart)
+        ansible.builtin.copy:
+          dest: "{{ condor_config_root }}/config.d/{{ schedd_ha_config_file }}"
+          mode: 0644
+          content: |
+            MASTER_HA_LIST=SCHEDD
+            HA_LOCK_URL=file:{{ spool_dir }}
+            VALID_SPOOL_FILES=$(VALID_SPOOL_FILES), SCHEDD.lock
+            HA_POLL_PERIOD=30
+        notify:
+        - Restart HTCondor
+      - name: Create SystemD override directory for HTCondor
+        ansible.builtin.file:
+          path: /etc/systemd/system/condor.service.d
+          state: directory
+          owner: root
+          group: root
+          mode: 0755
+      - name: Ensure HTCondor starts after shared filesystem is mounted
+        ansible.builtin.copy:
+          dest: /etc/systemd/system/condor.service.d/mount-spool.conf
+          mode: 0644
+          content: |
+            [Unit]
+            RequiresMountsFor={{ spool_dir }}
+        notify:
+        - Restart HTCondor
+    - name: Disable SchedD high availability
+      when: not job_queue_ha | bool
+      block:
+      - name: Remove SchedD HA configuration file
+        ansible.builtin.file:
+          path: "{{ condor_config_root }}/config.d/{{ schedd_ha_config_file }}"
+          state: absent
+        notify:
+        - Restart HTCondor
+      - name: Remove HTCondor SystemD override
+        ansible.builtin.file:
+          path: /etc/systemd/system/condor.service.d/mount-spool.conf
+          state: absent
   - name: Configure HTCondor StartD
     when: htcondor_role == 'get_htcondor_execute'
     block:
@@ -172,10 +225,11 @@
       args:
         creates: "{{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}"
   - name: Start HTCondor
-    ansible.builtin.service:
+    ansible.builtin.systemd:
       name: condor
       state: started
       enabled: true
+      daemon_reload: true
   - name: Inform users
     changed_when: false
     ansible.builtin.shell: |
@@ -186,3 +240,7 @@
     ansible.builtin.service:
       name: condor
       state: reloaded
+  - name: Restart HTCondor
+    ansible.builtin.service:
+      name: condor
+      state: restarted

--- a/community/modules/scheduler/htcondor-configure/main.tf
+++ b/community/modules/scheduler/htcondor-configure/main.tf
@@ -46,6 +46,8 @@ locals {
     "args" = join(" ", [
       "-e htcondor_role=get_htcondor_submit",
       "-e htcondor_central_manager_ips=${join(",", module.address.addresses)}",
+      "-e job_queue_ha=${var.job_queue_high_availability}",
+      "-e spool_dir=${var.spool_parent_dir}/spool",
       "-e password_id=${google_secret_manager_secret.pool_password.secret_id}",
       "-e project_id=${var.project_id}",
     ])

--- a/community/modules/scheduler/htcondor-configure/variables.tf
+++ b/community/modules/scheduler/htcondor-configure/variables.tf
@@ -82,3 +82,15 @@ variable "central_manager_high_availability" {
   type        = bool
   default     = false
 }
+
+variable "job_queue_high_availability" {
+  description = "Provision HTCondor access points in high availability mode"
+  type        = bool
+  default     = false
+}
+
+variable "spool_parent_dir" {
+  description = "HTCondor access point configuration SPOOL will be set to subdirectory named \"spool\""
+  type        = string
+  default     = "/var/lib/condor"
+}

--- a/community/modules/scheduler/htcondor-configure/variables.tf
+++ b/community/modules/scheduler/htcondor-configure/variables.tf
@@ -84,7 +84,7 @@ variable "central_manager_high_availability" {
 }
 
 variable "job_queue_high_availability" {
-  description = "Provision HTCondor access points in high availability mode"
+  description = "Provision HTCondor access points in high availability mode (experimental: see README)"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
This PR adds support for [Job Queue High Availability](https://htcondor.readthedocs.io/en/latest/admin-manual/high-availability.html#high-availability-of-the-job-queue) to the htcondor-configure module. During development of the module, we raised 2 issues to the HTCondor team. These issues have been resolved and will be made available in forthcoming releases, identified in our documentation:

- [HTCONDOR-1590](https://opensciencegrid.atlassian.net/jira/software/c/projects/HTCONDOR/issues/HTCONDOR-1590)
- [HTCONDOR-1594](https://opensciencegrid.atlassian.net/jira/software/c/projects/HTCONDOR/issues/HTCONDOR-1594)

Accordingly the feature is marked experimental.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?