### PR TITLE
Enable depth-first filling of HTCondor pools

### DIFF
--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -93,6 +93,7 @@
         content: |
           COLLECTOR_UPDATE_INTERVAL=30
           NEGOTIATOR_UPDATE_INTERVAL=30
+          NEGOTIATOR_DEPTH_FIRST=True
       notify:
       - Reload HTCondor
     - name: Create Central Manager HA configuration file


### PR DESCRIPTION
Ensure maximum utilization of each VM by filling machines depth-first rather than the entire pool breadth-first. Ensures that the number of machines provisioned for a given set of jobs is as close as possible to the minimum necessary.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?