### PR TITLE
Initial support for Spot VMs within HTCondor pools

### DIFF
--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -113,6 +113,7 @@ No resources.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HTCondor execute points will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region in which HTCondor execute points will be created | `string` | n/a | yes |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to HTCondor execute points | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
+| <a name="input_spot"></a> [spot](#input\_spot) | Provision VMs using discounted Spot pricing, allowing for preemption | `bool` | `false` | no |
 | <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script to run at boot-time for HTCondor execute points | `string` | `null` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork HTCondor execute points will join | `string` | `null` | no |
 | <a name="input_target_size"></a> [target\_size](#input\_target\_size) | Initial size of the HTCondor execute point pool; set to null (default) to avoid Terraform management of size. | `number` | `null` | no |

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -47,6 +47,7 @@ module "execute_point_instance_template" {
   labels          = var.labels
 
   machine_type         = var.machine_type
+  preemptible          = var.spot
   startup_script       = var.startup_script
   metadata             = local.metadata
   source_image_family  = var.image.family

--- a/community/modules/compute/htcondor-execute-point/variables.tf
+++ b/community/modules/compute/htcondor-execute-point/variables.tf
@@ -132,3 +132,9 @@ variable "enable_oslogin" {
     error_message = "Allowed string values for var.enable_oslogin are \"ENABLE\", \"DISABLE\", or \"INHERIT\"."
   }
 }
+
+variable "spot" {
+  description = "Provision VMs using discounted Spot pricing, allowing for preemption"
+  type        = bool
+  default     = false
+}

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -154,6 +154,23 @@
           SPOOL={{ spool_dir }}
           use feature:ScheddCronOneShot(cloud, $(LIBEXEC)/common-cloud-attributes-google.py)
           SCHEDD_CRON_cloud_PREFIX=Cloud
+          # the sequence of job transforms and submit requirements below set
+          # a default job attribute RequireSpot to False but allow the user to
+          # specify *only* a boolean value with +RequireSpot = True in their job
+          # submit file; the requirements of the job are transformed to filter
+          # on +RequireSpot unless job has explicit CloudInterruptible requirements
+          JOB_TRANSFORM_NAMES = SPOT_DEFAULT, SPOT_REQS
+          JOB_TRANSFORM_SPOT_DEFAULT @=end
+             DEFAULT RequireSpot False
+          @end
+          # Unless explicit, set CloudInterruptible requirements to job RequireSpot attribute
+          JOB_TRANSFORM_SPOT_REQS @=end
+             REQUIREMENTS ! unresolved(Requirements, "^CloudInterruptible$")
+             SET Requirements $(MY.Requirements) && (CloudInterruptible is My.RequireSpot)
+          @end
+          SUBMIT_REQUIREMENT_NAMES = REQSPOT
+          SUBMIT_REQUIREMENT_REQSPOT = isBoolean(RequireSpot)
+          SUBMIT_REQUIREMENT_REQSPOT_REASON = "Jobs must set +RequireSpot to either True or False"
       notify:
       - Reload HTCondor
     - name: Create IDTOKEN to advertise access point

--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -140,12 +140,12 @@ class AutoScaler:
             pprint(responseInstanceTemplateInfo["properties"])
 
         machine_type = responseInstanceTemplateInfo["properties"]["machineType"]
-        is_preemtible = responseInstanceTemplateInfo["properties"]["scheduling"][
+        is_spot = responseInstanceTemplateInfo["properties"]["scheduling"][
             "preemptible"
         ]
         if self.debug > 0:
             print("Machine Type: " + machine_type)
-            print("Is preemtible: " + str(is_preemtible))
+            print("Is spot: " + str(is_spot))
         request = self.service.machineTypes().get(
             project=self.project, zone=self.zone, machineType=machine_type
         )
@@ -159,7 +159,7 @@ class AutoScaler:
 
         instanceTemplateInfo = {
             "machine_type": machine_type,
-            "is_preemtible": is_preemtible,
+            "is_spot": is_spot,
             "guest_cpus": guest_cpus,
         }
         return instanceTemplateInfo


### PR DESCRIPTION
Initial support for Spot VMs in HTCondor pools

- expose spot setting in execute-point module
- change code terms to use "spot" instead of "preemptible"
- configure access points to automatically set and enforce a boolean +RequireSpot attribute on all jobs and use it to match jobs to cloud machines

This does not yet implement any autoscaling support for distinguishing between jobs that do/not +RequireSpot. However, it puts all the elements in place for the autoscaler to safely assume that jobs express a boolean value.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
