### PR TITLE
Support Spot VMs in HTCondor pools

### DIFF
--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -43,7 +43,7 @@ deployment_groups:
     use:
     - network1
 
-  - id: htcondor_configure_central_manager
+  - id: htcondor_startup_central_manager
     source: modules/scripts/startup-script
     settings:
       runners:
@@ -54,7 +54,7 @@ deployment_groups:
     source: modules/compute/vm-instance
     use:
     - network1
-    - htcondor_configure_central_manager
+    - htcondor_startup_central_manager
     settings:
       name_prefix: central-manager
       machine_type: c2-standard-4
@@ -77,25 +77,40 @@ deployment_groups:
     outputs:
     - internal_ip
 
-  - id: htcondor_configure_execute_point
+  - id: htcondor_startup_execute_point
     source: modules/scripts/startup-script
     settings:
       runners:
       - $(htcondor_install.install_htcondor_runner)
       - $(htcondor_configure.execute_point_runner)
 
+  # the HTCondor modules support up to 2 execute points per blueprint
+  # if using 1, it may use Spot or On-demand pricing
+  # if using 2, one must use Spot and the other must use On-demand (default)
   - id: htcondor_execute_point
     source: community/modules/compute/htcondor-execute-point
     use:
     - network1
-    - htcondor_configure_execute_point
+    - htcondor_startup_execute_point
     settings:
       service_account:
         email: $(htcondor_configure.execute_point_service_account)
         scopes:
         - cloud-platform
 
-  - id: htcondor_configure_access_point
+  - id: htcondor_execute_point_spot
+    source: community/modules/compute/htcondor-execute-point
+    use:
+    - network1
+    - htcondor_startup_execute_point
+    settings:
+      spot: true
+      service_account:
+        email: $(htcondor_configure.execute_point_service_account)
+        scopes:
+        - cloud-platform
+
+  - id: htcondor_startup_access_point
     source: modules/scripts/startup-script
     settings:
       runners:
@@ -104,6 +119,7 @@ deployment_groups:
       - $(htcondor_install.install_autoscaler_runner)
       - $(htcondor_configure.access_point_runner)
       - $(htcondor_execute_point.configure_autoscaler_runner)
+      - $(htcondor_execute_point_spot.configure_autoscaler_runner)
       - type: data
         destination: /var/tmp/helloworld.sub
         content: |
@@ -120,7 +136,7 @@ deployment_groups:
     source: modules/compute/vm-instance
     use:
     - network1
-    - htcondor_configure_access_point
+    - htcondor_startup_access_point
     settings:
       name_prefix: access-point
       machine_type: c2-standard-4

--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -123,11 +123,12 @@ deployment_groups:
       - type: data
         destination: /var/tmp/helloworld.sub
         content: |
-          universe       = docker
-          docker_image   = hello-world
-          output         = out
-          error          = err
-          log            = log
+          universe       = vanilla
+          executable     = /bin/echo
+          arguments      = "Hello, World!"
+          output         = out.\$(ClusterId).\$(ProcId)
+          error          = err.\$(ClusterId).\$(ProcId)
+          log            = log.\$(ClusterId).\$(ProcId)
           request_cpus   = 1
           request_memory = 100MB
           queue

--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -131,6 +131,7 @@ deployment_groups:
           log            = log.\$(ClusterId).\$(ProcId)
           request_cpus   = 1
           request_memory = 100MB
+          +RequireSpot   = true # if unset, defaults to false
           queue
 
   - id: htcondor_access

--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -19,7 +19,8 @@ execute points in an HTCondor pool. If using 1 set, it may use either Spot or
 On-demand pricing. If using 2 sets, one must use Spot and the other must
 use On-demand pricing. If you do not follow this constraint, you will likely
 receive an error while running `terraform apply` similar to that shown below.
-Future development is planned to support more heterogeneity within a pool.
+Future development is planned to support more than 2 sets of VM configurations,
+including all pricing options.
 
 ```text
 │     │ var.runners is list of map of string with 7 elements

--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -29,6 +29,30 @@ Future development is planned to support more heterogeneity within a pool.
 │ This was checked by the validation rule at modules/startup-script/variables.tf:72,3-13.
 ```
 
+### How to run HTCondor jobs on Spot VMs
+
+HTCondor access points provisioned by the Toolkit are specially configured to
+add an attribute named `RequireSpot` to each [Job ClassAd][jobad]. When this
+value is true, a job's `requirements` are automatically updated to require
+that it run on a Spot VM. When this value is false, the `requirements` are
+similarly updated to run only on On-Demand VMs. The default value of this
+attribute is false. A job submit file may override this value as shown below.
+
+```text
+universe       = vanilla
+executable     = /bin/echo
+arguments      = "Hello, World!"
+output         = out.\$(ClusterId).\$(ProcId)
+error          = err.\$(ClusterId).\$(ProcId)
+log            = log.\$(ClusterId).\$(ProcId)
+request_cpus   = 1
+request_memory = 100MB
++RequireSpot   = true
+queue
+```
+
+[jobad]: https://htcondor.readthedocs.io/en/latest/users-manual/matchmaking-with-classads.html
+
 ### Example
 
 A full example can be found in the [examples README][htc-example].

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -28,14 +28,14 @@ install the HTCondor software and adds custom configurations using
 - id: htcondor_install
   source: community/modules/scripts/htcondor-install
 
-- id: htcondor_configure_central_manager
+- id: htcondor_startup_central_manager
   source: modules/scripts/startup-script
   settings:
     runners:
     - $(htcondor_install.install_htcondor_runner)
     - $(htcondor_configure.central_manager_runner)
 
-- id: htcondor_configure_access_point
+- id: htcondor_startup_access_point
   source: modules/scripts/startup-script
   settings:
     runners:

--- a/docs/tutorials/htcondor.md
+++ b/docs/tutorials/htcondor.md
@@ -159,11 +159,12 @@ condor_submit helloworld.sub
 The job "submit file" will resemble:
 
 ```text
-universe       = docker
-docker_image   = hello-world
-output         = out.$(Cluster)-$(Process)
-error          = err.$(Cluster)-$(Process)
-log            = log.$(Cluster)-$(Process)
+universe       = vanilla
+executable     = /bin/echo
+arguments      = "Hello, World!"
+output         = out.\$(ClusterId).\$(ProcId)
+error          = err.\$(ClusterId).\$(ProcId)
+log            = log.\$(ClusterId).\$(ProcId)
 request_cpus   = 1
 request_memory = 100MB
 queue
@@ -194,12 +195,10 @@ ID: 1     1    -     -      1   1.0
 Once the pool autoscales (approx. 5 minutes), observe the output of your job:
 
 ```bash
-cat out
+cat out.1.0
 ```
 
-You should see the output of the Docker [Hello, World][helloworld] image.
-
-[helloworld]: https://hub.docker.com/_/hello-world
+You should see the output of your `echo` command: "Hello, World!"
 
 ## Destroy the Cluster
 


### PR DESCRIPTION
This PR completes initial support for Spot VMs in HTCondor pools by allowing for up to 2 MIGs per pool, autoscaled independently by filtering jobs with the attribute `RequireSpot=True` or `RequireSpot=False`. #973 ensured that each job has this attribute, that it defaults to `False` and that a job's `Requirements` automatically constrain the job to run _only_ on Spot or On-demand VMs.

If using 2 MIGs, one must be configured for On-demand pricing and the other for Spot pricing. This limitation is documented along with the error that arise if a blueprint does not respect this limitation.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?