### PR TITLE
Limiting line length to 2K to avoid bufio.Scanner: token too long issues

### DIFF
--- a/community/modules/scripts/omnia-install/templates/install_omnia.tpl
+++ b/community/modules/scripts/omnia-install/templates/install_omnia.tpl
@@ -118,7 +118,7 @@
         --inventory inventory \
         --user "{{ username }}" --become \
         --e "ansible_python_interpreter={{ venv }}/bin/python3" \
-        --skip-tags "kubernetes,nfs_client"
+        --skip-tags "kubernetes,nfs_client" | cut -c -2048
     args:
       chdir: "{{ omnia_dir }}"
     environment:
@@ -130,7 +130,7 @@
         --private-key /home/{{ username }}/.ssh/id_rsa \
         --inventory inventory \
         --user "{{ username }}" --become \
-        --skip-tags "kubernetes,nfs_client"
+        --skip-tags "kubernetes,nfs_client" | cut -c -2048
     args:
       chdir: "{{ omnia_dir }}"
     environment:


### PR DESCRIPTION
Under rare circumstances, the call to ansible-playbook omnia.yaml inside of our startup script will create a line that is longer than the bufio.Scanner limit. 

This PR will limit this specific call outputs to 2048 characters to avoid these issues. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
