### PR TITLE
Make readers usable outside of package modulereader

### DIFF
--- a/pkg/modulereader/packerreader.go
+++ b/pkg/modulereader/packerreader.go
@@ -31,6 +31,11 @@ type PackerReader struct {
 	allModInfo map[string]ModuleInfo
 }
 
+// NewPackerReader is a constructor for PackerReader
+func NewPackerReader() PackerReader {
+	return PackerReader{allModInfo: map[string]ModuleInfo{}}
+}
+
 // SetInfo sets the module info for a module key'd on the source
 func (r PackerReader) SetInfo(source string, modInfo ModuleInfo) {
 	r.allModInfo[source] = modInfo

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -103,8 +103,8 @@ type ModReader interface {
 }
 
 var kinds = map[string]ModReader{
-	"terraform": TFReader{allModInfo: make(map[string]ModuleInfo)},
-	"packer":    PackerReader{allModInfo: make(map[string]ModuleInfo)},
+	"terraform": NewTFReader(),
+	"packer":    NewPackerReader(),
 }
 
 // IsValidKind returns true if the kind input is valid

--- a/pkg/modulereader/resreader_test.go
+++ b/pkg/modulereader/resreader_test.go
@@ -193,27 +193,30 @@ func (s *MySuite) TestGetHCLInfo(c *C) {
 }
 
 // tfreader.go
-func (s *MySuite) TestGetInfo_TFWriter(c *C) {
-	reader := TFReader{allModInfo: make(map[string]ModuleInfo)}
-	moduleInfo, err := reader.GetInfo(terraformDir)
+func (s *MySuite) TestGetInfo_TFReder(c *C) {
+	reader := NewTFReader()
+	info, err := reader.GetInfo(terraformDir)
 	c.Assert(err, IsNil)
-	c.Assert(moduleInfo.Inputs[0].Name, Equals, "test_variable")
-	c.Assert(moduleInfo.Outputs[0].Name, Equals, "test_output")
+	c.Check(info, DeepEquals, ModuleInfo{
+		Inputs:  []VarInfo{{Name: "test_variable", Type: "string", Description: "This is just a test", Required: true}},
+		Outputs: []VarInfo{{Name: "test_output", Type: "", Description: "This is just a test"}},
+	})
+
 }
 
 // packerreader.go
 func (s *MySuite) TestGetInfo_PackerReader(c *C) {
 	// Didn't already exist, succeeds
-	reader := PackerReader{allModInfo: make(map[string]ModuleInfo)}
-	moduleInfo, err := reader.GetInfo(packerDir)
+	reader := NewPackerReader()
+	info, err := reader.GetInfo(packerDir)
 	c.Assert(err, IsNil)
-	c.Assert(moduleInfo.Inputs[0].Name, Equals, "test_variable")
+	c.Check(info, DeepEquals, ModuleInfo{
+		Inputs: []VarInfo{{Name: "test_variable", Type: "string", Description: "This is just a test", Required: true}}})
 
 	// Already exists, succeeds
-	existingModuleInfo, err := reader.GetInfo(packerDir)
+	infoAgain, err := reader.GetInfo(packerDir)
 	c.Assert(err, IsNil)
-	c.Assert(
-		existingModuleInfo.Inputs[0].Name, Equals, moduleInfo.Inputs[0].Name)
+	c.Check(infoAgain, DeepEquals, info)
 }
 
 // metareader.go

--- a/pkg/modulereader/tfreader.go
+++ b/pkg/modulereader/tfreader.go
@@ -23,6 +23,11 @@ type TFReader struct {
 	allModInfo map[string]ModuleInfo
 }
 
+// NewTFReader is a constructor for TFReader
+func NewTFReader() TFReader {
+	return TFReader{allModInfo: map[string]ModuleInfo{}}
+}
+
 // SetInfo sets the module info for a module key'd by the source string
 func (r TFReader) SetInfo(source string, modInfo ModuleInfo) {
 	r.allModInfo[source] = modInfo


### PR DESCRIPTION
Exported readers can't be used outside of package because they require initialization of un-exported state.

- Add constructors;
- Refactoring of related tests.

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
