### PR TITLE
Pin google terraform provider to latest version

### DIFF
--- a/pkg/modulewriter/tfversions.go
+++ b/pkg/modulewriter/tfversions.go
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.58.0"
+      version = "~> 4.61.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.58.0"
+      version = "~> 4.61.0"
     }
   }
 }


### PR DESCRIPTION
Pinning latest terraform provider version post release of v1.16.0.