### PR TITLE
Update OFE Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,10 @@ updates:
 - package-ecosystem: pip
   directory: /community/front-end/ofe/
   schedule:
-    interval: weekly
-    day: monday
+    interval: monthly
     time: "03:00"
     timezone: America/Los_Angeles
   target-branch: develop
+  reviewers:
+  - ek-nag
+  - mattstreet-nag


### PR DESCRIPTION
Update the dependabot configuration for OFE Python virtual environment:

- run monthly (non-configurable 1st of the month).
- add 2 reviewers from NAG team

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?