### PR TITLE
Enable intergroup references in "advanced usage" mode

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1358,11 +1358,11 @@ func (s *MySuite) TestResolveVariables(c *C) {
 func (s *MySuite) TestModuleGroup(c *C) {
 	dc := getDeploymentConfigForTest()
 
-	groupID := dc.Config.DeploymentGroups[0].Name
+	group := dc.Config.DeploymentGroups[0]
 	modID := dc.Config.DeploymentGroups[0].Modules[0].ID
 
-	foundGroupID := dc.Config.ModuleGroupOrDie(modID)
-	c.Assert(foundGroupID, Equals, groupID)
+	foundGroup := dc.Config.ModuleGroupOrDie(modID)
+	c.Assert(foundGroup, DeepEquals, group)
 
 	_, err := dc.Config.ModuleGroup("bad_module_id")
 	c.Assert(err, NotNil)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -330,7 +330,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 					matchingIntragroupName2: fmt.Sprintf("$(%s.%s)", modID0, matchingIntragroupName2),
 				},
 				Use: []string{
-					fmt.Sprintf("%s.%s", dg0Name, modID0),
+					modID0,
 				},
 			},
 		},
@@ -344,7 +344,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 				Source:   testModuleSource2,
 				Settings: map[string]interface{}{},
 				Use: []string{
-					fmt.Sprintf("%s.%s", testDeploymentGroup0.Name, testDeploymentGroup0.Modules[0].ID),
+					testDeploymentGroup0.Modules[0].ID,
 				},
 			},
 		},
@@ -471,7 +471,6 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 		fromModuleID: "usingModule",
 		toGroupID:    "group1",
 		fromGroupID:  "group1",
-		explicit:     true,
 	}
 	dc.addModuleConnection(modRef0, useConnection, []string{"var1"})
 	got = dc.listUnusedModules()
@@ -483,7 +482,6 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 		fromModuleID: "usingModule",
 		toGroupID:    "group1",
 		fromGroupID:  "group1",
-		explicit:     true,
 	}
 	dc.addModuleConnection(modRef1, useConnection, []string{})
 	got = dc.listUnusedModules()
@@ -495,7 +493,6 @@ func (s *MySuite) TestListUnusedModules(c *C) {
 		fromModuleID: "usingModule",
 		toGroupID:    "group1",
 		fromGroupID:  "group1",
-		explicit:     true,
 	}
 	dc.addModuleConnection(modRef2, useConnection, []string{})
 	got = dc.listUnusedModules()
@@ -604,7 +601,6 @@ func (s *MySuite) TestModuleConnections(c *C) {
 					fromModuleID: "TestModule1",
 					toGroupID:    "primary",
 					fromGroupID:  "primary",
-					explicit:     true,
 				},
 				kind:            useConnection,
 				sharedVariables: []string{"test_intra_0"},
@@ -628,7 +624,6 @@ func (s *MySuite) TestModuleConnections(c *C) {
 					fromModuleID: "TestModule2",
 					toGroupID:    "primary",
 					fromGroupID:  "secondary",
-					explicit:     true,
 				},
 				kind:            useConnection,
 				sharedVariables: []string{"test_inter_0"},
@@ -1279,7 +1274,6 @@ func (s *MySuite) TestModuleConnectionGetters(c *C) {
 			fromModuleID: "waldo",
 			toGroupID:    "baz",
 			fromGroupID:  "baz",
-			explicit:     true,
 		},
 		kind:            useConnection,
 		sharedVariables: sharedVariables,
@@ -1359,4 +1353,17 @@ func (s *MySuite) TestResolveVariables(c *C) {
 	err = ResolveVariables(settings, deploymentVars, []string{"not_a_variable"})
 	c.Assert(err, IsNil)
 	c.Assert(settings, DeepEquals, expectedSettings)
+}
+
+func (s *MySuite) TestModuleGroup(c *C) {
+	dc := getDeploymentConfigForTest()
+
+	groupID := dc.Config.DeploymentGroups[0].Name
+	modID := dc.Config.DeploymentGroups[0].Modules[0].ID
+
+	foundGroupID := dc.Config.ModuleGroupOrDie(modID)
+	c.Assert(foundGroupID, Equals, groupID)
+
+	_, err := dc.Config.ModuleGroup("bad_module_id")
+	c.Assert(err, NotNil)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -568,7 +568,7 @@ func (s *MySuite) TestModuleConnections(c *C) {
 	c.Assert(err, IsNil)
 	err = dc.expandVariables()
 	// TODO: this will become nil once intergroup references are enabled
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 
 	// check that ModuleConnections has map keys for each module ID
 	c.Check(dc.GetModuleConnections(), DeepEquals, map[string][]ModConnection{
@@ -1273,7 +1273,13 @@ func (s *MySuite) TestSkipValidator(c *C) {
 func (s *MySuite) TestModuleConnectionGetters(c *C) {
 	sharedVariables := []string{"foo", "bar"}
 	mc := ModConnection{
-		ref:             nil,
+		ref: modReference{
+			toModuleID:   "fred",
+			fromModuleID: "waldo",
+			toGroupID:    "baz",
+			fromGroupID:  "baz",
+			explicit:     true,
+		},
 		kind:            useConnection,
 		sharedVariables: sharedVariables,
 	}

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -578,13 +578,13 @@ func identifyModuleByReference(yamlReference string, bp Blueprint, fromMod strin
 	if err != nil {
 		return modReference{}, err
 	}
-	ref.fromGroupID = fromG
+	ref.fromGroupID = fromG.Name
 
 	toG, err := bp.ModuleGroup(ref.toModuleID)
 	if err != nil {
 		return modReference{}, err
 	}
-	ref.toGroupID = toG
+	ref.toGroupID = toG.Name
 
 	// should consider more sophisticated definition of valid values here.
 	// for now check that no fields are the empty string; due to the default
@@ -675,7 +675,7 @@ func identifySimpleVariable(s string, bp Blueprint, fromMod string) (varReferenc
 	}
 
 	ref := varReference{
-		fromGroupID:  fromG,
+		fromGroupID:  fromG.Name,
 		fromModuleID: fromMod,
 		toModuleID:   r.Module,
 		name:         r.Name,
@@ -689,7 +689,7 @@ func identifySimpleVariable(s string, bp Blueprint, fromMod string) (varReferenc
 		if err != nil {
 			return varReference{}, err
 		}
-		ref.toGroupID = g
+		ref.toGroupID = g.Name
 	}
 
 	// should consider more sophisticated definition of valid values here.

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -882,17 +882,13 @@ func expandSimpleVariable(context varContext, trackModuleGraph bool) (string, er
 		if toModIdx == -1 {
 			return "", fmt.Errorf("%s: %s", errorMessages["invalidMod"], varRef.toModuleID)
 		}
-		toMod := toGrp.Modules[toModIdx]
+		toMod := &toGrp.Modules[toModIdx]
 
 		// ensure that the target module outputs the value in the root module
 		// state and not just internally within its deployment group
 		if !slices.ContainsFunc(toMod.Outputs, func(o modulereader.OutputInfo) bool { return o.Name == varRef.name }) {
 			toMod.Outputs = append(toMod.Outputs, modulereader.OutputInfo{Name: varRef.name})
 		}
-
-		// TODO: remove error
-		return "", fmt.Errorf("%s: %s is an intergroup reference",
-			errorMessages["varInAnotherGroup"], context.varString)
 	}
 	return fmt.Sprintf("((%s))", varRef.HclString()), nil
 }

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -17,7 +17,6 @@ package config
 import (
 	"fmt"
 	"hpc-toolkit/pkg/modulereader"
-	"regexp"
 
 	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/exp/maps"
@@ -848,14 +847,15 @@ func (s *MySuite) TestExpandSimpleVariable(c *C) {
 		errorMessages["intergroupOrder"], testModule1.ID)
 	c.Assert(err, ErrorMatches, expectedErr)
 
-	// Intergroup variable: proper explicit reference to earlier group
-	// TODO: failure is temporary when support is added this should be a success!
+	// Intergroup variable
 	testVarInfoOutput = modulereader.OutputInfo{Name: existingOutput}
 	testModInfo = modulereader.ModuleInfo{
 		Outputs: []modulereader.OutputInfo{testVarInfoOutput},
 	}
 	reader.SetInfo(testModule0.Source, testModInfo)
-	testVarContext1.varString = fmt.Sprintf("$(%s.%s)", testModule0.ID, existingOutput)
-	_, err = expandSimpleVariable(testVarContext1, false)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("%s: %s .*", errorMessages["varInAnotherGroup"], regexp.QuoteMeta(testVarContext1.varString)))
+	testVarContext1.varString = fmt.Sprintf(
+		"$(%s.%s)", testModule0.ID, existingOutput)
+	got, err = expandSimpleVariable(testVarContext1, false)
+	c.Assert(err, IsNil)
+	c.Assert(got, Equals, fmt.Sprintf("((var.%s_%s))", existingOutput, testModule0.ID))
 }

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"log"
 	"path"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -113,6 +114,16 @@ func (i ModuleInfo) GetOutputsAsMap() map[string]OutputInfo {
 		outputsMap[output.Name] = output
 	}
 	return outputsMap
+}
+
+// GetVarNames returns all input variable names as a string slice
+func GetVarNames(vinfos []VarInfo) []string {
+	vnames := make([]string, len(vinfos))
+	for i, v := range vinfos {
+		vnames[i] = v.Name
+	}
+	sort.Strings(vnames)
+	return vnames
 }
 
 // GetModuleInfo gathers information about a module at a given source using the

--- a/pkg/modulewriter/license.go
+++ b/pkg/modulewriter/license.go
@@ -31,5 +31,4 @@ const license string = `/**
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
-
 `

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -26,12 +26,14 @@ import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/deploymentio"
+	"hpc-toolkit/pkg/modulereader"
 	"hpc-toolkit/pkg/sourcereader"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 
+	"github.com/zclconf/go-cty/cty"
 	"gopkg.in/yaml.v3"
 )
 
@@ -59,9 +61,10 @@ type deploymentMetadata struct {
 }
 
 type groupMetadata struct {
-	Name    string
-	Inputs  []string
-	Outputs []string
+	Name             string
+	DeploymentInputs []string `yaml:"deployment_inputs"`
+	IntergroupInputs []string `yaml:"intergroup_inputs"`
+	Outputs          []string
 }
 
 var kinds = map[string]ModuleWriter{
@@ -387,4 +390,29 @@ func writeDeploymentMetadata(depDir string, metadata deploymentMetadata) error {
 	}
 
 	return nil
+}
+
+func findIntergroupVariables(group config.DeploymentGroup, graph map[string][]config.ModConnection) []modulereader.VarInfo {
+	// var integroupVars []modulereader.VarInfo
+	var intergroupVars []modulereader.VarInfo
+
+	for _, mod := range group.Modules {
+		if connections, ok := graph[mod.ID]; ok {
+			for _, conn := range connections {
+				if conn.IsIntergroup() {
+					for _, v := range conn.GetSharedVariables() {
+						vinfo := modulereader.VarInfo{
+							Name:        v,
+							Type:        getHclType(cty.DynamicPseudoType),
+							Description: fmt.Sprintf("Toolkit automatically generated variable: %s", v),
+							Default:     nil,
+							Required:    true,
+						}
+						intergroupVars = append(intergroupVars, vinfo)
+					}
+				}
+			}
+		}
+	}
+	return intergroupVars
 }

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -44,6 +44,13 @@ const (
 	deploymentMetadataName     = "deployment_metadata.yaml"
 )
 
+const intergroupWarning string = `
+WARNING: this deployment group requires outputs from previous groups!
+This is an advanced feature under active development. The automatically generated
+instructions for executing terraform or packer below will not work as shown.
+
+`
+
 // ModuleWriter interface for writing modules to a deployment
 type ModuleWriter interface {
 	getNumModules() int

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -586,19 +586,21 @@ func (s *MySuite) TestWriteVariables(c *C) {
 		log.Fatal("Failed to create test directory for creating variables.tf file")
 	}
 
+	noIntergroupVars := []modulereader.VarInfo{}
+
 	// Simple success, empty vars
 	testVars := make(map[string]cty.Value)
-	err := writeVariables(testVars, testVarDir)
+	err := writeVariables(testVars, noIntergroupVars, testVarDir)
 	c.Assert(err, IsNil)
 
 	// Failure: Bad path
-	err = writeVariables(testVars, "not/a/real/path")
+	err = writeVariables(testVars, noIntergroupVars, "not/a/real/path")
 	c.Assert(err, ErrorMatches, "error creating variables.tf file: .*")
 
 	// Success, common vars
 	testVars["deployment_name"] = cty.StringVal("test_deployment")
 	testVars["project_id"] = cty.StringVal("test_project")
-	err = writeVariables(testVars, testVarDir)
+	err = writeVariables(testVars, noIntergroupVars, testVarDir)
 	c.Assert(err, IsNil)
 	exists, err := stringExistsInFile("\"deployment_name\"", varsFilePath)
 	c.Assert(err, IsNil)
@@ -607,7 +609,7 @@ func (s *MySuite) TestWriteVariables(c *C) {
 	// Success, "dynamic type"
 	testVars = make(map[string]cty.Value)
 	testVars["project_id"] = cty.NullVal(cty.DynamicPseudoType)
-	err = writeVariables(testVars, testVarDir)
+	err = writeVariables(testVars, noIntergroupVars, testVarDir)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -40,8 +40,11 @@ func (w *PackerWriter) addNumModules(value int) {
 	w.numModules += value
 }
 
-func printPackerInstructions(modPath string, moduleName string) {
+func printPackerInstructions(modPath string, moduleName string, printIntergroupWarning bool) {
 	printInstructionsPreamble("Packer", modPath, moduleName)
+	if printIntergroupWarning {
+		fmt.Print(intergroupWarning)
+	}
 	fmt.Printf("  cd %s\n", modPath)
 	fmt.Println("  packer init .")
 	fmt.Println("  packer validate .")
@@ -80,7 +83,7 @@ func (w PackerWriter) writeDeploymentGroup(
 		if err != nil {
 			return groupMetadata{}, err
 		}
-		printPackerInstructions(modPath, mod.ID)
+		printPackerInstructions(modPath, mod.ID, len(intergroupVarNames) > 0)
 	}
 
 	return groupMetadata{

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -66,12 +66,7 @@ func (w PackerWriter) writeDeploymentGroup(
 	groupPath := filepath.Join(deployDir, depGroup.Name)
 	allInputs := make(map[string]bool)
 	for _, mod := range depGroup.Modules {
-
 		ctySettings, err := config.ConvertMapToCty(mod.Settings)
-		for k := range ctySettings {
-			allInputs[k] = true
-		}
-
 		if err != nil {
 			return groupMetadata{}, fmt.Errorf(
 				"error converting packer module settings to cty for writing: %w", err)
@@ -89,9 +84,10 @@ func (w PackerWriter) writeDeploymentGroup(
 	}
 
 	return groupMetadata{
-		Name:    depGroup.Name,
-		Inputs:  orderKeys(allInputs),
-		Outputs: []string{},
+		Name:             depGroup.Name,
+		DeploymentInputs: orderKeys(allInputs),
+		IntergroupInputs: orderKeys(allInputs),
+		Outputs:          []string{},
 	}, nil
 }
 

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -335,8 +335,11 @@ func writeVersions(dst string) error {
 	return nil
 }
 
-func printTerraformInstructions(grpPath string, moduleName string) {
+func printTerraformInstructions(grpPath string, moduleName string, printIntergroupWarning bool) {
 	printInstructionsPreamble("Terraform", grpPath, moduleName)
+	if printIntergroupWarning {
+		fmt.Print(intergroupWarning)
+	}
 	fmt.Printf("  terraform -chdir=%s init\n", grpPath)
 	fmt.Printf("  terraform -chdir=%s validate\n", grpPath)
 	fmt.Printf("  terraform -chdir=%s apply\n\n", grpPath)
@@ -412,7 +415,7 @@ func (w TFWriter) writeDeploymentGroup(
 			depGroup.Name, err)
 	}
 
-	printTerraformInstructions(writePath, depGroup.Name)
+	printTerraformInstructions(writePath, depGroup.Name, len(intergroupInputs) > 0)
 
 	return gmd, nil
 }


### PR DESCRIPTION
- disable errors when references across groups are made
- add "advanced usage" warning to instructions for groups that make reference to previous groups
- modify metadata to eliminate "inputs" field and replace with the graph connections from the group to "deployment_inputs" and "intergroup_inputs"; these are the deployment variables and intergroup outputs necessary to resolve the group input settings (in Terraform these match group input variable names, for Packer they may not)
- enable deep resolution of deployment variables in Packer settings that are structural types
    - i.e. one can embed the value of `$(vars.zone)` in a object or tuple in `default.auto.pkrvars.hcl`
- eliminate "hidden" 2-field use keyword in favor of single field containing only the module

Packer groups are still subject to further development based upon active work building upon #1180. A multi-group Terraform deployment is shown below. If one executes the following command between invocations of `terraform apply` it will propagate the values to the second group. We anticipate automating this functionality in the near future.

```shell
terraform -chdir=igc-tf-test/zero output -json | jq 'with_entries(.value = .value.value)' > igc-tf-test/two/inputs.auto.tfvars.json
```

```yaml
---
blueprint_name: igc

vars:
  project_id: toolkit-demo-zero-e913
  deployment_name: igc-tf-test
  region: us-east4
  zone: us-east4-c

deployment_groups:
- group: zero
  modules:
  - id: network0
    source: modules/network/vpc
  - id: homefs
    source: modules/file-system/filestore
    use: [network0]
    settings:
      local_mount: /home
  - id: projectsfs
    source: modules/file-system/filestore
    use: [network0]
    settings:
      local_mount: /projects
- group: two
  modules:
  - id: network1
    source: modules/network/pre-existing-vpc
    use:
    - network0
  - id: vm
    source: modules/compute/vm-instance
    use:
    - network1
    - homefs
    - projectsfs
    settings:
      machine_type: n2-standard-4
```

A Packer blueprint is shown below. This has more limited functionality due to variable name matching and evaluation of settings that we have discussed offline. We anticipate automating both of these issues in near future.

```yaml
---
blueprint_name: igc

vars:
  project_id: toolkit-demo-zero-e913
  deployment_name: igc-pkr-test
  region: us-east4
  zone: us-east4-c

deployment_groups:
- group: zero
  modules:
  - id: network0
    source: modules/network/vpc
  - id: homefs
    source: modules/file-system/filestore
    use: [network0]
    settings:
      local_mount: /home
  - id: projectsfs
    source: modules/file-system/filestore
    use: [network0]
    settings:
      local_mount: /projects
  - id: script
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: shell
        destination: hellow.sh
        content: |
          #!/bin/bash
          echo "Hello, World!"

- group: one
  modules:
  - id: image
    source: modules/packer/custom-image
    kind: packer
    use:
    - network0
    - script

- group: two
  modules:
  - id: network1
    source: modules/network/pre-existing-vpc
    use:
    - network0
  - id: low_cost_ng
    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
    settings:
      node_count_dynamic_max: 10
      machine_type: n2-standard-4

  - id: low_cost_partition
    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
    use:
    - network1
    - homefs
    - projectsfs
    - low_cost_ng
    settings:
      partition_name: low_cost
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
