### PR TITLE
Make Blueprint.Vars a Dict instead of map[string]interface{}

### DIFF
--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -30,6 +30,15 @@ type Dict struct {
 	m map[string]cty.Value
 }
 
+// NewDict constructor
+func NewDict(m map[string]cty.Value) Dict {
+	d := Dict{}
+	for k, v := range m {
+		d.Set(k, v)
+	}
+	return d
+}
+
 // Get returns stored value or cty.NilVal.
 func (d *Dict) Get(k string) cty.Value {
 	if d.m == nil {

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -442,9 +442,15 @@ func combineModuleLabels(dc *DeploymentConfig, iGrp int, iMod int) error {
 	return nil
 }
 
-func mergeLabels[V interface{}](to map[string]V, from map[string]V) map[string]V {
-	r := maps.Clone(from)
-	maps.Copy(r, to)
+// mergeLabels returns a new map with the keys from both maps. If a key exists in both maps,
+// the value from the first map is used.
+func mergeLabels[V interface{}](a map[string]V, b map[string]V) map[string]V {
+	r := maps.Clone(a)
+	for k, v := range b {
+		if _, exists := a[k]; !exists {
+			r[k] = v
+		}
+	}
 	return r
 }
 

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -103,8 +103,7 @@ func (dc *DeploymentConfig) addMetadataToModules() error {
 	for iGrp, grp := range dc.Config.DeploymentGroups {
 		for iMod, mod := range grp.Modules {
 			if mod.RequiredApis == nil {
-				_, projectIDExists := dc.Config.Vars["project_id"].(string)
-				if !projectIDExists {
+				if dc.Config.Vars.Get("project_id").Type() != cty.String {
 					return fmt.Errorf("global variable project_id must be defined")
 				}
 
@@ -354,29 +353,29 @@ func toStringInterfaceMap(i interface{}) (map[string]interface{}, error) {
 // the global labels defined in Vars with module setting labels. It also
 // determines the role and sets it for each module independently.
 func (dc *DeploymentConfig) combineLabels() error {
-	defaultLabels := map[string]interface{}{
+	vars := &dc.Config.Vars
+	defaults := map[string]string{
 		blueprintLabel:  dc.Config.BlueprintName,
-		deploymentLabel: dc.Config.Vars["deployment_name"],
+		deploymentLabel: dc.Config.Vars.Get("deployment_name").AsString(),
 	}
 	labels := "labels"
-	var globalLabels map[string]interface{}
-
 	// Add defaults to global labels if they don't already exist
-	if _, exists := dc.Config.Vars[labels]; !exists {
-		dc.Config.Vars[labels] = defaultLabels
+	if !vars.Has(labels) {
+		mv := map[string]cty.Value{}
+		for k, v := range defaults {
+			mv[k] = cty.StringVal(v)
+		}
+		vars.Set(labels, cty.ObjectVal(mv))
 	}
 
 	// Cast global labels so we can index into them
-	globalLabels, err := toStringInterfaceMap(dc.Config.Vars[labels])
-	if err != nil {
-		return fmt.Errorf(
-			"%s: found %T",
-			errorMessages["globalLabelType"],
-			dc.Config.Vars[labels])
+	globals := map[string]string{}
+	for k, v := range vars.Get(labels).AsValueMap() {
+		globals[k] = v.AsString()
 	}
 
 	// Add both default labels if they don't already exist
-	mergeInLabels(globalLabels, defaultLabels)
+	globals = mergeLabels(globals, defaults)
 
 	for iGrp, grp := range dc.Config.DeploymentGroups {
 		for iMod := range grp.Modules {
@@ -385,7 +384,12 @@ func (dc *DeploymentConfig) combineLabels() error {
 			}
 		}
 	}
-	dc.Config.Vars[labels] = globalLabels
+
+	mv := map[string]cty.Value{}
+	for k, v := range globals {
+		mv[k] = cty.StringVal(v)
+	}
+	vars.Set(labels, cty.ObjectVal(mv))
 	return nil
 }
 
@@ -429,24 +433,24 @@ func combineModuleLabels(dc *DeploymentConfig, iGrp int, iMod int) error {
 		mod.WrapSettingsWith[labels] = []string{"merge(", ")"}
 		mod.Settings[labels] = []interface{}{"((var.labels))", modLabels}
 	} else if mod.Kind == "packer" {
-		mergeInLabels(modLabels, dc.Config.Vars[labels].(map[string]interface{}))
-		mod.Settings[labels] = modLabels
+		g := map[string]interface{}{}
+		for k, v := range dc.Config.Vars.Get(labels).AsValueMap() {
+			g[k] = v.AsString()
+		}
+		mod.Settings[labels] = mergeLabels(modLabels, g)
 	}
 	return nil
 }
 
-func mergeInLabels[V interface{}](to map[string]V, from map[string]V) {
-	for k, v := range from {
-		if _, exists := to[k]; !exists {
-			to[k] = v
-		}
-	}
+func mergeLabels[V interface{}](to map[string]V, from map[string]V) map[string]V {
+	r := maps.Clone(from)
+	maps.Copy(r, to)
+	return r
 }
 
 func (dc *DeploymentConfig) applyGlobalVarsInGroup(groupIndex int) error {
 	deploymentGroup := dc.Config.DeploymentGroups[groupIndex]
 	modInfo := dc.ModulesInfo[deploymentGroup.Name]
-	globalVars := dc.Config.Vars
 
 	for _, mod := range deploymentGroup.Modules {
 		for _, input := range modInfo[mod.Source].Inputs {
@@ -457,7 +461,7 @@ func (dc *DeploymentConfig) applyGlobalVarsInGroup(groupIndex int) error {
 			}
 
 			// If it's not set, is there a global we can use?
-			if _, ok := globalVars[input.Name]; ok {
+			if dc.Config.Vars.Has(input.Name) {
 				ref := varReference{
 					name:         input.Name,
 					toModuleID:   "vars",
@@ -496,11 +500,6 @@ func updateGlobalVarTypes(vars map[string]interface{}) error {
 // applyGlobalVariables takes any variables defined at the global level and
 // applies them to module settings if not already set.
 func (dc *DeploymentConfig) applyGlobalVariables() error {
-	// Update global variable types to match
-	if err := updateGlobalVarTypes(dc.Config.Vars); err != nil {
-		return err
-	}
-
 	for groupIndex := range dc.Config.DeploymentGroups {
 		err := dc.applyGlobalVarsInGroup(groupIndex)
 		if err != nil {
@@ -764,7 +763,7 @@ func (ref varReference) validate(bp Blueprint) error {
 	// simplest case to evaluate is a deployment variable's existence
 	if ref.toGroupID == globalGroupID {
 		if ref.toModuleID == "vars" {
-			if _, ok := bp.Vars[ref.name]; !ok {
+			if !bp.Vars.Has(ref.name) {
 				return fmt.Errorf("%s: %s is not a deployment variable",
 					errorMessages["varNotFound"], ref.name)
 			}
@@ -1014,9 +1013,9 @@ func (dc *DeploymentConfig) addDefaultValidators() error {
 		dc.Config.Validators = []validatorConfig{}
 	}
 
-	_, projectIDExists := dc.Config.Vars["project_id"]
-	_, regionExists := dc.Config.Vars["region"]
-	_, zoneExists := dc.Config.Vars["zone"]
+	projectIDExists := dc.Config.Vars.Has("project_id")
+	regionExists := dc.Config.Vars.Has("region")
+	zoneExists := dc.Config.Vars.Has("zone")
 
 	defaults := []validatorConfig{}
 	defaults = append(defaults, validatorConfig{

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -62,12 +62,6 @@ func (w PackerWriter) writeDeploymentGroup(
 	grpIdx int,
 	deployDir string,
 ) (groupMetadata, error) {
-	ctyGlobals, err := config.ConvertMapToCty(dc.Config.Vars)
-	if err != nil {
-		return groupMetadata{}, fmt.Errorf(
-			"error converting deployment vars to cty for writing: %w", err)
-	}
-
 	depGroup := dc.Config.DeploymentGroups[grpIdx]
 	groupPath := filepath.Join(deployDir, depGroup.Name)
 	allInputs := make(map[string]bool)
@@ -82,7 +76,7 @@ func (w PackerWriter) writeDeploymentGroup(
 			return groupMetadata{}, fmt.Errorf(
 				"error converting packer module settings to cty for writing: %w", err)
 		}
-		err = config.ResolveVariables(ctySettings, ctyGlobals)
+		err = config.ResolveVariables(ctySettings, dc.Config.Vars.Items())
 		if err != nil {
 			return groupMetadata{}, err
 		}

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -345,15 +345,8 @@ func (w TFWriter) writeDeploymentGroup(
 	groupIndex int,
 	deploymentDir string,
 ) (groupMetadata, error) {
-
-	ctyVars, err := config.ConvertMapToCty(dc.Config.Vars)
-	if err != nil {
-		return groupMetadata{}, fmt.Errorf(
-			"error converting deployment vars to cty for writing: %v", err)
-	}
-
 	depGroup := dc.Config.DeploymentGroups[groupIndex]
-	filteredVars := filterVarsByGraph(ctyVars, depGroup, dc.GetModuleConnections())
+	filteredVars := filterVarsByGraph(dc.Config.Vars.Items(), depGroup, dc.GetModuleConnections())
 	gmd := groupMetadata{
 		Name:    depGroup.Name,
 		Inputs:  orderKeys(filteredVars),


### PR DESCRIPTION
* move `validateVars` before `expand`.

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
