### PR TITLE
Gke node pool

### DIFF
--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -1,0 +1,69 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.60.0, < 5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.60.0, < 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.60.0, < 5.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.60.0, < 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
+| [google_project_iam_member.node_service_account_artifact_registry](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_log_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_metric_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.node_service_account_resource_metadata_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_compute_default_service_account.default_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | projects/{{project}}/locations/{{location}}/clusters/{{cluster}} | `string` | n/a | yes |
+| <a name="input_compact_placement"></a> [compact\_placement](#input\_compact\_placement) | Places node pool's nodes in a closer physical proximity in order to reduce network latency between nodes. | `bool` | `false` | no |
+| <a name="input_image_type"></a> [image\_type](#input\_image\_type) | The default image type used by NAP once a new node pool is being created. Use either COS\_CONTAINERD or UBUNTU\_CONTAINERD. | `string` | `"COS_CONTAINERD"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | GCE resource labels to be applied to resources. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The name of a Google Compute Engine machine type. | `string` | `"c2-standard-60"` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the node pool. If left blank, will default to the machine type. | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to host the cluster in. | `string` | n/a | yes |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to use with the system node pool | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
+| <a name="input_spot"></a> [spot](#input\_spot) | Provision VMs using discounted Spot pricing, allowing for preemption | `bool` | `false` | no |
+| <a name="input_taints"></a> [taints](#input\_taints) | Taints to be applied to the system node pool. | <pre>list(object({<br>    key    = string<br>    value  = any<br>    effect = string<br>  }))</pre> | `[]` | no |
+| <a name="input_threads_per_core"></a> [threads\_per\_core](#input\_threads\_per\_core) | Sets the number of threads per physical core. By setting threads\_per\_core<br>to 2, Simultaneous Multithreading (SMT) is enabled extending the total number<br>of virtual cores. For example, a machine of type c2-standard-60 will have 60<br>virtual cores with threads\_per\_core equal to 2. With threads\_per\_core equal<br>to 1 (SMT turned off), only the 30 physical cores will be available on the VM.<br><br>The default value of \"0\" will turn off SMT for supported machine types, and<br>will fall back to GCE defaults for unsupported machine types (t2d, shared-core<br>instances, or instances with less than 2 vCPU).<br><br>Disabling SMT can be more performant in many HPC workloads, therefore it is<br>disabled by default where compatible.<br><br>null = SMT configuration will use the GCE defaults for the machine type<br>0 = SMT will be disabled where compatible (default)<br>1 = SMT will always be disabled (will fail on incompatible machine types)<br>2 = SMT will always be enabled (will fail on incompatible machine types) | `number` | `0` | no |
+| <a name="input_total_max_nodes"></a> [total\_max\_nodes](#input\_total\_max\_nodes) | Total maximum number of nodes in the NodePool. | `number` | `1000` | no |
+| <a name="input_total_min_nodes"></a> [total\_min\_nodes](#input\_total\_min\_nodes) | Total minimum number of nodes in the NodePool. | `number` | `0` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -49,6 +49,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_auto_upgrade"></a> [auto\_upgrade](#input\_auto\_upgrade) | Whether the nodes will be automatically upgraded. | `bool` | `false` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | projects/{{project}}/locations/{{location}}/clusters/{{cluster}} | `string` | n/a | yes |
 | <a name="input_compact_placement"></a> [compact\_placement](#input\_compact\_placement) | Places node pool's nodes in a closer physical proximity in order to reduce network latency between nodes. | `bool` | `false` | no |
 | <a name="input_image_type"></a> [image\_type](#input\_image\_type) | The default image type used by NAP once a new node pool is being created. Use either COS\_CONTAINERD or UBUNTU\_CONTAINERD. | `string` | `"COS_CONTAINERD"` | no |

--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -1,0 +1,141 @@
+/**
+  * Copyright 2023 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+locals {
+  sa_email = var.service_account.email != null ? var.service_account.email : data.google_compute_default_service_account.default_sa.email
+}
+
+data "google_compute_default_service_account" "default_sa" {
+  project = var.project_id
+}
+
+resource "google_container_node_pool" "node_pool" {
+  provider = google-beta
+
+  name    = var.name == null ? var.machine_type : var.name
+  cluster = var.cluster_id
+  autoscaling {
+    total_min_node_count = var.total_min_nodes
+    total_max_node_count = var.total_max_nodes
+    location_policy      = "ANY"
+  }
+
+  upgrade_settings {
+    strategy        = "SURGE"
+    max_surge       = 0
+    max_unavailable = 20
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  dynamic "placement_policy" {
+    for_each = var.compact_placement ? [1] : []
+    content {
+      type = "COMPACT"
+    }
+  }
+
+  node_config {
+    resource_labels = var.labels
+    service_account = var.service_account.email
+    oauth_scopes    = var.service_account.scopes
+    machine_type    = var.machine_type
+    spot            = var.spot
+    taint           = var.taints
+
+    image_type = var.image_type
+
+    shielded_instance_config {
+      enable_secure_boot          = true
+      enable_integrity_monitoring = true
+    }
+
+    gvnic {
+      enabled = true
+    }
+
+    dynamic "advanced_machine_features" {
+      for_each = local.set_threads_per_core ? [1] : []
+      content {
+        threads_per_core = local.threads_per_core # relies on threads_per_core_calc.tf
+      }
+    }
+
+    # Implied by Workload Identity
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+    # Implied by workload identity.
+    metadata = {
+      "disable-legacy-endpoints" = "true"
+    }
+
+    linux_node_config {
+      sysctls = {
+        "net.ipv4.tcp_rmem" = "4096 87380 16777216"
+        "net.ipv4.tcp_wmem" = "4096 16384 16777216"
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      node_config[0].labels,
+    ]
+  }
+}
+
+# For container logs to show up under Cloud Logging and GKE metrics to show up
+# on Cloud Monitoring console, some project level roles are needed for the
+# node_service_account
+resource "google_project_iam_member" "node_service_account_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_resource_metadata_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_gcr" {
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${local.sa_email}"
+}
+
+resource "google_project_iam_member" "node_service_account_artifact_registry" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${local.sa_email}"
+}

--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -33,15 +33,15 @@ resource "google_container_node_pool" "node_pool" {
     location_policy      = "ANY"
   }
 
+  management {
+    auto_repair  = true
+    auto_upgrade = var.auto_upgrade
+  }
+
   upgrade_settings {
     strategy        = "SURGE"
     max_surge       = 0
-    max_unavailable = 20
-  }
-
-  management {
-    auto_repair  = true
-    auto_upgrade = true
+    max_unavailable = 1
   }
 
   dynamic "placement_policy" {

--- a/community/modules/compute/gke-node-pool/threads_per_core_calc.tf
+++ b/community/modules/compute/gke-node-pool/threads_per_core_calc.tf
@@ -33,7 +33,7 @@ locals {
   machine_not_shared_core = length(local.machine_vals) > 2
   machine_vcpus           = try(parseint(local.machine_vals[2], 10), 1)
 
-  smt_capable_family = !contains(["t2d"], local.machine_family)
+  smt_capable_family = !contains(["t2d", "t2a"], local.machine_family)
   smt_capable_vcpu   = local.machine_vcpus >= 2
 
   smt_capable          = local.smt_capable_family && local.smt_capable_vcpu && local.machine_not_shared_core

--- a/community/modules/compute/gke-node-pool/threads_per_core_calc.tf
+++ b/community/modules/compute/gke-node-pool/threads_per_core_calc.tf
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# This file is meant to be reused by multiple modules.
+# "description": Allows for 'threads_per_core=0: SMT will be disabled where compatible (default)'
+
+# "inputs":
+# var.machine_type: Machine type for the instance being evaluated.
+# var.threads_per_core : Sets the number of threads per physical core, where 0
+#                        has behavior described in description.
+
+# "outputs":
+# local.set_threads_per_core: bool that tells if threads per core should be set,
+#                             to be used with a dynamic block.
+# local.threads_per_core: actual threads_per_core to be used.
+
+locals {
+  machine_vals            = split("-", var.machine_type)
+  machine_family          = local.machine_vals[0]
+  machine_not_shared_core = length(local.machine_vals) > 2
+  machine_vcpus           = try(parseint(local.machine_vals[2], 10), 1)
+
+  smt_capable_family = !contains(["t2d"], local.machine_family)
+  smt_capable_vcpu   = local.machine_vcpus >= 2
+
+  smt_capable          = local.smt_capable_family && local.smt_capable_vcpu && local.machine_not_shared_core
+  set_threads_per_core = var.threads_per_core != null && (var.threads_per_core == 0 && local.smt_capable || try(var.threads_per_core >= 1, false))
+  threads_per_core     = var.threads_per_core == 2 ? 2 : 1
+}

--- a/community/modules/compute/gke-node-pool/variables.tf
+++ b/community/modules/compute/gke-node-pool/variables.tf
@@ -55,6 +55,12 @@ variable "total_max_nodes" {
   default     = 1000
 }
 
+variable "auto_upgrade" {
+  description = "Whether the nodes will be automatically upgraded."
+  type        = bool
+  default     = false
+}
+
 variable "threads_per_core" {
   description = <<-EOT
   Sets the number of threads per physical core. By setting threads_per_core

--- a/community/modules/compute/gke-node-pool/variables.tf
+++ b/community/modules/compute/gke-node-pool/variables.tf
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+variable "project_id" {
+  description = "The project ID to host the cluster in."
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "projects/{{project}}/locations/{{location}}/clusters/{{cluster}}"
+  type        = string
+}
+
+variable "name" {
+  description = "The name of the node pool. If left blank, will default to the machine type."
+  type        = string
+  default     = null
+}
+
+variable "machine_type" {
+  description = "The name of a Google Compute Engine machine type."
+  type        = string
+  default     = "c2-standard-60"
+}
+
+variable "image_type" {
+  description = "The default image type used by NAP once a new node pool is being created. Use either COS_CONTAINERD or UBUNTU_CONTAINERD."
+  type        = string
+  default     = "COS_CONTAINERD"
+}
+
+# TODO
+variable "total_min_nodes" {
+  description = "Total minimum number of nodes in the NodePool."
+  type        = number
+  default     = 0
+}
+
+variable "total_max_nodes" {
+  description = "Total maximum number of nodes in the NodePool."
+  type        = number
+  default     = 1000
+}
+
+variable "threads_per_core" {
+  description = <<-EOT
+  Sets the number of threads per physical core. By setting threads_per_core
+  to 2, Simultaneous Multithreading (SMT) is enabled extending the total number
+  of virtual cores. For example, a machine of type c2-standard-60 will have 60
+  virtual cores with threads_per_core equal to 2. With threads_per_core equal
+  to 1 (SMT turned off), only the 30 physical cores will be available on the VM.
+
+  The default value of \"0\" will turn off SMT for supported machine types, and
+  will fall back to GCE defaults for unsupported machine types (t2d, shared-core
+  instances, or instances with less than 2 vCPU).
+
+  Disabling SMT can be more performant in many HPC workloads, therefore it is
+  disabled by default where compatible.
+
+  null = SMT configuration will use the GCE defaults for the machine type
+  0 = SMT will be disabled where compatible (default)
+  1 = SMT will always be disabled (will fail on incompatible machine types)
+  2 = SMT will always be enabled (will fail on incompatible machine types)
+  EOT
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.threads_per_core == null || try(var.threads_per_core >= 0, false) && try(var.threads_per_core <= 2, false)
+    error_message = "Allowed values for threads_per_core are \"null\", \"0\", \"1\", \"2\"."
+  }
+}
+
+variable "spot" {
+  description = "Provision VMs using discounted Spot pricing, allowing for preemption"
+  type        = bool
+  default     = false
+}
+
+variable "compact_placement" {
+  description = "Places node pool's nodes in a closer physical proximity in order to reduce network latency between nodes."
+  type        = bool
+  default     = false
+}
+
+variable "service_account" {
+  description = "Service account to use with the system node pool"
+  type = object({
+    email  = string,
+    scopes = set(string)
+  })
+  default = {
+    email  = null
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+
+variable "taints" {
+  description = "Taints to be applied to the system node pool."
+  type = list(object({
+    key    = string
+    value  = any
+    effect = string
+  }))
+  default = []
+}
+
+variable "labels" {
+  description = "GCE resource labels to be applied to resources. Key-value pairs."
+  type        = map(string)
+}

--- a/community/modules/compute/gke-node-pool/versions.tf
+++ b/community/modules/compute/gke-node-pool/versions.tf
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.60.0, < 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.60.0, < 5.0"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:k8s-cluster/v1.15.0"
+  }
+}

--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -132,7 +132,7 @@ No modules.
 | <a name="input_system_node_pool_machine_type"></a> [system\_node\_pool\_machine\_type](#input\_system\_node\_pool\_machine\_type) | Machine type for the system node pool. | `string` | `"e2-standard-4"` | no |
 | <a name="input_system_node_pool_name"></a> [system\_node\_pool\_name](#input\_system\_node\_pool\_name) | Name of the system node pool. | `string` | `"system"` | no |
 | <a name="input_system_node_pool_node_count"></a> [system\_node\_pool\_node\_count](#input\_system\_node\_pool\_node\_count) | The total min and max nodes to be maintained in the system node pool. | <pre>object({<br>    total_min_nodes = number<br>    total_max_nodes = number<br>  })</pre> | <pre>{<br>  "total_max_nodes": 2,<br>  "total_min_nodes": 1<br>}</pre> | no |
-| <a name="input_system_node_pool_taints"></a> [system\_node\_pool\_taints](#input\_system\_node\_pool\_taints) | Taints to be applied to the system node pool. | <pre>list(object({<br>    key    = string<br>    value  = bool<br>    effect = string<br>  }))</pre> | <pre>[<br>  {<br>    "effect": "NO_SCHEDULE",<br>    "key": "components.gke.io/gke-managed-components",<br>    "value": true<br>  }<br>]</pre> | no |
+| <a name="input_system_node_pool_taints"></a> [system\_node\_pool\_taints](#input\_system\_node\_pool\_taints) | Taints to be applied to the system node pool. | <pre>list(object({<br>    key    = string<br>    value  = any<br>    effect = string<br>  }))</pre> | <pre>[<br>  {<br>    "effect": "NO_SCHEDULE",<br>    "key": "components.gke.io/gke-managed-components",<br>    "value": true<br>  }<br>]</pre> | no |
 
 ## Outputs
 

--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -138,5 +138,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | an identifier for the resource with format projects/<project\_id>/locations/<region>/clusters/<name>. |
 | <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions on how to connect to the created cluster. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -125,7 +125,7 @@ No modules.
 | <a name="input_prefix_with_deployment_name"></a> [prefix\_with\_deployment\_name](#input\_prefix\_with\_deployment\_name) | If true, cluster name will be prefixed by `deployment_name` (ex: <deployment\_name>-<name\_suffix>). | `bool` | `true` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to host the cluster in. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to host the cluster in. | `string` | n/a | yes |
-| <a name="input_release_channel"></a> [release\_channel](#input\_release\_channel) | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. | `string` | `"REGULAR"` | no |
+| <a name="input_release_channel"></a> [release\_channel](#input\_release\_channel) | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. | `string` | `"UNSPECIFIED"` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to use with the system node pool | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |
 | <a name="input_services_ip_range_name"></a> [services\_ip\_range\_name](#input\_services\_ip\_range\_name) | The name of the secondary subnet range to use for services. | `string` | `"services"` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork to host the cluster in. | `string` | n/a | yes |

--- a/community/modules/scheduler/gke-cluster/outputs.tf
+++ b/community/modules/scheduler/gke-cluster/outputs.tf
@@ -14,6 +14,11 @@
   * limitations under the License.
   */
 
+output "cluster_id" {
+  description = "an identifier for the resource with format projects/<project_id>/locations/<region>/clusters/<name>."
+  value       = google_container_cluster.gke_cluster.id
+}
+
 locals {
   private_endpoint_message = trimspace(
     <<-EOT

--- a/community/modules/scheduler/gke-cluster/variables.tf
+++ b/community/modules/scheduler/gke-cluster/variables.tf
@@ -131,7 +131,7 @@ variable "system_node_pool_taints" {
   description = "Taints to be applied to the system node pool."
   type = list(object({
     key    = string
-    value  = bool
+    value  = any
     effect = string
   }))
   default = [{

--- a/community/modules/scheduler/gke-cluster/variables.tf
+++ b/community/modules/scheduler/gke-cluster/variables.tf
@@ -76,7 +76,7 @@ variable "enable_private_ipv6_google_access" {
 variable "release_channel" {
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`."
   type        = string
-  default     = "REGULAR"
+  default     = "UNSPECIFIED"
 }
 
 variable "maintenance_start_time" {

--- a/modules/compute/vm-instance/threads_per_core_calc.tf
+++ b/modules/compute/vm-instance/threads_per_core_calc.tf
@@ -33,7 +33,7 @@ locals {
   machine_not_shared_core = length(local.machine_vals) > 2
   machine_vcpus           = try(parseint(local.machine_vals[2], 10), 1)
 
-  smt_capable_family = !contains(["t2d"], local.machine_family)
+  smt_capable_family = !contains(["t2d", "t2a"], local.machine_family)
   smt_capable_vcpu   = local.machine_vcpus >= 2
 
   smt_capable          = local.smt_capable_family && local.smt_capable_vcpu && local.machine_not_shared_core

--- a/modules/compute/vm-instance/threads_per_core_calc.tf
+++ b/modules/compute/vm-instance/threads_per_core_calc.tf
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# This file is meant to be reused by multiple modules.
+# "description": Allows for 'threads_per_core=0: SMT will be disabled where compatible (default)'
+
+# "inputs":
+# var.machine_type: Machine type for the instance being evaluated.
+# var.threads_per_core : Sets the number of threads per physical core, where 0
+#                        has behavior described in description.
+
+# "outputs":
+# local.set_threads_per_core: bool that tells if threads per core should be set,
+#                             to be used with a dynamic block.
+# local.threads_per_core: actual threads_per_core to be used.
+
+locals {
+  machine_vals            = split("-", var.machine_type)
+  machine_family          = local.machine_vals[0]
+  machine_not_shared_core = length(local.machine_vals) > 2
+  machine_vcpus           = try(parseint(local.machine_vals[2], 10), 1)
+
+  smt_capable_family = !contains(["t2d"], local.machine_family)
+  smt_capable_vcpu   = local.machine_vcpus >= 2
+
+  smt_capable          = local.smt_capable_family && local.smt_capable_vcpu && local.machine_not_shared_core
+  set_threads_per_core = var.threads_per_core != null && (var.threads_per_core == 0 && local.smt_capable || try(var.threads_per_core >= 1, false))
+  threads_per_core     = var.threads_per_core == 2 ? 2 : 1
+}

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -41,6 +41,10 @@ duplicates = [
         "community/modules/scheduler/schedmd-slurm-gcp-v5-login/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v5-controller/gpu_definition.tf",
     ],
+    [
+        "community/modules/compute/gke-node-pool/threads_per_core_calc.tf",
+        "modules/compute/vm-instance/threads_per_core_calc.tf"
+    ],
 ]
 
 for group in duplicates:


### PR DESCRIPTION
Creates a basic `gke-node-pool` module. 

Change is large, I suggest reviewing commits separately.
Bump of provider version was needed to get access to `threads_per_core`

Tested: manually deployed and ran job.

Items not addressed:
- variant examples (compute, network, gpu, and cost optimized). Plan to demonstrate examples in future change.
- Tier 1 networking: not yet supported in terraform
- Resolve `auto_upgrade`: conflicting recommendations to have `auto_upgrade=false` and `release_channel=regular`
- Node taits: leaving blank, need to understand recommendation
- Parametric pool creation: will evaluate a separate plural module or changing interface of this module 
- Documentation and instructions

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
