### PR TITLE
Increase reliability of blueprints using DDN Exascaler

### DIFF
--- a/community/modules/file-system/DDN-EXAScaler/outputs.tf
+++ b/community/modules/file-system/DDN-EXAScaler/outputs.tf
@@ -79,4 +79,7 @@ output "network_storage" {
     client_install_runner = local.client_install_runner
     mount_runner          = local.mount_runner
   }
+  depends_on = [
+    module.ddn_exascaler
+  ]
 }


### PR DESCRIPTION
The DDN exascaler Toolkit module outputs its network_storage block prior to many of its resources being in the Terraform graph. In real-world scenarios, we have observed sporadic DNS/IP failures when Slurm login nodes attempt to mount filesystems using the network_storage block. A plausible explanation is that the DDN resources are in a race condition with the startup of the Slurm login node.

This commit blocks creation of the network_storage output until all resources within the upstream DDN module have been created. This is arguably overkill, but there may exist race conditions within the module itself due to its historical reliance on Deployment Manager to block provisioning until intermediate services are available.

This is intended to address issues observed during review of #938 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
