### PR TITLE
Improve attribute tracking in HTCondor scheduler

### DIFF
--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -152,6 +152,8 @@
             CloudVMType CloudZone CloudInterruptible
           SYSTEM_JOB_MACHINE_ATTRS_HISTORY_LENGTH=10
           SPOOL={{ spool_dir }}
+          use feature:ScheddCronOneShot(cloud, $(LIBEXEC)/common-cloud-attributes-google.py)
+          SCHEDD_CRON_cloud_PREFIX=Cloud
       notify:
       - Reload HTCondor
     - name: Create IDTOKEN to advertise access point

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -149,7 +149,7 @@
           RunAsOwner=True
           use feature:JobsHaveInstanceIDs
           SYSTEM_JOB_MACHINE_ATTRS=$(SYSTEM_JOB_MACHINE_ATTRS) \
-            CloudMachineType CloudZone CloudInterruptible
+            CloudVMType CloudZone CloudInterruptible
           SYSTEM_JOB_MACHINE_ATTRS_HISTORY_LENGTH=10
           SPOOL={{ spool_dir }}
       notify:


### PR DESCRIPTION
- Ensure that HTCondor job queues advertise their cloud attributes for job matchmaking
- Fix attribute tracked by job history to match correct name for VM types

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?