### PR TITLE
Don't use hclwrite tokenizer for "literal" strings

### DIFF
--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -500,6 +500,7 @@ func (s *MySuite) TestWriteMain(c *C) {
 		ID: "test_module",
 		Settings: map[string]interface{}{
 			"testSetting": "testValue",
+			"passthrough": `(("${vars.deployment_name}-allow\"))`,
 		},
 	}
 	testModules = append(testModules, testModule)
@@ -508,6 +509,14 @@ func (s *MySuite) TestWriteMain(c *C) {
 	exists, err := stringExistsInFile("testSetting", mainFilePath)
 	c.Assert(err, IsNil)
 	c.Assert(exists, Equals, true)
+
+	exists, err = stringExistsInFile(`"${vars.deployment_name}-allow\"`, mainFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, true)
+
+	exists, err = stringExistsInFile(`("${vars.deployment_name}-allow\")`, mainFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
 
 	// Test with Backend
 	testBackend.Type = "gcs"


### PR DESCRIPTION

* Don't use hclwrite tokenizer for "literal" strings because it escapes and  breaks variables passthrough;
* Remove "map compactor" because it contains bug.

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
