### PR TITLE
Improve version constraint on batch-job-template module

### DIFF
--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -134,7 +134,7 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_instance_template"></a> [instance\_template](#module\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | > 7.6.0 |
+| <a name="module_instance_template"></a> [instance\_template](#module\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 8.0 |
 | <a name="module_netstorage_startup_script"></a> [netstorage\_startup\_script](#module\_netstorage\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | 64bc890 |
 
 ## Resources

--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -66,7 +66,7 @@ locals {
 
 module "instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "> 7.6.0"
+  version = "~> 8.0"
 
   name_prefix        = var.instance_template == null ? "${local.job_id}-instance-template" : "unused-template"
   project_id         = var.project_id


### PR DESCRIPTION
This PR does not alter the version of the module that would be installed today but prevents future breaking upgrades.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?