### PR TITLE
Reduce the number of execution hosts in pbs test to reduce the change…

### DIFF
--- a/tools/cloud-build/daily-tests/tests/pbspro.yml
+++ b/tools/cloud-build/daily-tests/tests/pbspro.yml
@@ -22,4 +22,4 @@ remote_node: "{{ deployment_name }}-server-0"
 post_deploy_tests:
 - test-pbspro.yml
 custom_vars:
-  execution_host_count: "10"
+  execution_host_count: "3"

--- a/tools/validate_configs/test_configs/pbs-unwrapped.yaml
+++ b/tools/validate_configs/test_configs/pbs-unwrapped.yaml
@@ -22,7 +22,7 @@ vars:
   zone: us-central1-c
   client_host_count: 1
   client_hostname_prefix: pbs-client
-  execution_host_count: 10
+  execution_host_count: 3
   execution_hostname_prefix: pbs-execution
   pbs_client_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-client-2021.1.3.20220217134230-0.el7.x86_64.rpm
   pbs_execution_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-execution-2021.1.3.20220217134230-0.el7.x86_64.rpm


### PR DESCRIPTION
Reduce flakiness of [pbs_unwrapped.yaml](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/tools/validate_configs/test_configs/pbs-unwrapped.yaml) integration test by reducing the number of nodes needed to run the test.

Tested: Ran PR-test-pbspro integration test.