### PR TITLE
Add deployment_name to HTCondor example VMs

### DIFF
--- a/community/examples/htcondor-pool.yaml
+++ b/community/examples/htcondor-pool.yaml
@@ -56,7 +56,8 @@ deployment_groups:
     - network1
     - htcondor_startup_central_manager
     settings:
-      name_prefix: central-manager
+      name_prefix: cm
+      add_deployment_name_before_prefix: true
       machine_type: c2-standard-4
       disable_public_ips: true
       service_account:
@@ -140,7 +141,8 @@ deployment_groups:
     - network1
     - htcondor_startup_access_point
     settings:
-      name_prefix: access-point
+      name_prefix: ap
+      add_deployment_name_before_prefix: true
       machine_type: c2-standard-4
       service_account:
         email: $(htcondor_configure.access_point_service_account)


### PR DESCRIPTION
Helpful in general, but will also enable HTCondor integration tests to run in parallel.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?