### PR TITLE
Silence daily cleanup notifications and enable retries for other builds

### DIFF
--- a/tools/cloud-build/provision/daily-cleanup.tf
+++ b/tools/cloud-build/provision/daily-cleanup.tf
@@ -15,7 +15,6 @@
 resource "google_cloudbuild_trigger" "daily_project_cleanup" {
   name        = "DAILY-project-cleanup"
   description = "A cleanup script to run periodically"
-  tags        = [local.notify_chat_tag]
 
   git_file_source {
     path      = "tools/cloud-build/project-cleanup.yaml"

--- a/tools/cloud-build/provision/trigger-schedule/README.md
+++ b/tools/cloud-build/provision/trigger-schedule/README.md
@@ -28,7 +28,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_retry_count"></a> [retry\_count](#input\_retry\_count) | Number of times to retry a failed build | `number` | `0` | no |
+| <a name="input_retry_count"></a> [retry\_count](#input\_retry\_count) | Number of times to retry a failed build | `number` | `1` | no |
 | <a name="input_schedule"></a> [schedule](#input\_schedule) | Describes the schedule on which the job will be executed. | `string` | n/a | yes |
 | <a name="input_trigger"></a> [trigger](#input\_trigger) | View of google\_cloudbuild\_trigger resource | <pre>object({<br>    name    = string<br>    id      = string<br>    project = string<br>  })</pre> | n/a | yes |
 

--- a/tools/cloud-build/provision/trigger-schedule/main.tf
+++ b/tools/cloud-build/provision/trigger-schedule/main.tf
@@ -19,10 +19,9 @@ resource "google_cloud_scheduler_job" "schedule" {
 
   attempt_deadline = "180s"
   retry_config {
-    max_backoff_duration = "0s"
-    max_doublings        = 5
-    max_retry_duration   = "3600s"
-    min_backoff_duration = "1m"
+    max_backoff_duration = "1200s"
+    max_doublings        = 2
+    min_backoff_duration = "300s"
     retry_count          = var.retry_count
   }
 

--- a/tools/cloud-build/provision/trigger-schedule/variables.tf
+++ b/tools/cloud-build/provision/trigger-schedule/variables.tf
@@ -29,5 +29,9 @@ variable "schedule" {
 variable "retry_count" {
   description = "Number of times to retry a failed build"
   type        = number
-  default     = 0
+  default     = 1
+  validation {
+    condition     = var.retry_count >= 0 && var.retry_count <= 5
+    error_message = "var.retry_count cannot be negative or greater than 5"
+  }
 }


### PR DESCRIPTION
- remove the "notify chat" tag from the daily cleanup trigger to reduce potential noise from 5 execution attempts per night
- enable a single retry for all other builds

The [defined behavior of the API](https://cloud.google.com/scheduler/docs/reference/rpc/google.cloud.scheduler.v1#google.cloud.scheduler.v1.RetryConfig) when setting both `max_retry_duration` and `retry_count` does not seem intuitive. In particular, "until both limits are reached." I have chosen to interpret this as a reason to remove `max_retry_duration`. Please review with fresh eyes.