### PR TITLE
Add HclExpression struct

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -617,7 +617,7 @@ func checkUsedModuleNames(bp Blueprint) error {
 }
 
 func checkBackend(b TerraformBackend) error {
-	const errMsg = "can not use variables in backend block, got '%s=%s'"
+	const errMsg = "can not use variables in terraform_backend block, got '%s=%s'"
 	// TerraformBackend.Type is typed as string, "simple" variables and HCL literals stay "as is".
 	if hasVariable(b.Type) {
 		return fmt.Errorf(errMsg, "type", b.Type)
@@ -627,7 +627,7 @@ func checkBackend(b TerraformBackend) error {
 	}
 	return cty.Walk(b.Configuration.AsObject(), func(p cty.Path, v cty.Value) (bool, error) {
 		if _, is := IsHclValue(v); is {
-			return false, fmt.Errorf("can not use variables in backend block")
+			return false, fmt.Errorf("can not use variables in terraform_backend block")
 		}
 		return true, nil
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -622,7 +622,7 @@ func checkBackend(b TerraformBackend) error {
 	if hasVariable(b.Type) {
 		return fmt.Errorf(errMsg, "type", b.Type)
 	}
-	if _, is := IsRawHclLiteral(cty.StringVal(b.Type)); is {
+	if _, is := IsYamlHclLiteral(cty.StringVal(b.Type)); is {
 		return fmt.Errorf(errMsg, "type", b.Type)
 	}
 	return cty.Walk(b.Configuration.AsObject(), func(p cty.Path, v cty.Value) (bool, error) {

--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -110,7 +110,7 @@ func (y *yamlValue) unmarshalScalar(n *yaml.Node) error {
 		return err
 	}
 
-	if l, is := IsRawHclLiteral(y.v); is { // HCL literal
+	if l, is := IsYamlHclLiteral(y.v); is { // HCL literal
 		var e HclExpression
 		if e, err = ParseExpression(l); err != nil {
 			return err
@@ -171,7 +171,7 @@ func (d *Dict) UnmarshalYAML(n *yaml.Node) error {
 func (d Dict) MarshalYAML() (interface{}, error) {
 	o, err := cty.Transform(d.AsObject(), func(p cty.Path, v cty.Value) (cty.Value, error) {
 		if e, is := IsHclValue(v); is {
-			return e.AsRawValue(), nil
+			return e.makeYamlLiteralValue(), nil
 		}
 		return v, nil
 	})

--- a/pkg/config/dict_test.go
+++ b/pkg/config/dict_test.go
@@ -90,6 +90,10 @@ m1: {}
 m2:
   m2f1: green
   m2f2: [1, 0.2, -3, false]
+  gv: $(vars.gold)
+  mv: $(lime.bloom)
+  igv: $(box.wet.shoe)
+  hl: ((3 + 9))
 `
 	want := Dict{}
 	want.
@@ -104,6 +108,10 @@ m2:
 				cty.NumberIntVal(-3),
 				cty.False,
 			}),
+			"gv":  MustParseExpression("var.gold").AsValue(),
+			"mv":  MustParseExpression("module.lime.bloom").AsValue(),
+			"igv": MustParseExpression("module.wet.shoe").AsValue().Mark(ExplicitGroupMark{"box"}),
+			"hl":  MustParseExpression("3 + 9").AsValue(),
 		}))
 	var got Dict
 	if err := yaml.Unmarshal([]byte(yml), &got); err != nil {
@@ -126,6 +134,7 @@ func TestMarshalYAML(t *testing.T) {
 				cty.NumberFloatVal(0.2),
 				cty.NumberIntVal(-3),
 				cty.False,
+				MustParseExpression("7 + 4").AsValue(),
 			}),
 		}))
 	want := map[string]interface{}{
@@ -133,7 +142,7 @@ func TestMarshalYAML(t *testing.T) {
 		"m1": map[string]interface{}{},
 		"m2": map[string]interface{}{
 			"m2f1": "green",
-			"m2f2": []interface{}{1.0, 0.2, -3.0, false},
+			"m2f2": []interface{}{1.0, 0.2, -3.0, false, "((7 + 4))"},
 		},
 	}
 	got, err := d.MarshalYAML()

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -668,7 +668,7 @@ string into a varReference struct as defined above. An input string consists of
 ensure the existence of the reference!
 */
 func identifySimpleVariable(s string, dg DeploymentGroup, fromMod Module) (varReference, error) {
-	r, err := SimpleVarToReference(s)
+	r, gr, err := SimpleVarToReference(s)
 	if err != nil {
 		return varReference{}, err
 	}
@@ -676,16 +676,16 @@ func identifySimpleVariable(s string, dg DeploymentGroup, fromMod Module) (varRe
 	ref := varReference{
 		fromGroupID:  dg.Name,
 		fromModuleID: fromMod.ID,
-		toGroupID:    r.Group,
+		toGroupID:    gr,
 		toModuleID:   r.Module,
 		name:         r.Name,
-		explicit:     r.Group != "",
+		explicit:     gr != "",
 	}
 
 	if r.GlobalVar {
 		ref.toGroupID = globalGroupID
 		ref.toModuleID = "vars"
-	} else if r.Group == "" {
+	} else if gr == "" {
 		ref.toGroupID = dg.Name
 	}
 

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -141,10 +141,10 @@ func TraversalToReference(t hcl.Traversal) (Reference, error) {
 	}
 }
 
-// IsRawHclLiteral checks if passed value of type cty.String
+// IsYamlHclLiteral checks if passed value of type cty.String
 // and its content starts with "((" and ends with "))".
 // Returns trimmed string and result of test.
-func IsRawHclLiteral(v cty.Value) (string, bool) {
+func IsYamlHclLiteral(v cty.Value) (string, bool) {
 	if v.Type() != cty.String {
 		return "", false
 	}
@@ -204,11 +204,11 @@ func (e HclExpression) References() []Reference {
 	return c
 }
 
-// AsRawValue returns a cty.Value, that is rendered as
+// makeYamlLiteralValue returns a cty.Value, that is rendered as
 // HCL literal in Blueprint syntax. Returned value isn't functional,
 // as it doesn't reference HclExpression.
 // This method should only be used for marshaling Blueprint YAML.
-func (e HclExpression) AsRawValue() cty.Value {
+func (e HclExpression) makeYamlLiteralValue() cty.Value {
 	return cty.StringVal("((" + e.s + "))")
 }
 
@@ -240,7 +240,7 @@ func (e HclExpression) AsValue() cty.Value {
 	k := e.key()
 	// we don't care if ot overrides as expressions are identical
 	globalHclExpressions[k] = e
-	return e.AsRawValue().Mark(e.key())
+	return cty.DynamicVal.Mark(e.key())
 }
 
 // IsHclValue checks if the value is result of `HclExpression.AsValue()`.

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -26,7 +29,6 @@ import (
 // representation of a reference text
 type Reference struct {
 	GlobalVar bool
-	Group     string // should be empty if GlobalVar, otherwise optional
 	Module    string // should be empty if GlobalVar. otherwise required
 	Name      string // required
 }
@@ -49,13 +51,14 @@ func MakeStringInterpolationError(s string) error {
 }
 
 // SimpleVarToReference takes a string `$(...)` and transforms it to `Reference`
-func SimpleVarToReference(s string) (Reference, error) {
+// Returns `Reference` and name of explicit group if one was set.
+func SimpleVarToReference(s string) (Reference, string, error) {
 	if !isSimpleVariable(s) {
-		return Reference{}, MakeStringInterpolationError(s)
+		return Reference{}, "", MakeStringInterpolationError(s)
 	}
 	contents := simpleVariableExp.FindStringSubmatch(s)
 	if len(contents) != 2 { // Should always be (match, contents) here
-		return Reference{}, fmt.Errorf("%s %s, failed to extract contents: %v",
+		return Reference{}, "", fmt.Errorf("%s %s, failed to extract contents: %v",
 			errorMessages["invalidVar"], s, contents)
 	}
 	components := strings.Split(contents[1], ".")
@@ -64,47 +67,216 @@ func SimpleVarToReference(s string) (Reference, error) {
 		if components[0] == "vars" {
 			return Reference{
 				GlobalVar: true,
-				Name:      components[1]}, nil
+				Name:      components[1]}, "", nil
 		}
 		return Reference{
 			Module: components[0],
-			Name:   components[1]}, nil
+			Name:   components[1]}, "", nil
 
 	case 3:
 		return Reference{
-			Group:  components[0],
 			Module: components[1],
-			Name:   components[2]}, nil
+			Name:   components[2]}, components[0], nil
 	default:
-		return Reference{}, fmt.Errorf(
+		return Reference{}, "", fmt.Errorf(
 			"expected either 2 or 3 components, got %d in %#v", len(components), s)
 	}
 }
 
-// VariableTranslator is an interface that provides function
-// to translate "simple" variable (`$(...)`) into HCL format
-type VariableTranslator interface {
-	TranslateSimpleToHcl(s string) (string, error)
+// SimpleVarToHclExpression takes a string `$(...)` and transforms it to `HclExpression`
+// Returns `HclExpression` and name of explicit group if one was set.
+func SimpleVarToHclExpression(s string) (HclExpression, string, error) {
+	ref, gr, err := SimpleVarToReference(s)
+	if err != nil {
+		return HclExpression{}, "", err
+	}
+	var ex HclExpression
+	if ref.GlobalVar {
+		ex, err = ParseExpression(fmt.Sprintf("var.%s", ref.Name))
+	} else {
+		ex, err = ParseExpression(fmt.Sprintf("module.%s.%s", ref.Module, ref.Name))
+	}
+	if err != nil {
+		return HclExpression{}, "", err
+	}
+	return ex, gr, nil
 }
 
-// DoNotAllowVariablesTranslator does not do any translation, it raises an error if any variables are met
-type DoNotAllowVariablesTranslator struct {
-	VariableTranslator
-}
-
-// TranslateSimpleToHcl raises an error
-func (t DoNotAllowVariablesTranslator) TranslateSimpleToHcl(s string) (string, error) {
-	return "", fmt.Errorf("variables aren't allowed here, got %#v", s)
-}
-
-// TransformSimpleToHcl produces a new value from passed one, replacing all occurrence
-// of simple variables `$(xxx)` with HCL ones `((yyy)`, using specified translator.
-func TransformSimpleToHcl(val cty.Value, translator VariableTranslator) (cty.Value, error) {
-	return cty.Transform(val, func(p cty.Path, v cty.Value) (cty.Value, error) {
-		if v.Type() != cty.String || !hasVariable(v.AsString()) {
-			return v, nil
+// TraversalToReference takes HCL traversal and returns `Reference`
+func TraversalToReference(t hcl.Traversal) (Reference, error) {
+	if t.IsRelative() {
+		return Reference{}, fmt.Errorf("got relative traversal")
+	}
+	getAttrName := func(i int) (string, error) {
+		if i >= len(t) {
+			return "", fmt.Errorf("traversal does not have enough components")
 		}
-		h, err := translator.TranslateSimpleToHcl(v.AsString())
-		return cty.StringVal(h), err
-	})
+		if a, ok := t[i].(hcl.TraverseAttr); ok {
+			return a.Name, nil
+		}
+		return "", fmt.Errorf("got unexpected traversal component: %#v", t[i])
+	}
+	switch root := t.RootName(); root {
+	case "var":
+		n, err := getAttrName(1)
+		if err != nil {
+			return Reference{}, fmt.Errorf("expected second component of global var reference to be a variable name, got %w", err)
+		}
+		return Reference{GlobalVar: true, Name: n}, nil
+	case "module":
+		m, err := getAttrName(1)
+		if err != nil {
+			return Reference{}, fmt.Errorf("expected second component of module var reference to be a module name, got %w", err)
+		}
+		n, err := getAttrName(2)
+		if err != nil {
+			return Reference{}, fmt.Errorf("expected third component of module var reference to be a variable name, got %w", err)
+		}
+		return Reference{Module: m, Name: n}, nil
+	default:
+		return Reference{}, fmt.Errorf("unexpected first component of reference: %#v", root)
+	}
+}
+
+// IsRawHclLiteral checks if passed value of type cty.String
+// and its content starts with "((" and ends with "))".
+// Returns trimmed string and result of test.
+func IsRawHclLiteral(v cty.Value) (string, bool) {
+	if v.Type() != cty.String {
+		return "", false
+	}
+	s := v.AsString()
+	if len(s) < 4 || s[:2] != "((" || s[len(s)-2:] != "))" {
+		return "", false
+	}
+	return s[2 : len(s)-2], true
+}
+
+// HclExpression is a representation of HCL literals in Blueprint
+type HclExpression struct {
+	e  hclsyntax.Expression
+	s  string
+	rs []Reference
+}
+
+// ParseExpression returns HclExpression
+func ParseExpression(s string) (HclExpression, error) {
+	e, diag := hclsyntax.ParseExpression([]byte(s), "", hcl.Pos{})
+	if diag.HasErrors() {
+		return HclExpression{}, diag
+	}
+	ts := e.Variables()
+	rs := make([]Reference, len(ts))
+	for i, t := range ts {
+		var err error
+		if rs[i], err = TraversalToReference(t); err != nil {
+			return HclExpression{}, err
+		}
+	}
+	return HclExpression{e: e, s: s, rs: rs}, nil
+}
+
+// MustParseExpression is "errorless" version of ParseExpression
+// NOTE: only use it if passed expression is guaranteed to be correct
+func MustParseExpression(s string) HclExpression {
+	if exp, err := ParseExpression(s); err != nil {
+		panic(fmt.Errorf("error while parsing %#v: %w", s, err))
+	} else {
+		return exp
+	}
+}
+
+// Tokenize returns Tokens to be used for marshalling HCL
+func (e HclExpression) Tokenize() hclwrite.Tokens {
+	return hclwrite.TokensForIdentifier(e.s)
+}
+
+// References return Reference for all variables used in the expression
+func (e HclExpression) References() []Reference {
+	c := make([]Reference, len(e.rs))
+	for i, r := range e.rs {
+		c[i] = r
+	}
+	return c
+}
+
+// AsRawValue returns a cty.Value, that is rendered as
+// HCL literal in Blueprint syntax. Returned value isn't functional,
+// as it doesn't reference HclExpression.
+// This method should only be used for marshaling Blueprint YAML.
+func (e HclExpression) AsRawValue() cty.Value {
+	return cty.StringVal("((" + e.s + "))")
+}
+
+// To associate cty.Value with HclExpression we use cty.Value.Mark
+// See: https://pkg.go.dev/github.com/zclconf/go-cty/cty#Value.Mark
+// "Marks" should be of hashable type, sadly HclExpression isn't one.
+// We work it around by using `hclExpressionKey` - unique identifier
+// of HclExpression and global map of used expressions `globalHclExpressions`.
+// There are two guarantees to hold:
+// * `ex1.key() == ex2.key()` => `ex1` and `ex2` are identical.
+// It's achieved by using HCL literal as a key.
+// * Every "mark" is in agreement with `globalHclExpressions`.
+// Achieved by declaring `HclExpression.AsValue()` as the ONLY way to produce "marks".
+type hclExpressionKey struct {
+	k string
+}
+
+var globalHclExpressions = map[hclExpressionKey]HclExpression{}
+
+// key returns unique identifier of this expression in universe of all possible HCL expressions.
+// `ex1.key() == ex2.key()` => `ex1` and `ex2` are identical.
+func (e HclExpression) key() hclExpressionKey {
+	return hclExpressionKey{k: e.s}
+}
+
+// AsValue returns a cty.Value that represents the expression.
+// This function should be the ONLY way to get HCL expression as a cty.Value.
+func (e HclExpression) AsValue() cty.Value {
+	k := e.key()
+	// we don't care if ot overrides as expressions are identical
+	globalHclExpressions[k] = e
+	return e.AsRawValue().Mark(e.key())
+}
+
+// IsHclValue checks if the value is result of `HclExpression.AsValue()`.
+// Returns original expression and result of check.
+// It will panic if the value is HCL-marked but not a result of `HclExpression.AsValue()`
+func IsHclValue(v cty.Value) (HclExpression, bool) {
+	key, ok := HasMark[hclExpressionKey](v)
+	if !ok {
+		return HclExpression{}, false
+	}
+	expr, stored := globalHclExpressions[key]
+	if !stored { // shouldn't happen
+		panic(fmt.Errorf("HclExpression isn't present in global state, while being referenced by value %#v", v))
+	}
+	return expr, true
+}
+
+// ExplicitGroupMark is mark attached to HclExpression if expression
+// was produced from "simple" variable and had group set explicitly.
+// This mark has no effect on expression and only may be used for validation of
+// original "simple" variable down the road.
+type ExplicitGroupMark struct {
+	Group string
+}
+
+// HasMark checks if cty.Value has mark of specified type T.
+// Returns found mark and result of check.
+// Panics if value has multiple marks of such type.
+func HasMark[T any](val cty.Value) (T, bool) {
+	var tgt T
+	found := false
+	for m := range val.Marks() {
+		t, ok := m.(T)
+		if !ok {
+			continue
+		}
+		if found { // shouldn't happen
+			panic(fmt.Errorf("more than one %T mark at %#v", tgt, val))
+		}
+		found, tgt = true, t
+	}
+	return tgt, found
 }

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -53,6 +53,9 @@ func MakeStringInterpolationError(s string) error {
 // SimpleVarToReference takes a string `$(...)` and transforms it to `Reference`
 // Returns `Reference` and name of explicit group if one was set.
 func SimpleVarToReference(s string) (Reference, string, error) {
+	if !hasVariable(s) {
+		return Reference{}, "", fmt.Errorf("%#v is not a variable", s)
+	}
 	if !isSimpleVariable(s) {
 		return Reference{}, "", MakeStringInterpolationError(s)
 	}
@@ -154,6 +157,7 @@ func IsRawHclLiteral(v cty.Value) (string, bool) {
 
 // HclExpression is a representation of HCL literals in Blueprint
 type HclExpression struct {
+	// Those fields should be accessed by HclExpression methods ONLY.
 	e  hclsyntax.Expression
 	s  string
 	rs []Reference

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -235,7 +235,8 @@ func (e HclExpression) key() hclExpressionKey {
 }
 
 // AsValue returns a cty.Value that represents the expression.
-// This function should be the ONLY way to get HCL expression as a cty.Value.
+// This function is the ONLY way to get an HCL expression as a cty.Value,
+// do not attempt to build it by other means.
 func (e HclExpression) AsValue() cty.Value {
 	k := e.key()
 	// we don't care if ot overrides as expressions are identical

--- a/pkg/config/expression_test.go
+++ b/pkg/config/expression_test.go
@@ -1,0 +1,130 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestTraversalToReference(t *testing.T) {
+	type test struct {
+		expr string
+		want Reference
+		err  bool
+	}
+	tests := []test{
+		{"var.green", Reference{GlobalVar: true, Name: "green"}, false},
+		{"var.green.sleeve", Reference{GlobalVar: true, Name: "green"}, false},
+		{`var.green["sleeve"]`, Reference{GlobalVar: true, Name: "green"}, false},
+		{"var.green[3]", Reference{GlobalVar: true, Name: "green"}, false},
+		{"var", Reference{}, true},
+		{`var["green"]`, Reference{}, true},
+		{`var[3]`, Reference{}, true},
+		{"local.place.here", Reference{}, true},
+		{"module.pink.lime", Reference{Module: "pink", Name: "lime"}, false},
+		{"module.pink.lime.red", Reference{Module: "pink", Name: "lime"}, false},
+		{"module.pink.lime[3]", Reference{Module: "pink", Name: "lime"}, false},
+		{"module.pink", Reference{}, true},
+		{`module.pink["lime"]`, Reference{}, true},
+		{"module.pink[3]", Reference{}, true},
+		{`module["lime"]`, Reference{}, true},
+		{"module[3]", Reference{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			e, diag := hclsyntax.ParseExpression([]byte(tc.expr), "", hcl.Pos{})
+			if diag.HasErrors() {
+				t.Fatal(diag)
+			}
+			te, ok := e.(*hclsyntax.ScopeTraversalExpr)
+			if !ok {
+				t.Fatalf("expected traversal expression, got %#v", e)
+			}
+			got, err := TraversalToReference(te.AsTraversal())
+			if tc.err != (err != nil) {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+
+		})
+	}
+}
+
+func TestIsRawHclLiteral(t *testing.T) {
+	type test struct {
+		input string
+		want  string
+		check bool
+	}
+	tests := []test{
+		{"((var.green))", "var.green", true},
+		{"((${var.green}))", "${var.green}", true},
+		{"(( 7 + a }))", " 7 + a }", true},
+		{"(var.green)", "", false},
+		{"((var.green)", "", false},
+		{"$(var.green)", "", false},
+		{"${var.green}", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, check := IsRawHclLiteral(cty.StringVal(tc.input))
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.check, check); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSimpleVarToReference(t *testing.T) {
+	type test struct {
+		input string
+		want  Reference
+		group string
+		err   bool
+	}
+	tests := []test{
+		{"$(vars.green)", Reference{GlobalVar: true, Name: "green"}, "", false},
+		{"$(var.green)", Reference{Module: "var", Name: "green"}, "", false},
+		{"$(sleeve.green)", Reference{Module: "sleeve", Name: "green"}, "", false},
+		{"$(box.sleeve.green)", Reference{Module: "sleeve", Name: "green"}, "box", false},
+		{"$(vars)", Reference{}, "", true},
+		{"$(az.buki.vedi.glagol)", Reference{}, "", true},
+		{"gold $(var.here)", Reference{}, "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, group, err := SimpleVarToReference(tc.input)
+			if tc.err != (err != nil) {
+				t.Errorf("got unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.group, group); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/config/expression_test.go
+++ b/pkg/config/expression_test.go
@@ -69,7 +69,7 @@ func TestTraversalToReference(t *testing.T) {
 	}
 }
 
-func TestIsRawHclLiteral(t *testing.T) {
+func TestIsYamlHclLiteral(t *testing.T) {
 	type test struct {
 		input string
 		want  string
@@ -86,7 +86,7 @@ func TestIsRawHclLiteral(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
-			got, check := IsRawHclLiteral(cty.StringVal(tc.input))
+			got, check := IsYamlHclLiteral(cty.StringVal(tc.input))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("diff (-want +got):\n%s", diff)
 			}

--- a/pkg/modulewriter/hcl_utils.go
+++ b/pkg/modulewriter/hcl_utils.go
@@ -69,7 +69,7 @@ func TokensForValue(val cty.Value) hclwrite.Tokens {
 	// We need to handle both cases, until `IsRawHclLiteral` is removed
 	if e, is := config.IsHclValue(val); is {
 		return e.Tokenize()
-	} else if s, is := config.IsRawHclLiteral(val); is { // return it "as is"
+	} else if s, is := config.IsYamlHclLiteral(val); is { // return it "as is"
 		return hclwrite.TokensForIdentifier(s)
 	}
 


### PR DESCRIPTION
* Implement HclExpression to represent HCL-literals;
* Transform both "simple" variables and HCL-literals into HclExpression during Dict YAML unmarshalling;
* Modify hcl writter to temporarily handle both cases (plain HCL literal string and special HclExpression value).
* Remove `Group` from `Reference`, store "explicit group name" as a mark on value.

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
