### PR TITLE
Adds a gke-cluster module to community

### DIFF
--- a/community/examples/gke.yaml
+++ b/community/examples/gke.yaml
@@ -1,0 +1,41 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: small-gke
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: cluster-01
+  region: us-central1
+  zone: us-central1-c
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network1
+    source: modules/network/vpc
+    settings:
+      subnetwork_name: gke-subnet
+      secondary_ranges:
+        gke-subnet:
+        - range_name: pods
+          ip_cidr_range: 10.4.0.0/14
+        - range_name: services
+          ip_cidr_range: 10.0.32.0/20
+
+  - id: gke_cluster
+    source: community/modules/scheduler/gke-cluster
+    use: [network1]

--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -1,0 +1,84 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.51.0, < 5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.51.0, < 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.51.0, < 5.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.51.0, < 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
+| [google-beta_google_container_node_pool.system_node_pools](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
+| [google_project_iam_member.node_service_account_artifact_registry](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_log_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_metric_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_resource_metadata_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_compute_default_service_account.default_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_authenticator_security_group"></a> [authenticator\_security\_group](#input\_authenticator\_security\_group) | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment. Used in the GKE cluster name by default and can be configured with `prefix_with_deployment_name`. | `string` | n/a | yes |
+| <a name="input_enable_dataplane_v2"></a> [enable\_dataplane\_v2](#input\_enable\_dataplane\_v2) | Enables [Dataplane v2](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2). This setting is immutable on clusters. | `bool` | `false` | no |
+| <a name="input_enable_istio"></a> [enable\_istio](#input\_enable\_istio) | (Beta) Enable Istio addon | `bool` | `true` | no |
+| <a name="input_enable_master_global_access"></a> [enable\_master\_global\_access](#input\_enable\_master\_global\_access) | Whether the cluster master is accessible globally (from any region) or only within the same region as the private endpoint. | `bool` | `false` | no |
+| <a name="input_enable_private_endpoint"></a> [enable\_private\_endpoint](#input\_enable\_private\_endpoint) | (Beta) Whether the master's internal IP address is used as the cluster endpoint. | `bool` | `true` | no |
+| <a name="input_enable_private_ipv6_google_access"></a> [enable\_private\_ipv6\_google\_access](#input\_enable\_private\_ipv6\_google\_access) | The private IPv6 google access type for the VMs in this subnet. | `bool` | `true` | no |
+| <a name="input_enable_private_nodes"></a> [enable\_private\_nodes](#input\_enable\_private\_nodes) | (Beta) Whether nodes have internal IP addresses only. | `bool` | `true` | no |
+| <a name="input_istio_auth"></a> [istio\_auth](#input\_istio\_auth) | (Beta) The authentication type between services in Istio. | `string` | `"AUTH_MUTUAL_TLS"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | GCE resource labels to be applied to resources. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_maintenance_exclusions"></a> [maintenance\_exclusions](#input\_maintenance\_exclusions) | List of maintenance exclusions. A cluster can have up to three. | <pre>list(object({<br>    name            = string<br>    start_time      = string<br>    end_time        = string<br>    exclusion_scope = string<br>  }))</pre> | `[]` | no |
+| <a name="input_maintenance_start_time"></a> [maintenance\_start\_time](#input\_maintenance\_start\_time) | Start time for daily maintenance operations. Specified in GMT with `HH:MM` format. | `string` | `"09:00"` | no |
+| <a name="input_master_ipv4_cidr_block"></a> [master\_ipv4\_cidr\_block](#input\_master\_ipv4\_cidr\_block) | (Beta) The IP range in CIDR notation to use for the hosted master network. | `string` | `"172.16.0.32/28"` | no |
+| <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Custom cluster name postpended to the `deployment_name`. See `prefix_with_deployment_name`. | `string` | `""` | no |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to host the cluster given in the format: `projects/<project_id>/global/networks/<network_name>`. | `string` | n/a | yes |
+| <a name="input_pods_ip_range_name"></a> [pods\_ip\_range\_name](#input\_pods\_ip\_range\_name) | The name of the secondary subnet ip range to use for pods. | `string` | `"pods"` | no |
+| <a name="input_prefix_with_deployment_name"></a> [prefix\_with\_deployment\_name](#input\_prefix\_with\_deployment\_name) | If true, cluster name will be prefixed by `deployment_name` (ex: <deployment\_name>-<name\_suffix>). | `bool` | `true` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to host the cluster in. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region to host the cluster in. | `string` | n/a | yes |
+| <a name="input_release_channel"></a> [release\_channel](#input\_release\_channel) | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. | `string` | `"REGULAR"` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to use with the system node pool | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
+| <a name="input_services_ip_range_name"></a> [services\_ip\_range\_name](#input\_services\_ip\_range\_name) | The name of the secondary subnet range to use for services. | `string` | `"services"` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork to host the cluster in. | `string` | n/a | yes |
+| <a name="input_system_node_pool_machine_type"></a> [system\_node\_pool\_machine\_type](#input\_system\_node\_pool\_machine\_type) | Machine type for the system node pool. | `string` | `"e2-standard-4"` | no |
+| <a name="input_system_node_pool_name"></a> [system\_node\_pool\_name](#input\_system\_node\_pool\_name) | Name of the system node pool. | `string` | `"system"` | no |
+| <a name="input_system_node_pool_node_count"></a> [system\_node\_pool\_node\_count](#input\_system\_node\_pool\_node\_count) | The total min and max nodes to be maintained in the system node pool. | <pre>object({<br>    total_min_nodes = number<br>    total_max_nodes = number<br>  })</pre> | <pre>{<br>  "total_max_nodes": 2,<br>  "total_min_nodes": 1<br>}</pre> | no |
+| <a name="input_system_node_pool_taints"></a> [system\_node\_pool\_taints](#input\_system\_node\_pool\_taints) | Taints to be applied to the system node pool. | <pre>list(object({<br>    key    = string<br>    value  = bool<br>    effect = string<br>  }))</pre> | <pre>[<br>  {<br>    "effect": "NO_SCHEDULE",<br>    "key": "components.gke.io/gke-managed-components",<br>    "value": true<br>  }<br>]</pre> | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/gke-cluster/main.tf
+++ b/community/modules/scheduler/gke-cluster/main.tf
@@ -1,0 +1,261 @@
+/**
+  * Copyright 2022 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+locals {
+  dash             = var.prefix_with_deployment_name && var.name_suffix != "" ? "-" : ""
+  prefix           = var.prefix_with_deployment_name ? var.deployment_name : ""
+  name_maybe_empty = "${local.prefix}${local.dash}${var.name_suffix}"
+  name             = local.name_maybe_empty != "" ? local.name_maybe_empty : "NO-NAME-GIVEN"
+
+  cluster_authenticator_security_group = var.authenticator_security_group == null ? [] : [{
+    security_group = var.authenticator_security_group
+  }]
+
+  sa_email = var.service_account.email != null ? var.service_account.email : data.google_compute_default_service_account.default_sa.email
+}
+
+data "google_compute_default_service_account" "default_sa" {
+  project = var.project_id
+}
+
+resource "google_container_cluster" "gke_cluster" {
+  provider = google-beta
+
+  project         = var.project_id
+  name            = local.name
+  location        = var.region
+  resource_labels = var.labels
+
+  # decouple node pool lifecyle from cluster life cycle
+  remove_default_node_pool = true
+  initial_node_count       = 1 # must be set when remove_default_node_pool is set
+
+  network    = var.network_id
+  subnetwork = var.subnetwork_self_link
+
+  # Note: the existence of the "master_authorized_networks_config" block enables
+  # the master authorized networks even if it's empty.
+  master_authorized_networks_config {
+  }
+
+  private_ipv6_google_access = var.enable_private_ipv6_google_access ? "PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE" : null
+
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  pod_security_policy_config {
+    enabled = true
+  }
+
+  enable_shielded_nodes = true
+
+  cluster_autoscaling { # Auto provisioning of node-pools
+    enabled = false
+    # Recomended profile if we ever turn on
+    # autoscaling_profile = "OPTIMIZE_UTILIZATION"
+  }
+
+  datapath_provider = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : "LEGACY_DATAPATH"
+
+  network_policy {
+    # Enabling NetworkPolicy for clusters with DatapathProvider=ADVANCED_DATAPATH
+    # is not allowed. Dataplane V2 will take care of network policy enforcement
+    # instead.
+    enabled = false
+    # GKE Dataplane V2 support. This must be set to PROVIDER_UNSPECIFIED in
+    # order to let the datapath_provider take effect.
+    # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/656#issuecomment-720398658
+    provider = "PROVIDER_UNSPECIFIED"
+  }
+
+  private_cluster_config {
+    enable_private_nodes    = var.enable_private_nodes
+    enable_private_endpoint = var.enable_private_endpoint
+    master_ipv4_cidr_block  = var.master_ipv4_cidr_block
+    master_global_access_config {
+      enabled = var.enable_master_global_access
+    }
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = var.pods_ip_range_name
+    services_secondary_range_name = var.services_ip_range_name
+  }
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  dynamic "authenticator_groups_config" {
+    for_each = local.cluster_authenticator_security_group
+    content {
+      security_group = authenticator_groups_config.value.security_group
+    }
+  }
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  maintenance_policy {
+    daily_maintenance_window {
+      start_time = var.maintenance_start_time
+    }
+
+    dynamic "maintenance_exclusion" {
+      for_each = var.maintenance_exclusions
+      content {
+        exclusion_name = maintenance_exclusion.value.name
+        start_time     = maintenance_exclusion.value.start_time
+        end_time       = maintenance_exclusion.value.end_time
+        exclusion_options {
+          scope = maintenance_exclusion.value.exclusion_scope
+        }
+      }
+    }
+  }
+
+  addons_config {
+    # Istio is required if there is any pod-to-pod communication.
+    istio_config {
+      disabled = !var.enable_istio
+      auth     = var.istio_auth
+    }
+
+    gce_persistent_disk_csi_driver_config {
+      enabled = true
+    }
+  }
+
+  lifecycle {
+    # Ignore all changes to the default node pool. It's being removed after creation.
+    ignore_changes = [
+      node_config
+    ]
+  }
+
+  logging_service    = "logging.googleapis.com/kubernetes"
+  monitoring_service = "monitoring.googleapis.com/kubernetes"
+}
+
+# We define explict node pools, so that it can be modified without
+# having to destroy the entire cluster.
+resource "google_container_node_pool" "system_node_pools" {
+  provider = google-beta
+
+  project = var.project_id
+  name    = var.system_node_pool_name
+  cluster = google_container_cluster.gke_cluster.self_link
+  autoscaling {
+    total_min_node_count = var.system_node_pool_node_count.total_min_nodes
+    total_max_node_count = var.system_node_pool_node_count.total_max_nodes
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  node_config {
+    resource_labels = var.labels
+    service_account = var.service_account.email
+    oauth_scopes    = var.service_account.scopes
+    machine_type    = var.system_node_pool_machine_type
+    taint           = var.system_node_pool_taints
+
+    # Forcing the use of the Container-optimized image, as it is the only
+    # image with the proper logging deamon installed.
+    #
+    # cos images use Shielded VMs since v1.13.6-gke.0.
+    # https://cloud.google.com/kubernetes-engine/docs/how-to/node-images
+    #
+    # We use COS_CONTAINERD to be compatible with (optional) gVisor.
+    # https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods
+    image_type = "COS_CONTAINERD"
+
+    shielded_instance_config {
+      enable_secure_boot          = true
+      enable_integrity_monitoring = true
+    }
+
+    gvnic {
+      enabled = true
+    }
+
+    # Implied by Workload Identity
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+    # Implied by workload identity.
+    metadata = {
+      "disable-legacy-endpoints" = "true"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      node_config[0].labels,
+      node_config[0].taint,
+    ]
+  }
+}
+
+# For container logs to show up under Cloud Logging and GKE metrics to show up
+# on Cloud Monitoring console, some project level roles are needed for the
+# node_service_account
+resource "google_project_iam_member" "node_service_account_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_resource_metadata_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_gcr" {
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_artifact_registry" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${local.sa_email}"
+}

--- a/community/modules/scheduler/gke-cluster/variables.tf
+++ b/community/modules/scheduler/gke-cluster/variables.tf
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+variable "project_id" {
+  description = "The project ID to host the cluster in."
+  type        = string
+}
+
+variable "name_suffix" {
+  description = "Custom cluster name postpended to the `deployment_name`. See `prefix_with_deployment_name`."
+  type        = string
+  default     = ""
+}
+
+variable "deployment_name" {
+  description = "Name of the HPC deployment. Used in the GKE cluster name by default and can be configured with `prefix_with_deployment_name`."
+  type        = string
+}
+
+variable "prefix_with_deployment_name" {
+  description = "If true, cluster name will be prefixed by `deployment_name` (ex: <deployment_name>-<name_suffix>)."
+  type        = bool
+  default     = true
+}
+
+variable "region" {
+  description = "The region to host the cluster in."
+  type        = string
+}
+
+variable "network_id" {
+  description = "The ID of the GCE VPC network to host the cluster given in the format: `projects/<project_id>/global/networks/<network_name>`."
+  type        = string
+  validation {
+    condition     = length(split("/", var.network_id)) == 5
+    error_message = "The network id must be provided in the following format: projects/<project_id>/global/networks/<network_name>."
+  }
+}
+
+variable "subnetwork_self_link" {
+  description = "The self link of the subnetwork to host the cluster in."
+  type        = string
+}
+
+variable "pods_ip_range_name" {
+  description = "The name of the secondary subnet ip range to use for pods."
+  type        = string
+  default     = "pods"
+}
+
+variable "services_ip_range_name" {
+  description = "The name of the secondary subnet range to use for services."
+  type        = string
+  default     = "services"
+}
+
+variable "enable_private_ipv6_google_access" {
+  description = "The private IPv6 google access type for the VMs in this subnet."
+  type        = bool
+  default     = true
+}
+
+variable "release_channel" {
+  description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`."
+  type        = string
+  default     = "REGULAR"
+}
+
+variable "maintenance_start_time" {
+  description = "Start time for daily maintenance operations. Specified in GMT with `HH:MM` format."
+  type        = string
+  default     = "09:00"
+}
+
+variable "maintenance_exclusions" {
+  description = "List of maintenance exclusions. A cluster can have up to three."
+  type = list(object({
+    name            = string
+    start_time      = string
+    end_time        = string
+    exclusion_scope = string
+  }))
+  default = []
+  validation {
+    condition = alltrue([
+      for x in var.maintenance_exclusions :
+      contains(["NO_UPGRADES", "NO_MINOR_UPGRADES", "NO_MINOR_OR_NODE_UPGRADES"], x.exclusion_scope)
+    ])
+    error_message = "`exclusion_scope` must be set to `NO_UPGRADES` OR `NO_MINOR_UPGRADES` OR `NO_MINOR_OR_NODE_UPGRADES`."
+  }
+}
+
+variable "system_node_pool_name" {
+  description = "Name of the system node pool."
+  type        = string
+  default     = "system"
+}
+
+variable "system_node_pool_node_count" {
+  description = "The total min and max nodes to be maintained in the system node pool."
+  type = object({
+    total_min_nodes = number
+    total_max_nodes = number
+  })
+  default = {
+    total_min_nodes = 1
+    total_max_nodes = 2
+  }
+}
+
+variable "system_node_pool_machine_type" {
+  description = "Machine type for the system node pool."
+  type        = string
+  default     = "e2-standard-4"
+}
+
+variable "system_node_pool_taints" {
+  description = "Taints to be applied to the system node pool."
+  type = list(object({
+    key    = string
+    value  = bool
+    effect = string
+  }))
+  default = [{
+    key    = "components.gke.io/gke-managed-components"
+    value  = true
+    effect = "NO_SCHEDULE"
+  }]
+}
+
+variable "enable_private_nodes" {
+  description = "(Beta) Whether nodes have internal IP addresses only."
+  type        = bool
+  default     = true
+}
+
+variable "enable_private_endpoint" {
+  description = "(Beta) Whether the master's internal IP address is used as the cluster endpoint."
+  type        = bool
+  default     = true
+}
+
+variable "master_ipv4_cidr_block" {
+  description = "(Beta) The IP range in CIDR notation to use for the hosted master network."
+  type        = string
+  default     = "172.16.0.32/28"
+}
+
+variable "enable_master_global_access" {
+  description = "Whether the cluster master is accessible globally (from any region) or only within the same region as the private endpoint."
+  type        = bool
+  default     = false
+}
+
+variable "service_account" {
+  description = "Service account to use with the system node pool"
+  type = object({
+    email  = string,
+    scopes = set(string)
+  })
+  default = {
+    email  = null
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+
+variable "authenticator_security_group" {
+  description = "The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com"
+  type        = string
+  default     = null
+}
+
+variable "enable_istio" {
+  description = "(Beta) Enable Istio addon"
+  type        = bool
+  default     = true
+}
+
+variable "istio_auth" {
+  type        = string
+  description = "(Beta) The authentication type between services in Istio."
+  default     = "AUTH_MUTUAL_TLS"
+}
+
+variable "enable_dataplane_v2" {
+  description = "Enables [Dataplane v2](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2). This setting is immutable on clusters."
+  type        = bool
+  default     = false
+}
+
+variable "labels" {
+  description = "GCE resource labels to be applied to resources. Key-value pairs."
+  type        = map(string)
+}

--- a/community/modules/scheduler/gke-cluster/versions.tf
+++ b/community/modules/scheduler/gke-cluster/versions.tf
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.51.0, < 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.51.0, < 5.0"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:k8s-cluster/v1.15.0"
+  }
+}


### PR DESCRIPTION
This change adds a module to create a k8s cluster.

This initial implementation seeks to achieve simplicity by exposing a limited set of functionality which will grow over time where there is clear value. As part of this objective the following functionality has been excluded:
- Autopilot is disabled
- Auto-provisioning of new node pools is disabled
- Network policies are not supported
- General addon configuration is not supported
- Only regional cluster is supported

Follow on change is coming with basic documentation for module and example.

Tested: Manually deployed 2 clusters into the same project using the provided example as a basis.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
