### PR TITLE
Add retries to apt tasks in chrome-remote-desktop to account for lock contention with unattended-upgrades

### DIFF
--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-chrome-desktop.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-chrome-desktop.yml
@@ -24,6 +24,10 @@
       - xfce4-goodies
       state: present
       update_cache: true
+    register: apt_result
+    retries: 6
+    delay: 10
+    until: apt_result is success
 
   - name: Download and configure CRD
     ansible.builtin.get_url:
@@ -36,6 +40,10 @@
       deb: /tmp/chrome-remote-desktop_current_amd64.deb
     environment:
       DEBIAN_FRONTEND: noninteractive
+    register: apt_result
+    retries: 6
+    delay: 10
+    until: apt_result is success
 
   - name: Configure CRD to use Xfce by default
     ansible.builtin.copy:

--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-grid-drivers.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-grid-drivers.yml
@@ -32,6 +32,10 @@
       - gdm3
       state: present
       update_cache: true
+    register: apt_result
+    retries: 6
+    delay: 10
+    until: apt_result is success
 
   - name: Download GPU driver
     ansible.builtin.get_url:


### PR DESCRIPTION
This change adds retries to apt tasks within the chrome-remote-desktop installation. This should decrease the chance of #1019 in the future. 6 times x 10 seconds was selected for retries to mimic the default 60s [lock_timeout](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#parameter-lock_timeout) which is not available to us due to ansible version (2.12 required).

I would like to rebase off of #1027 and run new integration test before merging (done). 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
