### PR TITLE
Include group kind in deployment metadata

### DIFF
--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -61,6 +61,7 @@ type ModuleWriter interface {
 		deployDir string,
 	) (groupMetadata, error)
 	restoreState(deploymentDir string) error
+	kind() config.ModuleKind
 }
 
 type deploymentMetadata struct {
@@ -69,14 +70,15 @@ type deploymentMetadata struct {
 
 type groupMetadata struct {
 	Name             string
+	Kind             config.ModuleKind
 	DeploymentInputs []string `yaml:"deployment_inputs"`
 	IntergroupInputs []string `yaml:"intergroup_inputs"`
 	Outputs          []string
 }
 
 var kinds = map[string]ModuleWriter{
-	"terraform": new(TFWriter),
-	"packer":    new(PackerWriter),
+	config.TerraformKind.String(): new(TFWriter),
+	config.PackerKind.String():    new(PackerWriter),
 }
 
 //go:embed *.tmpl

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -659,6 +659,13 @@ func (s *MySuite) TestNumModules_PackerWriter(c *C) {
 	c.Assert(testWriter.getNumModules(), Equals, 1)
 }
 
+func (s *MySuite) TestKind(c *C) {
+	tfw := TFWriter{}
+	c.Assert(tfw.kind(), Equals, config.TerraformKind)
+	pkrw := PackerWriter{}
+	c.Assert(pkrw.kind(), Equals, config.PackerKind)
+}
+
 func (s *MySuite) TestWriteDeploymentGroup_PackerWriter(c *C) {
 	deploymentio := deploymentio.GetDeploymentioLocal()
 	testWriter := PackerWriter{}

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -92,6 +92,7 @@ func (w PackerWriter) writeDeploymentGroup(
 
 	return groupMetadata{
 		Name:             depGroup.Name,
+		Kind:             w.kind(),
 		DeploymentInputs: orderKeys(deploymentVars),
 		IntergroupInputs: intergroupVarNames,
 		Outputs:          []string{},
@@ -101,4 +102,8 @@ func (w PackerWriter) writeDeploymentGroup(
 func (w PackerWriter) restoreState(deploymentDir string) error {
 	// TODO: implement state restoration for Packer
 	return nil
+}
+
+func (w PackerWriter) kind() config.ModuleKind {
+	return config.PackerKind
 }

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -365,6 +365,7 @@ func (w TFWriter) writeDeploymentGroup(
 	}
 	gmd := groupMetadata{
 		Name:             depGroup.Name,
+		Kind:             w.kind(),
 		DeploymentInputs: orderKeys(deploymentVars),
 		IntergroupInputs: orderKeys(intergroupInputs),
 		Outputs:          getAllOutputs(depGroup),
@@ -492,4 +493,8 @@ func getAllOutputs(group config.DeploymentGroup) []string {
 		}
 	}
 	return orderKeys(outputs)
+}
+
+func (w TFWriter) kind() config.ModuleKind {
+	return config.TerraformKind
 }

--- a/tools/validate_configs/golden_copies/packer_igc/.ghpc/deployment_metadata.yaml
+++ b/tools/validate_configs/golden_copies/packer_igc/.ghpc/deployment_metadata.yaml
@@ -14,6 +14,7 @@
 
 deployment_metadata:
   - name: zero
+    kind: terraform
     deployment_inputs:
       - deployment_name
       - labels
@@ -25,6 +26,7 @@ deployment_metadata:
       - startup_script_script
       - subnetwork_name_network0
   - name: one
+    kind: packer
     deployment_inputs:
       - deployment_name
       - labels

--- a/tools/validate_configs/golden_copies/terraform_igc/.ghpc/deployment_metadata.yaml
+++ b/tools/validate_configs/golden_copies/terraform_igc/.ghpc/deployment_metadata.yaml
@@ -14,6 +14,7 @@
 
 deployment_metadata:
   - name: zero
+    kind: terraform
     deployment_inputs:
       - deployment_name
       - labels
@@ -25,6 +26,7 @@ deployment_metadata:
       - network_id_network0
       - subnetwork_name_network0
   - name: one
+    kind: terraform
     deployment_inputs:
       - deployment_name
       - labels


### PR DESCRIPTION
The group kind is useful in deployment metadata for future functionality. Align around recently-introduced ModuleKind struct in config package.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?