### PR TITLE
Use optimize utilization autoscaling profile

### DIFF
--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -107,6 +107,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_authenticator_security_group"></a> [authenticator\_security\_group](#input\_authenticator\_security\_group) | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |
+| <a name="input_autoscaling_profile"></a> [autoscaling\_profile](#input\_autoscaling\_profile) | (Beta) Optimize for utilization or availability when deciding to remove nodes. Can be BALANCED or OPTIMIZE\_UTILIZATION. | `string` | `"OPTIMIZE_UTILIZATION"` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment. Used in the GKE cluster name by default and can be configured with `prefix_with_deployment_name`. | `string` | n/a | yes |
 | <a name="input_enable_dataplane_v2"></a> [enable\_dataplane\_v2](#input\_enable\_dataplane\_v2) | Enables [Dataplane v2](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2). This setting is immutable on clusters. | `bool` | `false` | no |
 | <a name="input_enable_istio"></a> [enable\_istio](#input\_enable\_istio) | (Beta) Enable Istio addon | `bool` | `true` | no |

--- a/community/modules/scheduler/gke-cluster/main.tf
+++ b/community/modules/scheduler/gke-cluster/main.tf
@@ -68,9 +68,12 @@ resource "google_container_cluster" "gke_cluster" {
 
   enable_shielded_nodes = true
 
-  cluster_autoscaling { # Auto provisioning of node-pools
-    enabled             = false
-    autoscaling_profile = "OPTIMIZE_UTILIZATION"
+  cluster_autoscaling {
+    # Controls auto provisioning of node-pools
+    enabled = false
+
+    # Controls autoscaling algorithm of node-pools
+    autoscaling_profile = var.autoscaling_profile
   }
 
   datapath_provider = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : "LEGACY_DATAPATH"

--- a/community/modules/scheduler/gke-cluster/main.tf
+++ b/community/modules/scheduler/gke-cluster/main.tf
@@ -69,9 +69,8 @@ resource "google_container_cluster" "gke_cluster" {
   enable_shielded_nodes = true
 
   cluster_autoscaling { # Auto provisioning of node-pools
-    enabled = false
-    # Recomended profile if we ever turn on
-    # autoscaling_profile = "OPTIMIZE_UTILIZATION"
+    enabled             = false
+    autoscaling_profile = "OPTIMIZE_UTILIZATION"
   }
 
   datapath_provider = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : "LEGACY_DATAPATH"

--- a/community/modules/scheduler/gke-cluster/variables.tf
+++ b/community/modules/scheduler/gke-cluster/variables.tf
@@ -186,6 +186,12 @@ variable "service_account" {
   }
 }
 
+variable "autoscaling_profile" {
+  description = "(Beta) Optimize for utilization or availability when deciding to remove nodes. Can be BALANCED or OPTIMIZE_UTILIZATION."
+  type        = string
+  default     = "OPTIMIZE_UTILIZATION"
+}
+
 variable "authenticator_security_group" {
   description = "The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com"
   type        = string


### PR DESCRIPTION
The optimize utilization profile is recommended for batch workloads. On original implementation, I had thought this related to auto-provisioning (automatic creation of node pools), which is not the case. It applies to horizontal scaling of node pools. 