### PR TITLE
Fix broken test config use-resources.yaml

### DIFF
--- a/tools/validate_configs/test_configs/use-resources.yaml
+++ b/tools/validate_configs/test_configs/use-resources.yaml
@@ -36,7 +36,6 @@ deployment_groups:
     use: [network1]
     settings:
       local_mount: /home
-      network_id: $(network1.network_id)
 
 
   - id: projectsfs
@@ -71,11 +70,8 @@ deployment_groups:
   - id: slurm_login
     source: ./community/modules/scheduler/SchedMD-slurm-on-gcp-login-node
     use:
-    - homefs
-    - scratchfs
     - projectsfs
     - slurm_controller
     - network1
     settings:
       login_machine_type: n2-standard-4
-      network_storage: $(projectsfs.network_storage)

--- a/tools/validate_configs/test_configs/use-resources.yaml
+++ b/tools/validate_configs/test_configs/use-resources.yaml
@@ -70,6 +70,8 @@ deployment_groups:
   - id: slurm_login
     source: ./community/modules/scheduler/SchedMD-slurm-on-gcp-login-node
     use:
+    - homefs
+    - scratchfs
     - projectsfs
     - slurm_controller
     - network1


### PR DESCRIPTION
```
$ ./ghpc create tools/validate_configs/test_configs/use-resources.yaml -l ERROR --vars="project_id=X"
module homefs uses module network1, but matching setting and outputs were not found. This may be because the value is set explicitly or set by a prior used module
module slurm_login uses module homefs, but matching setting and outputs were not found. This may be because the value is set explicitly or set by a prior used module
module slurm_login uses module scratchfs, but matching setting and outputs were not found. This may be because the value is set explicitly or set by a prior used module
module slurm_login uses module projectsfs, but matching setting and outputs were not found. This may be because the value is set explicitly or set by a prior used module
One or more used modules could not have their settings and outputs linked.
error: validator test_module_not_used failed
```

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
