### PR TITLE
Actually check mount instead of just checking dir exists

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
@@ -38,11 +38,21 @@
     msg: Test Check Partitions failed
   when: item not in partition_output.stdout
   loop: "{{ custom_vars.partitions }}"
-- name: Test Mounts on partitions
+
+- name: Get mounts on partitions
   register: srun_mounts
   changed_when: srun_mounts.rc == 0
-  ansible.builtin.command: "srun -N 1 -p {{ item }} ls -laF {{ custom_vars.mounts | join(' ') }}"
+  ansible.builtin.command: "srun -N 1 -p {{ item }} mount"
   loop: "{{ custom_vars.partitions }}"
+
+- name: Fail if partitions unmounted
+  ansible.builtin.fail: "mount: {{ item[1] }} was not found in {{ item[0].cmd }}"
+  # this is searching for "on /scratch " if local mount is /scratch
+  when: '"on " + item[1] + " "  not in item[0].stdout'
+  loop: "{{ srun_mounts.results | product( custom_vars.mounts ) | list }}"
+  loop_control:
+    label: "{{ item[1] }}"
+
 - name: Test partitions with hostname
   register: srun_hostname
   changed_when: srun_hostname.rc == 0

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
@@ -41,7 +41,7 @@
 - name: Test Mounts on partitions
   register: srun_mounts
   changed_when: srun_mounts.rc == 0
-  ansible.builtin.command: "srun -N 1 ls -laF {{ custom_vars.mounts | join(' ') }}"
+  ansible.builtin.command: "srun -N 1 -p {{ item }} ls -laF {{ custom_vars.mounts | join(' ') }}"
   loop: "{{ custom_vars.partitions }}"
 - name: Test partitions with hostname
   register: srun_hostname


### PR DESCRIPTION
This change:
- Resolves issue that we were only testing the default partition (but still running it multiple times). Now we test all partitions.
- Checks if a path has been mounted instead of just checking if a directory exists.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
