### PR TITLE
Fix bug in check for mixing module kinds within a group

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -440,6 +440,14 @@ func (s *MySuite) TestCheckModuleAndGroupNames(c *C) {
 		err := checkModuleAndGroupNames([]DeploymentGroup{ice, fire})
 		c.Check(err, ErrorMatches, "module IDs must be unique: pony used more than once")
 	}
+	{ // Mixing module kinds
+		g := DeploymentGroup{Name: "ice", Modules: []Module{
+			{ID: "pony", Kind: "packer"},
+			{ID: "zebra", Kind: "terraform"},
+		}}
+		err := checkModuleAndGroupNames([]DeploymentGroup{g})
+		c.Check(err, ErrorMatches, "mixing modules of differing kinds in a deployment group is not supported: deployment group ice, got packer and terraform")
+	}
 }
 
 func (s *MySuite) TestIsUnused(c *C) {


### PR DESCRIPTION
* Fix bug: using copy value for chain-compare while updating original one;
* Fix bug: using missing key from `errorMessages`;

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
