### PR TITLE
Add ghpc version to expanded blueprint

### DIFF
--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -78,6 +78,7 @@ func runExpandCmd(cmd *cobra.Command, args []string) {
 	if err := deploymentConfig.ExpandConfig(); err != nil {
 		log.Fatal(err)
 	}
+	deploymentConfig.Config.GhpcVersion = GitCommitInfo
 	deploymentConfig.ExportBlueprint(outputFilename)
 	fmt.Printf(
 		"Expanded Environment Definition created successfully, saved as %s.\n", outputFilename)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -312,6 +312,7 @@ func (m *Module) createWrapSettingsWith() {
 // integer is primarily for internal purposes even if it can be set in blueprint
 type Blueprint struct {
 	BlueprintName            string `yaml:"blueprint_name"`
+	GhpcVersion              string `yaml:"ghpc_version,omitempty"`
 	Validators               []validatorConfig
 	ValidationLevel          int `yaml:"validation_level,omitempty"`
 	Vars                     Dict

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -428,14 +428,16 @@ func (dc *DeploymentConfig) checkMovedModules() error {
 
 // NewDeploymentConfig is a constructor for DeploymentConfig
 func NewDeploymentConfig(configFilename string) (DeploymentConfig, error) {
-	var newDeploymentConfig DeploymentConfig
 	blueprint, err := importBlueprint(configFilename)
 	if err != nil {
-		return newDeploymentConfig, err
+		return DeploymentConfig{}, err
 	}
 
-	newDeploymentConfig = DeploymentConfig{Config: blueprint}
-	return newDeploymentConfig, nil
+	if blueprint.GhpcVersion != "" {
+		fmt.Printf("ghpc_version setting is ignored.")
+	}
+
+	return DeploymentConfig{Config: blueprint}, nil
 }
 
 // ImportBlueprint imports the blueprint configuration provided.


### PR DESCRIPTION
```
$ head expanded.yaml
...
blueprint_name: hpc-cluster-small
ghpc_version: v1.16.0-185-g1b863f09
validators:
...
```