### PR TITLE
Use a unique Packer SSH username to avoid clashes with previous Packer builds

### DIFF
--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -258,7 +258,7 @@ No resources.
 | <a name="input_source_image"></a> [source\_image](#input\_source\_image) | Source OS image to build from | `string` | `null` | no |
 | <a name="input_source_image_family"></a> [source\_image\_family](#input\_source\_image\_family) | Alternative to source\_image. Specify image family to build from latest image in family | `string` | `"hpc-centos-7"` | no |
 | <a name="input_source_image_project_id"></a> [source\_image\_project\_id](#input\_source\_image\_project\_id) | A list of project IDs to search for the source image. Packer will search the<br>first project ID in the list first, and fall back to the next in the list,<br>until it finds the source image. | `list(string)` | `null` | no |
-| <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username to use for SSH access to VM | `string` | `"packer"` | no |
+| <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username to use for SSH access to VM | `string` | `"hpc-toolkit-packer"` | no |
 | <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script (as raw string) used to build the custom Linux VM image (overridden by var.startup\_script\_file if both are set) | `string` | `null` | no |
 | <a name="input_startup_script_file"></a> [startup\_script\_file](#input\_startup\_script\_file) | File path to local shell script that will be used to customize the Linux VM image (overrides var.startup\_script) | `string` | `null` | no |
 | <a name="input_state_timeout"></a> [state\_timeout](#input\_state\_timeout) | The time to wait for instance state changes, including image creation | `string` | `"10m"` | no |

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -131,7 +131,7 @@ variable "use_os_login" {
 variable "ssh_username" {
   description = "Username to use for SSH access to VM"
   type        = string
-  default     = "packer"
+  default     = "hpc-toolkit-packer"
 }
 
 variable "ansible_playbooks" {


### PR DESCRIPTION
Issues can arise when building on an image created from a previous packer build where the SSH user was not properly cleaned up. By using a unique SSH username we can generally avoid these clashes.

Tested:
- Ran a build using `schedmd-v5-slurm-22-05-8-hpc-centos-7` image and `shell_scripts`. Observed error reported in #1172. 
- Ran again with enclosed change. Build was successful.