### PR TITLE
Implement stub import-inputs command

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -36,7 +36,7 @@ const defaultArtifactsDir string = ".ghpc"
 var (
 	artifactsDir string
 	exportCmd    = &cobra.Command{
-		Use:               "export-outputs DEPLOYMENT_DIRECTORY",
+		Use:               "export-outputs DEPLOYMENT_GROUP_DIRECTORY",
 		Short:             "Export outputs from deployment group.",
 		Long:              "Export output values from deployment group to other deployment groups that depend upon them.",
 		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkDir),

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd defines command line utilities for ghpc
+package cmd
+
+import (
+	"fmt"
+	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/shell"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	artifactsFlag := "artifacts"
+	importCmd.Flags().StringVarP(&artifactsDir, artifactsFlag, "a", "", "Artifacts directory (automatically configured if unset)")
+	importCmd.MarkFlagDirname(artifactsFlag)
+	rootCmd.AddCommand(importCmd)
+}
+
+var (
+	importCmd = &cobra.Command{
+		Use:               "import-inputs DEPLOYMENT_GROUP_DIRECTORY",
+		Short:             "Import input values from previous deployment groups.",
+		Long:              "Import input values from previous deployment groups upon which this group depends.",
+		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkDir),
+		ValidArgsFunction: matchDirs,
+		PreRun:            setArtifactsDir,
+		RunE:              runImportCmd,
+	}
+)
+
+func runImportCmd(cmd *cobra.Command, args []string) error {
+	workingDir := path.Clean(args[0])
+	deploymentGroup := path.Base(workingDir)
+	deploymentRoot := path.Clean(path.Join(workingDir, ".."))
+
+	if err := shell.CheckWritableDir(workingDir); err != nil {
+		return err
+	}
+
+	// only Terraform groups support outputs; fail on any other kind
+	metadataFile := path.Join(artifactsDir, "deployment_metadata.yaml")
+	groupKinds, err := shell.GetDeploymentKinds(metadataFile, deploymentRoot)
+	if err != nil {
+		return err
+	}
+	groupKind, ok := groupKinds[deploymentGroup]
+	if !ok {
+		return fmt.Errorf("deployment group %s not found at %s", deploymentGroup, workingDir)
+	}
+	// TODO: support writing Packer inputs (complexity due to variable resolution)
+	if groupKind != config.TerraformKind {
+		return fmt.Errorf("import command is only supported for Terraform deployment groups")
+	}
+	return nil
+}

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -172,3 +172,10 @@ func ExportOutputs(tf *tfexec.Terraform, metadataFile string, artifactsDir strin
 
 	return nil
 }
+
+// ImportInputs will search artifactsDir for files produced by ExportOutputs and
+// combine/filter them for the input values needed by the group in the Terraform
+// working directory
+func ImportInputs(tf *tfexec.Terraform, metadataFile string, artifactsDir string) error {
+	return nil
+}


### PR DESCRIPTION
Implement cobra-side functionality of import-inputs command. Underlying implementation is a stub that will be submitted as a standalone PR.