### PR TITLE
Add `image_storage_locations` input to `modules/packer/custom-image`

### DIFF
--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -230,6 +230,7 @@ No resources.
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
 | <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Defaults to `deployment_name` | `string` | `null` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | The name of the image to be built. If not supplied, it will be set to image\_family-$ISO\_TIMESTAMP | `string` | `null` | no |
+| <a name="input_image_storage_locations"></a> [image\_storage\_locations](#input\_image\_storage\_locations) | Storage location, either regional or multi-regional, where snapshot content is to be stored and only accepts 1 value.<br>See https://developer.hashicorp.com/packer/plugins/builders/googlecompute#image_storage_locations | `list(string)` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the short-lived VM | `map(string)` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2-standard-4"` | no |
 | <a name="input_manifest_file"></a> [manifest\_file](#input\_manifest\_file) | File to which to write Packer build manifest | `string` | `"packer-manifest.json"` | no |

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -71,6 +71,7 @@ source "googlecompute" "toolkit_image" {
   startup_script_file     = var.startup_script_file
   wrap_startup_script     = var.wrap_startup_script
   state_timeout           = var.state_timeout
+  image_storage_locations = var.image_storage_locations
 }
 
 build {

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -224,3 +224,12 @@ variable "communicator" {
     error_message = "Set var.communicator to \"ssh\", \"winrm\", or null."
   }
 }
+
+variable "image_storage_locations" {
+  description = <<EOD
+Storage location, either regional or multi-regional, where snapshot content is to be stored and only accepts 1 value.
+See https://developer.hashicorp.com/packer/plugins/builders/googlecompute#image_storage_locations
+EOD
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
Testing done:
* modified `examples/image-builder.yaml`, 
with `image_storage_locations=["europe-west1"]`;
* followed `examples/README.md` to build an image;
* run
```shell
$ gcloud compute images describe my-slurm-image-20230405X | grep -A 1 Location
storageLocations:
- europe-west1
```

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
