### PR TITLE
Use deadline instead of retries in wait-for-startup

### DIFF
--- a/community/modules/scripts/wait-for-startup/main.tf
+++ b/community/modules/scripts/wait-for-startup/main.tf
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-locals {
-  retries = var.timeout / 5
-}
-
 data "google_compute_instance" "vm_instance" {
   name    = var.instance_name
   zone    = var.zone
@@ -30,7 +26,6 @@ resource "null_resource" "wait_for_startup" {
       INSTANCE_NAME = var.instance_name
       ZONE          = var.zone
       PROJECT_ID    = var.project_id
-      RETRIES       = local.retries
       TIMEOUT       = var.timeout
     }
   }

--- a/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
+++ b/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
@@ -29,7 +29,7 @@ fi
 now=$(date +%s)
 deadline=$(("${now}" + "${TIMEOUT}"))
 
-until [ "${now}" -ge "${deadline}" ]; do
+until [ "${now}" -gt "${deadline}" ]; do
 	GCLOUD="gcloud compute instances get-serial-port-output ${INSTANCE_NAME} --port 1 --zone ${ZONE} --project ${PROJECT_ID}"
 	FINISH_LINE="startup-script exit status"
 	STATUS_LINE=$(${GCLOUD} 2>/dev/null | grep "${FINISH_LINE}")

--- a/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
+++ b/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
@@ -26,8 +26,10 @@ if [ -z "${PROJECT_ID}" ]; then
 	exit 1
 fi
 
-tries=0
-until [ $tries -ge "${RETRIES}" ]; do
+now=$(date +%s)
+deadline=$(("${now}" + "${TIMEOUT}"))
+
+until [ "${now}" -ge "${deadline}" ]; do
 	GCLOUD="gcloud compute instances get-serial-port-output ${INSTANCE_NAME} --port 1 --zone ${ZONE} --project ${PROJECT_ID}"
 	FINISH_LINE="startup-script exit status"
 	STATUS_LINE=$(${GCLOUD} 2>/dev/null | grep "${FINISH_LINE}")
@@ -35,7 +37,7 @@ until [ $tries -ge "${RETRIES}" ]; do
 	if [ -n "${STATUS}" ]; then break; fi
 	echo "could not detect end of startup script. Sleeping."
 	sleep 5
-	((tries++))
+	now=$(date +%s)
 done
 
 # This specific text is monitored for in tests, do not change.
@@ -45,7 +47,7 @@ if [ "${STATUS}" == 0 ]; then
 elif [ "${STATUS}" == 1 ]; then
 	echo "startup-script finished with errors, ${INSPECT_OUTPUT_TEXT}"
 	echo "${GCLOUD}"
-elif [ "$tries" -ge "${RETRIES}" ]; then
+elif [ "${now}" -ge "${deadline}" ]; then
 	echo "startup-script timed out after ${TIMEOUT} seconds"
 	echo "${INSPECT_OUTPUT_TEXT}"
 	echo "${GCLOUD}"

--- a/community/modules/scripts/wait-for-startup/variables.tf
+++ b/community/modules/scripts/wait-for-startup/variables.tf
@@ -33,4 +33,8 @@ variable "timeout" {
   description = "Timeout in seconds"
   type        = number
   default     = 1200
+  validation {
+    condition     = var.timeout >= 0
+    error_message = "The timeout should be non-negative"
+  }
 }


### PR DESCRIPTION
```shell
$ TIMEOUT=50 INSTANCE_NAME=A ZONE=A PROJECT_ID=A time community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
could not detect end of startup script. Sleeping.
...
could not detect end of startup script. Sleeping.
startup-script timed out after 50 seconds
to inspect the startup script output, please run:
gcloud compute instances get-serial-port-output A --port 1 --zone A --project A
Command exited with non-zero status 1
7.84user 1.78system 0:55.45elapsed
```