### PR TITLE
Remove deprecated pod_security_policy

### DIFF
--- a/community/modules/scheduler/gke-cluster/main.tf
+++ b/community/modules/scheduler/gke-cluster/main.tf
@@ -59,10 +59,6 @@ resource "google_container_cluster" "gke_cluster" {
     }
   }
 
-  pod_security_policy_config {
-    enabled = true
-  }
-
   enable_shielded_nodes = true
 
   cluster_autoscaling { # Auto provisioning of node-pools


### PR DESCRIPTION
This feature has been [deprecated](https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies). I will follow up on the possible replacement options ([PodSecurity admission controller](https://cloud.google.com/kubernetes-engine/docs/how-to/migrate-podsecuritypolicy)) but they have not yet been released in the regular release channel so it is too early to incorporate them.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
