### PR TITLE
Fix HTCondor central manager configuration

### DIFF
--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -86,7 +86,6 @@
       ansible.builtin.set_fact:
         central_manager_list: "{{ htcondor_central_manager_ips | split(',') }}"
     - name: Create Central Manager standard configuration file
-      when: central_manager_list | length > 1
       ansible.builtin.copy:
         dest: "{{ condor_config_root }}/config.d/{{ cm_config_file }}"
         mode: 0644


### PR DESCRIPTION
Ensure that a central manager optimization is configured even when high availability is not enabled. Without this change, autoscaling will take several minutes and machines will not be filled depth-first (typically cost-optimal).

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?