### PR TITLE
Update pre-commit hook repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 ---
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.77.0
+  rev: v1.77.1
   hooks:
   - id: terraform_fmt
   - id: terraform_tflint
@@ -66,7 +66,7 @@ repos:
   hooks:
   - id: go-critic
     args: [-disable, "#experimental,sloppyTypeAssert"]
-- repo: https://github.com/ansible/ansible-lint.git
+- repo: https://github.com/ansible/ansible-lint
   rev: v6.11.0
   hooks:
   - id: ansible-lint
@@ -75,13 +75,13 @@ repos:
     types: [yaml]
     additional_dependencies:
     - ansible==6.*
-- repo: https://github.com/adrienverge/yamllint.git
+- repo: https://github.com/adrienverge/yamllint
   rev: v1.29.0
   hooks:
   - id: yamllint
     args: [-c=.yamllint]
 - repo: https://github.com/jackdewinter/pymarkdown
-  rev: v0.9.8
+  rev: v0.9.9
   hooks:
   - id: pymarkdown
     # Rules at https://github.com/jackdewinter/pymarkdown/tree/main/docs/rules


### PR DESCRIPTION
I am intentionally not upgrading ansible-lint since there are some release notes indicating that support for Python 3.8 has been dropped. Might not be an issue for development, but we should give it more thought.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?