### PR TITLE
Add a test to enforce contracts on modules interfaces

### DIFF
--- a/pkg/inspect/list.go
+++ b/pkg/inspect/list.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspect
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// SourceAndKind is source and kind
+type SourceAndKind struct {
+	Source string
+	Kind   string
+}
+
+const rootPath = "../../"
+
+// ListModules in directory
+func ListModules(dir string) ([]SourceAndKind, error) {
+	ret := []SourceAndKind{}
+	err := filepath.WalkDir(filepath.Join(rootPath, dir), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && d.Name() == ".terraform" {
+			return filepath.SkipDir
+		}
+		src, err := filepath.Rel(rootPath, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() && filepath.Ext(d.Name()) == ".tf" {
+			ret = append(ret, SourceAndKind{src, "terraform"})
+			return filepath.SkipDir
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".pkr.hcl") {
+			ret = append(ret, SourceAndKind{src, "packer"})
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	return ret, err
+}
+
+// LocalModules returns source and kind for all local modules
+func LocalModules() ([]SourceAndKind, error) {
+	ret := []SourceAndKind{}
+
+	for _, sub := range []string{"modules", "community/modules"} {
+		mods, err := ListModules(sub)
+		if err != nil {
+			return []SourceAndKind{}, err
+		}
+		ret = append(ret, mods...)
+	}
+	return ret, nil
+}

--- a/pkg/inspect/list.go
+++ b/pkg/inspect/list.go
@@ -26,19 +26,17 @@ type SourceAndKind struct {
 	Kind   string
 }
 
-const rootPath = "../../"
-
 // ListModules in directory
-func ListModules(dir string) ([]SourceAndKind, error) {
+func ListModules(root string, dir string) ([]SourceAndKind, error) {
 	ret := []SourceAndKind{}
-	err := filepath.WalkDir(filepath.Join(rootPath, dir), func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(filepath.Join(root, dir), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() && d.Name() == ".terraform" {
 			return filepath.SkipDir
 		}
-		src, err := filepath.Rel(rootPath, filepath.Dir(path))
+		src, err := filepath.Rel(root, filepath.Dir(path))
 		if err != nil {
 			return err
 		}
@@ -61,7 +59,7 @@ func LocalModules() ([]SourceAndKind, error) {
 	ret := []SourceAndKind{}
 
 	for _, sub := range []string{"modules", "community/modules"} {
-		mods, err := ListModules(sub)
+		mods, err := ListModules("../../", sub)
 		if err != nil {
 			return []SourceAndKind{}, err
 		}

--- a/pkg/inspect/modules_test.go
+++ b/pkg/inspect/modules_test.go
@@ -89,6 +89,7 @@ func hasInput(name string) predicate {
 	}
 }
 
+// Fails test if slice is empty, returns not empty slice as is.
 func notEmpty[E any](l []E, t *testing.T) []E {
 	if l == nil || len(l) == 0 {
 		t.Fatal("Did not expect empty list")
@@ -96,7 +97,7 @@ func notEmpty[E any](l []E, t *testing.T) []E {
 	return l
 }
 
-// Self-test
+// Self-test checks that there are modules to inspect
 func TestSanity(t *testing.T) {
 	notEmpty(query(all()), t)
 }

--- a/pkg/inspect/modules_test.go
+++ b/pkg/inspect/modules_test.go
@@ -1,0 +1,111 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspect_test
+
+import (
+	"hpc-toolkit/pkg/inspect"
+	"hpc-toolkit/pkg/modulereader"
+	"log"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/exp/slices"
+)
+
+type varInfo = modulereader.VarInfo
+type predicate = func(modInfo) bool
+
+type modInfo struct {
+	modulereader.ModuleInfo
+	inspect.SourceAndKind
+}
+
+func (m *modInfo) Input(name string) (varInfo, bool) {
+	ind := slices.IndexFunc(m.Inputs, func(v varInfo) bool { return v.Name == name })
+	if ind == -1 {
+		return varInfo{}, false
+	}
+	return m.Inputs[ind], true
+}
+
+var allMods []modInfo = nil
+
+func getModules() []modInfo {
+	if allMods != nil {
+		return allMods
+	}
+	sks, err := inspect.LocalModules()
+	if err != nil {
+		log.Fatal(err)
+	}
+	allMods = []modInfo{}
+	for _, sk := range sks {
+		info, err := modulereader.GetModuleInfo(filepath.Join("../..", sk.Source), sk.Kind)
+		if err != nil {
+			log.Fatal(err)
+		}
+		allMods = append(allMods, modInfo{ModuleInfo: info, SourceAndKind: sk})
+	}
+	return allMods
+}
+
+func query(p predicate) []modInfo {
+	ret := []modInfo{}
+	for _, mod := range getModules() {
+		if p(mod) {
+			ret = append(ret, mod)
+		}
+	}
+	return ret
+}
+
+func all(ps ...predicate) predicate {
+	return func(mod modInfo) bool {
+		for _, p := range ps {
+			if !p(mod) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func hasInput(name string) predicate {
+	return func(mod modInfo) bool {
+		_, ok := mod.Input(name)
+		return ok
+	}
+}
+
+func notEmpty[E any](l []E, t *testing.T) []E {
+	if l == nil || len(l) == 0 {
+		t.Fatal("Did not expect empty list")
+	}
+	return l
+}
+
+// Self-test
+func TestSanity(t *testing.T) {
+	notEmpty(query(all()), t)
+}
+
+func TestLabelsType(t *testing.T) {
+	for _, mod := range notEmpty(query(hasInput("labels")), t) {
+		labels, _ := mod.Input("labels")
+		if labels.Type != "map(string)" {
+			t.Errorf("%s.labels has unexpected type %#v", mod.Source, labels.Type)
+		}
+	}
+}


### PR DESCRIPTION
- Add package `inspect` for tests and utils;
- Add test to check all modules input `labels` have type `map(string)`

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
