### PR TITLE
Simplify and relax type constraints for variables.tf

### DIFF
--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -399,22 +399,23 @@ func (s *MySuite) TestGetTypeTokens(c *C) {
 	// Success object
 	tok = getTypeTokens(cty.ObjectVal(map[string]cty.Value{}))
 	c.Assert(len(tok), Equals, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("map")))
+	c.Assert(string(tok[0].Bytes), Equals, string([]byte("any")))
 
 	val := cty.ObjectVal(map[string]cty.Value{"Lorum": cty.StringVal("Ipsum")})
 	tok = getTypeTokens(val)
 	c.Assert(len(tok), Equals, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("map")))
+	c.Assert(string(tok[0].Bytes), Equals, string([]byte("any")))
 
 	// Success Map
 	val = cty.MapVal(map[string]cty.Value{"Lorum": cty.StringVal("Ipsum")})
 	tok = getTypeTokens(val)
 	c.Assert(len(tok), Equals, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("map")))
+	c.Assert(string(tok[0].Bytes), Equals, string([]byte("any")))
 
-	// Failure
+	// Success any
 	tok = getTypeTokens(cty.NullVal(cty.DynamicPseudoType))
 	c.Assert(len(tok), Equals, 1)
+	c.Assert(string(tok[0].Bytes), Equals, string([]byte("any")))
 
 }
 


### PR DESCRIPTION
Primitive cty.Type => corresonding HCL type;
List, Set, and Tuple cty.Type => `list` (!sic, not `list(any)`)
else => `any`.
Motivation: We set constraint to `map` even though provided value can not be casted as a map, failing deployment.

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
