### PR TITLE
Add validation to prevent usage of variables in backend block.

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1051,7 +1051,7 @@ func (s *MySuite) TestValidatorConfigCheck(c *C) {
 }
 
 func (s *MySuite) TestCheckBackends(c *C) {
-	// Helper to create blueprient with backend blocks only (first one is defaults)
+	// Helper to create blueprint with backend blocks only (first one is defaults)
 	// and run checkBackends.
 	check := func(d TerraformBackend, gb ...TerraformBackend) error {
 		gs := []DeploymentGroup{}
@@ -1066,15 +1066,15 @@ func (s *MySuite) TestCheckBackends(c *C) {
 	}
 	dummy := TerraformBackend{}
 
-	{ // Absent
+	{ // OK. Absent
 		c.Check(checkBackends(Blueprint{}), IsNil)
 	}
 
-	{ // Dummies
+	{ // OK. Dummies
 		c.Check(check(dummy, dummy, dummy), IsNil)
 	}
 
-	{ // OK
+	{ // OK. No variables used
 		b := TerraformBackend{
 			Type: "gcs",
 			Configuration: map[string]interface{}{
@@ -1085,32 +1085,32 @@ func (s *MySuite) TestCheckBackends(c *C) {
 		c.Check(check(b), IsNil)
 	}
 
-	{ // Variable in defaults type
+	{ // FAIL. Variable in defaults type
 		b := TerraformBackend{Type: "$(vartype)"}
 		c.Check(check(b), ErrorMatches, ".*type.*vartype.*")
 	}
 
-	{ // Variable in group backend type
+	{ // FAIL. Variable in group backend type
 		b := TerraformBackend{Type: "$(vartype)"}
 		c.Check(check(dummy, b), ErrorMatches, ".*type.*vartype.*")
 	}
 
-	{ // Deployment variable in defaults type
+	{ // FAIL. Deployment variable in defaults type
 		b := TerraformBackend{Type: "$(vars.type)"}
 		c.Check(check(b), ErrorMatches, ".*type.*vars\\.type.*")
 	}
 
-	{ // Not a variable
+	{ // OK. Not a variable
 		b := TerraformBackend{Type: "\\$(vartype)"}
 		c.Check(check(b), IsNil)
 	}
 
-	{ // Mid-string variable in defaults type
+	{ // FAIL. Mid-string variable in defaults type
 		b := TerraformBackend{Type: "hugs_$(vartype)_hugs"}
 		c.Check(check(b), ErrorMatches, ".*type.*vartype.*")
 	}
 
-	{ // Variable in defaults configuration
+	{ // FAIL. Variable in defaults configuration
 		b := TerraformBackend{
 			Type:          "gcs",
 			Configuration: map[string]interface{}{"bucket": "$(trenta)"},
@@ -1118,7 +1118,7 @@ func (s *MySuite) TestCheckBackends(c *C) {
 		c.Check(check(b), ErrorMatches, ".*bucket.*trenta.*")
 	}
 
-	{ // OK with nested configuration
+	{ // OK. handles nested configuration
 		b := TerraformBackend{
 			Type: "gcs",
 			Configuration: map[string]interface{}{

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -911,13 +911,16 @@ func (dc *DeploymentConfig) expandVariables() error {
 	}
 
 	for iGrp, grp := range dc.Config.DeploymentGroups {
-		grpCtx := varContext{blueprint: dc.Config, groupIndex: iGrp}
-
 		for iMod, mod := range grp.Modules {
-			modCtx := grpCtx
-			modCtx.modIndex = iMod
-
-			err := updateVariables(modCtx, mod.Settings, dc.ModuleToGroup)
+			context := varContext{
+				groupIndex: iGrp,
+				modIndex:   iMod,
+				blueprint:  dc.Config,
+			}
+			err := updateVariables(
+				context,
+				mod.Settings,
+				dc.ModuleToGroup)
 			if err != nil {
 				return err
 			}

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -78,7 +78,9 @@ func (dc *DeploymentConfig) expand() {
 			"failed to apply deployment variables in modules when expanding the config: %v",
 			err)
 	}
-	dc.expandVariables()
+	if err := dc.expandVariables(); err != nil {
+		log.Fatalf("failed to expand variables: %v", err)
+	}
 }
 
 func (dc *DeploymentConfig) addSettingsToModules() {
@@ -899,27 +901,25 @@ func updateVariables(
 
 // expandVariables recurses through the data structures in the yaml config and
 // expands all variables
-func (dc *DeploymentConfig) expandVariables() {
+func (dc *DeploymentConfig) expandVariables() error {
 	for _, validator := range dc.Config.Validators {
 		err := updateVariables(varContext{blueprint: dc.Config}, validator.Inputs, make(map[string]int))
 		if err != nil {
-			log.Fatalf("expandVariables: %v", err)
+			return err
+
 		}
 	}
 
 	for iGrp, grp := range dc.Config.DeploymentGroups {
+		grpCtx := varContext{blueprint: dc.Config, groupIndex: iGrp}
+
 		for iMod, mod := range grp.Modules {
-			context := varContext{
-				groupIndex: iGrp,
-				modIndex:   iMod,
-				blueprint:  dc.Config,
-			}
-			err := updateVariables(
-				context,
-				mod.Settings,
-				dc.ModuleToGroup)
+			modCtx := grpCtx
+			modCtx.modIndex = iMod
+
+			err := updateVariables(modCtx, mod.Settings, dc.ModuleToGroup)
 			if err != nil {
-				log.Fatalf("expandVariables: %v", err)
+				return err
 			}
 
 			// ensure that variable references to projects in required APIs are expanded
@@ -927,7 +927,7 @@ func (dc *DeploymentConfig) expandVariables() {
 				if isDeploymentVariable(projectID) {
 					s, err := handleVariable(projectID, varContext{blueprint: dc.Config}, make(map[string]int))
 					if err != nil {
-						log.Fatalf("expandVariables: %v", err)
+						return err
 					}
 					mod.RequiredApis[s.(string)] = slices.Clone(requiredAPIs)
 					delete(mod.RequiredApis, projectID)
@@ -935,6 +935,7 @@ func (dc *DeploymentConfig) expandVariables() {
 			}
 		}
 	}
+	return nil
 }
 
 // this function adds default validators to the blueprint if none have been


### PR DESCRIPTION
- Add validation to prevent usage of variables in backend block.
- Unrelated minor refactoring.

```
$ ./ghpc create examples/hpc-cluster-small.yaml --backend-config "bucket=\$(trenta)"
2023/03/02 06:39:46 can not use variables in backend block, got 'bucket=$(trenta)'
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
