### PR TITLE
Track graph edges from modules to deployment variables

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ import (
 const (
 	expectedVarFormat        string = "$(vars.var_name) or $(module_id.output_name)"
 	expectedModFormat        string = "$(module_id) or $(group_id.module_id)"
-	unexpectedConnectionKind string = "connectionKind must be useConnection"
+	unexpectedConnectionKind string = "connectionKind must be useConnection or deploymentConnection"
 )
 
 var errorMessages = map[string]string{
@@ -267,12 +267,12 @@ type connectionKind int
 const (
 	undefinedConnection connectionKind = iota
 	useConnection
+	deploymentConnection
 	// explicitConnection
-	// globalConnection
 )
 
 func (c connectionKind) IsValid() bool {
-	return c == useConnection
+	return c == useConnection || c == deploymentConnection
 }
 
 // ModConnection defines details about connections between modules. Currently,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -505,6 +505,10 @@ func (s *MySuite) TestModuleConnections(c *C) {
 	modID0 := dc.Config.DeploymentGroups[0].Modules[0].ID
 	modID1 := dc.Config.DeploymentGroups[1].Modules[0].ID
 
+	dc.addSettingsToModules()
+	dc.addMetadataToModules()
+	dc.addDefaultValidators()
+
 	err := dc.applyUseModules()
 	c.Assert(err, IsNil)
 	err = dc.applyGlobalVariables()
@@ -546,23 +550,6 @@ func (s *MySuite) TestModuleConnections(c *C) {
 			c.ref.IsIntergroup()
 	})
 	c.Assert(found, Equals, true)
-
-	// the method of applying $(vars.project_id) to required APIs and default
-	// validators creates 2 extra edges in the graph that are attributed to group
-	// 0 and module 0 (L962 and L980 of expand.go)
-	dc = getMultiGroupDeploymentConfig()
-	dc.addSettingsToModules()
-	dc.addMetadataToModules()
-	dc.addDefaultValidators()
-	err = dc.applyUseModules()
-	c.Assert(err, IsNil)
-	err = dc.applyGlobalVariables()
-	c.Assert(err, IsNil)
-	err = dc.expandVariables()
-	// TODO: this will become nil once intergroup references are enabled
-	c.Assert(err, NotNil)
-	connectionsMod0 = dc.moduleConnections[modID0]
-	c.Assert(len(connectionsMod0), Equals, 4)
 }
 
 func (s *MySuite) TestSetModulesInfo(c *C) {

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -441,7 +441,7 @@ func mergeInLabels[V interface{}](to map[string]V, from map[string]V) {
 	}
 }
 
-func (dc DeploymentConfig) applyGlobalVarsInGroup(groupIndex int) error {
+func (dc *DeploymentConfig) applyGlobalVarsInGroup(groupIndex int) error {
 	deploymentGroup := dc.Config.DeploymentGroups[groupIndex]
 	modInfo := dc.ModulesInfo[deploymentGroup.Name]
 	globalVars := dc.Config.Vars
@@ -513,7 +513,7 @@ type varContext struct {
 	varString  string
 	groupIndex int
 	modIndex   int
-	dc         DeploymentConfig
+	dc         *DeploymentConfig
 }
 
 type reference interface {
@@ -961,7 +961,7 @@ func updateVariables(context varContext, interfaceMap map[string]interface{}, tr
 // expands all variables
 func (dc *DeploymentConfig) expandVariables() error {
 	for _, validator := range dc.Config.Validators {
-		err := updateVariables(varContext{dc: *dc}, validator.Inputs, false)
+		err := updateVariables(varContext{dc: dc}, validator.Inputs, false)
 		if err != nil {
 			return err
 
@@ -973,7 +973,7 @@ func (dc *DeploymentConfig) expandVariables() error {
 			context := varContext{
 				groupIndex: iGrp,
 				modIndex:   iMod,
-				dc:         *dc,
+				dc:         dc,
 			}
 			err := updateVariables(context, mod.Settings, true)
 			if err != nil {

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -538,7 +538,7 @@ func (ref modReference) String() string {
 }
 
 func (ref modReference) IsIntergroup() bool {
-	return ref.toGroupID == ref.fromGroupID
+	return ref.toGroupID != ref.fromGroupID
 }
 
 func (ref modReference) FromModuleID() string {
@@ -610,7 +610,7 @@ func (ref varReference) String() string {
 }
 
 func (ref varReference) IsIntergroup() bool {
-	return ref.toGroupID == ref.fromGroupID
+	return ref.toGroupID != ref.fromGroupID
 }
 
 func (ref varReference) FromModuleID() string {

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -280,49 +280,49 @@ func (s *MySuite) TestUpdateVariableType(c *C) {
 	// empty
 	testSlice := []interface{}{}
 	ctx := varContext{}
-	ret, err := updateVariableType(testSlice, ctx)
+	ret, err := updateVariableType(testSlice, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testSlice, DeepEquals, ret)
 	// single string
 	testSlice = append(testSlice, "string")
-	ret, err = updateVariableType(testSlice, ctx)
+	ret, err = updateVariableType(testSlice, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testSlice, DeepEquals, ret)
 	// add list
 	testSlice = append(testSlice, []interface{}{})
-	ret, err = updateVariableType(testSlice, ctx)
+	ret, err = updateVariableType(testSlice, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testSlice, DeepEquals, ret)
 	// add map
 	testSlice = append(testSlice, make(map[string]interface{}))
-	ret, err = updateVariableType(testSlice, ctx)
+	ret, err = updateVariableType(testSlice, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testSlice, DeepEquals, ret)
 
 	// map, success
 	testMap := make(map[string]interface{})
-	ret, err = updateVariableType(testMap, ctx)
+	ret, err = updateVariableType(testMap, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testMap, DeepEquals, ret)
 	// add string
 	testMap["string"] = "string"
-	ret, err = updateVariableType(testMap, ctx)
+	ret, err = updateVariableType(testMap, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testMap, DeepEquals, ret)
 	// add map
 	testMap["map"] = make(map[string]interface{})
-	ret, err = updateVariableType(testMap, ctx)
+	ret, err = updateVariableType(testMap, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testMap, DeepEquals, ret)
 	// add slice
 	testMap["slice"] = []interface{}{}
-	ret, err = updateVariableType(testMap, ctx)
+	ret, err = updateVariableType(testMap, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testMap, DeepEquals, ret)
 
 	// string, success
 	testString := "string"
-	ret, err = updateVariableType(testString, ctx)
+	ret, err = updateVariableType(testString, ctx, false)
 	c.Assert(err, IsNil)
 	c.Assert(testString, DeepEquals, ret)
 }
@@ -790,26 +790,26 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 
 	// Invalid variable -> no .
 	testVarContext1.varString = "$(varsStringWithNoDot)"
-	_, err := expandSimpleVariable(testVarContext1)
+	_, err := expandSimpleVariable(testVarContext1, false)
 	expectedErr := fmt.Sprintf("%s.*", errorMessages["invalidVar"])
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Global variable: Invalid -> not found
 	testVarContext1.varString = "$(vars.doesntExists)"
-	_, err = expandSimpleVariable(testVarContext1)
+	_, err = expandSimpleVariable(testVarContext1, false)
 	expectedErr = fmt.Sprintf("%s: .*", errorMessages["varNotFound"])
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Global variable: Success
 	testVarContext1.dc.Config.Vars["globalExists"] = "existsValue"
 	testVarContext1.varString = "$(vars.globalExists)"
-	got, err := expandSimpleVariable(testVarContext1)
+	got, err := expandSimpleVariable(testVarContext1, false)
 	c.Assert(err, IsNil)
 	c.Assert(got, Equals, "((var.globalExists))")
 
 	// Module variable: Invalid -> Module not found
 	testVarContext1.varString = "$(bad_mod.someVar)"
-	_, err = expandSimpleVariable(testVarContext1)
+	_, err = expandSimpleVariable(testVarContext1, false)
 	c.Assert(err, ErrorMatches, "module bad_mod was not found")
 
 	// Module variable: Invalid -> Output not found
@@ -817,7 +817,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule1.Source, modulereader.ModuleInfo{})
 	fakeOutput := "doesntExist"
 	testVarContext1.varString = fmt.Sprintf("$(%s.%s)", testModule1.ID, fakeOutput)
-	_, err = expandSimpleVariable(testVarContext1)
+	_, err = expandSimpleVariable(testVarContext1, false)
 	expectedErr = fmt.Sprintf("%s: module %s did not have output %s",
 		errorMessages["noOutput"], testModule1.ID, fakeOutput)
 	c.Assert(err, ErrorMatches, expectedErr)
@@ -831,7 +831,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
 		"$(%s.%s)", testModule1.ID, existingOutput)
-	got, err = expandSimpleVariable(testVarContext1)
+	got, err = expandSimpleVariable(testVarContext1, false)
 	c.Assert(err, IsNil)
 	expectedErr = fmt.Sprintf("((module.%s.%s))", testModule1.ID, existingOutput)
 	c.Assert(got, Equals, expectedErr)
@@ -845,7 +845,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
 		"$(%s.%s.%s)", testBlueprint.DeploymentGroups[1].Name, testModule1.ID, existingOutput)
-	got, err = expandSimpleVariable(testVarContext1)
+	got, err = expandSimpleVariable(testVarContext1, false)
 	c.Assert(err, IsNil)
 	c.Assert(got, Equals, fmt.Sprintf("((module.%s.%s))", testModule1.ID, existingOutput))
 
@@ -859,7 +859,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
 		"$(%s.%s.%s)", testBlueprint.DeploymentGroups[0].Name, testModule1.ID, existingOutput)
-	_, err = expandSimpleVariable(testVarContext1)
+	_, err = expandSimpleVariable(testVarContext1, false)
 	c.Assert(err, NotNil)
 
 	expectedErr = fmt.Sprintf("%s: %s.%s should be %s.%s",
@@ -876,7 +876,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule0.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
 		"$(%s.%s)", testModule0.ID, existingOutput)
-	_, err = expandSimpleVariable(testVarContext1)
+	_, err = expandSimpleVariable(testVarContext1, false)
 	expectedErr = fmt.Sprintf("%s: %s .*",
 		errorMessages["intergroupImplicit"], testModule0.ID)
 	c.Assert(err, ErrorMatches, expectedErr)
@@ -884,14 +884,14 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	// Intergroup variable: failure because explicit group and module does not exist
 	testVarContext1.varString = fmt.Sprintf("$(%s.%s.%s)",
 		testBlueprint.DeploymentGroups[0].Name, "bad_module", "bad_output")
-	_, err = expandSimpleVariable(testVarContext1)
+	_, err = expandSimpleVariable(testVarContext1, false)
 	c.Assert(err, ErrorMatches, "module bad_module was not found")
 
 	// Intergroup variable: failure because explicit group and output does not exist
 	fakeOutput = "bad_output"
 	testVarContext1.varString = fmt.Sprintf("$(%s.%s.%s)",
 		testBlueprint.DeploymentGroups[0].Name, testModule0.ID, fakeOutput)
-	_, err = expandSimpleVariable(testVarContext1)
+	_, err = expandSimpleVariable(testVarContext1, false)
 	expectedErr = fmt.Sprintf("%s: module %s did not have output %s",
 		errorMessages["noOutput"], testModule0.ID, fakeOutput)
 	c.Assert(err, ErrorMatches, expectedErr)
@@ -904,7 +904,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext0.varString = fmt.Sprintf(
 		"$(%s.%s.%s)", testBlueprint.DeploymentGroups[1].Name, testModule1.ID, existingOutput)
-	_, err = expandSimpleVariable(testVarContext0)
+	_, err = expandSimpleVariable(testVarContext0, false)
 	expectedErr = fmt.Sprintf("%s: %s .*",
 		errorMessages["intergroupOrder"], testModule1.ID)
 	c.Assert(err, ErrorMatches, expectedErr)
@@ -918,7 +918,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	reader.SetInfo(testModule0.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
 		"$(%s.%s.%s)", testBlueprint.DeploymentGroups[0].Name, testModule0.ID, existingOutput)
-	_, err = expandSimpleVariable(testVarContext1)
+	_, err = expandSimpleVariable(testVarContext1, false)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("%s: %s .*", errorMessages["varInAnotherGroup"], regexp.QuoteMeta(testVarContext1.varString)))
 }
 
@@ -926,7 +926,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 // presently it returns only an error
 func (s *MySuite) TestExpandVariable(c *C) {
 	testVarContext0 := varContext{}
-	str, err := expandVariable(testVarContext0)
+	str, err := expandVariable(testVarContext0, false)
 	c.Assert(str, Equals, "")
 	c.Assert(err, NotNil)
 }

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -773,13 +773,17 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	}
 
 	testVarContext0 := varContext{
-		blueprint:  testBlueprint,
+		dc: DeploymentConfig{
+			Config: testBlueprint,
+		},
 		modIndex:   0,
 		groupIndex: 0,
 	}
 
 	testVarContext1 := varContext{
-		blueprint:  testBlueprint,
+		dc: DeploymentConfig{
+			Config: testBlueprint,
+		},
 		modIndex:   0,
 		groupIndex: 1,
 	}
@@ -797,7 +801,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Global variable: Success
-	testVarContext1.blueprint.Vars["globalExists"] = "existsValue"
+	testVarContext1.dc.Config.Vars["globalExists"] = "existsValue"
 	testVarContext1.varString = "$(vars.globalExists)"
 	got, err := expandSimpleVariable(testVarContext1)
 	c.Assert(err, IsNil)

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -773,7 +773,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	}
 
 	testVarContext0 := varContext{
-		dc: DeploymentConfig{
+		dc: &DeploymentConfig{
 			Config: testBlueprint,
 		},
 		modIndex:   0,
@@ -781,7 +781,7 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	}
 
 	testVarContext1 := varContext{
-		dc: DeploymentConfig{
+		dc: &DeploymentConfig{
 			Config: testBlueprint,
 		},
 		modIndex:   0,


### PR DESCRIPTION
This PR adds support for tracking connections from all modules to deployment variables. Future PRs will make use of this functionality to

- detect unused deployment variables
- write only input variables that are used by a given deployment group

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?