### PR TITLE
Unused deployment variables validator

### DIFF
--- a/docs/blueprint-validation.md
+++ b/docs/blueprint-validation.md
@@ -12,32 +12,8 @@ project(s):
 One can [explicitly define validators](#explicit-validators), however, the
 expectation is that the implicit behavior will be useful for most users. When
 implicit, a validator is added if all deployment variables matching its inputs
-is defined. Validators listed below that have no inputs are always enabled
-because they read the entire blueprint and do not require any specific
-deployment variable. If `project_id`, `region`, and `zone` are defined as
-deployment variables, then the following validators are enabled:
-
-```yaml
-validators:
-- validator: test_project_exists
-  inputs:
-    project_id: $(vars.project_id)
-- validator: test_apis_enabled
-  inputs: {}
-- validator: test_region_exists
-  inputs:
-    project_id: $(vars.project_id)
-    region: $(vars.region)
-- validator: test_zone_exists
-  inputs:
-    project_id: $(vars.project_id)
-    zone: $(vars.zone)
-- validator: test_zone_in_region
-  inputs:
-    project_id: $(vars.project_id)
-    zone: $(vars.zone)
-    region: $(vars.region)
-```
+are defined. Validators that have no inputs are always enabled by default
+because they do not require any specific deployment variable.
 
 Each validator is described below:
 
@@ -90,7 +66,35 @@ Each validator is described below:
 ### Explicit validators
 
 Validators can be overwritten and supplied with alternative input values,
-however they are limited to the set of functions defined above.
+however they are limited to the set of functions defined above. As an example,
+the default validators added when `project_id`, `region`, and `zone` are defined
+is:
+
+```yaml
+validators:
+  - validator: test_module_not_used
+    inputs: {}
+  - validator: test_deployment_variable_not_used
+    inputs: {}
+  - validator: test_project_exists
+    inputs:
+      project_id: $(vars.project_id)
+  - validator: test_apis_enabled
+    inputs: {}
+  - validator: test_region_exists
+    inputs:
+      project_id: $(vars.project_id)
+      region: $(vars.region)
+  - validator: test_zone_exists
+    inputs:
+      project_id: $(vars.project_id)
+      zone: $(vars.zone)
+  - validator: test_zone_in_region
+    inputs:
+      project_id: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+```
 
 ### Skipping or disabling validators
 

--- a/docs/blueprint-validation.md
+++ b/docs/blueprint-validation.md
@@ -12,10 +12,10 @@ project(s):
 One can [explicitly define validators](#explicit-validators), however, the
 expectation is that the implicit behavior will be useful for most users. When
 implicit, a validator is added if all deployment variables matching its inputs
-is defined. The `test_apis_enabled` validator is always enabled because it reads
-the entire blueprint and does not require any specific deployment variable. If
-`project_id`, `region`, and `zone` are defined as deployment variables, then the
-following validators are enabled:
+is defined. Validators listed below that have no inputs are always enabled
+because they read the entire blueprint and do not require any specific
+deployment variable. If `project_id`, `region`, and `zone` are defined as
+deployment variables, then the following validators are enabled:
 
 ```yaml
 validators:
@@ -76,7 +76,16 @@ Each validator is described below:
   * FAIL: if either region or zone do not exist or the zone is not within the
     region
   * Common failure: changing 1 value but not the other
-  * Manual test: `gcloud compute regions describe us-central1 --format="text(zones)" --project $(vars.project_id)
+  * Manual test: `gcloud compute regions describe us-central1 --format="text(zones)" --project $(vars.project_id)`
+* `test_module_not_used`
+  * Inputs: none; reads whole blueprint
+  * PASS: if all instances of use keyword pass matching variables
+  * FAIL: if any instances of use keyword do not pass matching variables
+* `test_deployment_variable_not_used`
+  * Inputs: none; reads whole blueprint
+  * PASS: if all deployment variables are automatically or explicitly used in
+    blueprint
+  * FAIL: if any deployment variable is unused in the blueprint
 
 ### Explicit validators
 

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -1012,6 +1012,10 @@ func (dc *DeploymentConfig) addDefaultValidators() error {
 		Validator: testModuleNotUsedName.String(),
 		Inputs:    map[string]interface{}{},
 	})
+	defaults = append(defaults, validatorConfig{
+		Validator: testDeploymentVariableNotUsedName.String(),
+		Inputs:    map[string]interface{}{},
+	})
 
 	// always add the project ID validator before subsequent validators that can
 	// only succeed if credentials can access the project. If the project ID

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -284,12 +284,13 @@ func (dc DeploymentConfig) validateModuleSettings() error {
 
 func (dc *DeploymentConfig) getValidators() map[string]func(validatorConfig) error {
 	allValidators := map[string]func(validatorConfig) error{
-		testApisEnabledName.String():   dc.testApisEnabled,
-		testProjectExistsName.String(): dc.testProjectExists,
-		testRegionExistsName.String():  dc.testRegionExists,
-		testZoneExistsName.String():    dc.testZoneExists,
-		testZoneInRegionName.String():  dc.testZoneInRegion,
-		testModuleNotUsedName.String(): dc.testModuleNotUsed,
+		testApisEnabledName.String():               dc.testApisEnabled,
+		testProjectExistsName.String():             dc.testProjectExists,
+		testRegionExistsName.String():              dc.testRegionExists,
+		testZoneExistsName.String():                dc.testZoneExists,
+		testZoneInRegionName.String():              dc.testZoneInRegion,
+		testModuleNotUsedName.String():             dc.testModuleNotUsed,
+		testDeploymentVariableNotUsedName.String(): dc.testDeploymentVariableNotUsed,
 	}
 	return allValidators
 }
@@ -471,6 +472,18 @@ func (dc *DeploymentConfig) testModuleNotUsed(c validatorConfig) error {
 	if err := validators.TestModuleNotUsed(dc.listUnusedModules()); err != nil {
 		log.Print(err)
 		return fmt.Errorf(funcErrorMsgTemplate, testModuleNotUsedName.String())
+	}
+	return nil
+}
+
+func (dc *DeploymentConfig) testDeploymentVariableNotUsed(c validatorConfig) error {
+	if err := c.check(testDeploymentVariableNotUsedName, []string{}); err != nil {
+		return err
+	}
+
+	if err := validators.TestDeploymentVariablesNotUsed(dc.listUnusedDeploymentVariables()); err != nil {
+		log.Print(err)
+		return fmt.Errorf(funcErrorMsgTemplate, testDeploymentVariableNotUsedName.String())
 	}
 	return nil
 }

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -183,17 +183,17 @@ func (s *MySuite) TestValidateOutputs(c *C) {
 func (s *MySuite) TestAddDefaultValidators(c *C) {
 	dc := getDeploymentConfigForTest()
 	dc.addDefaultValidators()
-	c.Assert(dc.Config.Validators, HasLen, 3)
+	c.Assert(dc.Config.Validators, HasLen, 4)
 
 	dc.Config.Validators = nil
 	dc.Config.Vars["region"] = "us-central1"
 	dc.addDefaultValidators()
-	c.Assert(dc.Config.Validators, HasLen, 4)
+	c.Assert(dc.Config.Validators, HasLen, 5)
 
 	dc.Config.Validators = nil
 	dc.Config.Vars["zone"] = "us-central1-c"
 	dc.addDefaultValidators()
-	c.Assert(dc.Config.Validators, HasLen, 6)
+	c.Assert(dc.Config.Validators, HasLen, 7)
 }
 
 // return the actual value of a global variable specified by the literal

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -54,13 +54,11 @@ func handleClientError(e error) error {
 // TestDeploymentVariablesNotUsed errors if there are any unused deployment
 // variables and prints any to the output for the user
 func TestDeploymentVariablesNotUsed(unusedVariables []string) error {
-	var foundUnused bool
 	for _, v := range unusedVariables {
-		foundUnused = true
 		log.Printf(unusedDeploymentVariableMsg, v)
 	}
 
-	if foundUnused {
+	if len(unusedVariables) > 0 {
 		return fmt.Errorf(unusedDeploymentVariableError)
 	}
 

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -39,6 +39,8 @@ const computeDisabledMsg = "the Compute Engine API must be enabled in project %s
 const serviceDisabledMsg = "the Service Usage API must be enabled in project %s to validate that all APIs needed by the blueprint are enabled"
 const unusedModuleMsg = "module %s uses module %s, but matching setting and outputs were not found. This may be because the value is set explicitly or set by a prior used module"
 const unusedModuleError = "One or more used modules could not have their settings and outputs linked."
+const unusedDeploymentVariableMsg = "the deployment variable \"%s\" was not used in this blueprint"
+const unusedDeploymentVariableError = "one or more deployment variables was not used by any modules"
 
 func handleClientError(e error) error {
 	if strings.Contains(e.Error(), "could not find default credentials") {
@@ -47,6 +49,22 @@ func handleClientError(e error) error {
 
 	}
 	return e
+}
+
+// TestDeploymentVariablesNotUsed errors if there are any unused deployment
+// variables and prints any to the output for the user
+func TestDeploymentVariablesNotUsed(unusedVariables []string) error {
+	var foundUnused bool
+	for _, v := range unusedVariables {
+		foundUnused = true
+		log.Printf(unusedDeploymentVariableMsg, v)
+	}
+
+	if foundUnused {
+		return fmt.Errorf(unusedDeploymentVariableError)
+	}
+
+	return nil
 }
 
 // TestModuleNotUsed validates that all modules referenced in the "use" field

--- a/tools/validate_configs/test_configs/apt-collision.yaml
+++ b/tools/validate_configs/test_configs/apt-collision.yaml
@@ -23,7 +23,6 @@ vars:
   zone: us-central1-a
   name_prefix: workstation
   machine_type: a2-highgpu-2g
-  gpu_per_vm: 2
   instance_image:
     family: pytorch-1-10-gpu-debian-10
     project: ml-images

--- a/tools/validate_configs/test_configs/complex-data.yaml
+++ b/tools/validate_configs/test_configs/complex-data.yaml
@@ -16,6 +16,11 @@
 
 blueprint_name: complex_data
 
+validators:
+- validator: test_deployment_variable_not_used
+  inputs: {}
+  skip: true
+
 vars:
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: test_complex-data

--- a/tools/validate_configs/test_configs/dashboards.yaml
+++ b/tools/validate_configs/test_configs/dashboards.yaml
@@ -19,8 +19,6 @@ blueprint_name: dashboards
 vars:
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: dashboards-test
-  region: europe-west4
-  zone: europe-west4-a
 
 deployment_groups:
 - group: primary

--- a/tools/validate_configs/test_configs/hpc-cluster-project.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-project.yaml
@@ -21,7 +21,6 @@ vars:
   deployment_name: hpc-slurm-project
   region: europe-west4
   zone: europe-west4-a
-  slurm_sa: slurm-sa
 
 terraform_backend_defaults:
   type: gcs

--- a/tools/validate_configs/test_configs/new_project.yaml
+++ b/tools/validate_configs/test_configs/new_project.yaml
@@ -17,6 +17,7 @@
 blueprint_name: new_project
 
 vars:
+  project_id: test_project
   deployment_name: new_project_deployment
 
 deployment_groups:
@@ -25,7 +26,6 @@ deployment_groups:
   - id: project
     source: ./community/modules/project/new-project
     settings:
-      project_id: test_project
       folder_id: 334688113020  # random number
-      billing_account: "111110-M2N704-854685"  # random billing number
+      billing_account: 111110-M2N704-854685  # random billing number
       org_id: 123456789  # random org id

--- a/tools/validate_configs/test_configs/pbs-unwrapped.yaml
+++ b/tools/validate_configs/test_configs/pbs-unwrapped.yaml
@@ -25,7 +25,6 @@ vars:
   execution_host_count: 10
   execution_hostname_prefix: pbs-execution
   pbs_client_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-client-2021.1.3.20220217134230-0.el7.x86_64.rpm
-  pbs_devel_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-devel-2021.1.3.20220217134230-0.el7.x86_64.rpm
   pbs_execution_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-execution-2021.1.3.20220217134230-0.el7.x86_64.rpm
   pbs_server_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-server-2021.1.3.20220217134230-0.el7.x86_64.rpm
 


### PR DESCRIPTION
Add new validator `test_deployment_variable_not_used` which ensures that all deployment variables (`vars` block in blueprint) are used automatically or explicitly in blueprint settings. Ignore `deployment_name` as it is required by `ghpc` and also ignore `labels` as it is automatically generated and applied.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?\