### PR TITLE
Check validations during `make tests`; Add flag to skip validators 

### DIFF
--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -33,8 +33,8 @@ func init() {
 		"Output file for the expanded HPC Environment Definition.")
 	expandCmd.Flags().StringSliceVar(&cliVariables, "vars", nil, msgCLIVars)
 	expandCmd.Flags().StringSliceVar(&cliBEConfigVars, "backend-config", nil, msgCLIBackendConfig)
-	expandCmd.Flags().StringVarP(&validationLevel, "validation-level", "l", "WARNING",
-		validationLevelDesc)
+	expandCmd.Flags().StringVarP(&validationLevel, "validation-level", "l", "WARNING", validationLevelDesc)
+	expandCmd.Flags().StringSliceVar(&validatorsToSkip, "skip-validators", nil, skipValidatorsDesc)
 	rootCmd.AddCommand(expandCmd)
 }
 
@@ -70,6 +70,9 @@ func runExpandCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to set the backend config at CLI: %v", err)
 	}
 	if err := deploymentConfig.SetValidationLevel(validationLevel); err != nil {
+		log.Fatal(err)
+	}
+	if err := skipValidators(&deploymentConfig); err != nil {
 		log.Fatal(err)
 	}
 	if err := deploymentConfig.ExpandConfig(); err != nil {

--- a/docs/blueprint-validation.md
+++ b/docs/blueprint-validation.md
@@ -81,12 +81,28 @@ Each validator is described below:
 ### Explicit validators
 
 Validators can be overwritten and supplied with alternative input values,
-however they are limited to the set of functions defined above. One method by
-which to disable validators is to explicitly set them to the empty list:
+however they are limited to the set of functions defined above.
+
+### Skipping or disabling validators
+
+There are three methods to disable configured validators:
+
+* Set `skip` value in validator config:
 
 ```yaml
-validators: []
+validators:
+- validator: test_apis_enabled
+  inputs: {}
+  skip: true
 ```
+
+* Use `skip-validators` CLI flag:
+
+```shell
+./ghpc create ... --skip-validators="test_project_exists,test_apis_enabled"
+```
+
+* To disable all validators, set the [validation level to IGNORE](#validation-levels).
 
 ### Validation levels
 

--- a/docs/blueprint-validation.md
+++ b/docs/blueprint-validation.md
@@ -64,7 +64,7 @@ Each validator is described below:
   * FAIL: if region does not exist or is not accessible within the project
   * Typical failures involve simple typos
   * Manual test: `gcloud compute regions describe $(vars.region) --project $(vars.project_id)`
-* `test_region_exists`
+* `test_zone_exists`
   * Inputs: `zone` (string)
   * PASS: if zone exists and is accessible within the project
   * FAIL: if zone does not exist or is not accessible within the project

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -184,6 +184,7 @@ func (v validatorName) String() string {
 type validatorConfig struct {
 	Validator string
 	Inputs    map[string]interface{}
+	Skip      bool
 }
 
 func (v *validatorConfig) check(name validatorName, requiredInputs []string) error {
@@ -652,6 +653,25 @@ func (dc *DeploymentConfig) SetBackendConfig(cliBEConfigVars []string) error {
 
 	}
 
+	return nil
+}
+
+// SkipValidator marks validator(s) as skipped,
+// if no validator is present, adds one, marked as skipped.
+func (dc *DeploymentConfig) SkipValidator(name string) error {
+	if dc.Config.Validators == nil {
+		dc.Config.Validators = []validatorConfig{}
+	}
+	skipped := false
+	for i, v := range dc.Config.Validators {
+		if v.Validator == name {
+			dc.Config.Validators[i].Skip = true
+			skipped = true
+		}
+	}
+	if !skipped {
+		dc.Config.Validators = append(dc.Config.Validators, validatorConfig{Validator: name, Skip: true})
+	}
 	return nil
 }
 

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -21,6 +21,7 @@ run_test() {
 	exampleFile=$(basename "$example")
 	DEPLOYMENT=$(echo "${exampleFile%.yaml}-$(basename "${tmpdir##*.}")" | sed -e 's/\(.*\)/\L\1/')
 	PROJECT="invalid-project"
+	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region"
 	GHPC_PATH="${cwd}/ghpc"
 	# Cover the three possible starting sequences for local sources: ./ ../ /
 	LOCAL_SOURCE_PATTERN='source:\s\+\(\./\|\.\./\|/\)'
@@ -35,7 +36,10 @@ run_test() {
 	else
 		cd "${tmpdir}"
 	fi
-	${GHPC_PATH} create -l IGNORE --vars "project_id=${PROJECT},deployment_name=${DEPLOYMENT}" "${tmpdir}"/"${exampleFile}" >/dev/null ||
+	${GHPC_PATH} create -l ERROR \
+		--skip-validators="${VALIDATORS_TO_SKIP}" \
+		--vars="project_id=${PROJECT},deployment_name=${DEPLOYMENT}" \
+		"${tmpdir}"/"${exampleFile}" >/dev/null ||
 		{
 			echo "*** ERROR: error creating deployment with ghpc for ${exampleFile}"
 			exit 1


### PR DESCRIPTION
* Add `Skip bool` to `validatorConfig`;
* Add flag `skip-validators` to `create` and `expand` commands;
* Change validation level IGNORE -> ERROR in validate_configs.sh;
* Add default validators even if others are present;

```
$ make && ./ghpc expand examples/hpc-cluster-small.yaml --vars="project_id=GG" --skip-validators="test_project_exists,test_apis_enabled"
```

expanded.yaml:

```
...
validators:
  - validator: test_project_exists
    inputs: {}
    skip: true
  - validator: test_apis_enabled
    inputs: {}
    skip: true
  - validator: test_module_not_used
    inputs: {}
    skip: false
...
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
