### PR TITLE
OFE deployment using config file.

### DIFF
--- a/community/front-end/ofe/deploy.sh
+++ b/community/front-end/ofe/deploy.sh
@@ -547,13 +547,16 @@ TFVARS
 		# TODO - upload terraform files to the FE server, so that they can be recovered if ever
 		#        needed
 
-		case $(ask "    Proceed to deploy? [y/N] ") in
-		[Yy]*) ;;
-		*)
-			echo "Exiting."
-			exit 0
-			;;
-		esac
+		if [ -z "$config_file" ]; then
+			# Ask for user confirmation before deploying
+			case $(ask "    Proceed to deploy? [y/N] ") in
+			[Yy]*) ;;
+			*)
+				echo "Exiting."
+				exit 0
+				;;
+			esac
+		fi
 
 		# -- Start the deployment using Terraform.
 		#    Note: Extract $? for terraform using PIPESTATUS, as $? below is

--- a/community/front-end/ofe/docs/admin_guide.md
+++ b/community/front-end/ofe/docs/admin_guide.md
@@ -182,6 +182,8 @@ parameters, to configure TKFE.
 #### Automated deployment process
 TKFE can also be deployed automatically using a YAML configuration file with all the required parameters. To deploy using this option, run ./deploy.sh --config <path-to-config-file>. All required parameters for deployment must be specified in the YAML file. If any required parameter is missing or invalid, the script will exit with an error. If all parameters are provided correctly, the deployment process will proceed automatically without any prompts for user input. Note that in case of any errors during deployment, the script will exit with an error and no resources will be created or modified.
 
+If the DJANGO_SUPERUSER_PASSWORD environment variable is set, the script will use it to set the Django superuser password instead of the value in the YAML file. This is a more secure way of handling passwords.
+
 To use this configuration file for automated deployment, follow these steps:
 
 1. Create a file called config.yaml.
@@ -194,14 +196,14 @@ To use this configuration file for automated deployment, follow these steps:
   dns_hostname: myhostname.com # (optional)
   ip_address: 1.2.3.4 # (optional)
   django_superuser_username: sysadm
-  django_superuser_password: Passw0rd!
+  django_superuser_password: Passw0rd! # (optional if DJANGO_SUPERUSER_PASSWORD is passed)
   django_superuser_email: sysadmin@example.com
   ```
 
  1. Save the file in the same directory as the deploy.sh script.
  1. Open a terminal and navigate to the directory where the files are located.
  1. Run the following command: ./deploy.sh --config config.yaml
- 1. The script will read the parameters from the config file and proceed with the deployment process.
+ 1. The script will read the parameters from the config file and proceed with the deployment process. If DJANGO_SUPERUSER_PASSWORD environment variable is set, the script will use it to set the Django superuser password instead of the value in the YAML file.
 
 <!--
 TODO:  Give instruction for a custom deployment.
@@ -477,6 +479,8 @@ destroying it. These resources will otherwise persist and accrue costs.**
 To tear down the web interface and its hosting infrastructure, run
 directory `./teardown.sh` on the original client machine
 in the same directory that was used to deploy TKFE.
+
+Note: If the -y flag is passed to the script, all user questions will be answered with "yes". This is intended for automated deployments where user input is not possible.
 
 ## Troubleshooting
 

--- a/community/front-end/ofe/docs/admin_guide.md
+++ b/community/front-end/ofe/docs/admin_guide.md
@@ -41,6 +41,8 @@ TKFE is deployed from a client machine using a script. The script will guide
 the admin through the setup process, prompting for input of required
 parameters, then deploy TKFE into the Google Cloud Platform.
 
+TKFE can also be deployed using a configuration file specified with the --config option. In this case, the script will read the required parameters from the YAML file instead of prompting the user for input. This allows for more streamlined and automated deployment processes. However, it is important to ensure that all required parameters are properly specified in the configuration file before deploying.
+
 ### Prerequisites
 
 #### Client Machine
@@ -140,6 +142,8 @@ If further help is needed, please refer to GCP documentation for:
 - [Granting and roles/permissions](https://cloud.google.com/iam/docs/creating-custom-roles)
 
 ### Deployment Process
+#### Manual deployment process
+
 TKFE uses a deployment script run on the client machine, prompting for required
 parameters, to configure TKFE.
 
@@ -174,6 +178,30 @@ parameters, to configure TKFE.
    - **Note: after the deploy script has completed, it will still take up to
      another 15 minutes to fully install the TKFE server with its full
      software stack.**
+
+#### Automated deployment process
+TKFE can also be deployed automatically using a YAML configuration file with all the required parameters. To deploy using this option, run ./deploy.sh --config <path-to-config-file>. All required parameters for deployment must be specified in the YAML file. If any required parameter is missing or invalid, the script will exit with an error. If all parameters are provided correctly, the deployment process will proceed automatically without any prompts for user input. Note that in case of any errors during deployment, the script will exit with an error and no resources will be created or modified.
+
+To use this configuration file for automated deployment, follow these steps:
+
+1. Create a file called config.yaml.
+
+  ```yaml
+  deployment_name: MyDeployment
+  project_id: my-project-id
+  zone: us-west1-a
+  subnet_name: my-subnet # (optional)
+  dns_hostname: myhostname.com # (optional)
+  ip_address: 1.2.3.4 # (optional)
+  django_superuser_username: sysadm
+  django_superuser_password: Passw0rd!
+  django_superuser_email: sysadmin@example.com
+  ```
+
+ 1. Save the file in the same directory as the deploy.sh script.
+ 1. Open a terminal and navigate to the directory where the files are located.
+ 1. Run the following command: ./deploy.sh --config config.yaml
+ 1. The script will read the parameters from the config file and proceed with the deployment process.
 
 <!--
 TODO:  Give instruction for a custom deployment.

--- a/community/front-end/ofe/teardown.sh
+++ b/community/front-end/ofe/teardown.sh
@@ -125,15 +125,18 @@ fi
 if [[ ! -f tf/.tkfe.lock ]]; then
 	echo "  Warning: No lock file found"
 	echo "           It is likely there is no FrontEnd currently deployed"
-	read -r -p "           Proceed anyway? [y/N]: " ready
-	case "$ready" in
-	[Yy]*) ;;
-
-	*)
-		echo "Exiting."
-		exit 0
-		;;
-	esac
+	if [[ "$1" == "-y" ]]; then
+		echo "           -y flag passed. Proceeding anyway."
+	else
+		read -r -p "           Proceed anyway? [y/N]: " ready
+		case "$ready" in
+		[Yy]*) ;;
+		*)
+			echo "Exiting."
+			exit 0
+			;;
+		esac
+	fi
 	echo ""
 fi
 
@@ -169,15 +172,18 @@ fi
 echo "  This will destroy the running FrontEnd: ${dname}"
 echo "  Please ensure all resources deployed by the FrontEnd have been deleted."
 echo ""
-read -r -p "           Proceed? [y/N]: " ready
-case "$ready" in
-[Yy]*) ;;
-
-*)
-	echo "Exiting."
-	exit 0
-	;;
-esac
+if [[ "$1" == "-y" ]]; then
+	echo "           -y flag passed. Proceeding anyway."
+else
+	read -r -p "           Proceed? [y/N]: " ready
+	case "$ready" in
+	[Yy]*) ;;
+	*)
+		echo "Exiting."
+		exit 0
+		;;
+	esac
+fi
 echo ""
 
 # TODO: Spawn a shutdown script on FE server, via gcloud, which finds


### PR DESCRIPTION
New feature:
* Added support for automated OFE deployment using a config file, allowing for faster and more efficient deployment of OFE.

Changes:
 * Modified the OFE deployment script to automatically read parameters from a config file if the --config option is used.
 * Modified the deployment script to skip the confirmation prompt if deploying from the config file using the --config option.
 * Added a new documentation section on automated OFE deployment using a config file with an example YAML file.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
