### PR TITLE
Fix slurm gcp v5 validation message in partition

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
@@ -97,9 +97,7 @@ EOD
   default     = "ANY_SINGLE_ZONE"
   validation {
     condition     = contains(["ANY", "ANY_SINGLE_ZONE", "BALANCED"], var.zone_target_shape)
-    error_message = <<-EOD
-      Allowed values for zone_target_shape are "ANY", "ANY_SINGLE_ZONE", or "BALANCED".
-    EOD
+    error_message = "Allowed values for zone_target_shape are \"ANY\", \"ANY_SINGLE_ZONE\", or \"BALANCED\"."
   }
 }
 


### PR DESCRIPTION
The format in these files only became valid at a later version of terraform and would break with terraform 1.13 and older.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
