### PR TITLE
Mask sleep/suspend targets on chrome-remote-desktop to prevent shutdown

### DIFF
--- a/community/modules/remote-desktop/chrome-remote-desktop/main.tf
+++ b/community/modules/remote-desktop/chrome-remote-desktop/main.tf
@@ -40,6 +40,14 @@ locals {
       destination = "/usr/local/ghpc/configure-chrome-desktop.yml"
     }
   ]
+
+  disable_sleep = [
+    {
+      type        = "ansible-local"
+      content     = file("${path.module}/scripts/disable-sleep.yml")
+      destination = "/usr/local/ghpc/disable-sleep.yml"
+    }
+  ]
 }
 
 module "client_startup_script" {
@@ -51,7 +59,10 @@ module "client_startup_script" {
   labels          = var.labels
 
   runners = flatten([
-    local.user_startup_script_runners, local.configure_nvidia_driver_runners, local.configure_chrome_remote_desktop_runners
+    local.user_startup_script_runners,
+    local.configure_nvidia_driver_runners,
+    local.configure_chrome_remote_desktop_runners,
+    local.disable_sleep
   ])
 }
 

--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/disable-sleep.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/disable-sleep.yml
@@ -1,0 +1,39 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Mask sleep, suspend, hibernate, and hybrid-sleep targets
+  hosts: localhost
+  become: true
+  tasks:
+
+  - name: Mask sleep target
+    ansible.builtin.systemd:
+      name: sleep.target
+      masked: yes
+
+  - name: Mask suspend target
+    ansible.builtin.systemd:
+      name: suspend.target
+      masked: yes
+
+  - name: Mask hibernate target
+    ansible.builtin.systemd:
+      name: hibernate.target
+      masked: yes
+
+  - name: Mask hybrid-sleep target
+    ansible.builtin.systemd:
+      name: hybrid-sleep.target
+      masked: yes


### PR DESCRIPTION
Follow up from #966, merging to `develop` in addition to `release-candidate`.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
