### PR TITLE
Rename `HclExpression` -> `Expression`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -622,11 +622,11 @@ func checkBackend(b TerraformBackend) error {
 	if hasVariable(b.Type) {
 		return fmt.Errorf(errMsg, "type", b.Type)
 	}
-	if _, is := IsYamlHclLiteral(cty.StringVal(b.Type)); is {
+	if _, is := IsYamlExpressionLiteral(cty.StringVal(b.Type)); is {
 		return fmt.Errorf(errMsg, "type", b.Type)
 	}
 	return cty.Walk(b.Configuration.AsObject(), func(p cty.Path, v cty.Value) (bool, error) {
-		if _, is := IsHclValue(v); is {
+		if _, is := IsExpressionValue(v); is {
 			return false, fmt.Errorf("can not use variables in terraform_backend block")
 		}
 		return true, nil

--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -110,14 +110,14 @@ func (y *yamlValue) unmarshalScalar(n *yaml.Node) error {
 		return err
 	}
 
-	if l, is := IsYamlHclLiteral(y.v); is { // HCL literal
-		var e HclExpression
+	if l, is := IsYamlExpressionLiteral(y.v); is { // HCL literal
+		var e Expression
 		if e, err = ParseExpression(l); err != nil {
 			return err
 		}
 		y.v = e.AsValue()
 	} else if y.v.Type() == cty.String && hasVariable(y.v.AsString()) { // "simple" variable
-		e, err := SimpleVarToHclExpression(y.v.AsString())
+		e, err := SimpleVarToExpression(y.v.AsString())
 		if err != nil {
 			return err
 		}
@@ -167,8 +167,8 @@ func (d *Dict) UnmarshalYAML(n *yaml.Node) error {
 // MarshalYAML implements custom YAML marshaling.
 func (d Dict) MarshalYAML() (interface{}, error) {
 	o, err := cty.Transform(d.AsObject(), func(p cty.Path, v cty.Value) (cty.Value, error) {
-		if e, is := IsHclValue(v); is {
-			return e.makeYamlLiteralValue(), nil
+		if e, is := IsExpressionValue(v); is {
+			return e.makeYamlExpressionValue(), nil
 		}
 		return v, nil
 	})

--- a/pkg/config/expression_test.go
+++ b/pkg/config/expression_test.go
@@ -86,7 +86,7 @@ func TestIsYamlHclLiteral(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
-			got, check := IsYamlHclLiteral(cty.StringVal(tc.input))
+			got, check := IsYamlExpressionLiteral(cty.StringVal(tc.input))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("diff (-want +got):\n%s", diff)
 			}

--- a/pkg/modulewriter/hcl_utils.go
+++ b/pkg/modulewriter/hcl_utils.go
@@ -66,10 +66,10 @@ func writeHclAttributes(vars map[string]cty.Value, dst string) error {
 // TokensForValue is a modification of hclwrite.TokensForValue.
 // The only difference in behavior is handling "HCL literal" strings.
 func TokensForValue(val cty.Value) hclwrite.Tokens {
-	// We need to handle both cases, until `IsRawHclLiteral` is removed
-	if e, is := config.IsHclValue(val); is {
+	// We need to handle both cases, until all "expression" users are moved to Expression
+	if e, is := config.IsExpressionValue(val); is {
 		return e.Tokenize()
-	} else if s, is := config.IsYamlHclLiteral(val); is { // return it "as is"
+	} else if s, is := config.IsYamlExpressionLiteral(val); is { // return it "as is"
 		return hclwrite.TokensForIdentifier(s)
 	}
 


### PR DESCRIPTION
Rename `HclExpression` -> `Expression` to signify that this is our main way to handle expressions and hide HCL-nature of it from code that shouldn't care about it.

### Submission Checklist

* [ ] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [ ] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [ ] Have you followed the guidelines in our Contributing document?
