### PR TITLE
Add utils for parising and normalizing HCL dtype

### DIFF
--- a/pkg/modulereader/hcl_utils_test.go
+++ b/pkg/modulereader/hcl_utils_test.go
@@ -12,12 +12,10 @@ func (s *MySuite) TestNormalizeType(c *C) {
 
 	c.Check(normalizeType("?invalid_type"), Equals, "?invalid_type")
 
-	c.Check(normalizeType("object({b=string,a=number})"), Equals, "object({a=number,b=string})")
-
 	// `any` is special type, check that it works
-	c.Check(normalizeType("object({b=any,a=number})"), Equals, "object({a=number,b=any})")
+	c.Check(normalizeType("object({b=any,a=number})"), Equals, normalizeType("object({a=number,b=any})"))
 
-	c.Check(normalizeType(" object (  {\na=any\n} ) "), Equals, "object({a=any})")
+	c.Check(normalizeType(" object (  {\na=any\n} ) "), Equals, normalizeType("object({a=any})"))
 
-	c.Check(normalizeType(" string # comment"), Equals, "string")
+	c.Check(normalizeType(" string # comment"), Equals, normalizeType("string"))
 }

--- a/pkg/modulereader/hcl_utils_test.go
+++ b/pkg/modulereader/hcl_utils_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modulereader
 
 import (

--- a/pkg/modulereader/hcl_utils_test.go
+++ b/pkg/modulereader/hcl_utils_test.go
@@ -1,0 +1,23 @@
+package modulereader
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (s *MySuite) TestNormalizeType(c *C) {
+	c.Check(
+		normalizeType("object({count=number,kind=string})"),
+		Equals,
+		normalizeType("object({kind=string,count=number})"))
+
+	c.Check(normalizeType("?invalid_type"), Equals, "?invalid_type")
+
+	c.Check(normalizeType("object({b=string,a=number})"), Equals, "object({a=number,b=string})")
+
+	// `any` is special type, check that it works
+	c.Check(normalizeType("object({b=any,a=number})"), Equals, "object({a=number,b=any})")
+
+	c.Check(normalizeType(" object (  {\na=any\n} ) "), Equals, "object({a=any})")
+
+	c.Check(normalizeType(" string # comment"), Equals, "string")
+}


### PR DESCRIPTION
Those utils will be used later for variables dtype validators and checks

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
