### PR TITLE
Roll-forward:"Rename filestore network_name to network_id to enable shared VPC via use"

### DIFF
--- a/community/examples/hpc-cluster-small-sharedvpc.yaml
+++ b/community/examples/hpc-cluster-small-sharedvpc.yaml
@@ -54,7 +54,6 @@ deployment_groups:
     settings:
       local_mount: /home
       connect_mode: PRIVATE_SERVICE_ACCESS
-      network_name: $(network1.network_id)
 
   # This debug_partition will work out of the box without requesting additional GCP quota.
   - id: debug_partition

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -162,7 +162,7 @@ No modules.
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the filestore instance. List key, value pairs. | `any` | n/a | yes |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint for this filestore instance. Note: If set to the same as the `filestore_share_name`, it will trigger a known Slurm bug ([troubleshooting](../../../docs/slurm-troubleshooting.md)). | `string` | `"/shared"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resource name of the instance. | `string` | `null` | no |
-| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The name of the GCE VPC network to which the instance is connected. <br>If using shared VPC, full network id must be given with format:<br>`projects/<project_id>/global/networks/<network_name>`"<br>Plain network name is accepted for non-shared VPC case. | `string` | n/a | yes |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is connected given in the format:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Filestore instance will be created. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Location for Filestore instances at Enterprise tier. | `string` | n/a | yes |
 | <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `1024` | no |

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -162,7 +162,7 @@ No modules.
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the filestore instance. List key, value pairs. | `any` | n/a | yes |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint for this filestore instance. Note: If set to the same as the `filestore_share_name`, it will trigger a known Slurm bug ([troubleshooting](../../../docs/slurm-troubleshooting.md)). | `string` | `"/shared"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resource name of the instance. | `string` | `null` | no |
-| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the GCE VPC network to which the instance is connected. | `string` | n/a | yes |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The name of the GCE VPC network to which the instance is connected. <br>If using shared VPC, full network id must be given with format:<br>`projects/<project_id>/global/networks/<network_name>`"<br>Plain network name is accepted for non-shared VPC case. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Filestore instance will be created. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Location for Filestore instances at Enterprise tier. | `string` | n/a | yes |
 | <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `1024` | no |

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -53,7 +53,7 @@ resource "google_filestore_instance" "filestore_instance" {
   labels = var.labels
 
   networks {
-    network      = var.network_name
+    network      = var.network_id
     connect_mode = var.connect_mode
     modes        = ["MODE_IPV4"]
   }

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -36,6 +36,12 @@ locals {
     "args"        = "\"${local.server_ip}\" \"${local.remote_mount}\" \"${var.local_mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
     "destination" = "mount${replace(var.local_mount, "/", "_")}.sh"
   }
+
+  # id format: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network#id
+  split_network_id = split("/", var.network_id)
+  network_name     = local.split_network_id[4]
+  network_project  = local.split_network_id[1]
+  shared_vpc       = local.network_project != var.project_id
 }
 
 resource "google_filestore_instance" "filestore_instance" {
@@ -53,7 +59,7 @@ resource "google_filestore_instance" "filestore_instance" {
   labels = var.labels
 
   networks {
-    network      = var.network_id
+    network      = local.shared_vpc ? var.network_id : local.network_name
     connect_mode = var.connect_mode
     modes        = ["MODE_IPV4"]
   }

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -36,12 +36,14 @@ variable "region" {
 
 variable "network_id" {
   description = <<-EOT
-    The name of the GCE VPC network to which the instance is connected. 
-    If using shared VPC, full network id must be given with format:
+    The ID of the GCE VPC network to which the instance is connected given in the format:
     `projects/<project_id>/global/networks/<network_name>`"
-    Plain network name is accepted for non-shared VPC case.
     EOT
   type        = string
+  validation {
+    condition     = length(split("/", var.network_id)) == 5
+    error_message = "The network id must be provided in the following format: projects/<project_id>/global/networks/<network_name>."
+  }
 }
 
 variable "name" {

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -34,8 +34,13 @@ variable "region" {
   type        = string
 }
 
-variable "network_name" {
-  description = "The name of the GCE VPC network to which the instance is connected."
+variable "network_id" {
+  description = <<-EOT
+    The name of the GCE VPC network to which the instance is connected. 
+    If using shared VPC, full network id must be given with format:
+    `projects/<project_id>/global/networks/<network_name>`"
+    Plain network name is accepted for non-shared VPC case.
+    EOT
   type        = string
 }
 

--- a/tools/validate_configs/test_configs/pre-existing-fs.yaml
+++ b/tools/validate_configs/test_configs/pre-existing-fs.yaml
@@ -27,10 +27,12 @@ vars:
 deployment_groups:
 - group: storage
   modules:
-  # the pre-existing-vpc is not needed here, since filestore will use the
-  # network-name from deployment vars
+  - id: network0
+    source: modules/network/pre-existing-vpc
+
   - id: homefs-filestore
     source: modules/file-system/filestore
+    use: [network0]
 
 - group: compute
   modules:

--- a/tools/validate_configs/test_configs/use-resources.yaml
+++ b/tools/validate_configs/test_configs/use-resources.yaml
@@ -36,7 +36,7 @@ deployment_groups:
     use: [network1]
     settings:
       local_mount: /home
-      network_name: $(network1.network_name)
+      network_id: $(network1.network_id)
 
 
   - id: projectsfs


### PR DESCRIPTION
Original PR: #962 
Rollback PR: #967 

Filestore is particular and will store the `network_name` when the network is in the service project and will store `network_id` when it is using a shared VPC. We must discern which case we are in and provide the correct input to avoid destroy/create cycles upon re-apply

### Using Data Source

I tried to use a data source in place of parsing the network id, but it is not possible without doing the same network id parsing that is done in this PR. It would be possible to do the parsing done in this PR and then feed it through a data source and pull values back out the other side (as a sort of validation) but this is just extra steps and results in the same sort of errors that filestore will emit. 

Things tried:
- Try using the `google_compute_network` data source: this requires network name and project id as inputs. The name field will not take network_id or network_self_link. To get network_name and project_id they must be parsed from network_id.
- Try using `google_compute_subnetwork` and `google_compute_network` together: I was hoping to look up `google_compute_subnetwork` with `subnetwork_self_link` and then use the `network` attribute to look up the `google_compute_network` but this is not possible as  `subnetwork_self_link.network` gives off the network_self_link and not the network name.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
