### PR TITLE
Add support for sensitive output values

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -365,12 +365,45 @@ value is in the following priority order:
 
 ### Outputs (Optional)
 
-The `outputs` field allows a module-level output to be made available at the
-deployment group level and therefore will be available via `terraform output` in
-terraform-based deployment groups. This can useful for displaying the IP of a
-login node or simply displaying instructions on how to use a module, as we
-have in the
+The `outputs` field adds the output of individual Terraform modules to the
+output of its deployment group. This enables the value to be available via
+`terraform output`. This can useful for displaying the IP of a login node or
+priting instructions on how to use a module, as we have in the
 [monitoring dashboard module](monitoring/dashboard/README.md#Outputs).
+
+The outputs field is a lists that it can be in either of two formats: a string
+equal to the name of the module output, or a map specifying the `name`,
+`description`, and whether the value is `sensitive` and should be suppressed
+from the standard output of Terraform commands. An example is shown below
+that displays the internal and public IP addresses of a VM created by the
+vm-instance module:
+
+```yaml
+  - id: vm
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    settings:
+      machine_type: e2-medium
+    outputs:
+    - internal_ip
+    - name: external_ip
+      description: "External IP of VM"
+      sensitive: true
+```
+
+The outputs shown after running Terraform apply will resemble:
+
+```text
+Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+external_ip_simplevm = <sensitive>
+internal_ip_simplevm = [
+  "10.128.0.19",
+]
+```
 
 ### Required Services (APIs) (optional)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -236,7 +236,7 @@ type Module struct {
 	ID               string
 	Use              []string
 	WrapSettingsWith map[string][]string
-	Outputs          []string `yaml:"outputs,omitempty"`
+	Outputs          []modulereader.OutputInfo `yaml:"outputs,omitempty"`
 	Settings         map[string]interface{}
 	RequiredApis     map[string][]string `yaml:"required_apis"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -275,7 +275,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 				Type: "string",
 			},
 		},
-		Outputs: []modulereader.VarInfo{
+		Outputs: []modulereader.OutputInfo{
 			{
 				Name: matchingIntergroupName,
 			},
@@ -302,7 +302,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 				Name: matchingIntragroupName2,
 			},
 		},
-		Outputs: []modulereader.VarInfo{},
+		Outputs: []modulereader.OutputInfo{},
 	}
 
 	testModuleInfo2 := modulereader.ModuleInfo{
@@ -315,7 +315,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 				Name: matchingIntergroupName,
 			},
 		},
-		Outputs: []modulereader.VarInfo{},
+		Outputs: []modulereader.OutputInfo{},
 	}
 
 	dg0Name := "primary"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -330,7 +330,9 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 				Settings: map[string]interface{}{
 					altProjectIDSetting: "$(vars.project_id)",
 				},
-				Outputs: []string{matchingIntergroupName},
+				Outputs: []modulereader.OutputInfo{
+					{Name: matchingIntergroupName},
+				},
 			},
 			{
 				ID:     "TestModule1",

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -206,7 +206,7 @@ func useModule(
 	useMod Module,
 	useModGroupID string,
 	modInputs []modulereader.VarInfo,
-	useOutputs []modulereader.VarInfo,
+	useOutputs []modulereader.OutputInfo,
 	settingsToIgnore []string,
 ) ([]string, error) {
 	usedVars := []string{}
@@ -809,7 +809,7 @@ func (ref varReference) validate(bp Blueprint) error {
 			"failed to get info for module at %s while expanding variables: %e",
 			refMod.Source, err)
 	}
-	found := slices.ContainsFunc(modInfo.Outputs, func(o modulereader.VarInfo) bool { return o.Name == ref.name })
+	found := slices.ContainsFunc(modInfo.Outputs, func(o modulereader.OutputInfo) bool { return o.Name == ref.name })
 	if !found {
 		return fmt.Errorf("%s: module %s did not have output %s",
 			errorMessages["noOutput"], refMod.ID, ref.name)

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -880,8 +880,8 @@ func expandSimpleVariable(context varContext, trackModuleGraph bool) (string, er
 
 		// ensure that the target module outputs the value in the root module
 		// state and not just internally within its deployment group
-		if !slices.Contains(toMod.Outputs, varRef.name) {
-			toMod.Outputs = append(toMod.Outputs, varRef.name)
+		if !slices.ContainsFunc(toMod.Outputs, func(o modulereader.OutputInfo) bool { return o.Name == varRef.name }) {
+			toMod.Outputs = append(toMod.Outputs, modulereader.OutputInfo{Name: varRef.name})
 		}
 
 		// TODO: remove error

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -132,7 +132,10 @@ func (s *MySuite) TestUseModule(c *C) {
 		Name: "val1",
 		Type: "number",
 	}
-	usedInfo.Outputs = []modulereader.VarInfo{varInfoNumber}
+	outputInfoNumber := modulereader.OutputInfo{
+		Name: "val1",
+	}
+	usedInfo.Outputs = []modulereader.OutputInfo{outputInfoNumber}
 	usedVars, err = useModule(&mod, usedMod, usedModGroup, modInfo.Inputs, usedInfo.Outputs, []string{})
 	c.Assert(err, IsNil)
 	c.Assert(len(usedVars), Equals, 0)
@@ -224,7 +227,9 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 		Name: sharedVarName,
 		Type: "number",
 	}
-
+	sharedOutput := modulereader.OutputInfo{
+		Name: sharedVarName,
+	}
 	// Simple Case
 	dc := getDeploymentConfigForTest()
 	err := dc.applyUseModules()
@@ -240,7 +245,7 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 	usingInfo := dc.ModulesInfo[grpName][usingModuleSource]
 	usedInfo := dc.ModulesInfo[grpName][usedModuleSource]
 	usingInfo.Inputs = []modulereader.VarInfo{sharedVar}
-	usedInfo.Outputs = []modulereader.VarInfo{sharedVar}
+	usedInfo.Outputs = []modulereader.OutputInfo{sharedOutput}
 	err = dc.applyUseModules()
 	c.Assert(err, IsNil)
 
@@ -824,9 +829,9 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 
 	// Module variable: Success
 	existingOutput := "outputExists"
-	testVarInfoOutput := modulereader.VarInfo{Name: existingOutput}
+	testVarInfoOutput := modulereader.OutputInfo{Name: existingOutput}
 	testModInfo := modulereader.ModuleInfo{
-		Outputs: []modulereader.VarInfo{testVarInfoOutput},
+		Outputs: []modulereader.OutputInfo{testVarInfoOutput},
 	}
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
@@ -838,9 +843,9 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 
 	// Module variable: Success when using correct explicit intragroup
 	existingOutput = "outputExists"
-	testVarInfoOutput = modulereader.VarInfo{Name: existingOutput}
+	testVarInfoOutput = modulereader.OutputInfo{Name: existingOutput}
 	testModInfo = modulereader.ModuleInfo{
-		Outputs: []modulereader.VarInfo{testVarInfoOutput},
+		Outputs: []modulereader.OutputInfo{testVarInfoOutput},
 	}
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
@@ -852,9 +857,9 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	// Module variable: Failure when using incorrect explicit intragroup
 	// Correct group is at index 1, specify group at index 0
 	existingOutput = "outputExists"
-	testVarInfoOutput = modulereader.VarInfo{Name: existingOutput}
+	testVarInfoOutput = modulereader.OutputInfo{Name: existingOutput}
 	testModInfo = modulereader.ModuleInfo{
-		Outputs: []modulereader.VarInfo{testVarInfoOutput},
+		Outputs: []modulereader.OutputInfo{testVarInfoOutput},
 	}
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
@@ -869,9 +874,9 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Intergroup variable: failure because other group was implicit in reference
-	testVarInfoOutput = modulereader.VarInfo{Name: existingOutput}
+	testVarInfoOutput = modulereader.OutputInfo{Name: existingOutput}
 	testModInfo = modulereader.ModuleInfo{
-		Outputs: []modulereader.VarInfo{testVarInfoOutput},
+		Outputs: []modulereader.OutputInfo{testVarInfoOutput},
 	}
 	reader.SetInfo(testModule0.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(
@@ -897,9 +902,9 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Intergroup variable: failure due to later group
-	testVarInfoOutput = modulereader.VarInfo{Name: existingOutput}
+	testVarInfoOutput = modulereader.OutputInfo{Name: existingOutput}
 	testModInfo = modulereader.ModuleInfo{
-		Outputs: []modulereader.VarInfo{testVarInfoOutput},
+		Outputs: []modulereader.OutputInfo{testVarInfoOutput},
 	}
 	reader.SetInfo(testModule1.Source, testModInfo)
 	testVarContext0.varString = fmt.Sprintf(
@@ -911,9 +916,9 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 
 	// Intergroup variable: proper explicit reference to earlier group
 	// TODO: failure is temporary when support is added this should be a success!
-	testVarInfoOutput = modulereader.VarInfo{Name: existingOutput}
+	testVarInfoOutput = modulereader.OutputInfo{Name: existingOutput}
 	testModInfo = modulereader.ModuleInfo{
-		Outputs: []modulereader.VarInfo{testVarInfoOutput},
+		Outputs: []modulereader.OutputInfo{testVarInfoOutput},
 	}
 	reader.SetInfo(testModule0.Source, testModInfo)
 	testVarContext1.varString = fmt.Sprintf(

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -186,7 +186,7 @@ func hasIllegalChars(name string) bool {
 func validateOutputs(mod Module, modInfo modulereader.ModuleInfo) error {
 
 	// Only get the map if needed
-	var outputsMap map[string]modulereader.VarInfo
+	var outputsMap map[string]modulereader.OutputInfo
 	if len(mod.Outputs) > 0 {
 		outputsMap = modInfo.GetOutputsAsMap()
 	}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -193,9 +193,9 @@ func validateOutputs(mod Module, modInfo modulereader.ModuleInfo) error {
 
 	// Ensure output exists in the underlying modules
 	for _, output := range mod.Outputs {
-		if _, ok := outputsMap[output]; !ok {
+		if _, ok := outputsMap[output.Name]; !ok {
 			return fmt.Errorf("%s, module: %s output: %s",
-				errorMessages["invalidOutput"], mod.ID, output)
+				errorMessages["invalidOutput"], mod.ID, output.Name)
 		}
 	}
 	return nil

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -155,13 +155,13 @@ func (s *MySuite) TestValidateModule(c *C) {
 func (s *MySuite) TestValidateOutputs(c *C) {
 	// Simple case, no outputs in either
 	testMod := Module{ID: "testMod"}
-	testInfo := modulereader.ModuleInfo{Outputs: []modulereader.VarInfo{}}
+	testInfo := modulereader.ModuleInfo{Outputs: []modulereader.OutputInfo{}}
 	err := validateOutputs(testMod, testInfo)
 	c.Assert(err, IsNil)
 
 	// Output in varInfo, nothing in module
 	matchingName := "match"
-	testVarInfo := modulereader.VarInfo{Name: matchingName}
+	testVarInfo := modulereader.OutputInfo{Name: matchingName}
 	testInfo.Outputs = append(testInfo.Outputs, testVarInfo)
 	err = validateOutputs(testMod, testInfo)
 	c.Assert(err, IsNil)

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -167,13 +167,15 @@ func (s *MySuite) TestValidateOutputs(c *C) {
 	c.Assert(err, IsNil)
 
 	// Output matches between varInfo and module
-	testMod.Outputs = []string{matchingName}
+	testMod.Outputs = []modulereader.OutputInfo{
+		{Name: matchingName},
+	}
 	err = validateOutputs(testMod, testInfo)
 	c.Assert(err, IsNil)
 
 	// Addition output found in modules, not in varinfo
 	missingName := "missing"
-	testMod.Outputs = append(testMod.Outputs, missingName)
+	testMod.Outputs = append(testMod.Outputs, modulereader.OutputInfo{Name: missingName})
 	err = validateOutputs(testMod, testInfo)
 	c.Assert(err, Not(IsNil))
 	expErr := fmt.Sprintf("%s.*", errorMessages["invalidOutput"])

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -57,7 +57,7 @@ func getHCLInfo(source string) (ModuleInfo, error) {
 	}
 
 	var vars []VarInfo
-	var outs []VarInfo
+	var outs []OutputInfo
 	for _, v := range module.Variables {
 		vInfo := VarInfo{
 			Name:        v.Name,
@@ -70,11 +70,11 @@ func getHCLInfo(source string) (ModuleInfo, error) {
 	}
 	ret.Inputs = vars
 	for _, v := range module.Outputs {
-		vInfo := VarInfo{
+		oInfo := OutputInfo{
 			Name:        v.Name,
 			Description: v.Description,
 		}
-		outs = append(outs, vInfo)
+		outs = append(outs, oInfo)
 	}
 	ret.Outputs = outs
 	return ret, nil

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -25,18 +25,78 @@ import (
 	"log"
 	"path"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // ModuleFS contains embedded modules (./modules) for use in building
 var ModuleFS embed.FS
 
-// VarInfo stores information about a module's input or output variables
+// VarInfo stores information about a module input variables
 type VarInfo struct {
 	Name        string
 	Type        string
 	Description string
 	Default     interface{}
 	Required    bool
+}
+
+// OutputInfo stores information about module output values
+type OutputInfo struct {
+	Name        string
+	Description string `yaml:",omitempty"`
+	Sensitive   bool   `yaml:",omitempty"`
+	// DependsOn   []string `yaml:"depends_on,omitempty"`
+}
+
+// UnmarshalYAML supports parsing YAML OutputInfo fields as a simple list of
+// strings or as a list of maps directly into OutputInfo struct
+func (mo *OutputInfo) UnmarshalYAML(value *yaml.Node) error {
+	var name string
+	const yamlErrorMsg string = "block beginning at line %d: %s"
+
+	err := value.Decode(&name)
+	if err == nil {
+		mo.Name = name
+		return nil
+	}
+
+	var fields map[string]interface{}
+	err = value.Decode(&fields)
+	if err != nil {
+		return fmt.Errorf(yamlErrorMsg, value.Line, "outputs must each be a string or a map{name: string, description: string, sensitive: bool}")
+	}
+
+	err = enforceMapKeys(fields, map[string]bool{
+		"name": true, "description": false, "sensitive": false},
+	)
+	if err != nil {
+		return fmt.Errorf(yamlErrorMsg, value.Line, err)
+	}
+
+	type rawOutputInfo OutputInfo
+	if err := value.Decode((*rawOutputInfo)(mo)); err != nil {
+		return fmt.Errorf("line %d: %s", value.Line, err)
+	}
+	return nil
+}
+
+// enforceMapKeys ensures the presence of required keys and absence of unallowed
+// keys with a useful error message; input is a map of all allowed keys to a
+// boolean that is true when key is required and false when optional
+func enforceMapKeys(input map[string]interface{}, allowedKeys map[string]bool) error {
+	for key := range input {
+		if _, ok := allowedKeys[key]; !ok {
+			return fmt.Errorf("provided invalid key: %#v", key)
+		}
+		allowedKeys[key] = false
+	}
+	for key, req := range allowedKeys {
+		if req {
+			return fmt.Errorf("missing required key: %#v", key)
+		}
+	}
+	return nil
 }
 
 // ModuleInfo stores information about a module

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -102,13 +102,13 @@ func enforceMapKeys(input map[string]interface{}, allowedKeys map[string]bool) e
 // ModuleInfo stores information about a module
 type ModuleInfo struct {
 	Inputs       []VarInfo
-	Outputs      []VarInfo
+	Outputs      []OutputInfo
 	RequiredApis []string
 }
 
 // GetOutputsAsMap returns the outputs list as a map for quicker access
-func (i ModuleInfo) GetOutputsAsMap() map[string]VarInfo {
-	outputsMap := make(map[string]VarInfo)
+func (i ModuleInfo) GetOutputsAsMap() map[string]OutputInfo {
+	outputsMap := make(map[string]OutputInfo)
 	for _, output := range i.Outputs {
 		outputsMap[output.Name] = output
 	}

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -64,7 +64,7 @@ func (mo *OutputInfo) UnmarshalYAML(value *yaml.Node) error {
 	var fields map[string]interface{}
 	err = value.Decode(&fields)
 	if err != nil {
-		return fmt.Errorf(yamlErrorMsg, value.Line, "outputs must each be a string or a map{name: string, description: string, sensitive: bool}")
+		return fmt.Errorf(yamlErrorMsg, value.Line, "outputs must each be a string or a map{name: string, description: string, sensitive: bool}; "+err.Error())
 	}
 
 	err = enforceMapKeys(fields, map[string]bool{

--- a/pkg/modulereader/resreader_test.go
+++ b/pkg/modulereader/resreader_test.go
@@ -89,8 +89,8 @@ func (s *MySuite) TestGetOutputsAsMap(c *C) {
 
 	testDescription := "This is a test description"
 	testName := "testName"
-	varInfo := VarInfo{Name: testName, Description: testDescription}
-	modInfo.Outputs = []VarInfo{varInfo}
+	outputInfo := OutputInfo{Name: testName, Description: testDescription}
+	modInfo.Outputs = []OutputInfo{outputInfo}
 	outputMap = modInfo.GetOutputsAsMap()
 	c.Assert(len(outputMap), Equals, 1)
 	c.Assert(outputMap[testName].Description, Equals, testDescription)
@@ -200,7 +200,7 @@ func (s *MySuite) TestGetInfo_TFReder(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(info, DeepEquals, ModuleInfo{
 		Inputs:  []VarInfo{{Name: "test_variable", Type: "string", Description: "This is just a test", Required: true}},
-		Outputs: []VarInfo{{Name: "test_output", Type: "", Description: "This is just a test"}},
+		Outputs: []OutputInfo{{Name: "test_output", Description: "This is just a test"}},
 	})
 
 }

--- a/pkg/modulereader/resreader_test.go
+++ b/pkg/modulereader/resreader_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/afero"
 	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -226,6 +227,45 @@ func (s *MySuite) TestGetInfo_MetaReader(c *C) {
 	_, err := reader.GetInfo("")
 	expErr := "Meta GetInfo not implemented: .*"
 	c.Assert(err, ErrorMatches, expErr)
+}
+
+// module outputs can be specified as a simple string for the output name or as
+// a YAML mapping of name/description/sensitive (str,str,bool)
+func (s *MySuite) TestUnmarshalOutputInfo(c *C) {
+	var oinfo OutputInfo
+	var y string
+
+	y = "foo"
+	c.Check(yaml.Unmarshal([]byte(y), &oinfo), IsNil)
+	c.Check(oinfo, DeepEquals, OutputInfo{Name: "foo", Description: "", Sensitive: false})
+
+	y = "{ name: foo }"
+	c.Check(yaml.Unmarshal([]byte(y), &oinfo), IsNil)
+	c.Check(oinfo, DeepEquals, OutputInfo{Name: "foo", Description: "", Sensitive: false})
+
+	y = "{ name: foo, description: bar }"
+	c.Check(yaml.Unmarshal([]byte(y), &oinfo), IsNil)
+	c.Check(oinfo, DeepEquals, OutputInfo{Name: "foo", Description: "bar", Sensitive: false})
+
+	y = "{ name: foo, description: bar, sensitive: true }"
+	c.Check(yaml.Unmarshal([]byte(y), &oinfo), IsNil)
+	c.Check(oinfo, DeepEquals, OutputInfo{Name: "foo", Description: "bar", Sensitive: true})
+
+	// extra key should generate error
+	y = "{ name: foo, description: bar, sensitive: true, extrakey: extraval }"
+	c.Check(yaml.Unmarshal([]byte(y), &oinfo), NotNil)
+
+	// missing required key name should generate error
+	y = "{ description: bar, sensitive: true }"
+	c.Check(yaml.Unmarshal([]byte(y), &oinfo), NotNil)
+
+	// should not ummarshal a sequence
+	y = "[ foo ]"
+	c.Check(yaml.Unmarshal([]byte(y), &oinfo), NotNil)
+
+	// should not ummarshal an object with non-boolean sensitive type
+	y = "{ name: foo, description: bar, sensitive: contingent }"
+	c.Check(yaml.Unmarshal([]byte(y), &oinfo), NotNil)
 }
 
 // Util Functions

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/deploymentio"
+	"hpc-toolkit/pkg/modulereader"
 	"hpc-toolkit/pkg/sourcereader"
 	"io/ioutil"
 	"log"
@@ -555,15 +556,18 @@ func (s *MySuite) TestWriteOutputs(c *C) {
 	c.Assert(err, ErrorMatches, "error creating outputs.tf file: .*")
 
 	// Success: Outputs added
-	outputList := []string{"output1", "output2"}
+	outputList := []modulereader.OutputInfo{
+		{Name: "output1"},
+		{Name: "output2"},
+	}
 	moduleWithOutputs := config.Module{Outputs: outputList, ID: "testMod"}
 	testModules = []config.Module{moduleWithOutputs}
 	err = writeOutputs(testModules, testOutputsDir)
 	c.Assert(err, IsNil)
-	exists, err := stringExistsInFile(outputList[0], outputsFilePath)
+	exists, err := stringExistsInFile(outputList[0].Name, outputsFilePath)
 	c.Assert(err, IsNil)
 	c.Assert(exists, Equals, true)
-	exists, err = stringExistsInFile(outputList[1], outputsFilePath)
+	exists, err = stringExistsInFile(outputList[1].Name, outputsFilePath)
 	c.Assert(err, IsNil)
 	c.Assert(exists, Equals, true)
 }

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -100,15 +100,21 @@ func writeOutputs(
 	for _, mod := range modules {
 		for _, output := range mod.Outputs {
 			// Create output block
-			outputName := fmt.Sprintf("%s_%s", output, mod.ID)
+			outputName := fmt.Sprintf("%s_%s", output.Name, mod.ID)
 			hclBlock := hclBody.AppendNewBlock("output", []string{outputName})
 			blockBody := hclBlock.Body()
 
 			// Add attributes (description, value)
-			desc := fmt.Sprintf("Generated output from module '%s'", mod.ID)
+			desc := output.Description
+			if desc == "" {
+				desc = fmt.Sprintf("Generated output from module '%s'", mod.ID)
+			}
 			blockBody.SetAttributeValue("description", cty.StringVal(desc))
-			value := fmt.Sprintf("((module.%s.%s))", mod.ID, output)
+			value := fmt.Sprintf("((module.%s.%s))", mod.ID, output.Name)
 			blockBody.SetAttributeValue("value", cty.StringVal(value))
+			if output.Sensitive {
+				blockBody.SetAttributeValue("sensitive", cty.BoolVal(output.Sensitive))
+			}
 			hclBody.AppendNewline()
 		}
 	}


### PR DESCRIPTION
Modify code so that:

- output values have their own struct (they support [a subset of the properties of input variables](https://developer.hashicorp.com/terraform/language/values/outputs))
- support specifying the `sensitive` attribute of output values
- retain support for the simple "name-only" method of identifying output values while adding a new method which enables specification of the 3 primary attributes via a map (name, description, sensitive, depends_on)
- adopt this new struct where appropriate in existing code

If the `name` key is missing, this error is generated:

```
2023/04/06 22:46:53 failed to parse the blueprint in simple-vm.yaml, check YAML syntax for errors, err=line 52: missing required keys: ["name"]
```

If all required keys are present, but invalid keys are added to the `outputs` field, this error is generated:

```
2023/04/06 22:28:30 failed to parse the blueprint in simple-vm.yaml, check YAML syntax for errors, err=line 52: provided invalid keys: ["badkey0" "badkey1"]
```

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
