### PR TITLE
Test infra automation. Init commit

### DIFF
--- a/tools/cloud-build/README.md
+++ b/tools/cloud-build/README.md
@@ -16,3 +16,4 @@
   pre-commits on all files.
 * `project-cleanup.yaml`: Cloud build config that performs a regular cleanup of
   resources in the test project.
+* `provision`: Terraform module that sets up CloudBuild triggers and schedule.

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -1,0 +1,46 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.58.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 4.58.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.58.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_daily_project_cleanup_schedule"></a> [daily\_project\_cleanup\_schedule](#module\_daily\_project\_cleanup\_schedule) | ./trigger-schedule | n/a |
+| <a name="module_weekly_build_dependency_check_schedule"></a> [weekly\_build\_dependency\_check\_schedule](#module\_weekly\_build\_dependency\_check\_schedule) | ./trigger-schedule | n/a |
+| <a name="module_weekly_builder_image_schedule"></a> [weekly\_builder\_image\_schedule](#module\_weekly\_builder\_image\_schedule) | ./trigger-schedule | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_cloudbuild_trigger.daily_project_cleanup](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.weekly_build_dependency_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.weekly_builder_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.zebug_fast_build_failure](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.zebug_fast_build_success](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | `"hpc-toolkit-dev"` | no |
+| <a name="input_region"></a> [region](#input\_region) | GCP region | `string` | `"us-central1"` | no |
+| <a name="input_repo_uri"></a> [repo\_uri](#input\_repo\_uri) | URI of GitHub repo | `string` | `"https://github.com/GoogleCloudPlatform/hpc-toolkit"` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | GCP zone | `string` | `"us-central1-c"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -1,3 +1,5 @@
+`provision` module creates CloudBuilds triggers and schedules.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -35,7 +37,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | `"hpc-toolkit-dev"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | GCP region | `string` | `"us-central1"` | no |
 | <a name="input_repo_uri"></a> [repo\_uri](#input\_repo\_uri) | URI of GitHub repo | `string` | `"https://github.com/GoogleCloudPlatform/hpc-toolkit"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | GCP zone | `string` | `"us-central1-c"` | no |

--- a/tools/cloud-build/provision/daily-cleanup.tf
+++ b/tools/cloud-build/provision/daily-cleanup.tf
@@ -1,0 +1,38 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloudbuild_trigger" "daily_project_cleanup" {
+  name        = "DAILY-project-cleanup"
+  description = "A cleanup script to run periodically"
+  tags        = [local.notify_chat_tag]
+
+  git_file_source {
+    path      = "tools/cloud-build/project-cleanup.yaml"
+    revision  = local.ref_develop
+    uri       = var.repo_uri
+    repo_type = "GITHUB"
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.ref_develop
+    repo_type = "GITHUB"
+  }
+}
+
+module "daily_project_cleanup_schedule" {
+  source   = "./trigger-schedule"
+  trigger  = google_cloudbuild_trigger.daily_project_cleanup
+  schedule = "0 0 * * MON-FRI"
+}

--- a/tools/cloud-build/provision/main.tf
+++ b/tools/cloud-build/provision/main.tf
@@ -1,0 +1,26 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  backend "gcs" {
+    bucket = "hpc-toolkit-dev-automation"
+    prefix = "dev-infra-tf/state"
+  }
+}
+
+locals {
+  ref_main        = "refs/heads/main"
+  ref_develop     = "refs/heads/develop"
+  notify_chat_tag = "notify_chat_on_failure"
+}

--- a/tools/cloud-build/provision/main.tf
+++ b/tools/cloud-build/provision/main.tf
@@ -14,7 +14,6 @@
 
 terraform {
   backend "gcs" {
-    bucket = "hpc-toolkit-dev-automation"
     prefix = "dev-infra-tf/state"
   }
 }

--- a/tools/cloud-build/provision/providers.tf
+++ b/tools/cloud-build/provision/providers.tf
@@ -1,0 +1,27 @@
+/**
+  * Copyright 2023 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+provider "google" {
+  project = var.project_id
+  zone    = var.zone
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  zone    = var.zone
+  region  = var.region
+}

--- a/tools/cloud-build/provision/trigger-schedule/README.md
+++ b/tools/cloud-build/provision/trigger-schedule/README.md
@@ -1,3 +1,5 @@
+`trigger-schedule` is a helper module to schedule CloudBuild triggers, mimics default behaviour of CloudBuild UI schedule wizzard.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 

--- a/tools/cloud-build/provision/trigger-schedule/README.md
+++ b/tools/cloud-build/provision/trigger-schedule/README.md
@@ -1,0 +1,35 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.58.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.58.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_cloud_scheduler_job.schedule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_schedule"></a> [schedule](#input\_schedule) | Describes the schedule on which the job will be executed. | `string` | n/a | yes |
+| <a name="input_trigger"></a> [trigger](#input\_trigger) | View of google\_cloudbuild\_trigger resource | <pre>object({<br>    name    = string<br>    id      = string<br>    project = string<br>  })</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/tools/cloud-build/provision/trigger-schedule/main.tf
+++ b/tools/cloud-build/provision/trigger-schedule/main.tf
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloud_scheduler_job" "schedule" {
+  name      = "${var.trigger.name}-schedule"
+  schedule  = var.schedule
+  time_zone = "America/Los_Angeles"
+
+  attempt_deadline = "180s"
+  retry_config {
+    max_backoff_duration = "3600s"
+    max_doublings        = 5
+    max_retry_duration   = "0s"
+    min_backoff_duration = "5s"
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://cloudbuild.googleapis.com/v1/${var.trigger.id}:run"
+    headers     = { "User-Agent" = "Google-Cloud-Scheduler" }
+    oauth_token {
+      service_account_email = "cloud-build-trigger-scheduler@${var.trigger.project}.iam.gserviceaccount.com"
+    }
+  }
+}

--- a/tools/cloud-build/provision/trigger-schedule/variables.tf
+++ b/tools/cloud-build/provision/trigger-schedule/variables.tf
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "trigger" {
+  description = "View of google_cloudbuild_trigger resource"
+  type = object({
+    name    = string
+    id      = string
+    project = string
+  })
+}
+
+variable "schedule" {
+  description = "Describes the schedule on which the job will be executed."
+  type        = string
+}

--- a/tools/cloud-build/provision/trigger-schedule/versions.tf
+++ b/tools/cloud-build/provision/trigger-schedule/versions.tf
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.58.0"
+    }
+  }
+}

--- a/tools/cloud-build/provision/variables.tf
+++ b/tools/cloud-build/provision/variables.tf
@@ -17,7 +17,6 @@
 variable "project_id" {
   description = "GCP project ID"
   type        = string
-  default     = "hpc-toolkit-dev"
 }
 
 variable "region" {

--- a/tools/cloud-build/provision/variables.tf
+++ b/tools/cloud-build/provision/variables.tf
@@ -1,0 +1,39 @@
+/**
+  * Copyright 2023 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+  default     = "hpc-toolkit-dev"
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP zone"
+  type        = string
+  default     = "us-central1-c"
+}
+
+variable "repo_uri" {
+  description = "URI of GitHub repo"
+  type        = string
+  default     = "https://github.com/GoogleCloudPlatform/hpc-toolkit"
+}

--- a/tools/cloud-build/provision/versions.tf
+++ b/tools/cloud-build/provision/versions.tf
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.58.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.58.0"
+    }
+  }
+}

--- a/tools/cloud-build/provision/weekly.tf
+++ b/tools/cloud-build/provision/weekly.tf
@@ -1,0 +1,64 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloudbuild_trigger" "weekly_build_dependency_check" {
+  name        = "WEEKLY-build-dependency-check"
+  description = "A set of tests to make sure no extra dependencies creep in"
+  tags        = [local.notify_chat_tag]
+
+  git_file_source {
+    path      = "tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml"
+    revision  = local.ref_develop
+    uri       = var.repo_uri
+    repo_type = "GITHUB"
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.ref_develop
+    repo_type = "GITHUB"
+  }
+}
+
+module "weekly_build_dependency_check_schedule" {
+  source   = "./trigger-schedule"
+  trigger  = google_cloudbuild_trigger.weekly_build_dependency_check
+  schedule = "0 7 * * 1"
+}
+
+
+resource "google_cloudbuild_trigger" "weekly_builder_image" {
+  name        = "WEEKLY-builder-image"
+  description = "Builds a container tailored to build and test ghpc"
+  tags        = [local.notify_chat_tag]
+
+  git_file_source {
+    path      = "tools/cloud-build/hpc-toolkit-builder.yaml"
+    revision  = local.ref_develop
+    uri       = var.repo_uri
+    repo_type = "GITHUB"
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.ref_develop
+    repo_type = "GITHUB"
+  }
+}
+
+module "weekly_builder_image_schedule" {
+  source   = "./trigger-schedule"
+  trigger  = google_cloudbuild_trigger.weekly_builder_image
+  schedule = "0 8 * * 1"
+}

--- a/tools/cloud-build/provision/weekly_build_dependency_check.tf
+++ b/tools/cloud-build/provision/weekly_build_dependency_check.tf
@@ -1,0 +1,38 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloudbuild_trigger" "weekly_build_dependency_check" {
+  name        = "WEEKLY-build-dependency-check"
+  description = "A set of tests to make sure no extra dependencies creep in"
+  tags        = [local.notify_chat_tag]
+
+  git_file_source {
+    path      = "tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml"
+    revision  = local.ref_develop
+    uri       = var.repo_uri
+    repo_type = "GITHUB"
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.ref_develop
+    repo_type = "GITHUB"
+  }
+}
+
+module "weekly_build_dependency_check_schedule" {
+  source   = "./trigger-schedule"
+  trigger  = google_cloudbuild_trigger.weekly_build_dependency_check
+  schedule = "0 7 * * MON"
+}

--- a/tools/cloud-build/provision/weekly_builder_image.tf
+++ b/tools/cloud-build/provision/weekly_builder_image.tf
@@ -12,32 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_cloudbuild_trigger" "weekly_build_dependency_check" {
-  name        = "WEEKLY-build-dependency-check"
-  description = "A set of tests to make sure no extra dependencies creep in"
-  tags        = [local.notify_chat_tag]
-
-  git_file_source {
-    path      = "tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml"
-    revision  = local.ref_develop
-    uri       = var.repo_uri
-    repo_type = "GITHUB"
-  }
-
-  source_to_build {
-    uri       = var.repo_uri
-    ref       = local.ref_develop
-    repo_type = "GITHUB"
-  }
-}
-
-module "weekly_build_dependency_check_schedule" {
-  source   = "./trigger-schedule"
-  trigger  = google_cloudbuild_trigger.weekly_build_dependency_check
-  schedule = "0 7 * * 1"
-}
-
-
 resource "google_cloudbuild_trigger" "weekly_builder_image" {
   name        = "WEEKLY-builder-image"
   description = "Builds a container tailored to build and test ghpc"
@@ -60,5 +34,5 @@ resource "google_cloudbuild_trigger" "weekly_builder_image" {
 module "weekly_builder_image_schedule" {
   source   = "./trigger-schedule"
   trigger  = google_cloudbuild_trigger.weekly_builder_image
-  schedule = "0 8 * * 1"
+  schedule = "0 8 * * MON"
 }

--- a/tools/cloud-build/provision/zebug.tf
+++ b/tools/cloud-build/provision/zebug.tf
@@ -1,0 +1,49 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloudbuild_trigger" "zebug_fast_build_failure" {
+  name        = "ZEBUG-fast-build-failure"
+  description = "A build that always fails fast"
+
+  build {
+    step {
+      name = "busybox"
+      args = ["false"]
+    }
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.ref_main
+    repo_type = "GITHUB"
+  }
+}
+
+resource "google_cloudbuild_trigger" "zebug_fast_build_success" {
+  name        = "ZEBUG-fast-build-success"
+  description = "A build that always succeeds fast"
+
+  build {
+    step {
+      name = "busybox"
+      args = ["true"]
+    }
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.ref_main
+    repo_type = "GITHUB"
+  }
+}


### PR DESCRIPTION
Add terraform module `tools/cloud-build/provision` to manage all test infrastructure. In this PR define following triggers and schedule them:
* `DAILY-project-cleanup`
* `WEEKLY-build-dependency-check`
* `WEEKLY-builder-image`
* `ZEBUG-fast-build-failure`
* `ZEBUG-fast-build-success`

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
