### PR TITLE
Remove hostname test as it is not providing incremental value

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
@@ -39,10 +39,10 @@
   when: item not in partition_output.stdout
   loop: "{{ custom_vars.partitions }}"
 
-- name: Get mounts on partitions
+- name: Test partition mounts, multi-node creation, & placement (when on)
   register: srun_mounts
   changed_when: srun_mounts.rc == 0
-  ansible.builtin.command: "srun -N 1 -p {{ item }} mount"
+  ansible.builtin.command: "srun -N 2 -p {{ item }} mount"
   loop: "{{ custom_vars.partitions }}"
 
 - name: Fail if partitions unmounted
@@ -53,11 +53,6 @@
   loop_control:
     label: "{{ item[1] }}"
 
-- name: Test partitions with hostname
-  register: srun_hostname
-  changed_when: srun_hostname.rc == 0
-  ansible.builtin.command: srun -N 2 --partition {{ item }} hostname
-  loop: "{{ custom_vars.partitions }}"
 - name: Ensure all nodes are powered down
   ansible.builtin.command: sinfo -t 'IDLE&POWERED_DOWN' --noheader --format "%n"
   register: final_node_count


### PR DESCRIPTION
We are already calling srun on each partition to get mount information. I don't believe we are getting enough incremental value out of also running hostname to justify the time it takes to run across each partition.

If #1004 is merged first then this PR will have to be rebased. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
