### PR TITLE
Remove dependency on unused module

### DIFF
--- a/community/examples/hpc-cluster-localssd.yaml
+++ b/community/examples/hpc-cluster-localssd.yaml
@@ -112,7 +112,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
     use:
     - network1
-    - homefs
     - slurm_controller
     settings:
       machine_type: n1-standard-4

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
@@ -17,7 +17,6 @@ terraform modules. The login node is used in conjunction with the
   use:
   - network1
   - slurm_controller
-  - homefs
   settings:
     machine_type: n2-standard-4
 ```
@@ -25,13 +24,12 @@ terraform modules. The login node is used in conjunction with the
 This creates a Slurm login node which is:
 
 * connected to the primary subnet of network1 via `use`
-* mounted to the homefs filesystem via `use`
 * associated with the `slurm_controller` module as the slurm controller via
   `use`
 * of VM machine type `n2-standard-4`
 
 For a complete example using this module, see
-[slurm-gcp-v5-cluster.yaml](../../../examples/slurm-gcp-v5-cluster.yaml).
+[slurm-gcp-v5-hpc-centos7.yaml](../../../examples/slurm-gcp-v5-hpc-centos7.yaml).
 
 ## Custom Images
 


### PR DESCRIPTION
In `community/examples/hpc-cluster-localssd.yaml` the `slurm_login` misused `homefs` module. Removed dependency.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
