### PR TITLE
Update hcls spack builder to use c2 machine

### DIFF
--- a/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
+++ b/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
@@ -75,17 +75,17 @@ deployment_groups:
     settings: {filestore_share_name: appsshare}
 
   - id: bucket-software-create
-    source: ./community/modules/file-system/cloud-storage-bucket
+    source: community/modules/file-system/cloud-storage-bucket
     settings:
       name_prefix: $(vars.bucket_name_software)
 
   - id: bucket-input-create
-    source: ./community/modules/file-system/cloud-storage-bucket
+    source: community/modules/file-system/cloud-storage-bucket
     settings:
       name_prefix: $(vars.bucket_name_inputs)
 
   - id: bucket-output-create
-    source: ./community/modules/file-system/cloud-storage-bucket
+    source: community/modules/file-system/cloud-storage-bucket
     settings:
       name_prefix: $(vars.bucket_name_outputs)
 
@@ -322,7 +322,7 @@ deployment_groups:
   ### Remote Desktop ###
 
   - id: desktop
-    source: ./community/modules/remote-desktop/chrome-remote-desktop
+    source: community/modules/remote-desktop/chrome-remote-desktop
     use:
     - network1
     - homefs

--- a/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
+++ b/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
@@ -271,7 +271,7 @@ deployment_groups:
     settings:
       name_prefix: spack-builder
       threads_per_core: 2
-      machine_type: a2-highgpu-1g
+      machine_type: c2-standard-16
 
 - group: cluster
   modules:


### PR DESCRIPTION
This change updates the spack builder to use a c2 machine instead of a a2 machine. This results in less expense to the end user.

This change also cleans up some instances where local resources were used instead of embedded. 

I have manually verified by building from scratch and running the included GROMACS examples.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
