### PR TITLE
Pass empty string instead of null to avoid mounting failure in Slurm

### DIFF
--- a/community/modules/file-system/cloud-storage-bucket/outputs.tf
+++ b/community/modules/file-system/cloud-storage-bucket/outputs.tf
@@ -21,7 +21,7 @@ output "network_storage" {
     local_mount           = var.local_mount
     fs_type               = "gcsfuse"
     mount_options         = var.mount_options
-    server_ip             = null
+    server_ip             = ""
     client_install_runner = local.client_install_runner
     mount_runner          = local.mount_runner
   }


### PR DESCRIPTION
Prior to this change Slurm V5 would fail to mount a bucket created by `cloud-storage-bucket`.

Tested manually on Slurm v5.6. I will request that Slurm change this behavior but there is no need for us to be broken in the intervening time. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
