### PR TITLE
Copy all embedded modules into deployment, use unique source for locals

### DIFF
--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -18,7 +18,9 @@
 package modulewriter
 
 import (
+	"crypto/md5"
 	"embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
@@ -89,22 +91,14 @@ func WriteDeployment(blueprint *config.Blueprint, outputDir string, overwriteFla
 	}
 
 	for _, grp := range blueprint.DeploymentGroups {
-
-		deploymentName, err := blueprint.DeploymentName()
-		if err != nil {
-			return err
-		}
-
-		deploymentPath := filepath.Join(outputDir, deploymentName)
 		writer, ok := kinds[grp.Kind]
 		if !ok {
 			return fmt.Errorf(
 				"Invalid kind in deployment group %s, got '%s'", grp.Name, grp.Kind)
 		}
 
-		if err := writer.writeDeploymentGroup(
-			grp, blueprint.Vars, deploymentPath,
-		); err != nil {
+		err := writer.writeDeploymentGroup(grp, blueprint.Vars, deploymentDir)
+		if err != nil {
 			return fmt.Errorf("error writing deployment group %s: %w", grp.Name, err)
 		}
 	}
@@ -133,38 +127,92 @@ func createGroupDirs(deploymentPath string, deploymentGroups *[]config.Deploymen
 	return nil
 }
 
-func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGroup) error {
+// Get module source within deployment group
+// Rules are following:
+//   - git source
+//     => keep the same source
+//   - packer
+//     => <mod.ID>
+//   - embedded (source starts with "modules" or "comunity/modules")
+//     => ./modules/embedded/<source>
+//   - other
+//     => ./modules/<basename(source)>-<hash(abs(source))>
+func deploymentSource(mod config.Module) (string, error) {
+	if sourcereader.IsGitPath(mod.Source) {
+		return mod.Source, nil
+	}
+	switch mod.Kind {
+	case "packer":
+		return mod.ID, nil
+	case "terraform": // see below
+	default:
+		return "", fmt.Errorf("unexpected module kind %#v", mod.Kind)
+	}
 
+	if sourcereader.IsEmbeddedPath(mod.Source) {
+		return "./modules/" + filepath.Join("embedded", mod.Source), nil
+	}
+	if !sourcereader.IsLocalPath(mod.Source) {
+		return "", fmt.Errorf("unuexpected module source %s", mod.Source)
+	}
+
+	abs, err := filepath.Abs(mod.Source)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path for %#v: %v", mod.Source, err)
+	}
+	base := filepath.Base(mod.Source)
+	return fmt.Sprintf("./modules/%s-%s", base, shortHash(abs)), nil
+}
+
+// Returns first 4 characters of md5 sum in hex form
+func shortHash(s string) string {
+	h := md5.Sum([]byte(s))
+	return hex.EncodeToString(h[:])[:4]
+}
+
+func copyEmbeddedModules(base string) error {
+	r := sourcereader.EmbeddedSourceReader{}
+	for _, src := range []string{"modules", "community/modules"} {
+		dst := filepath.Join(base, "modules/embedded", src)
+		if err := os.MkdirAll(dst, 0755); err != nil {
+			return err
+		}
+		if err := r.CopyDir(src, dst); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGroup) error {
 	for iGrp := range *deploymentGroups {
 		grp := &(*deploymentGroups)[iGrp]
 		basePath := filepath.Join(deploymentPath, grp.Name)
+		if err := copyEmbeddedModules(basePath); err != nil {
+			return fmt.Errorf("failed to copy embedded modules: %v", err)
+		}
+
 		for iMod := range grp.Modules {
 			mod := &grp.Modules[iMod]
+			ds, err := deploymentSource(*mod)
+			if err != nil {
+				return err
+			}
+			mod.DeploymentSource = ds
+
 			if sourcereader.IsGitPath(mod.Source) {
-				mod.DeploymentSource = mod.Source
-				continue
+				continue // do not download
 			}
-
 			/* Copy source files */
-			moduleName := filepath.Base(mod.Source)
-			var deplSource string
-			switch mod.Kind {
-			case "terraform":
-				deplSource = "./" + filepath.Join("modules", moduleName)
-			case "packer":
-				deplSource = mod.ID
-			}
-			mod.DeploymentSource = deplSource
-			fullPath := filepath.Join(basePath, deplSource)
-			if _, err := os.Stat(fullPath); err == nil {
+			dst := filepath.Join(basePath, mod.DeploymentSource)
+			if _, err := os.Stat(dst); err == nil {
 				continue
 			}
-
 			reader := sourcereader.Factory(mod.Source)
-			if err := reader.GetModule(mod.Source, fullPath); err != nil {
-				return fmt.Errorf("failed to get module from %s to %s: %v", mod.Source, fullPath, err)
+			if err := reader.GetModule(mod.Source, dst); err != nil {
+				return fmt.Errorf("failed to get module from %s to %s: %v", mod.Source, dst, err)
 			}
-
 			/* Create module level files */
 			writer := factory(mod.Kind)
 			writer.addNumModules(1)

--- a/pkg/sourcereader/embedded.go
+++ b/pkg/sourcereader/embedded.go
@@ -61,14 +61,14 @@ func copyDirFromModules(fs BaseFS, source string, dest string) error {
 		} else {
 			fileBytes, err := fs.ReadFile(entrySource)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to read embedded %#v: %v", entrySource, err)
 			}
 			copyFile, err := os.Create(entryDest)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create %#v: %v", entryDest, err)
 			}
 			if _, err = copyFile.Write(fileBytes); err != nil {
-				return err
+				return fmt.Errorf("failed to write %#v: %v", entryDest, err)
 			}
 		}
 	}
@@ -89,6 +89,9 @@ func copyFSToTempDir(fs BaseFS, modulePath string) (string, error) {
 
 // GetModule copies the embedded source to a provided destination (the deployment directory)
 func (r EmbeddedSourceReader) GetModule(modPath string, copyPath string) error {
+	if ModuleFS == nil {
+		return fmt.Errorf("embedded file system is not initialized")
+	}
 	if !IsEmbeddedPath(modPath) {
 		return fmt.Errorf("Source is not valid: %s", modPath)
 	}
@@ -102,4 +105,12 @@ func (r EmbeddedSourceReader) GetModule(modPath string, copyPath string) error {
 	}
 
 	return copyFromPath(modDir, copyPath)
+}
+
+// CopyDir copies embedded directory to destination path
+func (r EmbeddedSourceReader) CopyDir(src string, dst string) error {
+	if ModuleFS == nil {
+		return fmt.Errorf("embedded file system is not initialized")
+	}
+	return copyDirFromModules(ModuleFS, src, dst)
 }

--- a/pkg/sourcereader/embedded_test.go
+++ b/pkg/sourcereader/embedded_test.go
@@ -156,3 +156,15 @@ func (s *MySuite) TestGetModule_Embedded(c *C) {
 	expectedErr = "Source is not valid: .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 }
+
+func (s *MySuite) TestGetModule_NilFs(c *C) {
+	ModuleFS = nil
+	r := EmbeddedSourceReader{}
+	c.Assert(r.GetModule("here", "there"), ErrorMatches, "embedded file system is not initialized")
+}
+
+func (s *MySuite) TestCopyDir_NilFs(c *C) {
+	ModuleFS = nil
+	r := EmbeddedSourceReader{}
+	c.Assert(r.CopyDir("here", "there"), ErrorMatches, "embedded file system is not initialized")
+}


### PR DESCRIPTION
Modify logic of selecting deployment source. Rules are following:
* git source => keep the same source
* packer  => <mod.ID>
* embedded  => ./modules/embedded/<source>
* other => ./modules/<basename(source)>-<hash(abs(source))>

Copy all embedded modules into deployment folder

```
blueprint_name: lucky
vars: { deployment_name: mango }
deployment_groups:
- group: red
  modules:
  - {id: emb, source: modules/green}
  - {id: dev, source: ./modules/green}
  - {id: rel, source: ../../../../../../../tmp/green/}
  - {id: abs, source: /tmp/green}

$ terraform -chdir=mango/red init
Initializing modules...
- abs in modules/green-b6a4
- dev in modules/green-c71e
- emb in modules/embedded/modules/green
- rel in modules/green-b6a4

$ tree mango/red/ -d
mango/red/
└── modules
    ├── embedded
    │   ├── community
    │   │   └── modules
    │   │       ├── compute
    │   │       │   ├── htcondor-execute-point
    │   │       ...
    │   └── modules
    │       ├── compute
    │       │   └── vm-instance
    │       ├── green
    │       ...
    ├── green-b6a4
    └── green-c71e
```
### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
