### PR TITLE
Enable OS Login by default in HTCondor execute points

### DIFF
--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -20,10 +20,6 @@ vars:
   deployment_name: htcondor-001
   region: us-central1
   zone: us-central1-c
-  # if using OS Login with "external users" (outside of the Google Cloud
-  # organization), then Docker universe jobs will fail as of 2022-11-09
-  # consider setting DISABLE if this atypical situation applies
-  enable_oslogin: ENABLE
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -94,8 +90,6 @@ deployment_groups:
     - network1
     - htcondor_configure_execute_point
     settings:
-      metadata:
-        enable-oslogin: "TRUE"
       service_account:
         email: $(htcondor_configure.execute_point_service_account)
         scopes:

--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -17,10 +17,6 @@ modules.
 The following code snippet creates a pool of HTCondor execute points using
 a startup script and network created in previous steps.
 
-> **_NOTE:_** HTCondor does not appear to interoperate correctly with the user
-> identities created by OS Login. Until this is resolved, we advise disabling
-> OS Login on all HTCondor nodes, including execute points.
-
 ```yaml
 - id: htcondor_execute_point
   source: community/modules/compute/htcondor-execute-point
@@ -28,9 +24,6 @@ a startup script and network created in previous steps.
   - network1
   - htcondor_configure_execute_point
   settings:
-    metadata:
-      central-manager: ((module.htcondor_cm.internal_ip[0]))
-      enable-oslogin: "FALSE"
     service_account:
       email: $(htcondor_configure.execute_point_service_account)
       scopes:
@@ -51,6 +44,20 @@ the University of Wisconsin-Madison. Support for HTCondor is available via:
 - [HTCondor manual](https://htcondor.readthedocs.io/en/latest/)
 
 [chtc]: https://chtc.cs.wisc.edu/
+
+## Known Issues
+
+When using OS Login with "external users" (outside of the Google Cloud
+organization), then Docker universe jobs will fail and cause the Docker daemon
+to crash. This stems from the use of POSIX user ids (uid) outside the range
+supported by Docker. Please consider disabling OS Login if this atypical
+situation applies.
+
+```yaml
+vars:
+  # add setting below to existing deployment variables
+  enable_oslogin: DISABLE
+```
 
 ## License
 
@@ -95,7 +102,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
-| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with "ENABLE" or "DISABLE". Set to "INHERIT" to inherit project OS Login setting. | `string` | `"DISABLE"` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with "ENABLE" or "DISABLE". Set to "INHERIT" to inherit project OS Login setting. | `string` | `"ENABLE"` | no |
 | <a name="input_image"></a> [image](#input\_image) | HTCondor execute point VM image | <pre>object({<br>    family  = string,<br>    project = string<br>  })</pre> | <pre>{<br>  "family": "hpc-centos-7",<br>  "project": "cloud-hpc-image-public"<br>}</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to HTConodr execute points | `map(string)` | n/a | yes |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to use for HTCondor execute points | `string` | `"n2-standard-4"` | no |

--- a/community/modules/compute/htcondor-execute-point/variables.tf
+++ b/community/modules/compute/htcondor-execute-point/variables.tf
@@ -126,5 +126,9 @@ variable "metadata" {
 variable "enable_oslogin" {
   description = "Enable or Disable OS Login with \"ENABLE\" or \"DISABLE\". Set to \"INHERIT\" to inherit project OS Login setting."
   type        = string
-  default     = "DISABLE"
+  default     = "ENABLE"
+  validation {
+    condition     = var.enable_oslogin == null ? false : contains(["ENABLE", "DISABLE", "INHERIT"], var.enable_oslogin)
+    error_message = "Allowed string values for var.enable_oslogin are \"ENABLE\", \"DISABLE\", or \"INHERIT\"."
+  }
 }


### PR DESCRIPTION
Ensure that HTCondor execute points use the same default settings as the vm-instance module to align user IDs in the job execution environment with the uids in the job submission environment. Remove all vestiges of (unused) metadata approach from examples and create a Known Issue in the execute point README module.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?