### PR TITLE
Bugfix to HTCondor autoscaler script

### DIFF
--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -180,9 +180,10 @@ class AutoScaler:
         else:
             self.zoneargs = {"zone": self.zone}
 
-        # Get total number of jobs in the queue that includes number of jos waiting as well as number of jobs already assigned to nodes
+        # Get total number of jobs in the queue that includes number of jobs
+        # waiting as well as number of jobs already assigned to nodes
         queue_length_req = (
-            'condor_q -totals -format "%d " Jobs -format "%d " Idle -format "%d " Held'
+            'condor_q -allusers -totals -format "%d " Jobs -format "%d " Idle -format "%d " Held'
         )
         queue_length_resp = os.popen(queue_length_req).read().split()
 


### PR DESCRIPTION
When the autoscaler script is run on a machine other than the active Access Point, the behavior of condor_q when run by the condor user will be to print only jobs belonging to the condor user. This has the unintended consequence of autoscaling the pool to 0 execute points. Adding the -allusers flag ensures that all jobs are printed regardless of where the script is run or the POSIX user it is run by (the condor user is "special").

This change has been tested manually by provisioning an HTCondor pool using our public example on the develop branch, observing autoscaling, and replacing the script with the new copy and observing the same autoscaling behavior. The bug was observed while testing the experimental Job Queue High Availability features in our HTCondor modules.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?