### PR TITLE
Add mounting of cloud-storage-bucket to Slurm v5 test

### DIFF
--- a/tools/cloud-build/daily-tests/tests/slurm-v5-startup-scripts.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-startup-scripts.yml
@@ -35,3 +35,4 @@ custom_vars:
   - debug
   mounts:
   - /home
+  - /data

--- a/tools/validate_configs/test_configs/slurm-gcp-v5-startup-scripts.yaml
+++ b/tools/validate_configs/test_configs/slurm-gcp-v5-startup-scripts.yaml
@@ -38,6 +38,14 @@ deployment_groups:
       local_mounts: [/home]
       auto_delete_disk: true
 
+  - id: bucket
+    source: community/modules/file-system/cloud-storage-bucket
+    settings:
+      name_prefix: input-data
+      local_mount: /data
+      random_suffix: true
+      mount_options: defaults,_netdev,implicit_dirs,allow_other
+
   # Used by the partitions, this tests startup scripts that are partition specific
   - id: startup-partition
     source: modules/scripts/startup-script
@@ -61,6 +69,7 @@ deployment_groups:
     use:
     - network1
     - homefs
+    - bucket
     - debug_node_group
     settings:
       partition_name: debug
@@ -77,6 +86,7 @@ deployment_groups:
     use:
     - network1
     - homefs
+    - bucket
     - compute_node_group
     - startup-partition
     settings:
@@ -101,6 +111,7 @@ deployment_groups:
     - debug_partition
     - compute_partition
     - homefs
+    - bucket
     - startup-all
     settings:
       disable_controller_public_ips: false


### PR DESCRIPTION
This change will prevent regression of ability so mount gcs buckets to Slurm v5 clusters.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
