### PR TITLE
Remove ghpc_role setting from nfs-server example

### DIFF
--- a/community/modules/file-system/nfs-server/README.md
+++ b/community/modules/file-system/nfs-server/README.md
@@ -23,8 +23,6 @@ Toolkit, see the extended [Network Storage documentation](../../../../docs/netwo
   use: [network1]
   settings:
     auto_delete_disk: true
-    labels:
-      ghpc_role: storage-home
 ```
 
 This creates a NFS on a virtual machine which allow other VMs to mount the


### PR DESCRIPTION
Label of `ghpc_role : file-system` is automatically added. Example is 2 years old.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
