### PR TITLE
Do not populate subnetwork_project as it is populated from subnetwork_self_link

### DIFF
--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -75,7 +75,7 @@ locals {
   default_network_interface = {
     network            = var.network_self_link
     subnetwork         = var.subnetwork_self_link
-    subnetwork_project = var.project_id
+    subnetwork_project = null # will populate from subnetwork_self_link
     network_ip         = null
     nic_type           = local.enable_gvnic ? "GVNIC" : null
     stack_type         = null


### PR DESCRIPTION
When used with a shared VPC, this subnetwork_project is incorrectly populated with the client project. The [provider docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#subnetwork_project) state that the field is optional and will default to using subnetwork as long as a self link is provided. For the default case we always provide the subnetwork self link. We still need to keep the variable (as null) to allow users to provide the full network_interface block.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
