### PR TITLE
Update year of Terraform deployment license

### DIFF
--- a/pkg/modulewriter/license.go
+++ b/pkg/modulewriter/license.go
@@ -17,7 +17,7 @@
 package modulewriter
 
 const license string = `/**
-  * Copyright 2022 Google LLC
+  * Copyright 2023 Google LLC
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Because deployment folders are dynamically created, the license that is automatically included should use the present year.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?