### PR TITLE
Write group metadata to deployment folder

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -101,7 +101,7 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 	if err := deploymentConfig.ExpandConfig(); err != nil {
 		log.Fatal(err)
 	}
-	if err := modulewriter.WriteDeployment(&deploymentConfig.Config, outputDir, overwriteDeployment); err != nil {
+	if err := modulewriter.WriteDeployment(&deploymentConfig.Config, deploymentConfig.GetModuleConnections(), outputDir, overwriteDeployment); err != nil {
 		var target *modulewriter.OverwriteDeniedError
 		if errors.As(err, &target) {
 			fmt.Printf("\n%s\n", err.Error())

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -101,7 +101,7 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 	if err := deploymentConfig.ExpandConfig(); err != nil {
 		log.Fatal(err)
 	}
-	if err := modulewriter.WriteDeployment(&deploymentConfig.Config, deploymentConfig.GetModuleConnections(), outputDir, overwriteDeployment); err != nil {
+	if err := modulewriter.WriteDeployment(deploymentConfig, outputDir, overwriteDeployment); err != nil {
 		var target *modulewriter.OverwriteDeniedError
 		if errors.As(err, &target) {
 			fmt.Printf("\n%s\n", err.Error())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -364,6 +364,12 @@ func (dc *DeploymentConfig) GetModuleConnections() map[string][]ModConnection {
 	return dc.moduleConnections
 }
 
+// SetModuleConnections directly sets module connection graph (primarily for
+// unit testing where config expansion is not well-supported)
+func (dc *DeploymentConfig) SetModuleConnections(mc map[string][]ModConnection) {
+	dc.moduleConnections = mc
+}
+
 // listUnusedModules provides a mapping of modules to modules that are in the
 // "use" field, but not actually used.
 func (dc *DeploymentConfig) listUnusedModules() map[string][]string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -292,11 +292,26 @@ type ModConnection struct {
 	sharedVariables []string
 }
 
+// IsDeploymentKind returns true if connection is to a deployment variable
+func (c ModConnection) IsDeploymentKind() bool {
+	return c.kind == deploymentConnection
+}
+
+// IsUseKind returns true if connection is module-to-module via use keyword
+func (c ModConnection) IsUseKind() bool {
+	return c.kind == useConnection
+}
+
+// GetSharedVariables returns variables used in the connection (can be empty!)
+func (c ModConnection) GetSharedVariables() []string {
+	return c.sharedVariables
+}
+
 // Returns true if a connection does not functionally link the outputs and
 // inputs of the modules. This can happen when a module is connected with "use"
 // but none of the outputs of fromID match the inputs of toID.
-func (mc *ModConnection) isUnused() bool {
-	return mc.kind == useConnection && len(mc.sharedVariables) == 0
+func (c *ModConnection) isUnused() bool {
+	return c.kind == useConnection && len(c.sharedVariables) == 0
 }
 
 // DeploymentConfig is a container for the imported YAML data and supporting data for
@@ -341,6 +356,12 @@ func (dc *DeploymentConfig) addModuleConnection(ref reference, kind connectionKi
 	fromModID := ref.FromModuleID()
 	dc.moduleConnections[fromModID] = append(dc.moduleConnections[fromModID], conn)
 	return nil
+}
+
+// GetModuleConnections returns the graph of connections between modules and
+// from modules to deployment variables
+func (dc *DeploymentConfig) GetModuleConnections() map[string][]ModConnection {
+	return dc.moduleConnections
 }
 
 // listUnusedModules provides a mapping of modules to modules that are in the

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -573,7 +573,7 @@ func (s *MySuite) TestModuleConnections(c *C) {
 	c.Assert(err, NotNil)
 
 	// check that ModuleConnections has map keys for each module ID
-	c.Check(dc.moduleConnections, DeepEquals, map[string][]ModConnection{
+	c.Check(dc.GetModuleConnections(), DeepEquals, map[string][]ModConnection{
 		modID0: {
 			{
 				ref: varReference{
@@ -1301,4 +1301,16 @@ func (s *MySuite) TestSkipValidator(c *C) {
 			{Validator: "zebra", Skip: true}})
 	}
 
+}
+
+func (s *MySuite) TestModuleConnectionGetters(c *C) {
+	sharedVariables := []string{"foo", "bar"}
+	mc := ModConnection{
+		ref:             nil,
+		kind:            useConnection,
+		sharedVariables: sharedVariables,
+	}
+	c.Check(mc.IsUseKind(), Equals, true)
+	c.Check(mc.IsDeploymentKind(), Equals, false)
+	c.Check(mc.GetSharedVariables(), DeepEquals, sharedVariables)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1313,4 +1313,8 @@ func (s *MySuite) TestModuleConnectionGetters(c *C) {
 	c.Check(mc.IsUseKind(), Equals, true)
 	c.Check(mc.IsDeploymentKind(), Equals, false)
 	c.Check(mc.GetSharedVariables(), DeepEquals, sharedVariables)
+
+	mc = ModConnection{}
+	c.Check(mc.IsUseKind(), Equals, false)
+	c.Check(mc.IsDeploymentKind(), Equals, false)
 }

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -641,6 +641,11 @@ func (ref varReference) ToModuleID() string {
 	return ref.toModuleID
 }
 
+// AutomaticOutputName generates unique deployment-group-level output names
+func AutomaticOutputName(outputName string, moduleID string) string {
+	return outputName + "_" + moduleID
+}
+
 func (ref varReference) HclString() string {
 	switch ref.toGroupID {
 	case globalGroupID:
@@ -651,7 +656,7 @@ func (ref varReference) HclString() string {
 		return "module." + ref.toModuleID + "." + ref.name
 	default:
 		// intergroup references to automatically created input variables
-		return "var." + ref.name + "_" + ref.toModuleID
+		return "var." + AutomaticOutputName(ref.name, ref.toModuleID)
 	}
 }
 

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -47,10 +47,10 @@ type ModuleWriter interface {
 	getNumModules() int
 	addNumModules(int)
 	writeDeploymentGroup(
-		depGroup config.DeploymentGroup,
-		globalVars map[string]interface{},
+		dc config.DeploymentConfig,
+		grpIdx int,
 		deployDir string,
-	) error
+	) (groupMetadata, error)
 	restoreState(deploymentDir string) error
 }
 
@@ -84,47 +84,41 @@ func factory(kind string) ModuleWriter {
 
 // WriteDeployment writes a deployment directory using modules defined the
 // environment blueprint.
-func WriteDeployment(blueprint *config.Blueprint, graph map[string][]config.ModConnection, outputDir string, overwriteFlag bool) error {
-	deploymentName, err := blueprint.DeploymentName()
+func WriteDeployment(dc config.DeploymentConfig, outputDir string, overwriteFlag bool) error {
+	deploymentName, err := dc.Config.DeploymentName()
 	if err != nil {
 		return err
 	}
 	deploymentDir := filepath.Join(outputDir, deploymentName)
 
-	overwrite := isOverwriteAllowed(deploymentDir, blueprint, overwriteFlag)
+	overwrite := isOverwriteAllowed(deploymentDir, &dc.Config, overwriteFlag)
 	if err := prepDepDir(deploymentDir, overwrite); err != nil {
 		return err
 	}
 
-	if err := copySource(deploymentDir, &blueprint.DeploymentGroups); err != nil {
+	if err := copySource(deploymentDir, &dc.Config.DeploymentGroups); err != nil {
 		return err
 	}
 
-	if err := createGroupDirs(deploymentDir, &blueprint.DeploymentGroups); err != nil {
+	if err := createGroupDirs(deploymentDir, &dc.Config.DeploymentGroups); err != nil {
 		return err
 	}
 
 	metadata := deploymentMetadata{
 		DeploymentMetadata: []groupMetadata{},
 	}
-	for _, grp := range blueprint.DeploymentGroups {
+	for grpIdx, grp := range dc.Config.DeploymentGroups {
 		writer, ok := kinds[grp.Kind]
 		if !ok {
 			return fmt.Errorf(
-				"Invalid kind in deployment group %s, got '%s'", grp.Name, grp.Kind)
+				"invalid kind in deployment group %s, got '%s'", grp.Name, grp.Kind)
 		}
 
-		filteredVars := filterVarsByGraph(blueprint.Vars, grp, graph)
-		metadata.DeploymentMetadata = append(metadata.DeploymentMetadata, groupMetadata{
-			Name:    grp.Name,
-			Inputs:  orderKeys(filteredVars),
-			Outputs: getAllOutputs(grp),
-		})
-
-		err := writer.writeDeploymentGroup(grp, filteredVars, deploymentDir)
+		gmd, err := writer.writeDeploymentGroup(dc, grpIdx, deploymentDir)
 		if err != nil {
 			return fmt.Errorf("error writing deployment group %s: %w", grp.Name, err)
 		}
+		metadata.DeploymentMetadata = append(metadata.DeploymentMetadata, gmd)
 	}
 
 	if err := writeDeploymentMetadata(deploymentDir, metadata); err != nil {
@@ -330,15 +324,15 @@ func prepDepDir(depDir string, overwrite bool) error {
 		// Confirm we have a previously written deployment dir before overwritting.
 		if _, err := os.Stat(ghpcDir); os.IsNotExist(err) {
 			return fmt.Errorf(
-				"While trying to update the deployment directory at %s, the '.ghpc/' dir could not be found", depDir)
+				"while trying to update the deployment directory at %s, the '.ghpc/' dir could not be found", depDir)
 		}
 	} else {
 		if err := deploymentio.CreateDirectory(ghpcDir); err != nil {
-			return fmt.Errorf("Failed to create directory at %s: err=%w", ghpcDir, err)
+			return fmt.Errorf("failed to create directory at %s: err=%w", ghpcDir, err)
 		}
 
 		if err := deploymentio.CopyFromFS(templatesFS, gitignoreTemplate, gitignoreFile); err != nil {
-			return fmt.Errorf("Failed to copy template.gitignore file to %s: err=%w", gitignoreFile, err)
+			return fmt.Errorf("failed to copy template.gitignore file to %s: err=%w", gitignoreFile, err)
 		}
 	}
 
@@ -346,7 +340,7 @@ func prepDepDir(depDir string, overwrite bool) error {
 	prevGroupDir := filepath.Join(ghpcDir, prevDeploymentGroupDirName)
 	os.RemoveAll(prevGroupDir)
 	if err := os.MkdirAll(prevGroupDir, 0755); err != nil {
-		return fmt.Errorf("Failed to create directory to save previous deployment groups at %s: %w", prevGroupDir, err)
+		return fmt.Errorf("failed to create directory to save previous deployment groups at %s: %w", prevGroupDir, err)
 	}
 
 	// move deployment groups
@@ -367,67 +361,30 @@ func prepDepDir(depDir string, overwrite bool) error {
 	return nil
 }
 
-func filterVarsByGraph(vars map[string]interface{}, group config.DeploymentGroup, graph map[string][]config.ModConnection) map[string]interface{} {
-	if graph == nil {
-		return vars
-	}
-
-	groupInputs := make(map[string]bool)
-	for _, mod := range group.Modules {
-		if connections, ok := graph[mod.ID]; ok {
-			for _, conn := range connections {
-				if conn.IsDeploymentKind() {
-					for _, v := range conn.GetSharedVariables() {
-						groupInputs[v] = true
-					}
-				}
-			}
-		}
-	}
-
-	filteredVars := make(map[string]interface{})
-	for key, val := range vars {
-		if _, ok := groupInputs[key]; ok {
-			filteredVars[key] = val
-		}
-	}
-	return filteredVars
-}
-
 func writeDeploymentMetadata(depDir string, metadata deploymentMetadata) error {
 	ghpcDir := filepath.Join(depDir, hiddenGhpcDirName)
 	if _, err := os.Stat(ghpcDir); os.IsNotExist(err) {
 		return fmt.Errorf(
-			"While trying to update the deployment directory at %s, the '.ghpc/' dir could not be found", depDir)
+			"while trying to update the deployment directory at %s, the '.ghpc/' dir could not be found", depDir)
 	}
 
 	metadataFile := filepath.Join(ghpcDir, deploymentMetadataName)
 	f, err := os.OpenFile(metadataFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+	defer f.Close()
 
 	var buf bytes.Buffer
 	encoder := yaml.NewEncoder(&buf)
+	defer encoder.Close()
 	encoder.SetIndent(2)
-	err = encoder.Encode(metadata)
-	encoder.Close()
-	if err != nil {
+	if err := encoder.Encode(metadata); err != nil {
 		return err
 	}
 	if _, err := f.Write(buf.Bytes()); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	return nil
-}
-
-func getAllOutputs(group config.DeploymentGroup) []string {
-	outputs := make(map[string]bool)
-	for _, mod := range group.Modules {
-		for _, output := range mod.Outputs {
-			outputs[config.AutomaticOutputName(output.Name, mod.ID)] = true
-		}
-	}
-	return orderKeys(outputs)
 }

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -154,7 +154,7 @@ func (s *MySuite) TestPrepDepDir_OverwriteRealDep(c *C) {
 	realDepDir := filepath.Join(testDir, testBlueprint.Vars["deployment_name"].(string))
 
 	// writes a full deployment w/ actual resource groups
-	WriteDeployment(&testBlueprint, testDir, false /* overwrite */)
+	WriteDeployment(&testBlueprint, nil, testDir, false /* overwrite */)
 
 	// confirm existence of resource groups (beyond .ghpc dir)
 	files, _ := ioutil.ReadDir(realDepDir)
@@ -224,13 +224,13 @@ func (s *MySuite) TestWriteDeployment(c *C) {
 
 	testBlueprint := getBlueprintForTest()
 	testBlueprint.Vars = map[string]interface{}{"deployment_name": "test_write_deployment"}
-	err := WriteDeployment(&testBlueprint, testDir, false /* overwriteFlag */)
+	err := WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
 	c.Check(err, IsNil)
 	// Overwriting the deployment fails
-	err = WriteDeployment(&testBlueprint, testDir, false /* overwriteFlag */)
+	err = WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
 	c.Check(err, NotNil)
 	// Overwriting the deployment succeeds with flag
-	err = WriteDeployment(&testBlueprint, testDir, true /* overwriteFlag */)
+	err = WriteDeployment(&testBlueprint, nil, testDir, true /* overwriteFlag */)
 	c.Check(err, IsNil)
 }
 
@@ -297,19 +297,19 @@ func (s *MySuite) TestWriteDeployment_BadDeploymentName(c *C) {
 	var e *config.InputValueError
 
 	testBlueprint.Vars = map[string]interface{}{"deployment_name": 100}
-	err := WriteDeployment(&testBlueprint, testDir, false /* overwriteFlag */)
+	err := WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
 	c.Check(errors.As(err, &e), Equals, true)
 
 	testBlueprint.Vars = map[string]interface{}{"deployment_name": false}
-	err = WriteDeployment(&testBlueprint, testDir, false /* overwriteFlag */)
+	err = WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
 	c.Check(errors.As(err, &e), Equals, true)
 
 	testBlueprint.Vars = map[string]interface{}{"deployment_name": ""}
-	err = WriteDeployment(&testBlueprint, testDir, false /* overwriteFlag */)
+	err = WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
 	c.Check(errors.As(err, &e), Equals, true)
 
 	testBlueprint.Vars = map[string]interface{}{}
-	err = WriteDeployment(&testBlueprint, testDir, false /* overwriteFlag */)
+	err = WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
 	c.Check(errors.As(err, &e), Equals, true)
 }
 

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -74,13 +74,23 @@ func teardown() {
 }
 
 // Test Data Producers
-func getBlueprintForTest() config.Blueprint {
+func getDeploymentConfigForTest() config.DeploymentConfig {
 	testModuleSource := filepath.Join(testDir, terraformModuleDir)
 	testModule := config.Module{
-		Source:   testModuleSource,
-		Kind:     "terraform",
-		ID:       "testModule",
-		Settings: make(map[string]interface{}),
+		Source: testModuleSource,
+		Kind:   "terraform",
+		ID:     "testModule",
+		Settings: map[string]interface{}{
+			"deployment_name": nil,
+			"project_id":      nil,
+		},
+		Outputs: []modulereader.OutputInfo{
+			{
+				Name:        "test-output",
+				Description: "",
+				Sensitive:   false,
+			},
+		},
 	}
 	testModuleSourceWithLabels := filepath.Join(testDir, terraformModuleDir)
 	testModuleWithLabels := config.Module{
@@ -98,13 +108,21 @@ func getBlueprintForTest() config.Blueprint {
 			Modules: []config.Module{testModule, testModuleWithLabels},
 		},
 	}
-	testBlueprint := config.Blueprint{
-		BlueprintName:    "simple",
-		Vars:             map[string]interface{}{},
-		DeploymentGroups: testDeploymentGroups,
+	testDC := config.DeploymentConfig{
+		Config: config.Blueprint{
+			BlueprintName: "simple",
+			Vars: map[string]interface{}{
+				"deployment_name": "deployment_name",
+				"project_id":      "test-project",
+			},
+			DeploymentGroups: testDeploymentGroups,
+		},
+		ModulesInfo: map[string]map[string]modulereader.ModuleInfo{},
 	}
 
-	return testBlueprint
+	testDC.SetModuleConnections(make(map[string][]config.ModConnection))
+
+	return testDC
 }
 
 // Tests
@@ -149,12 +167,12 @@ func (s *MySuite) TestPrepDepDir(c *C) {
 
 func (s *MySuite) TestPrepDepDir_OverwriteRealDep(c *C) {
 	// Test with a real deployment previously written
-	testBlueprint := getBlueprintForTest()
-	testBlueprint.Vars = map[string]interface{}{"deployment_name": "test_prep_dir"}
-	realDepDir := filepath.Join(testDir, testBlueprint.Vars["deployment_name"].(string))
+	testDC := getDeploymentConfigForTest()
+	testDC.Config.Vars = map[string]interface{}{"deployment_name": "test_prep_dir"}
+	realDepDir := filepath.Join(testDir, testDC.Config.Vars["deployment_name"].(string))
 
 	// writes a full deployment w/ actual resource groups
-	WriteDeployment(&testBlueprint, nil, testDir, false /* overwrite */)
+	WriteDeployment(testDC, testDir, false /* overwrite */)
 
 	// confirm existence of resource groups (beyond .ghpc dir)
 	files, _ := ioutil.ReadDir(realDepDir)
@@ -165,7 +183,7 @@ func (s *MySuite) TestPrepDepDir_OverwriteRealDep(c *C) {
 	c.Check(isDeploymentDirPrepped(realDepDir), IsNil)
 
 	// Check prev resource groups were moved
-	prevModuleDir := filepath.Join(testDir, testBlueprint.Vars["deployment_name"].(string), hiddenGhpcDirName, prevDeploymentGroupDirName)
+	prevModuleDir := filepath.Join(testDir, testDC.Config.Vars["deployment_name"].(string), hiddenGhpcDirName, prevDeploymentGroupDirName)
 	files1, _ := ioutil.ReadDir(prevModuleDir)
 	c.Check(len(files1) > 0, Equals, true)
 
@@ -222,15 +240,16 @@ func (s *MySuite) TestWriteDeployment(c *C) {
 	afero.WriteFile(aferoFS, "community/modules/green/lime/main.tf", []byte("lime"), 0644)
 	sourcereader.ModuleFS = afero.NewIOFS(aferoFS)
 
-	testBlueprint := getBlueprintForTest()
-	testBlueprint.Vars = map[string]interface{}{"deployment_name": "test_write_deployment"}
-	err := WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
+	testDC := getDeploymentConfigForTest()
+
+	testDC.Config.Vars = map[string]interface{}{"deployment_name": "test_write_deployment"}
+	err := WriteDeployment(testDC, testDir, false /* overwriteFlag */)
 	c.Check(err, IsNil)
 	// Overwriting the deployment fails
-	err = WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
+	err = WriteDeployment(testDC, testDir, false /* overwriteFlag */)
 	c.Check(err, NotNil)
 	// Overwriting the deployment succeeds with flag
-	err = WriteDeployment(&testBlueprint, nil, testDir, true /* overwriteFlag */)
+	err = WriteDeployment(testDC, testDir, true /* overwriteFlag */)
 	c.Check(err, IsNil)
 }
 
@@ -293,23 +312,23 @@ func (s *MySuite) TestCreateGroupDirs(c *C) {
 }
 
 func (s *MySuite) TestWriteDeployment_BadDeploymentName(c *C) {
-	testBlueprint := getBlueprintForTest()
+	testDC := getDeploymentConfigForTest()
 	var e *config.InputValueError
 
-	testBlueprint.Vars = map[string]interface{}{"deployment_name": 100}
-	err := WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
+	testDC.Config.Vars = map[string]interface{}{"deployment_name": 100}
+	err := WriteDeployment(testDC, testDir, false /* overwriteFlag */)
 	c.Check(errors.As(err, &e), Equals, true)
 
-	testBlueprint.Vars = map[string]interface{}{"deployment_name": false}
-	err = WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
+	testDC.Config.Vars = map[string]interface{}{"deployment_name": false}
+	err = WriteDeployment(testDC, testDir, false /* overwriteFlag */)
 	c.Check(errors.As(err, &e), Equals, true)
 
-	testBlueprint.Vars = map[string]interface{}{"deployment_name": ""}
-	err = WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
+	testDC.Config.Vars = map[string]interface{}{"deployment_name": ""}
+	err = WriteDeployment(testDC, testDir, false /* overwriteFlag */)
 	c.Check(errors.As(err, &e), Equals, true)
 
-	testBlueprint.Vars = map[string]interface{}{}
-	err = WriteDeployment(&testBlueprint, nil, testDir, false /* overwriteFlag */)
+	testDC.Config.Vars = map[string]interface{}{}
+	err = WriteDeployment(testDC, testDir, false /* overwriteFlag */)
 	c.Check(errors.As(err, &e), Equals, true)
 }
 
@@ -679,15 +698,29 @@ func (s *MySuite) TestWriteDeploymentGroup_PackerWriter(c *C) {
 		Name:    "packerGroup",
 		Modules: []config.Module{testPackerModule},
 	}
-	testWriter.writeDeploymentGroup(testDeploymentGroup, testVars, deploymentDir)
+
+	testDC := config.DeploymentConfig{
+		Config: config.Blueprint{
+			BlueprintName:   "",
+			Validators:      nil,
+			ValidationLevel: 0,
+			Vars:            testVars,
+			DeploymentGroups: []config.DeploymentGroup{
+				testDeploymentGroup,
+			},
+		},
+		ModulesInfo: map[string]map[string]modulereader.ModuleInfo{},
+	}
+
+	testWriter.writeDeploymentGroup(testDC, 0, deploymentDir)
 	_, err := os.Stat(filepath.Join(moduleDir, packerAutoVarFilename))
 	c.Assert(err, IsNil)
 }
 
 func (s *MySuite) TestWritePackerAutoVars(c *C) {
-	testBlueprint := getBlueprintForTest()
-	testBlueprint.Vars["testkey"] = "testval"
-	ctyVars, _ := config.ConvertMapToCty(testBlueprint.Vars)
+	testDC := getDeploymentConfigForTest()
+	testDC.Config.Vars["testkey"] = "testval"
+	ctyVars, _ := config.ConvertMapToCty(testDC.Config.Vars)
 
 	// fail writing to a bad path
 	badDestPath := "not/a/real/path"

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -93,7 +93,7 @@ func writeOutputs(
 	for _, mod := range modules {
 		for _, output := range mod.Outputs {
 			// Create output block
-			outputName := fmt.Sprintf("%s_%s", output.Name, mod.ID)
+			outputName := config.AutomaticOutputName(output.Name, mod.ID)
 			hclBlock := hclBody.AppendNewBlock("output", []string{outputName})
 			blockBody := hclBlock.Body()
 

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -157,7 +157,7 @@ func writeVariables(vars map[string]cty.Value, dst string) error {
 
 	// for each variable
 	for _, k := range orderKeys(vars) {
-		v, _ := vars[k]
+		v := vars[k]
 		// Create variable block
 		hclBlock := hclBody.AppendNewBlock("variable", []string{k})
 		blockBody := hclBlock.Body()
@@ -223,7 +223,7 @@ func writeMain(
 
 		// For each Setting
 		for _, setting := range orderKeys(ctySettings) {
-			value, _ := ctySettings[setting]
+			value := ctySettings[setting]
 			if wrap, ok := mod.WrapSettingsWith[setting]; ok {
 				if len(wrap) != 2 {
 					return fmt.Errorf(
@@ -341,15 +341,23 @@ func printTerraformInstructions(grpPath string, moduleName string) {
 // variables.tf
 // groupDir: The path to the directory the resource group will be created in
 func (w TFWriter) writeDeploymentGroup(
-	depGroup config.DeploymentGroup,
-	globalVars map[string]interface{},
+	dc config.DeploymentConfig,
+	groupIndex int,
 	deploymentDir string,
-) error {
+) (groupMetadata, error) {
 
-	ctyVars, err := config.ConvertMapToCty(globalVars)
+	ctyVars, err := config.ConvertMapToCty(dc.Config.Vars)
 	if err != nil {
-		return fmt.Errorf(
+		return groupMetadata{}, fmt.Errorf(
 			"error converting deployment vars to cty for writing: %v", err)
+	}
+
+	depGroup := dc.Config.DeploymentGroups[groupIndex]
+	filteredVars := filterVarsByGraph(ctyVars, depGroup, dc.GetModuleConnections())
+	gmd := groupMetadata{
+		Name:    depGroup.Name,
+		Inputs:  orderKeys(filteredVars),
+		Outputs: getAllOutputs(depGroup),
 	}
 
 	writePath := filepath.Join(deploymentDir, depGroup.Name)
@@ -358,48 +366,48 @@ func (w TFWriter) writeDeploymentGroup(
 	if err := writeMain(
 		depGroup.Modules, depGroup.TerraformBackend, writePath,
 	); err != nil {
-		return fmt.Errorf("error writing main.tf file for deployment group %s: %v",
+		return groupMetadata{}, fmt.Errorf("error writing main.tf file for deployment group %s: %v",
 			depGroup.Name, err)
 	}
 
 	// Write variables.tf file
-	if err := writeVariables(ctyVars, writePath); err != nil {
-		return fmt.Errorf(
+	if err := writeVariables(filteredVars, writePath); err != nil {
+		return groupMetadata{}, fmt.Errorf(
 			"error writing variables.tf file for deployment group %s: %v",
 			depGroup.Name, err)
 	}
 
 	// Write outputs.tf file
 	if err := writeOutputs(depGroup.Modules, writePath); err != nil {
-		return fmt.Errorf(
+		return groupMetadata{}, fmt.Errorf(
 			"error writing outputs.tf file for deployment group %s: %v",
 			depGroup.Name, err)
 	}
 
 	// Write terraform.tfvars file
-	if err := writeTfvars(ctyVars, writePath); err != nil {
-		return fmt.Errorf(
+	if err := writeTfvars(filteredVars, writePath); err != nil {
+		return groupMetadata{}, fmt.Errorf(
 			"error writing terraform.tfvars file for deployment group %s: %v",
 			depGroup.Name, err)
 	}
 
 	// Write providers.tf file
-	if err := writeProviders(ctyVars, writePath); err != nil {
-		return fmt.Errorf(
+	if err := writeProviders(filteredVars, writePath); err != nil {
+		return groupMetadata{}, fmt.Errorf(
 			"error writing providers.tf file for deployment group %s: %v",
 			depGroup.Name, err)
 	}
 
 	// Write versions.tf file
 	if err := writeVersions(writePath); err != nil {
-		return fmt.Errorf(
+		return groupMetadata{}, fmt.Errorf(
 			"error writing versions.tf file for deployment group %s: %v",
 			depGroup.Name, err)
 	}
 
 	printTerraformInstructions(writePath, depGroup.Name)
 
-	return nil
+	return gmd, nil
 }
 
 // Transfers state files from previous resource groups (in .ghpc/) to a newly written blueprint
@@ -422,7 +430,7 @@ func (w TFWriter) restoreState(deploymentDir string) error {
 			if bytesRead, err := ioutil.ReadFile(src); err == nil {
 				err = ioutil.WriteFile(dest, bytesRead, 0644)
 				if err != nil {
-					return fmt.Errorf("Failed to write previous state file %s, %w", dest, err)
+					return fmt.Errorf("failed to write previous state file %s, %w", dest, err)
 				}
 			}
 		}
@@ -438,4 +446,40 @@ func orderKeys[T any](settings map[string]T) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func filterVarsByGraph(vars map[string]cty.Value, group config.DeploymentGroup, graph map[string][]config.ModConnection) map[string]cty.Value {
+	// labels must always be written as a variable as it is implicitly added
+	groupInputs := map[string]bool{
+		"labels": true,
+	}
+	for _, mod := range group.Modules {
+		if connections, ok := graph[mod.ID]; ok {
+			for _, conn := range connections {
+				if conn.IsDeploymentKind() {
+					for _, v := range conn.GetSharedVariables() {
+						groupInputs[v] = true
+					}
+				}
+			}
+		}
+	}
+
+	filteredVars := make(map[string]cty.Value)
+	for key, val := range vars {
+		if groupInputs[key] {
+			filteredVars[key] = val
+		}
+	}
+	return filteredVars
+}
+
+func getAllOutputs(group config.DeploymentGroup) []string {
+	outputs := make(map[string]bool)
+	for _, mod := range group.Modules {
+		for _, output := range mod.Outputs {
+			outputs[config.AutomaticOutputName(output.Name, mod.ID)] = true
+		}
+	}
+	return orderKeys(outputs)
 }


### PR DESCRIPTION
- for each deployment group, write only the deployment variables blocks and attributes that are used
- in the GHPC hidden directory, write a metadata file that contains minimal information about each group's inputs and outputs

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?