### PR TITLE
Developer setup on login is causing workstation to crash on startup

### DIFF
--- a/tools/cloud-workstations/Dockerfile
+++ b/tools/cloud-workstations/Dockerfile
@@ -19,10 +19,6 @@ FROM us-central1-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:la
 
 ARG TFLINT_VERSION
 
-COPY tools/cloud-workstations/configure-hpc-toolkit.sh /bin/
-COPY tools/cloud-workstations/030_configure-hpc-toolkit.sh /etc/workstation-startup.d/
-
-
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     apt-get -y update && apt-get -y install \
     software-properties-common \


### PR DESCRIPTION
Machine startup logs report: `bash: /bin/configure-hpc-toolkit.sh: Permission denied` and machine never becomes healthy.

There is a task open to follow up with a fix but for now I would just like to make it functional.