### PR TITLE
Add specialized tokenizer to handle `((HCL literals))`

### DIFF
--- a/pkg/modulewriter/hcl_utils.go
+++ b/pkg/modulewriter/hcl_utils.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -58,4 +59,51 @@ func writeHclAttributes(vars map[string]cty.Value, dst string) error {
 		return fmt.Errorf("error writing HCL to %v: %v", filepath.Base(dst), err)
 	}
 	return err
+}
+
+// IsHclLiteral checks if passed value of type cty.String
+// and its content starts with "((" and ends with "))".
+// Returns trimmed string and result of test.
+func IsHclLiteral(v cty.Value) (string, bool) {
+	if v.Type() != cty.String {
+		return "", false
+	}
+	s := v.AsString()
+	if len(s) < 4 || s[:2] != "((" || s[len(s)-2:] != "))" {
+		return "", false
+	}
+	return s[2 : len(s)-2], true
+}
+
+// TokensForValue is a modification of hclwrite.TokensForValue.
+// The only difference in behavior is handling "HCL literal" strings.
+func TokensForValue(val cty.Value) hclwrite.Tokens {
+	if s, is := IsHclLiteral(val); is { // return it "as is"
+		return hclwrite.TokensForIdentifier(s)
+	}
+
+	ty := val.Type()
+	if ty.IsListType() || ty.IsSetType() || ty.IsTupleType() {
+		tl := []hclwrite.Tokens{}
+		for it := val.ElementIterator(); it.Next(); {
+			_, v := it.Element()
+			tl = append(tl, TokensForValue(v))
+		}
+		return hclwrite.TokensForTuple(tl)
+	}
+	if ty.IsMapType() || ty.IsObjectType() {
+		tl := []hclwrite.ObjectAttrTokens{}
+		for it := val.ElementIterator(); it.Next(); {
+			k, v := it.Element()
+			kt := hclwrite.TokensForIdentifier(k.AsString())
+			if !hclsyntax.ValidIdentifier(k.AsString()) {
+				kt = TokensForValue(k)
+			}
+			vt := TokensForValue(v)
+			tl = append(tl, hclwrite.ObjectAttrTokens{Name: kt, Value: vt})
+		}
+		return hclwrite.TokensForObject(tl)
+
+	}
+	return hclwrite.TokensForValue(val) // rely on hclwrite implementation
 }

--- a/pkg/modulewriter/hcl_utils_test.go
+++ b/pkg/modulewriter/hcl_utils_test.go
@@ -1,0 +1,91 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modulewriter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestIsHclLiteral(t *testing.T) {
+	type test struct {
+		input string
+		want  string
+		check bool
+	}
+
+	tests := []test{
+		{"((var.green))", "var.green", true},
+		{"((${var.green}))", "${var.green}", true},
+		{"(( 7 + a }))", " 7 + a }", true},
+		{"(var.green)", "", false},
+		{"((var.green)", "", false},
+		{"$(var.green)", "", false},
+		{"${var.green}", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, check := IsHclLiteral(cty.StringVal(tc.input))
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.check, check); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+
+	}
+}
+
+func TestTokensForValueNoLiteral(t *testing.T) {
+	val := cty.ObjectVal(map[string]cty.Value{
+		"tan": cty.TupleVal([]cty.Value{
+			cty.StringVal("biege"),
+			cty.MapVal(map[string]cty.Value{
+				"cu": cty.NumberIntVal(29),
+				"ba": cty.NumberIntVal(56),
+			})}),
+		"pony.zebra": cty.NilVal,
+	})
+	want := hclwrite.NewEmptyFile()
+	want.Body().AppendUnstructuredTokens(hclwrite.TokensForValue(val))
+
+	got := hclwrite.NewEmptyFile()
+	got.Body().AppendUnstructuredTokens(TokensForValue(val))
+
+	if diff := cmp.Diff(string(want.Bytes()), string(got.Bytes())); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestTokensForValueWithLiteral(t *testing.T) {
+	val := cty.ObjectVal(map[string]cty.Value{
+		"tan": cty.TupleVal([]cty.Value{
+			cty.StringVal("((var.kilo + 8))")})})
+	want := `
+{
+  tan = [var.kilo + 8]
+}`[1:]
+
+	got := hclwrite.NewEmptyFile()
+	got.Body().AppendUnstructuredTokens(TokensForValue(val))
+
+	if diff := cmp.Diff(want, string(got.Bytes())); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -500,6 +500,7 @@ func (s *MySuite) TestWriteMain(c *C) {
 		ID: "test_module",
 		Settings: map[string]interface{}{
 			"testSetting": "testValue",
+			"passthrough": `(("${vars.deployment_name}-allow\"))`,
 		},
 	}
 	testModules = append(testModules, testModule)
@@ -508,6 +509,14 @@ func (s *MySuite) TestWriteMain(c *C) {
 	exists, err := stringExistsInFile("testSetting", mainFilePath)
 	c.Assert(err, IsNil)
 	c.Assert(exists, Equals, true)
+
+	exists, err = stringExistsInFile(`"${vars.deployment_name}-allow\"`, mainFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, true)
+
+	exists, err = stringExistsInFile(`("${vars.deployment_name}-allow\")`, mainFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
 
 	// Test with Backend
 	testBackend.Type = "gcs"

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -31,7 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
@@ -429,14 +428,6 @@ func (s *MySuite) TestGetTypeTokens(c *C) {
 
 }
 
-func (s *MySuite) TestSimpleTokenFromString(c *C) {
-	inputString := "Lorem"
-	tok := simpleTokenFromString("Lorem")
-	c.Assert(tok.Type, Equals, hclsyntax.TokenIdent)
-	c.Assert(len(tok.Bytes), Equals, len(inputString))
-	c.Assert(string(tok.Bytes), Equals, inputString)
-}
-
 func (s *MySuite) TestCreateBaseFile(c *C) {
 	// Success
 	baseFilename := "main.tf_TestCreateBaseFile"
@@ -644,22 +635,6 @@ func (s *MySuite) TestWriteProviders(c *C) {
 	c.Assert(err, IsNil)
 	exists, err = stringExistsInFile("var.region", provFilePath)
 	c.Assert(err, IsNil)
-	c.Assert(exists, Equals, true)
-}
-
-func (s *MySuite) TestHandleLiteralVariables(c *C) {
-	// Setup
-	hclFile := hclwrite.NewEmptyFile()
-	hclBody := hclFile.Body()
-
-	// Set literal var value
-	hclBody.SetAttributeValue("dummyAttributeName1", cty.StringVal("((var.literal))"))
-	hclBody.AppendNewline()
-	hclBytes := handleLiteralVariables(hclFile.Bytes())
-	hclString := string(hclBytes)
-
-	// Sucess
-	exists := strings.Contains(hclString, "dummyAttributeName1 = var.literal")
 	c.Assert(exists, Equals, true)
 }
 


### PR DESCRIPTION
#### Problem A: 
`hclwrite.TokensForValue` is aggressively escaping characters, rendering `((HCL literals))` beyond trivial unusable.
E.g. `"(( \"${vars.foo}-bar\" ))"` becomes `"(( \\\"$${vars.foo}-bar\\\" ))"`.
#### Problem B:
To unwrap literals `tfwriter` uses `handleLiteralVariables` function that performs naive find-and-replace on text of **whole** tf-file. This is dangerous and have to be addressed.

#### Solution:
Do not use `hclwrite.TokensForValue` , instead implement specialized tokenizer that has same behavior, except it tokenizes 
`((HCL literals))` "as is". 
Remove `handleLiteralVariables` as all valid cases for using `((HCL literals))` are covered by value-tokenizer.

#### Other changes:
* Remove "map-compactor" as it has a bug and is not required for validity;
* Simplify `simpleTokenFromString `.

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
