### PR TITLE
Address need for SystemD override in HTCondor module

### DIFF
--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -201,8 +201,10 @@
             SCHEDD_NAME=had-schedd@
         notify:
         - Restart HTCondor
-      # the need for this SystemD override will be eliminated in HTCondor 10.0.3
-      # (LTS) and 10.4 (feature release) by resolving HTCONDOR-1594
+      # although HTCondor is guaranteed to start after mounting remote
+      # filesystems is *attempted*, it does not guarantee successful mounts;
+      # this additional SystemD setting will refuse to start HTCondor if the
+      # spool shared filesystem has not been mounted
       - name: Create SystemD override directory for HTCondor
         ansible.builtin.file:
           path: /etc/systemd/system/condor.service.d


### PR DESCRIPTION
Although [HTCONDOR-1594](https://opensciencegrid.atlassian.net/browse/HTCONDOR-1594) has been addressed upstream in the most recent releases of HTCondor, I believe it is in the best interest of our solution to continue to additionally _Require_ that the spool remote filesystem has been successfully mounted when the job queue high availability feature is enabled. Otherwise, the potential is there for HTCondor to start with a spool in the local filesystem at the mount point which is likely a worse outcome to recover from.

[RequireMountsFor](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#RequiresMountsFor=) will have the effect of ensuring that "systemctl start condor" will trigger an attempt to mount the remote filesystem; if it fails, SystemD will not attempt to start condor.

Conclusion: update the comment to reflect this logic.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?