### PR TITLE
Convert HTCondor autoscaler to SystemD timer

### DIFF
--- a/community/modules/compute/htcondor-execute-point/files/htcondor_configure_autoscaler.yml
+++ b/community/modules/compute/htcondor-execute-point/files/htcondor_configure_autoscaler.yml
@@ -23,6 +23,7 @@
   vars:
     python: /usr/local/htcondor/bin/python3
     autoscaler: /usr/local/htcondor/bin/autoscaler.py
+    systemd_override_path: /etc/systemd/system
   become: true
   tasks:
   - name: User must supply HTCondor role
@@ -33,9 +34,45 @@
       - zone is defined
       - mig_id is defined
       - max_size is defined
-  - name: Run autoscaler periodically
-    # this defaults to * for every time unit
-    ansible.builtin.cron:
-      name: "run HTCondor autoscaler"
-      user: condor
-      job: "{{ python }} {{ autoscaler }} --p {{ project_id }} --r {{ region }} --z {{ zone }} --mz --g {{ mig_id }} --c {{ max_size }} | /bin/logger"
+  - name: Create SystemD service for HTCondor autoscaler
+    ansible.builtin.copy:
+      dest: "{{ systemd_override_path }}/htcondor-autoscaler@.service"
+      mode: 0644
+      content: |
+        [Unit]
+        Description=HTCondor Autoscaler MIG: %i
+
+        [Service]
+        User=condor
+        Type=oneshot
+        ExecStart={{ python }} {{ autoscaler }} --p {{ project_id }} --r {{ region }} --z {{ zone }} --mz --g %i --c {{ max_size }}
+    notify:
+    - Reload SystemD
+  - name: Create SystemD timer for HTCondor autoscaler
+    ansible.builtin.copy:
+      dest: "{{ systemd_override_path }}/htcondor-autoscaler@.timer"
+      mode: 0644
+      content: |
+        [Unit]
+        Description=Run HTCondor Autoscaler Periodically
+
+        [Timer]
+        OnCalendar=minutely
+        AccuracySec=1us
+        RandomizedDelaySec=30
+        # the directive below is ignored harmlessly on CentOS 7; this has impact
+        # that timing averages to 1 minute but is not precisely 1 minute; still
+        # useful to ensure that timers for different MIGs do not overlap
+        FixedRandomDelay=true
+    notify:
+    - Reload SystemD
+  handlers:
+  - name: Reload SystemD
+    ansible.builtin.systemd:
+      daemon_reload: true
+  post_tasks:
+  - name: Activate HTCondor Autoscaler timer
+    ansible.builtin.systemd:
+      name: htcondor-autoscaler@{{ mig_id }}.timer
+      enabled: true
+      state: started


### PR DESCRIPTION
This PR converts the HTCondor autoscaler to run as a SystemD timer and service pair. The primary advantage of this is to ensure that the autoscaler does not run precisely 0 seconds past the minute, but rather on a time-averaged frequency of once-per-minute.

The timer is implemented as a SystemD template (using `%i` as a value substitution after the `@` symbol in the activation) anticipating the possibility that the timer + service pair will be invoked multiple times for multiple MIGs. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
