### PR TITLE
Hotfix: incorrect syntax for terraform interpolation in string

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ HPC deployments on the Google Cloud Platform.`,
 				log.Fatalf("cmd.Help function failed: %s", err)
 			}
 		},
-		Version:     "v1.14.0",
+		Version:     "v1.14.1",
 		Annotations: annotation,
 	}
 )

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.14.1"
   }
   required_version = ">= 0.13.0"
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.14.1"
   }
   required_version = ">= 0.13.0"
 }

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -30,10 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.14.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.14.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/community/modules/file-system/cloud-storage-bucket/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.14.1"
   }
   required_version = ">= 0.14.0"
 }

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/htcondor-configure/versions.tf
+++ b/community/modules/scheduler/htcondor-configure/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-configure/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-configure/v1.14.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -22,7 +22,7 @@ locals {
   { network_storage = jsonencode(var.network_storage) }) : {}
 
   prefix_optional_deployment_name = var.name_prefix != null ? var.name_prefix : var.deployment_name
-  prefix_always_deployment_name   = var.name_prefix != null ? "{var.deployment_name}-{var.name_prefix}" : var.deployment_name
+  prefix_always_deployment_name   = var.name_prefix != null ? "${var.deployment_name}-${var.name_prefix}" : var.deployment_name
   resource_prefix                 = var.add_deployment_name_before_prefix ? local.prefix_always_deployment_name : local.prefix_optional_deployment_name
 
   enable_gvnic  = var.bandwidth_tier != "not_enabled"

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -27,10 +27,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.14.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.14.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scheduler/batch-login-node/versions.tf
+++ b/modules/scheduler/batch-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.14.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.14.0"
+    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.14.1"
   }
 
   required_version = ">= 0.14.0"


### PR DESCRIPTION
Fix is in `vm-instance/main.tf`. This syntax is used in the HCLS Blueprint. 

Tested: Using the `add_deployment_name_before_prefix: true` setting, confirmed deploy failure prior to fix and successful deploy after the fix. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
