### PR TITLE
Resolve accidental destruction of startup-scripts

### DIFF
--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -88,7 +88,7 @@ resource "google_storage_bucket" "configs_bucket" {
 resource "google_storage_bucket_object" "scripts" {
   # this writes all scripts exactly once into GCS
   for_each = local.runners_map
-  name     = "${local.storage_folder_path_prefix}${each.key}-${try(md5(each.value.content), filemd5(each.value.source))}"
+  name     = "${local.storage_folder_path_prefix}${each.key}-${substr(try(md5(each.value.content), filemd5(each.value.source)), 0, 4)}"
   content  = each.value.content
   source   = each.value.source
   bucket   = local.storage_bucket_name

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -64,8 +64,7 @@ locals {
   stdlib = join("", local.stdlib_list)
 
   runners_map = { for runner in local.runners :
-    basename(runner["destination"])
-    => {
+    basename(runner["destination"]) => {
       content = lookup(runner, "content", null)
       source  = lookup(runner, "source", null)
     }
@@ -89,9 +88,9 @@ resource "google_storage_bucket" "configs_bucket" {
 resource "google_storage_bucket_object" "scripts" {
   # this writes all scripts exactly once into GCS
   for_each = local.runners_map
-  name     = "${local.storage_folder_path_prefix}${each.key}"
-  content  = each.value["content"]
-  source   = each.value["source"]
+  name     = "${local.storage_folder_path_prefix}${each.key}-${try(md5(each.value.content), filemd5(each.value.source))}"
+  content  = each.value.content
+  source   = each.value.source
   bucket   = local.storage_bucket_name
   timeouts {
     create = "10m"


### PR DESCRIPTION
When the startup-script module is used with VM instance templates that have create_before_destroy enabled (a common setting), a change to the script contents will result in the script being created, then destroyed. This commit resolves that by ensuring that all startup-script objects are created with unique, repeatable identifiers. This allows the new object to be created while destroying the old object with a different identifier.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?