### PR TITLE
Rename filestore network_name to network_id to enable shared VPC via use

### DIFF
--- a/community/examples/fluent-tutorial.yaml
+++ b/community/examples/fluent-tutorial.yaml
@@ -112,7 +112,7 @@ deployment_groups:
     kind: terraform
     id: homefs
     settings:
-      network_name: "default"
+      network_id: "default"
       size_gb: 1024
       filestore_tier: "BASIC_HDD"
       local_mount: /home
@@ -121,7 +121,7 @@ deployment_groups:
     kind: terraform
     id: sharefs
     settings:
-      network_name: "default"
+      network_id: "default"
       size_gb: 1024
       filestore_tier: "BASIC_HDD"
       local_mount: /shared

--- a/community/examples/hpc-cluster-small-sharedvpc.yaml
+++ b/community/examples/hpc-cluster-small-sharedvpc.yaml
@@ -54,7 +54,6 @@ deployment_groups:
     settings:
       local_mount: /home
       connect_mode: PRIVATE_SERVICE_ACCESS
-      network_name: $(network1.network_id)
 
   # This debug_partition will work out of the box without requesting additional GCP quota.
   - id: debug_partition

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -162,7 +162,7 @@ No modules.
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the filestore instance. List key, value pairs. | `any` | n/a | yes |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint for this filestore instance. Note: If set to the same as the `filestore_share_name`, it will trigger a known Slurm bug ([troubleshooting](../../../docs/slurm-troubleshooting.md)). | `string` | `"/shared"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resource name of the instance. | `string` | `null` | no |
-| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the GCE VPC network to which the instance is connected. | `string` | n/a | yes |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The name of the GCE VPC network to which the instance is connected. <br>If using shared VPC, full network id must be given with format:<br>`projects/<project_id>/global/networks/<network_name>`"<br>Plain network name is accepted for non-shared VPC case. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Filestore instance will be created. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Location for Filestore instances at Enterprise tier. | `string` | n/a | yes |
 | <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `1024` | no |

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -53,7 +53,7 @@ resource "google_filestore_instance" "filestore_instance" {
   labels = var.labels
 
   networks {
-    network      = var.network_name
+    network      = var.network_id
     connect_mode = var.connect_mode
     modes        = ["MODE_IPV4"]
   }

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -34,8 +34,13 @@ variable "region" {
   type        = string
 }
 
-variable "network_name" {
-  description = "The name of the GCE VPC network to which the instance is connected."
+variable "network_id" {
+  description = <<-EOT
+    The name of the GCE VPC network to which the instance is connected. 
+    If using shared VPC, full network id must be given with format:
+    `projects/<project_id>/global/networks/<network_name>`"
+    Plain network name is accepted for non-shared VPC case.
+    EOT
   type        = string
 }
 

--- a/tools/validate_configs/test_configs/pre-existing-fs.yaml
+++ b/tools/validate_configs/test_configs/pre-existing-fs.yaml
@@ -27,10 +27,12 @@ vars:
 deployment_groups:
 - group: storage
   modules:
-  # the pre-existing-vpc is not needed here, since filestore will use the
-  # network-name from deployment vars
+  - id: network0
+    source: modules/network/pre-existing-vpc
+
   - id: homefs-filestore
     source: modules/file-system/filestore
+    use: [network0]
 
 - group: compute
   modules:

--- a/tools/validate_configs/test_configs/use-resources.yaml
+++ b/tools/validate_configs/test_configs/use-resources.yaml
@@ -36,7 +36,7 @@ deployment_groups:
     use: [network1]
     settings:
       local_mount: /home
-      network_name: $(network1.network_name)
+      network_id: $(network1.network_id)
 
 
   - id: projectsfs


### PR DESCRIPTION
This change allows for the use of a shared VPC with the Filestore module via the `use` field. When a filestore needs to be provisioned in a client project but use a shared VPC from a host project, filestore must be provided with the `network_id` which includes information about the VPC project, instead of just `network_name`.

## Breaking Change  
This is technically a breaking change. In some edge cases a user will be required to change the key for a setting input from `network_name` to `network_id`. While the name has changed the functionality has not changed. It is expected that the majority of blueprints will be passing `network_name` and `network_id` via the `use` keyword, in which case this will not be a breaking change. 

In the case that a blueprint was explicitly using `network_name` the user will get the following error at create time:

```
found an issue while validating settings for module at ./modules/file-system/filestore: invalid setting provided to a module, cause: a setting was added that is not found in the module
Module ID: homefs Setting: network_name
```

Or in the case that they are not `use`ing a network they will get:

```
failed to apply deployment variables in modules when expanding the config: a required setting is missing from a module: Module ID: homefs Setting: network_id
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
