### PR TITLE
Add an integration test for chrome-remote-desktop module

### DIFF
--- a/tools/cloud-build/daily-tests/integration-group-4.yaml
+++ b/tools/cloud-build/daily-tests/integration-group-4.yaml
@@ -20,7 +20,7 @@
 #    └── htcondor (group 4)
 #       └── Cloud Batch
 #          └── slurm-gcp-v5-ubuntu2004
-
+#             └── chrome-remote-desktop
 
 timeout: 14400s  # 4hr
 steps:
@@ -107,3 +107,26 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml"
+
+## Test chrome-remote-desktop module
+- id: chrome-remote-desktop
+  waitFor:
+  - slurm-gcp-v5-ubuntu2004
+  - fetch_builder
+  - build_ghpc
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml"

--- a/tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml
+++ b/tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+test_name: chrome-remote-desktop
+deployment_name: chrome-remote-desktop-{{ build }}
+zone: us-central1-c
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/tools/validate_configs/test_configs/remote-desktop.yaml"
+network: "{{ deployment_name }}-net"
+remote_node: "{{ deployment_name }}-0"
+post_deploy_tests: []
+custom_vars:
+  project: "{{ project }}"

--- a/tools/validate_configs/test_configs/remote-desktop.yaml
+++ b/tools/validate_configs/test_configs/remote-desktop.yaml
@@ -19,8 +19,8 @@ blueprint_name: remote-desktop
 vars:
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: remote-desktop
-  region: us-east4
-  zone: us-east4-c
+  region: us-central1
+  zone: us-central1-c
 
 deployment_groups:
 - group: primary


### PR DESCRIPTION
This change adds a simple integration test to confirm the installation and startup of the chrome-remote-desktop module.

This test will help monitor for issues such as the one raised in #1019, and will prevent breakage to the CRD startup scripts as changes are made.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
