### PR TITLE
Refactoring to support edge-tracking in graph

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -319,8 +319,8 @@ func (dc *DeploymentConfig) listUnusedModules() map[string][]string {
 	unusedModules := make(map[string][]string)
 	for _, conn := range dc.moduleConnections {
 		if conn.isEmpty() {
-			fromMod := conn.ref.getFromModuleID()
-			unusedModules[fromMod] = append(unusedModules[fromMod], conn.ref.getToModuleID())
+			fromMod := conn.ref.FromModuleID()
+			unusedModules[fromMod] = append(unusedModules[fromMod], conn.ref.ToModuleID())
 		}
 	}
 	return unusedModules
@@ -520,7 +520,7 @@ func checkUsedModuleNames(bp Blueprint) error {
 				}
 
 				// TODO: remove this when support is added!
-				if ref.FromGroupID != ref.ToGroupID {
+				if ref.fromGroupID != ref.toGroupID {
 					return fmt.Errorf("%s: %s is an intergroup reference",
 						errorMessages["varInAnotherGroup"], usedMod)
 				}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -403,11 +403,11 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 	// test used module with shared variables
 	usedConn := ModConnection{
 		ref: modReference{
-			ToModuleID:   "usedModule",
-			FromModuleID: "usingModule",
-			ToGroupID:    "group1",
-			FromGroupID:  "group1",
-			Explicit:     true,
+			toModuleID:   "usedModule",
+			fromModuleID: "usingModule",
+			toGroupID:    "group1",
+			fromGroupID:  "group1",
+			explicit:     true,
 		},
 		kind:            useConnection,
 		sharedVariables: []string{"var1"},
@@ -419,11 +419,11 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 	// test used module with no shared variables (i.e. "unused")
 	unusedConn := ModConnection{
 		ref: modReference{
-			ToModuleID:   "firstUnusedModule",
-			FromModuleID: "usingModule",
-			ToGroupID:    "group1",
-			FromGroupID:  "group1",
-			Explicit:     true,
+			toModuleID:   "firstUnusedModule",
+			fromModuleID: "usingModule",
+			toGroupID:    "group1",
+			fromGroupID:  "group1",
+			explicit:     true,
 		},
 		kind:            useConnection,
 		sharedVariables: []string{},
@@ -435,11 +435,11 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 	// test second used module with no shared variables (i.e. "unused")
 	secondUnusedConn := ModConnection{
 		ref: modReference{
-			ToModuleID:   "secondUnusedModule",
-			FromModuleID: "usingModule",
-			ToGroupID:    "group1",
-			FromGroupID:  "group1",
-			Explicit:     true,
+			toModuleID:   "secondUnusedModule",
+			fromModuleID: "usingModule",
+			toGroupID:    "group1",
+			fromGroupID:  "group1",
+			explicit:     true,
 		},
 		kind:            useConnection,
 		sharedVariables: []string{},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -400,10 +400,15 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 	got := dc.listUnusedModules()
 	c.Assert(got, HasLen, 0)
 
-	// All "use" modules actually used
+	// test used module with shared variables
 	usedConn := ModConnection{
-		toID:            "usedModule",
-		fromID:          "usingModule",
+		ref: modReference{
+			ToModuleID:   "usedModule",
+			FromModuleID: "usingModule",
+			ToGroupID:    "group1",
+			FromGroupID:  "group1",
+			Explicit:     true,
+		},
 		kind:            useConnection,
 		sharedVariables: []string{"var1"},
 	}
@@ -411,10 +416,15 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 	got = dc.listUnusedModules()
 	c.Assert(got["usingModule"], HasLen, 0)
 
-	// One fully unused module
+	// test used module with no shared variables (i.e. "unused")
 	unusedConn := ModConnection{
-		toID:            "usedModule",
-		fromID:          "usingModule",
+		ref: modReference{
+			ToModuleID:   "firstUnusedModule",
+			FromModuleID: "usingModule",
+			ToGroupID:    "group1",
+			FromGroupID:  "group1",
+			Explicit:     true,
+		},
 		kind:            useConnection,
 		sharedVariables: []string{},
 	}
@@ -422,17 +432,21 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 	got = dc.listUnusedModules()
 	c.Assert(got["usingModule"], HasLen, 1)
 
-	// Two fully unused modules
+	// test second used module with no shared variables (i.e. "unused")
 	secondUnusedConn := ModConnection{
-		toID:            "secondUnusedModule",
-		fromID:          "usingModule",
+		ref: modReference{
+			ToModuleID:   "secondUnusedModule",
+			FromModuleID: "usingModule",
+			ToGroupID:    "group1",
+			FromGroupID:  "group1",
+			Explicit:     true,
+		},
 		kind:            useConnection,
 		sharedVariables: []string{},
 	}
 	dc.moduleConnections = append(dc.moduleConnections, secondUnusedConn)
 	got = dc.listUnusedModules()
 	c.Assert(got["usingModule"], HasLen, 2)
-
 }
 
 func (s *MySuite) TestAddKindToModules(c *C) {

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -213,7 +213,7 @@ func useModule(
 	for _, useOutput := range useOutputs {
 		settingName := useOutput.Name
 
-		// Explicitly ignore these settings (typically those in blueprint)
+		// explicitly ignore these settings (typically those in blueprint)
 		if slices.Contains(settingsToIgnore, settingName) {
 			continue
 		}
@@ -268,14 +268,14 @@ func (dc *DeploymentConfig) applyUseModules() error {
 				}
 
 				// to get the module struct, we first needs its group
-				toGroup, err := dc.getGroupByID(modRef.ToGroupID)
+				toGroup, err := dc.getGroupByID(modRef.toGroupID)
 				if err != nil {
 					return err
 				}
 
 				// this module contains information about the target module that
 				// was specified by the user in the blueprint
-				toMod, err := toGroup.getModuleByID(modRef.ToModuleID)
+				toMod, err := toGroup.getModuleByID(modRef.toModuleID)
 				if err != nil {
 					return err
 				}
@@ -294,7 +294,7 @@ func (dc *DeploymentConfig) applyUseModules() error {
 				// tested but it our unit test infrastructure does not support
 				// running dc.setModulesInfo() on our test configurations
 				toModInfo := dc.ModulesInfo[toGroup.Name][toMod.Source]
-				usedVars, err := useModule(fromMod, toMod, modRef.ToGroupID,
+				usedVars, err := useModule(fromMod, toMod, modRef.toGroupID,
 					fromModInfo.Inputs, toModInfo.Outputs, settingsInBlueprint)
 				if err != nil {
 					return err
@@ -514,44 +514,44 @@ type varContext struct {
 
 type reference interface {
 	validate(Blueprint) error
-	isIntergroup() bool
+	IsIntergroup() bool
 	String() string
-	getFromModuleID() string
-	getToModuleID() string
+	FromModuleID() string
+	ToModuleID() string
 }
 
 /*
 A module reference is made by the use keyword and is subject to IGC constraints
 of references (ordering, explicitness). It has the following fields:
-  - ToModuleID: the target module ID
-  - FromModuleID: the source module ID
-  - ToGroupID: the deployment group in which the module is *expected* to be found
-  - FromGroupID: the deployment group from which the reference is made
-  - Explicit: a boolean value indicating whether the user made a reference that
-    explicitly identified ToGroupID rather than inferring it using FromGroupID
+  - toModuleID: the target module ID
+  - fromModuleID: the source module ID
+  - toGroupID: the deployment group in which the module is *expected* to be found
+  - fromGroupID: the deployment group from which the reference is made
+  - explicit: a boolean value indicating whether the user made a reference that
+    explicitly identified toGroupID rather than inferring it using fromGroupID
 */
 type modReference struct {
-	ToModuleID   string
-	FromModuleID string
-	ToGroupID    string
-	FromGroupID  string
-	Explicit     bool
+	toModuleID   string
+	fromModuleID string
+	toGroupID    string
+	fromGroupID  string
+	explicit     bool
 }
 
 func (ref modReference) String() string {
-	return ref.ToGroupID + "." + ref.ToModuleID
+	return ref.toGroupID + "." + ref.toModuleID
 }
 
-func (ref modReference) isIntergroup() bool {
-	return ref.ToGroupID == ref.FromGroupID
+func (ref modReference) IsIntergroup() bool {
+	return ref.toGroupID == ref.fromGroupID
 }
 
-func (ref modReference) getFromModuleID() string {
-	return ref.FromModuleID
+func (ref modReference) FromModuleID() string {
+	return ref.fromModuleID
 }
 
-func (ref modReference) getToModuleID() string {
-	return ref.FromModuleID
+func (ref modReference) ToModuleID() string {
+	return ref.toModuleID
 }
 
 /*
@@ -568,21 +568,21 @@ func identifyModuleByReference(yamlReference string, dg DeploymentGroup) (modRef
 	modComponents := strings.Split(yamlReference, ".")
 	switch len(modComponents) {
 	case 1:
-		ref.ToModuleID = modComponents[0]
-		ref.ToGroupID = dg.Name
-		ref.FromGroupID = dg.Name
+		ref.toModuleID = modComponents[0]
+		ref.toGroupID = dg.Name
+		ref.fromGroupID = dg.Name
 	case 2:
-		ref.ToGroupID = modComponents[0]
-		ref.ToModuleID = modComponents[1]
-		ref.FromGroupID = dg.Name
-		ref.Explicit = true
+		ref.toGroupID = modComponents[0]
+		ref.toModuleID = modComponents[1]
+		ref.fromGroupID = dg.Name
+		ref.explicit = true
 	}
 
 	// should consider more sophisticated definition of valid values here.
 	// for now check that no fields are the empty string; due to the default
 	// zero values for strings in the "ref" struct, this will also cover the
 	// case that modComponents has wrong # of fields
-	if ref.ToModuleID == "" || ref.ToGroupID == "" || ref.FromGroupID == "" {
+	if ref.toModuleID == "" || ref.toGroupID == "" || ref.fromGroupID == "" {
 		return ref, fmt.Errorf("%s: %s, expected %s",
 			errorMessages["invalidMod"], yamlReference, expectedModFormat)
 	}
@@ -593,36 +593,36 @@ func identifyModuleByReference(yamlReference string, dg DeploymentGroup) (modRef
 /*
 A variable reference has the following fields
   - Name: the name of the module output or deployment variable
-  - ToModuleID: the target module ID or "vars" if referring to a deployment variable
-  - FromModuleID: the source module ID
-  - ToGroupID: the deployment group in which the module is *expected* to be found
-  - FromGroupID: the deployment group from which the reference is made
-  - Explicit: a boolean value indicating whether the user made a reference that
-    explicitly identified ToGroupID rather than inferring it using FromGroupID
+  - toModuleID: the target module ID or "vars" if referring to a deployment variable
+  - fromModuleID: the source module ID
+  - toGroupID: the deployment group in which the module is *expected* to be found
+  - fromGroupID: the deployment group from which the reference is made
+  - explicit: a boolean value indicating whether the user made a reference that
+    explicitly identified toGroupID rather than inferring it using fromGroupID
 */
 type varReference struct {
-	Name         string
-	ToModuleID   string
-	FromModuleID string
-	ToGroupID    string
-	FromGroupID  string
-	Explicit     bool
+	name         string
+	toModuleID   string
+	fromModuleID string
+	toGroupID    string
+	fromGroupID  string
+	explicit     bool
 }
 
 func (ref varReference) String() string {
-	return ref.ToGroupID + "." + ref.ToModuleID + "." + ref.Name
+	return ref.toGroupID + "." + ref.toModuleID + "." + ref.name
 }
 
-func (ref varReference) isIntergroup() bool {
-	return ref.ToGroupID == ref.FromGroupID
+func (ref varReference) IsIntergroup() bool {
+	return ref.toGroupID == ref.fromGroupID
 }
 
-func (ref varReference) getFromModuleID() string {
-	return ref.FromModuleID
+func (ref varReference) FromModuleID() string {
+	return ref.fromModuleID
 }
 
-func (ref varReference) getToModuleID() string {
-	return ref.FromModuleID
+func (ref varReference) ToModuleID() string {
+	return ref.toModuleID
 }
 
 /*
@@ -637,31 +637,31 @@ func identifySimpleVariable(yamlReference string, dg DeploymentGroup) (varRefere
 
 	// struct defaults: empty strings and false booleans
 	var ref varReference
-	ref.FromGroupID = dg.Name
+	ref.fromGroupID = dg.Name
 
 	// intra-group references length 2 and inter-group references length 3
 	switch len(varComponents) {
 	case 2:
-		ref.ToModuleID = varComponents[0]
-		ref.Name = varComponents[1]
+		ref.toModuleID = varComponents[0]
+		ref.name = varComponents[1]
 
-		if ref.ToModuleID == "vars" {
-			ref.ToGroupID = "deployment"
+		if ref.toModuleID == "vars" {
+			ref.toGroupID = "deployment"
 		} else {
-			ref.ToGroupID = dg.Name
+			ref.toGroupID = dg.Name
 		}
 	case 3:
-		ref.ToGroupID = varComponents[0]
-		ref.ToModuleID = varComponents[1]
-		ref.Name = varComponents[2]
-		ref.Explicit = true
+		ref.toGroupID = varComponents[0]
+		ref.toModuleID = varComponents[1]
+		ref.name = varComponents[2]
+		ref.explicit = true
 	}
 
 	// should consider more sophisticated definition of valid values here.
 	// for now check that source and name are not empty strings; due to the
 	// default zero values for strings in the "ref" struct, this will also
 	// cover the case that varComponents has wrong # of fields
-	if ref.FromGroupID == "" || ref.ToGroupID == "" || ref.ToModuleID == "" || ref.Name == "" {
+	if ref.fromGroupID == "" || ref.toGroupID == "" || ref.toModuleID == "" || ref.name == "" {
 		return varReference{}, fmt.Errorf("%s %s, expected format: %s",
 			errorMessages["invalidVar"], yamlReference, expectedVarFormat)
 	}
@@ -669,12 +669,12 @@ func identifySimpleVariable(yamlReference string, dg DeploymentGroup) (varRefere
 }
 
 func (ref modReference) validate(bp Blueprint) error {
-	callingModuleGroupIndex := slices.IndexFunc(bp.DeploymentGroups, func(d DeploymentGroup) bool { return d.Name == ref.FromGroupID })
+	callingModuleGroupIndex := slices.IndexFunc(bp.DeploymentGroups, func(d DeploymentGroup) bool { return d.Name == ref.fromGroupID })
 	if callingModuleGroupIndex == -1 {
-		return fmt.Errorf("%s: %s", errorMessages["groupNotFound"], ref.FromGroupID)
+		return fmt.Errorf("%s: %s", errorMessages["groupNotFound"], ref.fromGroupID)
 	}
 
-	targetModuleGroupIndex, err := modToGrp(bp.DeploymentGroups, ref.ToModuleID)
+	targetModuleGroupIndex, err := modToGrp(bp.DeploymentGroups, ref.toModuleID)
 	if err != nil {
 		return err
 	}
@@ -683,17 +683,17 @@ func (ref modReference) validate(bp Blueprint) error {
 	// Ensure module is from the correct group
 	isInterGroupReference := callingModuleGroupIndex != targetModuleGroupIndex
 	isRefToLaterGroup := targetModuleGroupIndex > callingModuleGroupIndex
-	isCorrectToGroup := ref.ToGroupID == targetModuleGroupName
+	isCorrectToGroup := ref.toGroupID == targetModuleGroupName
 
 	if isInterGroupReference {
 		if isRefToLaterGroup {
 			return fmt.Errorf("%s: %s is in a later group",
-				errorMessages["intergroupOrder"], ref.ToModuleID)
+				errorMessages["intergroupOrder"], ref.toModuleID)
 		}
 
-		if !ref.Explicit {
+		if !ref.explicit {
 			return fmt.Errorf("%s: %s must specify a group ID before the module ID",
-				errorMessages["intergroupImplicit"], ref.ToModuleID)
+				errorMessages["intergroupImplicit"], ref.toModuleID)
 		}
 	}
 
@@ -702,7 +702,7 @@ func (ref modReference) validate(bp Blueprint) error {
 	// error after enforcing explicitness of intergroup references
 	if !isCorrectToGroup {
 		return fmt.Errorf("%s: %s.%s",
-			errorMessages["referenceWrongGroup"], ref.ToGroupID, ref.ToModuleID)
+			errorMessages["referenceWrongGroup"], ref.toGroupID, ref.toModuleID)
 	}
 
 	return nil
@@ -712,50 +712,50 @@ func (ref modReference) validate(bp Blueprint) error {
 // the reference must be to the same or earlier group.
 // ref.GroupID: this group must exist or be the value "deployment"
 // ref.ID: must be an existing module ID or "vars" (if groupID is "deployment")
-// ref.Name: must match a module output name or deployment variable name
-// ref.ExplicitInterGroup: intergroup references must explicitly identify the
+// ref.name: must match a module output name or deployment variable name
+// ref.explicitInterGroup: intergroup references must explicitly identify the
 // target group ID and intragroup references cannot have an incorrect explicit
 // group ID
 func (ref *varReference) validate(bp Blueprint) error {
 	// simplest case to evaluate is a deployment variable's existence
-	if ref.ToGroupID == "deployment" {
-		if ref.ToModuleID == "vars" {
-			if _, ok := bp.Vars[ref.Name]; !ok {
+	if ref.toGroupID == "deployment" {
+		if ref.toModuleID == "vars" {
+			if _, ok := bp.Vars[ref.name]; !ok {
 				return fmt.Errorf("%s: %s is not a deployment variable",
-					errorMessages["varNotFound"], ref.Name)
+					errorMessages["varNotFound"], ref.name)
 			}
 			return nil
 		}
 		return fmt.Errorf("%s: %s", errorMessages["invalidDeploymentRef"], ref)
 	}
 
-	targetModuleGroupIndex, err := modToGrp(bp.DeploymentGroups, ref.ToModuleID)
+	targetModuleGroupIndex, err := modToGrp(bp.DeploymentGroups, ref.toModuleID)
 	if err != nil {
 		return err
 	}
 	targetModuleGroup := bp.DeploymentGroups[targetModuleGroupIndex]
 
-	callingModuleGroupIndex := slices.IndexFunc(bp.DeploymentGroups, func(d DeploymentGroup) bool { return d.Name == ref.FromGroupID })
+	callingModuleGroupIndex := slices.IndexFunc(bp.DeploymentGroups, func(d DeploymentGroup) bool { return d.Name == ref.fromGroupID })
 	if callingModuleGroupIndex == -1 {
-		return fmt.Errorf("%s: %s", errorMessages["groupNotFound"], ref.FromGroupID)
+		return fmt.Errorf("%s: %s", errorMessages["groupNotFound"], ref.fromGroupID)
 	}
 
 	// at this point, we know the target module exists. now record whether it
 	// is intergroup and whether it comes in a (disallowed) later group
 	isInterGroupReference := targetModuleGroupIndex != callingModuleGroupIndex
 	isRefToLaterGroup := targetModuleGroupIndex > callingModuleGroupIndex
-	isCorrectToGroup := ref.ToGroupID == targetModuleGroup.Name
+	isCorrectToGroup := ref.toGroupID == targetModuleGroup.Name
 
 	// intergroup references must be explicit about group and refer to an earlier group;
 	if isInterGroupReference {
 		if isRefToLaterGroup {
 			return fmt.Errorf("%s: %s is in the later group %s",
-				errorMessages["intergroupOrder"], ref.ToModuleID, ref.ToGroupID)
+				errorMessages["intergroupOrder"], ref.toModuleID, ref.toGroupID)
 		}
 
-		if !ref.Explicit {
+		if !ref.explicit {
 			return fmt.Errorf("%s: %s must specify the group ID %s before the module ID",
-				errorMessages["intergroupImplicit"], ref.ToModuleID, ref.ToGroupID)
+				errorMessages["intergroupImplicit"], ref.toModuleID, ref.toGroupID)
 		}
 	}
 
@@ -764,15 +764,15 @@ func (ref *varReference) validate(bp Blueprint) error {
 	// error after enforcing explicitness of intergroup references
 	if !isCorrectToGroup {
 		return fmt.Errorf("%s: %s.%s should be %s.%s",
-			errorMessages["referenceWrongGroup"], ref.ToGroupID, ref.ToModuleID, targetModuleGroup.Name, ref.ToModuleID)
+			errorMessages["referenceWrongGroup"], ref.toGroupID, ref.toModuleID, targetModuleGroup.Name, ref.toModuleID)
 	}
 
 	// at this point, we have a valid intragroup or intergroup references to a
 	// module. must now determine whether the output value actually exists in
 	// the module.
-	refModIndex := slices.IndexFunc(targetModuleGroup.Modules, func(m Module) bool { return m.ID == ref.ToModuleID })
+	refModIndex := slices.IndexFunc(targetModuleGroup.Modules, func(m Module) bool { return m.ID == ref.toModuleID })
 	if refModIndex == -1 {
-		log.Fatalf("Could not find module %s", ref.ToModuleID)
+		log.Fatalf("Could not find module %s", ref.toModuleID)
 	}
 	refMod := targetModuleGroup.Modules[refModIndex]
 	modInfo, err := modulereader.GetModuleInfo(refMod.Source, refMod.Kind)
@@ -781,10 +781,10 @@ func (ref *varReference) validate(bp Blueprint) error {
 			"failed to get info for module at %s while expanding variables: %e",
 			refMod.Source, err)
 	}
-	found := slices.ContainsFunc(modInfo.Outputs, func(o modulereader.VarInfo) bool { return o.Name == ref.Name })
+	found := slices.ContainsFunc(modInfo.Outputs, func(o modulereader.VarInfo) bool { return o.Name == ref.name })
 	if !found {
 		return fmt.Errorf("%s: module %s did not have output %s",
-			errorMessages["noOutput"], refMod.ID, ref.Name)
+			errorMessages["noOutput"], refMod.ID, ref.name)
 	}
 
 	return nil
@@ -813,37 +813,37 @@ func expandSimpleVariable(context varContext) (string, error) {
 	}
 
 	var expandedVariable string
-	switch varRef.ToGroupID {
+	switch varRef.toGroupID {
 	case "deployment":
 		// deployment variables
-		expandedVariable = fmt.Sprintf("((var.%s))", varRef.Name)
-	case varRef.FromGroupID:
+		expandedVariable = fmt.Sprintf("((var.%s))", varRef.name)
+	case varRef.fromGroupID:
 		// intragroup reference can make direct reference to module output
-		expandedVariable = fmt.Sprintf("((module.%s.%s))", varRef.ToModuleID, varRef.Name)
+		expandedVariable = fmt.Sprintf("((module.%s.%s))", varRef.toModuleID, varRef.name)
 	default:
 
 		// intergroup reference; begin by finding the target module in blueprint
 		toGrpIdx := slices.IndexFunc(
 			context.blueprint.DeploymentGroups,
-			func(g DeploymentGroup) bool { return g.Name == varRef.ToGroupID })
+			func(g DeploymentGroup) bool { return g.Name == varRef.toGroupID })
 
 		if toGrpIdx == -1 {
-			return "", fmt.Errorf("invalid group reference: %s", varRef.ToGroupID)
+			return "", fmt.Errorf("invalid group reference: %s", varRef.toGroupID)
 		}
 		toGrp := context.blueprint.DeploymentGroups[toGrpIdx]
-		toModIdx := slices.IndexFunc(toGrp.Modules, func(m Module) bool { return m.ID == varRef.ToModuleID })
+		toModIdx := slices.IndexFunc(toGrp.Modules, func(m Module) bool { return m.ID == varRef.toModuleID })
 		if toModIdx == -1 {
-			return "", fmt.Errorf("%s: %s", errorMessages["invalidMod"], varRef.ToModuleID)
+			return "", fmt.Errorf("%s: %s", errorMessages["invalidMod"], varRef.toModuleID)
 		}
 		toMod := toGrp.Modules[toModIdx]
 
 		// ensure that the target module outputs the value in the root module
 		// state and not just internally within its deployment group
-		if !slices.Contains(toMod.Outputs, varRef.Name) {
-			toMod.Outputs = append(toMod.Outputs, varRef.Name)
+		if !slices.Contains(toMod.Outputs, varRef.name) {
+			toMod.Outputs = append(toMod.Outputs, varRef.name)
 		}
 
-		// TODO: expandedVariable = fmt.Sprintf("((var.%s_%s))", ref.Name, ref.ID)
+		// TODO: expandedVariable = fmt.Sprintf("((var.%s_%s))", ref.name, ref.ID)
 		return "", fmt.Errorf("%s: %s is an intergroup reference",
 			errorMessages["varInAnotherGroup"], context.varString)
 	}

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -553,24 +553,24 @@ func (s *MySuite) TestIdentifyModuleByReference(c *C) {
 
 	ref, err = identifyModuleByReference("module_id", dg)
 	c.Assert(err, IsNil)
-	c.Assert(ref.ToGroupID, Equals, dg.Name)
-	c.Assert(ref.FromGroupID, Equals, dg.Name)
-	c.Assert(ref.ToModuleID, Equals, "module_id")
-	c.Assert(ref.Explicit, Equals, false)
+	c.Assert(ref.toGroupID, Equals, dg.Name)
+	c.Assert(ref.fromGroupID, Equals, dg.Name)
+	c.Assert(ref.toModuleID, Equals, "module_id")
+	c.Assert(ref.explicit, Equals, false)
 
 	ref, err = identifyModuleByReference("explicit_group_id.module_id", dg)
 	c.Assert(err, IsNil)
-	c.Assert(ref.ToGroupID, Equals, "explicit_group_id")
-	c.Assert(ref.FromGroupID, Equals, dg.Name)
-	c.Assert(ref.ToModuleID, Equals, "module_id")
-	c.Assert(ref.Explicit, Equals, true)
+	c.Assert(ref.toGroupID, Equals, "explicit_group_id")
+	c.Assert(ref.fromGroupID, Equals, dg.Name)
+	c.Assert(ref.toModuleID, Equals, "module_id")
+	c.Assert(ref.explicit, Equals, true)
 
 	ref, err = identifyModuleByReference(fmt.Sprintf("%s.module_id", dg.Name), dg)
 	c.Assert(err, IsNil)
-	c.Assert(ref.ToGroupID, Equals, dg.Name)
-	c.Assert(ref.FromGroupID, Equals, dg.Name)
-	c.Assert(ref.ToModuleID, Equals, "module_id")
-	c.Assert(ref.Explicit, Equals, true)
+	c.Assert(ref.toGroupID, Equals, dg.Name)
+	c.Assert(ref.fromGroupID, Equals, dg.Name)
+	c.Assert(ref.toModuleID, Equals, "module_id")
+	c.Assert(ref.explicit, Equals, true)
 
 	ref, err = identifyModuleByReference("explicit_group_id.module_id.output_name", dg)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("%s: .*", errorMessages["invalidMod"]))
@@ -611,71 +611,71 @@ func (s *MySuite) TestValidateModuleReference(c *C) {
 
 	// An intragroup reference from group 0 to module B in 0 (good)
 	ref0ToB0 := modReference{
-		ToModuleID:   dg[0].Modules[1].ID,
-		FromModuleID: "",
-		ToGroupID:    dg[0].Name,
-		FromGroupID:  dg[0].Name,
-		Explicit:     false,
+		toModuleID:   dg[0].Modules[1].ID,
+		fromModuleID: "",
+		toGroupID:    dg[0].Name,
+		fromGroupID:  dg[0].Name,
+		explicit:     false,
 	}
 	c.Assert(ref0ToB0.validate(bp), IsNil)
 
 	// An explicit intergroup reference from group 1 to module A in 0 (good)
 	xRef1ToA0 := modReference{
-		ToModuleID:   dg[0].Modules[0].ID,
-		FromModuleID: "",
-		ToGroupID:    dg[0].Name,
-		FromGroupID:  dg[1].Name,
-		Explicit:     true,
+		toModuleID:   dg[0].Modules[0].ID,
+		fromModuleID: "",
+		toGroupID:    dg[0].Name,
+		fromGroupID:  dg[1].Name,
+		explicit:     true,
 	}
 	c.Assert(xRef1ToA0.validate(bp), IsNil)
 
 	// An implicit intergroup reference from group 1 to module A in 0 (bad due to implicit)
 	iRef1ToA0 := modReference{
-		ToModuleID:   dg[0].Modules[0].ID,
-		FromModuleID: "",
-		ToGroupID:    dg[0].Name,
-		FromGroupID:  dg[1].Name,
-		Explicit:     false,
+		toModuleID:   dg[0].Modules[0].ID,
+		fromModuleID: "",
+		toGroupID:    dg[0].Name,
+		fromGroupID:  dg[1].Name,
+		explicit:     false,
 	}
 	c.Assert(iRef1ToA0.validate(bp), ErrorMatches, fmt.Sprintf("%s: .*", errorMessages["intergroupImplicit"]))
 
 	// An explicit intergroup reference from group 0 to module 1 in 1 (bad due to group ordering)
 	xRefA0To1 := modReference{
-		ToModuleID:   dg[1].Modules[0].ID,
-		FromModuleID: "",
-		ToGroupID:    dg[1].Name,
-		FromGroupID:  dg[0].Name,
-		Explicit:     true,
+		toModuleID:   dg[1].Modules[0].ID,
+		fromModuleID: "",
+		toGroupID:    dg[1].Name,
+		fromGroupID:  dg[0].Name,
+		explicit:     true,
 	}
 	c.Assert(xRefA0To1.validate(bp), ErrorMatches, fmt.Sprintf("%s: .*", errorMessages["intergroupOrder"]))
 
 	// An explicit intergroup reference from group 0 to B0 with a bad Group ID
 	badRef0ToB0 := modReference{
-		ToModuleID:   dg[0].Modules[1].ID,
-		FromModuleID: "",
-		ToGroupID:    dg[1].Name,
-		FromGroupID:  dg[0].Name,
-		Explicit:     true,
+		toModuleID:   dg[0].Modules[1].ID,
+		fromModuleID: "",
+		toGroupID:    dg[1].Name,
+		fromGroupID:  dg[0].Name,
+		explicit:     true,
 	}
 	c.Assert(badRef0ToB0.validate(bp), ErrorMatches, fmt.Sprintf("%s: .*", errorMessages["referenceWrongGroup"]))
 
 	// A target module that doesn't exist (bad)
 	badTargetMod := modReference{
-		ToModuleID:   "bad-module",
-		FromModuleID: "",
-		ToGroupID:    dg[0].Name,
-		FromGroupID:  dg[0].Name,
-		Explicit:     true,
+		toModuleID:   "bad-module",
+		fromModuleID: "",
+		toGroupID:    dg[0].Name,
+		fromGroupID:  dg[0].Name,
+		explicit:     true,
 	}
 	c.Assert(badTargetMod.validate(bp), ErrorMatches, "module bad-module was not found")
 
 	// A source group ID that doesn't exist (bad)
 	badSourceGroup := modReference{
-		ToModuleID:   dg[0].Modules[0].ID,
-		FromModuleID: "",
-		ToGroupID:    dg[0].Name,
-		FromGroupID:  "bad-group",
-		Explicit:     true,
+		toModuleID:   dg[0].Modules[0].ID,
+		fromModuleID: "",
+		toGroupID:    dg[0].Name,
+		fromGroupID:  "bad-group",
+		explicit:     true,
 	}
 	c.Assert(badSourceGroup.validate(bp), ErrorMatches, fmt.Sprintf("%s: .*", errorMessages["groupNotFound"]))
 }
@@ -690,27 +690,27 @@ func (s *MySuite) TestIdentifySimpleVariable(c *C) {
 
 	ref, err = identifySimpleVariable("group_id.module_id.output_name", dg)
 	c.Assert(err, IsNil)
-	c.Assert(ref.ToGroupID, Equals, "group_id")
-	c.Assert(ref.FromGroupID, Equals, dg.Name)
-	c.Assert(ref.ToModuleID, Equals, "module_id")
-	c.Assert(ref.Name, Equals, "output_name")
-	c.Assert(ref.Explicit, Equals, true)
+	c.Assert(ref.toGroupID, Equals, "group_id")
+	c.Assert(ref.fromGroupID, Equals, dg.Name)
+	c.Assert(ref.toModuleID, Equals, "module_id")
+	c.Assert(ref.name, Equals, "output_name")
+	c.Assert(ref.explicit, Equals, true)
 
 	ref, err = identifySimpleVariable("module_id.output_name", dg)
 	c.Assert(err, IsNil)
-	c.Assert(ref.ToGroupID, Equals, "calling_group_id")
-	c.Assert(ref.FromGroupID, Equals, "calling_group_id")
-	c.Assert(ref.ToModuleID, Equals, "module_id")
-	c.Assert(ref.Name, Equals, "output_name")
-	c.Assert(ref.Explicit, Equals, false)
+	c.Assert(ref.toGroupID, Equals, "calling_group_id")
+	c.Assert(ref.fromGroupID, Equals, "calling_group_id")
+	c.Assert(ref.toModuleID, Equals, "module_id")
+	c.Assert(ref.name, Equals, "output_name")
+	c.Assert(ref.explicit, Equals, false)
 
 	ref, err = identifySimpleVariable("vars.variable_name", dg)
 	c.Assert(err, IsNil)
-	c.Assert(ref.ToGroupID, Equals, "deployment")
-	c.Assert(ref.FromGroupID, Equals, dg.Name)
-	c.Assert(ref.ToModuleID, Equals, "vars")
-	c.Assert(ref.Name, Equals, "variable_name")
-	c.Assert(ref.Explicit, Equals, false)
+	c.Assert(ref.toGroupID, Equals, "deployment")
+	c.Assert(ref.fromGroupID, Equals, dg.Name)
+	c.Assert(ref.toModuleID, Equals, "vars")
+	c.Assert(ref.name, Equals, "variable_name")
+	c.Assert(ref.explicit, Equals, false)
 
 	ref, err = identifySimpleVariable("foo", dg)
 	c.Assert(err, NotNil)


### PR DESCRIPTION
- Re-implement `modReference` and `varReference` structs to implement a new interface named `reference`
- Adopt the `reference` interface in the `ModConnection` struct that tracks edges within the blueprint graph

These changes represent some design elements considered during implementation of references but weren't quite yet necessary to glue together.

Coverage in expand.go drops slightly due to the inclusion of new getter functions that seem too simple to merit unit testing. There appears to be no way to mark code as unreachable/not-meriting-testing for coverage percentages. This is area of active discussion in various Go channels.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?