### PR TITLE
Update TFLint and rules plugin for Google Cloud Platform

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -13,7 +13,7 @@
 // limitations under the License.
 plugin "google" {
   enabled = true
-  version = "0.20.0"
+  version = "0.23.0"
   source  = "github.com/terraform-linters/tflint-ruleset-google"
 }
 rule "terraform_deprecated_index" {

--- a/tools/cloud-build/hpc-toolkit-builder.yaml
+++ b/tools/cloud-build/hpc-toolkit-builder.yaml
@@ -24,7 +24,7 @@ steps:
   - '--cache-from'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder:latest'
   - '--build-arg'
-  - 'TFLINT_VERSION=v0.45.0'
+  - 'TFLINT_VERSION=v0.46.0'
   - '-f'
   - 'tools/cloud-build/Dockerfile'
   - '.'


### PR DESCRIPTION
Manually running `pre-commit run -a` on my workstation with v0.46 yields no Terraform related errors though it does surface some `shfmt` problems that snuck in undetected. A separate task has been created for those errors.

```text
Terraform fmt............................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
terraform-readme.........................................................Passed
packer-readme............................................................Passed
duplicate-diff...........................................................Passed
go fmt...................................................................Passed
go vet...................................................................Passed
go lint..................................................................Passed
go imports...............................................................Passed
go-cyclo.................................................................Passed
go-unit-tests............................................................Passed
go-build.................................................................Passed
go-mod-tidy..............................................................Passed
go-critic................................................................Passed
Ansible-lint.............................................................Passed
yamllint.................................................................Passed
PyMarkdown...............................................................Passed
Non-executable shell script filename ends in .sh.........................Passed
Test shell scripts with shellcheck.......................................Failed
- hook id: shellcheck
- exit code: 1

In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 19:
echo $PROTEIN
     ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo "$PROTEIN"


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 31:
grep -v -e HETATM -e CONECT ${PDB_FILE} >${PROTEIN}_protein.pdb
                                         ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
grep -v -e HETATM -e CONECT ${PDB_FILE} >"${PROTEIN}"_protein.pdb


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 34:
mpirun -n 1 gmx_mpi pdb2gmx -f ${PROTEIN}_protein.pdb -o ${PROTEIN}_processed.gro -water tip3p -ff "charmm27"
                               ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                         ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mpirun -n 1 gmx_mpi pdb2gmx -f "${PROTEIN}"_protein.pdb -o "${PROTEIN}"_processed.gro -water tip3p -ff "charmm27"


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 37:
mpirun -n 1 gmx_mpi editconf -f ${PROTEIN}_processed.gro -o ${PROTEIN}_newbox.gro -c -d 1.0 -bt dodecahedron
                                ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                            ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mpirun -n 1 gmx_mpi editconf -f "${PROTEIN}"_processed.gro -o "${PROTEIN}"_newbox.gro -c -d 1.0 -bt dodecahedron


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 38:
mpirun -n 1 gmx_mpi solvate -cp ${PROTEIN}_newbox.gro -cs spc216.gro -o ${PROTEIN}_solv.gro -p topol.top
                                ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                        ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mpirun -n 1 gmx_mpi solvate -cp "${PROTEIN}"_newbox.gro -cs spc216.gro -o "${PROTEIN}"_solv.gro -p topol.top


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 41:
mpirun -n 1 gmx_mpi grompp -f config/ions.mdp -c ${PROTEIN}_solv.gro -p topol.top -o ions.tpr
                                                 ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mpirun -n 1 gmx_mpi grompp -f config/ions.mdp -c "${PROTEIN}"_solv.gro -p topol.top -o ions.tpr


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 42:
printf "SOL\n" | mpirun -n 1 gmx_mpi genion -s ions.tpr -o ${PROTEIN}_solv_ions.gro -p topol.top -pname NA -nname CL -neutral
                                                           ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
printf "SOL\n" | mpirun -n 1 gmx_mpi genion -s ions.tpr -o "${PROTEIN}"_solv_ions.gro -p topol.top -pname NA -nname CL -neutral


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 48:
mpirun -n 1 gmx_mpi grompp -f config/emin-charmm.mdp -c ${PROTEIN}_solv_ions.gro -p topol.top -o em.tpr
                                                        ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mpirun -n 1 gmx_mpi grompp -f config/emin-charmm.mdp -c "${PROTEIN}"_solv_ions.gro -p topol.top -o em.tpr


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 68:
cp ${PROTEIN}_newbox.gro /data_output/
   ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "${PROTEIN}"_newbox.gro /data_output/


In docs/videos/healthcare-and-life-sciences/lysozyme-example/submit.sh line 69:
cp md_fit.xtc /data_output/${PROTEIN}_md.xtc
                           ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp md_fit.xtc /data_output/"${PROTEIN}"_md.xtc

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

Check shell style with shfmt.............................................Passed
fix end of files.........................................................Passed
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
