### PR TITLE
Use HTCondor Python bindings in autoscaler

### DIFF
--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -185,7 +185,14 @@ class AutoScaler:
         # stewardship. A full list of Job ClassAd attributes can be found at
         # https://htcondor.readthedocs.io/en/latest/classad-attributes/job-classad-attributes.html
         schedd = htcondor.Schedd()
-        job_attributes = [ "RequestCpus", "RequestMemory", "RequestGpus" ]
+        REQUEST_CPUS_ATTRIBUTE = "RequestCpus"
+        REQUEST_GPUS_ATTRIBUTE = "RequestGpus"
+        REQUEST_MEMORY_ATTRIBUTE = "RequestMemory"
+        job_attributes = [
+            REQUEST_CPUS_ATTRIBUTE,
+            REQUEST_GPUS_ATTRIBUTE,
+            REQUEST_MEMORY_ATTRIBUTE,
+        ]
 
         # For purpose of scaling a Managed Instance Group, count only jobs that
         # are running or idle ("potentially runnable"). Filter JobStatus by:
@@ -193,8 +200,8 @@ class AutoScaler:
         running_job_ads = schedd.query(constraint="JobStatus==2", projection=job_attributes)
         idle_job_ads = schedd.query(constraint="JobStatus==1", projection=job_attributes)
 
-        total_idle_request_cpus = sum(j["RequestCpus"] for j in idle_job_ads)
-        total_running_request_cpus = sum(j["RequestCpus"] for j in running_job_ads)
+        total_idle_request_cpus = sum(j[REQUEST_CPUS_ATTRIBUTE] for j in idle_job_ads)
+        total_running_request_cpus = sum(j[REQUEST_CPUS_ATTRIBUTE] for j in running_job_ads)
         queue = total_idle_request_cpus + total_running_request_cpus
 
         print(f"Total CPUs requested by running jobs: {total_running_request_cpus}")

--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -156,12 +156,12 @@ class AutoScaler:
         if self.debug > 0:
             print("Guest CPUs: " + str(guest_cpus))
 
-        instanceTemlateInfo = {
+        instanceTemplateInfo = {
             "machine_type": machine_type,
             "is_preemtible": is_preemtible,
             "guest_cpus": guest_cpus,
         }
-        return instanceTemlateInfo
+        return instanceTemplateInfo
 
     def scale(self):
         # diagnosis
@@ -200,12 +200,12 @@ class AutoScaler:
         print("Idle jobs: " + str(idle_jobs))
         print("Jobs on hold: " + str(on_hold_jobs))
 
-        instanceTemlateInfo = self.getInstanceTemplateInfo()
+        instanceTemplateInfo = self.getInstanceTemplateInfo()
         if self.debug > 1:
             print("Information about the compute instance template")
-            pprint(instanceTemlateInfo)
+            pprint(instanceTemplateInfo)
 
-        self.cores_per_node = instanceTemlateInfo["guest_cpus"]
+        self.cores_per_node = instanceTemplateInfo["guest_cpus"]
         print("Number of CPU per compute node: " + str(self.cores_per_node))
 
         # Get state for for all jobs in Condor


### PR DESCRIPTION
- Replace all shell call-outs and parsing with efficient queries to the scheduler and collector daemons
- Anticipate future work to base auto-scaling on GPU and memory requests by including those job requests in queries
- Alter scaling code to account for the number of CPUs requested by each job. Previous solution implicitly assumes each job requests 1 CPU and will underscale for multi-core jobs
- Do not scale down any execute points that have not been active for less than 150 seconds

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?