### PR TITLE
Fix startup-options test

### DIFF
--- a/tools/validate_configs/test_configs/startup-options.yaml
+++ b/tools/validate_configs/test_configs/startup-options.yaml
@@ -67,7 +67,6 @@ deployment_groups:
     settings:
       name_prefix: use-startup
       machine_type: e2-standard-4
-      startup_script: $(startup.startup_script)
 
   - id: instance-metadata-startup
     source: ./modules/compute/vm-instance


### PR DESCRIPTION
`instance-use-startup` case is meant to "use" it, not pass value explicitly.

```
$ ./ghpc create tools/validate_configs/test_configs/startup-options.yaml -l ERROR --vars="project_id=X"
module instance-use-startup uses module startup, but matching setting and outputs were not found. This may be because the value is set explicitly or set by a prior used module
One or more used modules could not have their settings and outputs linked.
error: validator test_module_not_used failed
```

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
