### PR TITLE
Track explicit connections between modules

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -263,19 +263,26 @@ type Blueprint struct {
 	TerraformBackendDefaults TerraformBackend  `yaml:"terraform_backend_defaults"`
 }
 
-// connectionKind defines the kind of module connection, defined by the source
-// of the connection. Currently, only Use is supported.
+// connectionKind defines tracks graph edges between modules and from modules to
+// deployment variables:
+//
+// use: created via module-module use keyword
+// deployment: created by a module setting equal to $(vars.name)
+// explicit: created by a module setting equal to $(mod_id.output)
+//
+// no attempt is made to track edges made via Toolkit literal strings presently
+// required when wanting to index a list or map "((mod_id.output[0]))"
 type connectionKind int
 
 const (
 	undefinedConnection connectionKind = iota
 	useConnection
 	deploymentConnection
-	// explicitConnection
+	explicitConnection
 )
 
 func (c connectionKind) IsValid() bool {
-	return c == useConnection || c == deploymentConnection
+	return c == useConnection || c == deploymentConnection || c == explicitConnection
 }
 
 // ModConnection defines details about connections between modules. Currently,

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -832,6 +832,9 @@ func expandSimpleVariable(context varContext, trackModuleGraph bool) (string, er
 		if trackModuleGraph {
 			var found bool
 			for _, conn := range context.dc.moduleConnections[varRef.fromModuleID] {
+				if conn.kind != useConnection {
+					continue
+				}
 				if slices.Contains(conn.sharedVariables, varRef.name) {
 					found = true
 					break

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -829,6 +829,18 @@ func expandSimpleVariable(context varContext, trackModuleGraph bool) (string, er
 	case varRef.fromGroupID:
 		// intragroup reference can make direct reference to module output
 		expandedVariable = fmt.Sprintf("((module.%s.%s))", varRef.toModuleID, varRef.name)
+		if trackModuleGraph {
+			var found bool
+			for _, conn := range context.dc.moduleConnections[varRef.fromModuleID] {
+				if slices.Contains(conn.sharedVariables, varRef.name) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				context.dc.addModuleConnection(varRef, explicitConnection, []string{varRef.name})
+			}
+		}
 	default:
 
 		// intergroup reference; begin by finding the target module in blueprint


### PR DESCRIPTION
- track "explicit" module references made when a module setting is set to `$(module_id.output_name)`
- alter a unit test to cover behavior of `use` when the existing setting is set via deployment variables or explicitly

An alternative implementation could be considered in which the `useModule` function directly sets module settings into Toolkit-internal module format. e.g. `((module_id.output_name))`. This would avoid a brute force search through the graph, however, it would presently require the conversion from user syntax "`$(module_id.output_name)`" to internal format to occur in 2 different sections of the code. I believe it is safer to focus this conversion on a section of code that has access to the `reference` implementation. When references across groups are implemented I anticipate a function similar to:

```
type reference interface {
    HCLstring()
}
```

which will encapsulate a lot of the `fmt.Sprintf()` strewn about this section of code.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?