### PR TITLE
Increase get URL timeout for CRD module

### DIFF
--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-chrome-desktop.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-chrome-desktop.yml
@@ -34,6 +34,7 @@
       url: https://dl.google.com/linux/direct/chrome-remote-desktop_current_amd64.deb
       dest: /tmp/chrome-remote-desktop_current_amd64.deb
       mode: "0755"
+      timeout: 30
 
   - name: Install CRD
     ansible.builtin.apt:

--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-grid-drivers.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-grid-drivers.yml
@@ -50,6 +50,7 @@
         url: https://storage.googleapis.com/nvidia-drivers-us-public/GRID/vGPU14.2/NVIDIA-Linux-x86_64-510.85.02-grid.run
         dest: /tmp/
         mode: "0755"
+        timeout: 30
 
     - name: Stop gdm service
       ansible.builtin.systemd:
@@ -67,6 +68,7 @@
       url: https://sourceforge.net/projects/virtualgl/files/3.0.2/virtualgl_3.0.2_amd64.deb/download
       dest: /tmp/virtualgl_3.0.2_amd64.deb
       mode: "0755"
+      timeout: 30
 
   - name: Install VirtualGL
     ansible.builtin.command: gdebi /tmp/virtualgl_3.0.2_amd64.deb --non-interactive


### PR DESCRIPTION
Address observed failure mode of CRD installation scripts when remote download of a `.deb` package fails to complete within 10 seconds.

- https://sourceforge.net/projects/virtualgl/files/3.0.2/virtualgl_3.0.2_amd64.deb/download

Add the timeout to each `get_url` invocation within CRD module in anticipation of similar problems.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?