### PR TITLE
Improve Slurm log capturing

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -194,7 +194,20 @@
 
     ## Always cleanup, even on failure
     always:
-    - name: Recover Resume Logs
+    - name: Recover Setup Log
+      become: true
+      become_user: slurm
+      changed_when: false
+      failed_when: false
+      delegate_to: "{{ hostvars['localhost']['controller_ip']['stdout'] }}"
+      ansible.builtin.command: cat /slurm/scripts/setup.log
+      register: setup_output
+    - name: Print Slurm setup.log
+      ansible.builtin.debug:
+        var: setup_output.stdout_lines
+    - name: Recover Resume Log
+      become: true
+      become_user: slurm
       changed_when: false
       failed_when: false
       delegate_to: "{{ hostvars['localhost']['controller_ip']['stdout'] }}"
@@ -203,7 +216,9 @@
     - name: Print Slurm resume.log
       ansible.builtin.debug:
         var: resume_output.stdout_lines
-    - name: Recover Suspend Logs
+    - name: Recover Suspend Log
+      become: true
+      become_user: slurm
       changed_when: false
       failed_when: false
       delegate_to: "{{ hostvars['localhost']['controller_ip']['stdout'] }}"


### PR DESCRIPTION
- Capture Slurm setup log. Use v5 location of log; ignores failure to find the log.
- In slurm-gcp v5 several of the logs are now written with a umask that only allows reading by root or by the slurm user. This change causes Ansible to become the slurm user when reading these files.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?