### PR TITLE
Prefer local_mount (non-plural) in nfs-server to match project convention

### DIFF
--- a/community/modules/file-system/nfs-server/README.md
+++ b/community/modules/file-system/nfs-server/README.md
@@ -124,7 +124,8 @@ No modules.
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Storage size gb | `number` | `"100"` | no |
 | <a name="input_image"></a> [image](#input\_image) | the VM image used by the nfs server | `string` | `"cloud-hpc-image-public/hpc-centos-7"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NFS instance. List key, value pairs. | `any` | n/a | yes |
-| <a name="input_local_mounts"></a> [local\_mounts](#input\_local\_mounts) | Mountpoint for this NFS compute instance | `list(string)` | <pre>[<br>  "/data"<br>]</pre> | no |
+| <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint for this NFS compute instance | `string` | `"/data"` | no |
+| <a name="input_local_mounts"></a> [local\_mounts](#input\_local\_mounts) | DEPRECATED: Use `local_mount` instead: Mountpoint for this NFS compute instance | `list(string)` | `[]` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Type of the VM instance to use | `string` | `"n2d-standard-2"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resource name of the instance. | `string` | `null` | no |

--- a/community/modules/file-system/nfs-server/variables.tf
+++ b/community/modules/file-system/nfs-server/variables.tf
@@ -100,10 +100,20 @@ variable "scopes" {
   default     = ["https://www.googleapis.com/auth/cloud-platform"]
 }
 
-variable "local_mounts" {
+variable "local_mount" {
   description = "Mountpoint for this NFS compute instance"
+  type        = string
+  default     = "/data"
+  validation {
+    condition     = substr(var.local_mount, 0, 1) == "/"
+    error_message = "Local mountpoint must start with '/'."
+  }
+}
+
+variable "local_mounts" {
+  description = "DEPRECATED: Use `local_mount` instead: Mountpoint for this NFS compute instance"
   type        = list(string)
-  default     = ["/data"]
+  default     = []
 
   validation {
     condition = alltrue([
@@ -112,7 +122,7 @@ variable "local_mounts" {
     error_message = "Local mountpoints have to start with '/'."
   }
   validation {
-    condition     = length(var.local_mounts) > 0
-    error_message = "At least one local mount must be specified in var.local_mounts."
+    condition     = var.local_mounts != null
+    error_message = "Do not set local mounts to null."
   }
 }

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -129,7 +129,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.19 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -32,5 +32,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.14.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = ">= 1.2.0"
 }


### PR DESCRIPTION
This naming mismatch has always bothered me. I expect some discussion. 

Validation is caught on terraform plan or apply (before any resources are created).

Note there is a known bad case:
```
    settings: # the bad case
      local_mounts: [/share]
      local_mount: /data
```

In this case there will be no error and the local mount will be `/share` as we won't recognize that the user is overriding the default with the default. I think this is a reasonable bad case to allow for the benefit of having the default show in the docs.

Additional Work:
- Update examples

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
