### PR TITLE
Add health check for HTCondor VMs

### DIFF
--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -90,8 +90,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_execute_point_instance_template"></a> [execute\_point\_instance\_template](#module\_execute\_point\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 7.8.0 |
-| <a name="module_mig"></a> [mig](#module\_mig) | terraform-google-modules/vm/google//modules/mig | ~> 7.8.0 |
+| <a name="module_execute_point_instance_template"></a> [execute\_point\_instance\_template](#module\_execute\_point\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 8.0 |
+| <a name="module_mig"></a> [mig](#module\_mig) | terraform-google-modules/vm/google//modules/mig | ~> 8.0 |
 
 ## Resources
 

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -37,7 +37,7 @@ locals {
 
 module "execute_point_instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "~> 7.8.0"
+  version = "~> 8.0"
 
   name_prefix     = "${var.deployment_name}-xp"
   project_id      = var.project_id
@@ -55,7 +55,7 @@ module "execute_point_instance_template" {
 
 module "mig" {
   source            = "terraform-google-modules/vm/google//modules/mig"
-  version           = "~> 7.8.0"
+  version           = "~> 8.0"
   project_id        = var.project_id
   region            = var.region
   target_size       = var.target_size

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -61,4 +61,21 @@ module "mig" {
   target_size       = var.target_size
   hostname          = "${var.deployment_name}-x"
   instance_template = module.execute_point_instance_template.self_link
+
+  health_check_name = "active-htcondor-service-${var.deployment_name}"
+  health_check = {
+    type                = "tcp"
+    initial_delay_sec   = 600
+    check_interval_sec  = 20
+    healthy_threshold   = 2
+    timeout_sec         = 8
+    unhealthy_threshold = 3
+    response            = ""
+    proxy_header        = "NONE"
+    port                = 9618
+    request             = ""
+    request_path        = ""
+    host                = ""
+    enable_logging      = true
+  }
 }

--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -218,6 +218,7 @@ limitations under the License.
 | <a name="module_address"></a> [address](#module\_address) | terraform-google-modules/address/google | ~> 3.0 |
 | <a name="module_central_manager_service_account"></a> [central\_manager\_service\_account](#module\_central\_manager\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
 | <a name="module_execute_point_service_account"></a> [execute\_point\_service\_account](#module\_execute\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
+| <a name="module_health_check_firewall_rule"></a> [health\_check\_firewall\_rule](#module\_health\_check\_firewall\_rule) | terraform-google-modules/network/google//modules/firewall-rules | ~> 6.0 |
 
 ## Resources
 
@@ -229,6 +230,7 @@ limitations under the License.
 | [google_secret_manager_secret_iam_member.execute_point](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.pool_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [random_password.pool](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [google_compute_subnetwork.htcondor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 
 ## Inputs
 


### PR DESCRIPTION
Google Cloud Managed Instance Groups support a variety of health checks that enable autohealing policies of VMs detected to be in an unhealthy state. This commit adds a simple health check of port 9618 on any machine within the execute Point MIGs. TCP:9618 is the default "shared port" configuration recommended for modern installations. It also adds a single firewall rule to allow this check to run on any machine with an HTCondor service account attached to it. This anticipates the possibility of running Access Points or Central Managers in a Managed Instance Group.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?