### PR TITLE
Add TransformSimpleToHcl for cty.Value

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,7 +62,6 @@ var errorMessages = map[string]string{
 	"intergroupOrder":      "References to outputs from other groups must be to earlier groups",
 	"referenceWrongGroup":  "Reference specified the wrong group for the module",
 	"noOutput":             "Output not found for a variable",
-	"varWithinStrings":     "variables \"$(...)\" within strings are not yet implemented. remove them or add a backslash to render literally.",
 	"groupNotFound":        "The group ID was not found",
 	"cannotUsePacker":      "Packer modules cannot be used by other modules",
 	// validator
@@ -622,12 +621,8 @@ func checkBackend(b TerraformBackend) error {
 	if hasVariable(b.Type) {
 		return fmt.Errorf(errMsg, "type", b.Type)
 	}
-	for k, v := range b.Configuration.Items() {
-		if v.Type() == cty.String && hasVariable(v.AsString()) {
-			return fmt.Errorf(errMsg, k, v.AsString())
-		}
-	}
-	return nil
+	_, err := TransformSimpleToHcl(b.Configuration.AsObject(), DoNotAllowVariablesTranslator{})
+	return err
 }
 
 func checkBackends(bp Blueprint) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1241,7 +1241,7 @@ func (s *MySuite) TestCheckBackends(c *C) {
 	{ // FAIL. Variable in defaults configuration
 		b := TerraformBackend{Type: "gcs"}
 		b.Configuration.Set("bucket", cty.StringVal("$(trenta)"))
-		c.Check(check(b), ErrorMatches, ".*bucket.*trenta.*")
+		c.Check(check(b), ErrorMatches, ".*trenta.*")
 	}
 
 	{ // OK. handles nested configuration
@@ -1250,9 +1250,9 @@ func (s *MySuite) TestCheckBackends(c *C) {
 			Set("bucket", cty.StringVal("trenta")).
 			Set("complex", cty.MapVal(map[string]cty.Value{
 				"alpha": cty.StringVal("a"),
-				"beta":  cty.StringVal("b"),
+				"beta":  cty.StringVal("$(boba)"),
 			}))
-		c.Check(check(b), IsNil)
+		c.Check(check(b), ErrorMatches, ".*boba.*")
 	}
 }
 

--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -71,6 +71,11 @@ func (d *Dict) Items() map[string]cty.Value {
 	return m
 }
 
+// AsObject returns Dict as cty.ObjectVal
+func (d *Dict) AsObject() cty.Value {
+	return cty.ObjectVal(d.Items())
+}
+
 // yamlValue is wrapper around cty.Value to handle YAML unmarshal.
 type yamlValue struct {
 	v cty.Value

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Reference is data struct that represents a reference to a variable.
+// Neither checks are performed, nor context is captured, just a structural
+// representation of a reference text
+type Reference struct {
+	GlobalVar bool
+	Group     string // should be empty if GlobalVar, otherwise optional
+	Module    string // should be empty if GlobalVar. otherwise required
+	Name      string // required
+}
+
+// SimpleVarToReference takes a string `$(...)` and transforms it to `Reference`
+func SimpleVarToReference(s string) (Reference, error) {
+	if !isSimpleVariable(s) {
+		return Reference{}, fmt.Errorf(
+			"got %s, variables \"$(...)\" within strings are not yet implemented. remove them or add a backslash to render literally", s)
+	}
+	contents := simpleVariableExp.FindStringSubmatch(s)
+	if len(contents) != 2 { // Should always be (match, contents) here
+		return Reference{}, fmt.Errorf("%s %s, failed to extract contents: %v",
+			errorMessages["invalidVar"], s, contents)
+	}
+	components := strings.Split(contents[1], ".")
+	switch len(components) {
+	case 2:
+		if components[0] == "vars" {
+			return Reference{
+				GlobalVar: true,
+				Name:      components[1]}, nil
+		}
+		return Reference{
+			Module: components[0],
+			Name:   components[1]}, nil
+
+	case 3:
+		return Reference{
+			Group:  components[0],
+			Module: components[1],
+			Name:   components[2]}, nil
+	default:
+		return Reference{}, fmt.Errorf(
+			"expected either 2 or 3 compontens, got %d in %#v", len(components), s)
+	}
+}
+
+// VariableTranslator is an interface that provides function
+// to translate "simple" variable (`$(...)`) into HCL format
+type VariableTranslator interface {
+	TranlateSimpleToHcl(s string) (string, error)
+}
+
+// DoNotAllowVariablesTranslator does not do any translation, it raises an error if any varaibles are met
+type DoNotAllowVariablesTranslator struct {
+	VariableTranslator
+}
+
+// TranlateSimpleToHcl raises an error
+func (t DoNotAllowVariablesTranslator) TranlateSimpleToHcl(s string) (string, error) {
+	return "", fmt.Errorf("variables aren't allowed here, got %#v", s)
+}
+
+// TransformSimpleToHcl produces a new value from passed one, replacing all occurrence
+// of simple variables `$(xxx)` with HCL ones `((yyy)`, using specified translator.
+func TransformSimpleToHcl(val cty.Value, translator VariableTranslator) (cty.Value, error) {
+	return cty.Transform(val, func(p cty.Path, v cty.Value) (cty.Value, error) {
+		if v.Type() != cty.String || !hasVariable(v.AsString()) {
+			return v, nil
+		}
+		h, err := translator.TranlateSimpleToHcl(v.AsString())
+		return cty.StringVal(h), err
+	})
+}

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -68,16 +68,16 @@ func SimpleVarToReference(s string) (Reference, error) {
 // VariableTranslator is an interface that provides function
 // to translate "simple" variable (`$(...)`) into HCL format
 type VariableTranslator interface {
-	TranlateSimpleToHcl(s string) (string, error)
+	TranslateSimpleToHcl(s string) (string, error)
 }
 
-// DoNotAllowVariablesTranslator does not do any translation, it raises an error if any varaibles are met
+// DoNotAllowVariablesTranslator does not do any translation, it raises an error if any variables are met
 type DoNotAllowVariablesTranslator struct {
 	VariableTranslator
 }
 
-// TranlateSimpleToHcl raises an error
-func (t DoNotAllowVariablesTranslator) TranlateSimpleToHcl(s string) (string, error) {
+// TranslateSimpleToHcl raises an error
+func (t DoNotAllowVariablesTranslator) TranslateSimpleToHcl(s string) (string, error) {
 	return "", fmt.Errorf("variables aren't allowed here, got %#v", s)
 }
 
@@ -88,7 +88,7 @@ func TransformSimpleToHcl(val cty.Value, translator VariableTranslator) (cty.Val
 		if v.Type() != cty.String || !hasVariable(v.AsString()) {
 			return v, nil
 		}
-		h, err := translator.TranlateSimpleToHcl(v.AsString())
+		h, err := translator.TranslateSimpleToHcl(v.AsString())
 		return cty.StringVal(h), err
 	})
 }

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -61,7 +61,7 @@ func SimpleVarToReference(s string) (Reference, error) {
 			Name:   components[2]}, nil
 	default:
 		return Reference{}, fmt.Errorf(
-			"expected either 2 or 3 compontens, got %d in %#v", len(components), s)
+			"expected either 2 or 3 components, got %d in %#v", len(components), s)
 	}
 }
 


### PR DESCRIPTION
This is a preparatory step for replacing "simple" variables with HCL ones in Blueprint.

* Add `TransformSimpleToHcl` for cty.Value;
* Add `Reference` struct, as "contextless" `varReference`;
* Minor changes of existing code to use them;
* Change `identifySimpleVariable ` to take `$(xxx)` instead of `xxx`

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
