### PR TITLE
Unify validatorConfig check logic, reduce code duplication

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,28 +190,23 @@ func (v *validatorConfig) check(name validatorName, requiredInputs []string) err
 	if v.Validator != name.String() {
 		return fmt.Errorf("passed wrong validator to %s implementation", name.String())
 	}
-	err := testInputList(v.Validator, v.Inputs, requiredInputs)
-	return err
-}
 
-// check that the keys in inputs and requiredInputs are identical sets of strings
-func testInputList(function string, inputs map[string]interface{}, requiredInputs []string) error {
 	var errored bool
-	for _, requiredInput := range requiredInputs {
-		if _, found := inputs[requiredInput]; !found {
-			log.Printf("a required input %s was not provided to %s!", requiredInput, function)
+	for _, inp := range requiredInputs {
+		if _, found := v.Inputs[inp]; !found {
+			log.Printf("a required input %s was not provided to %s!", inp, v.Validator)
 			errored = true
 		}
 	}
 
 	if errored {
-		return fmt.Errorf("at least one required input was not provided to %s", function)
+		return fmt.Errorf("at least one required input was not provided to %s", v.Validator)
 	}
 
 	// ensure that no extra inputs were provided by comparing length
-	if len(requiredInputs) != len(inputs) {
+	if len(requiredInputs) != len(v.Inputs) {
 		errStr := "only %v inputs %s should be provided to %s"
-		return fmt.Errorf(errStr, len(requiredInputs), requiredInputs, function)
+		return fmt.Errorf(errStr, len(requiredInputs), requiredInputs, v.Validator)
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -992,3 +992,60 @@ func (s *MySuite) TestCheckMovedModules(c *C) {
 	err = dc.checkMovedModules()
 	c.Assert(err, NotNil)
 }
+
+func (s *MySuite) TestValidatorConfigCheck(c *C) {
+	const vn = testProjectExistsName // some valid name
+
+	{ // FAIL: names mismatch
+		v := validatorConfig{
+			"who_is_this",
+			map[string]interface{}{},
+		}
+		err := v.check(vn, []string{})
+		c.Check(err, ErrorMatches, "passed wrong validator to test_project_exists implementation")
+	}
+
+	{ // OK: names match
+		v := validatorConfig{
+			vn.String(),
+			map[string]interface{}{},
+		}
+		c.Check(v.check(vn, []string{}), IsNil)
+	}
+
+	{ // OK: Inputs is equal to required inputs without regard to ordering
+		v := validatorConfig{
+			vn.String(),
+			map[string]interface{}{"in0": nil, "in1": nil},
+		}
+		c.Check(v.check(vn, []string{"in0", "in1"}), IsNil)
+		c.Check(v.check(vn, []string{"in1", "in0"}), IsNil)
+	}
+
+	{ // FAIL: inputs are a proper subset of required inputs
+		v := validatorConfig{
+			vn.String(),
+			map[string]interface{}{"in0": nil, "in1": nil},
+		}
+		err := v.check(vn, []string{"in0", "in1", "in2"})
+		c.Check(err, ErrorMatches, missingRequiredInputRegex)
+	}
+
+	{ // FAIL: inputs intersect with required inputs but are not a proper subset
+		v := validatorConfig{
+			vn.String(),
+			map[string]interface{}{"in0": nil, "in1": nil, "in3": nil},
+		}
+		err := v.check(vn, []string{"in0", "in1", "in2"})
+		c.Check(err, ErrorMatches, missingRequiredInputRegex)
+	}
+
+	{ // FAIL inputs are a proper superset of required inputs
+		v := validatorConfig{
+			vn.String(),
+			map[string]interface{}{"in0": nil, "in1": nil, "in2": nil, "in3": nil},
+		}
+		err := v.check(vn, []string{"in0", "in1", "in2"})
+		c.Check(err, ErrorMatches, "only 3 inputs \\[in0 in1 in2\\] should be provided to test_project_exists")
+	}
+}

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -197,47 +197,6 @@ func (s *MySuite) TestAddDefaultValidators(c *C) {
 	c.Assert(dc.Config.Validators, HasLen, 6)
 }
 
-func (s *MySuite) TestTestInputList(c *C) {
-	var err error
-	var requiredInputs []string
-
-	// SUCCESS: inputs is equal to required inputs without regard to ordering
-	requiredInputs = []string{"in0", "in1"}
-	inputs := map[string]interface{}{
-		"in0": nil,
-		"in1": nil,
-	}
-	err = testInputList("testfunc", inputs, requiredInputs)
-	c.Assert(err, IsNil)
-	requiredInputs = []string{"in1", "in0"}
-	err = testInputList("testfunc", inputs, requiredInputs)
-	c.Assert(err, IsNil)
-
-	// FAIL: inputs are a proper subset of required inputs
-	requiredInputs = []string{"in0", "in1", "in2"}
-	err = testInputList("testfunc", inputs, requiredInputs)
-	c.Assert(err, ErrorMatches, missingRequiredInputRegex)
-
-	// FAIL: inputs intersect with required inputs but are not a proper subset
-	inputs = map[string]interface{}{
-		"in0": nil,
-		"in1": nil,
-		"in3": nil,
-	}
-	err = testInputList("testfunc", inputs, requiredInputs)
-	c.Assert(err, ErrorMatches, missingRequiredInputRegex)
-
-	// FAIL inputs are a proper superset of required inputs
-	inputs = map[string]interface{}{
-		"in0": nil,
-		"in1": nil,
-		"in2": nil,
-		"in3": nil,
-	}
-	err = testInputList("testfunc", inputs, requiredInputs)
-	c.Assert(err, ErrorMatches, "only [0-9]+ inputs \\[.*\\] should be provided to testfunc")
-}
-
 // return the actual value of a global variable specified by the literal
 // variable inputReference in form ((var.project_id))
 // if it is a literal global variable defined as a string, return value as string


### PR DESCRIPTION
Currently all validator implementations have same code copied around. Move it into a `func (v *validatorConfig) check`

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
