### PR TITLE
Making OFE deploy.sh MacOS compatible. Fixes #978

### DIFF
--- a/community/front-end/ofe/deploy.sh
+++ b/community/front-end/ofe/deploy.sh
@@ -451,7 +451,7 @@ deploy() {
 		sdir=${SCRIPT_DIR#"${basedir}"}
 		tdir=/tmp/hpc-toolkit
 
-		cp --recursive "${basedir}" ${tdir}/
+		cp -R "${basedir}" ${tdir}/
 		(
 			cd ${tdir}
 			#
@@ -465,9 +465,10 @@ deploy() {
 				--exclude=.terraform \
 				--exclude=.terraform.lock.hcl \
 				--exclude=tf \
-				../hpc-toolkit 2>/dev/null
+				--directory=/tmp \
+				./hpc-toolkit 2>/dev/null
 		)
-		rm --force --recursive ${tdir}
+		rm -rf ${tdir}
 	fi
 
 	# -- All Terraform operations to be done in tf subdir


### PR DESCRIPTION
Certain commands used in `deploy.sh` are not compatible with macOS. 
For example, macOS does not support --recursive flag used with cp command, or rm does not accept --force --recursive. This PR making deploy.sh compatible with macOS.

### Submission Checklist

* [ x ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ x ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
