### PR TITLE
Allow Packer groups to resolve deployment variables in structural types (list, map)

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1317,4 +1318,69 @@ func (s *MySuite) TestModuleConnectionGetters(c *C) {
 	mc = ModConnection{}
 	c.Check(mc.IsUseKind(), Equals, false)
 	c.Check(mc.IsDeploymentKind(), Equals, false)
+}
+
+func (s *MySuite) TestResolveVariables(c *C) {
+	projectID := cty.StringVal("test-project")
+	deploymentName := cty.StringVal("test-deployment")
+	labels := cty.MapVal(map[string]cty.Value{
+		"ghpc_deployment": deploymentName,
+	})
+	customNumber := cty.NumberVal(big.NewFloat(2.0))
+	customBool := cty.BoolVal(true)
+	deploymentVars := map[string]cty.Value{
+		"project_id":      projectID,
+		"deployment_name": deploymentName,
+		"labels":          labels,
+		"custom_number":   customNumber,
+		"custom_bool":     customBool,
+	}
+
+	settings := map[string]cty.Value{
+		"project_id": cty.StringVal("((var.project_id))"),
+		"labels":     cty.StringVal("((var.labels))"),
+		"direct":     cty.StringVal("directly-set"),
+		"number-list": cty.TupleVal([]cty.Value{
+			cty.NumberVal(big.NewFloat(0.0)),
+			cty.StringVal("((var.custom_number))"),
+		}),
+		"bool-map": cty.ObjectVal(map[string]cty.Value{
+			"first":  cty.BoolVal(true),
+			"second": cty.StringVal("((var.custom_bool))"),
+		}),
+	}
+
+	expectedSettings := map[string]cty.Value{
+		"project_id": projectID,
+		"labels":     labels,
+		"direct":     cty.StringVal("directly-set"),
+		"number-list": cty.TupleVal([]cty.Value{
+			cty.NumberVal(big.NewFloat(0.0)),
+			customNumber,
+		}),
+		"bool-map": cty.ObjectVal(map[string]cty.Value{
+			"first":  cty.BoolVal(true),
+			"second": customBool,
+		}),
+	}
+
+	err := ResolveVariables(settings, deploymentVars)
+	c.Assert(err, IsNil)
+	c.Assert(settings, DeepEquals, expectedSettings)
+
+	settings["new-key"] = cty.StringVal("((var.not_a_variable))")
+	err = ResolveVariables(settings, deploymentVars)
+	c.Assert(err, NotNil)
+
+	settings["new-key"] = cty.ObjectVal(map[string]cty.Value{
+		"bad": cty.StringVal("((var.not_a_variable))"),
+	})
+	err = ResolveVariables(settings, deploymentVars)
+	c.Assert(err, NotNil)
+
+	settings["new-key"] = cty.TupleVal([]cty.Value{
+		cty.StringVal("((var.not_a_variable))"),
+	})
+	err = ResolveVariables(settings, deploymentVars)
+	c.Assert(err, NotNil)
 }


### PR DESCRIPTION
Enable deployment variables nested inside structural values to properly resolve in Packer groups when written to `defaults.auto.pkrvars.hcl`. The status quo is for nested values to be skipped and for this file to have "blueprint literals" populated without erroring to the user. Unit test coverage is improved from 84.2% to 85.8% for the config package.

Example blueprint (with vars.labels set to a value that demonstrates the functionality without intending to be interpreted as valid GCP labels):

```yaml
blueprint_name: image-builder

vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: image-builder-001
  zone: us-central1-c
  new_image_family: my-slurm-image
  subnetwork_name: image-builder-us-central1
  disk_size: 32

deployment_groups:
- group: packer
  modules:
  - id: custom-image
    source: modules/packer/custom-image
    kind: packer
    settings:
      source_image_project_id: [schedmd-slurm-public]
      source_image_family: schedmd-v5-slurm-22-05-8-hpc-centos-7
      disk_size: $(vars.disk_size)
      image_family: $(vars.new_image_family)
      state_timeout: 15m
      labels:
        hello: $(vars.zone)
        tata:
          fornow: $(vars.zone)
        toodaloo:
        - $(vars.disk_size)
      tags:
      - $(vars.zone)
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
