### PR TITLE
Initial implementation of import-inputs command

### DIFF
--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -36,7 +36,11 @@ func (s *MySuite) TestIsDir(c *C) {
 	err = checkDir(nil, []string{dir})
 	c.Assert(err, NotNil)
 
-	f, _ := os.CreateTemp("", "test-*")
+	f, err := os.CreateTemp("", "test-*")
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer os.Remove(f.Name())
 	err = checkDir(nil, []string{f.Name()})
 	c.Assert(err, NotNil)
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -64,7 +64,12 @@ func runImportCmd(cmd *cobra.Command, args []string) error {
 	}
 	// TODO: support writing Packer inputs (complexity due to variable resolution)
 	if groupKind != config.TerraformKind {
-		return fmt.Errorf("import command is only supported for Terraform deployment groups")
+		return fmt.Errorf("import command is only supported (for now) on Terraform deployment groups")
 	}
+
+	if err = shell.ImportInputs(workingDir, metadataFile, artifactsDir); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/zclconf/go-cty/cty"
@@ -108,4 +109,28 @@ func NormalizeType(hclType string) string {
 		return hclType
 	}
 	return typeexpr.TypeString(ctyType)
+}
+
+// ReadHclAttributes reads cty.Values in from a .tfvars-style file
+// it will error if any of the Values are not statically defined
+func ReadHclAttributes(file string) (map[string]cty.Value, error) {
+	f, diags := hclparse.NewParser().ParseHCLFile(file)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	attrs, diags := f.Body.JustAttributes()
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	a := make(map[string]cty.Value)
+	for k, v := range attrs {
+		ctyV, diags := v.Expr.Value(nil)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		a[k] = ctyV
+	}
+
+	return a, nil
 }

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -116,6 +116,11 @@ func NormalizeType(hclType string) string {
 func ReadHclAttributes(file string) (map[string]cty.Value, error) {
 	f, diags := hclparse.NewParser().ParseHCLFile(file)
 	if diags.HasErrors() {
+		// work around ugly <nil> in error message missing d.Subject
+		// https://github.com/hashicorp/hcl2/blob/fb75b3253c80b3bc7ca99c4bfa2ad6743841b1af/hcl/diagnostic.go#L76-L78
+		if len(diags) == 1 {
+			return nil, fmt.Errorf(diags[0].Detail)
+		}
 		return nil, diags
 	}
 	attrs, diags := f.Body.JustAttributes()

--- a/pkg/modulereader/hcl_utils_test.go
+++ b/pkg/modulereader/hcl_utils_test.go
@@ -15,6 +15,8 @@
 package modulereader
 
 import (
+	"os"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -32,4 +34,19 @@ func (s *MySuite) TestNormalizeType(c *C) {
 	c.Check(NormalizeType(" object (  {\na=any\n} ) "), Equals, NormalizeType("object({a=any})"))
 
 	c.Check(NormalizeType(" string # comment"), Equals, NormalizeType("string"))
+}
+
+// a full-loop test of ReadWrite is implemented in modulewriter package
+// focus on modes that should error
+func (s *MySuite) TestReadHclAtttributes(c *C) {
+	fn, err := os.CreateTemp("", "test-*")
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer os.Remove(fn.Name())
+
+	fn.WriteString("attribute_name = var.name")
+
+	_, err = ReadHclAttributes(fn.Name())
+	c.Assert(err, NotNil)
 }

--- a/pkg/modulewriter/hcl_utils_test.go
+++ b/pkg/modulewriter/hcl_utils_test.go
@@ -16,9 +16,12 @@ package modulewriter
 
 import (
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/modulereader"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -59,6 +62,32 @@ func TestTokensForValueWithLiteral(t *testing.T) {
 	got.Body().AppendUnstructuredTokens(TokensForValue(val))
 
 	if diff := cmp.Diff(want, string(got.Bytes())); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestHclAtttributesRW(t *testing.T) {
+	want := make(map[string]cty.Value)
+	// test that a string that needs escaping when written is read correctly
+	want["key1"] = cty.StringVal("${value1}")
+
+	fn, err := os.CreateTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(fn.Name())
+
+	err = WriteHclAttributes(want, fn.Name())
+	if err != nil {
+		t.Errorf("could not write HCL attributes file")
+	}
+
+	got, err := modulereader.ReadHclAttributes(fn.Name())
+	if err != nil {
+		t.Errorf("could not read HCL attributes file")
+	}
+
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(cty.Value{})); diff != "" {
 		t.Errorf("diff (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -29,8 +29,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// GetDeploymentKinds performs a basic sanity check of metadata file and returns
-// the module kinds for the deployment
+// GetDeploymentKinds returns the kind of each group in the deployment as a map;
+// additionally it provides a mechanism for validating the deployment directory
+// structure; for now, validation tests only existence of each directory
 func GetDeploymentKinds(metadataFile string, deploymentRoot string) (map[string]config.ModuleKind, error) {
 	md, err := loadMetadata(metadataFile)
 	if err != nil {
@@ -67,7 +68,7 @@ func loadMetadata(metadataFile string) ([]modulewriter.GroupMetadata, error) {
 }
 
 // return a map from group names to a list of outputs that are needed by this group
-func getOutputsFromEarlierGroups(thisGroup string, metadataFile string) (map[string][]string, error) {
+func getIntergroupOutputNamesByGroup(thisGroup string, metadataFile string) (map[string][]string, error) {
 	md, err := loadMetadata(metadataFile)
 	if err != nil {
 		return nil, err

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path"
 
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 )
@@ -64,6 +66,48 @@ func loadMetadata(metadataFile string) ([]modulewriter.GroupMetadata, error) {
 	return md.DeploymentMetadata, nil
 }
 
+// return a map from group names to a list of outputs that are needed by this group
+func getOutputsFromEarlierGroups(thisGroup string, metadataFile string) (map[string][]string, error) {
+	md, err := loadMetadata(metadataFile)
+	if err != nil {
+		return nil, err
+	}
+
+	thisGroupIdx := slices.IndexFunc(md, func(g modulewriter.GroupMetadata) bool { return g.Name == thisGroup })
+	if thisGroupIdx == -1 {
+		return nil, fmt.Errorf("this group wasn't found in the deployment metadata")
+	}
+	if thisGroupIdx == 0 {
+		return nil, nil
+	}
+
+	thisIntergroupInputs := md[thisGroupIdx].IntergroupInputs
+	outputsByGroup := make(map[string][]string)
+	for _, v := range md[:thisGroupIdx] {
+		outputsByGroup[v.Name] = intersection(thisIntergroupInputs, v.Outputs)
+	}
+	return outputsByGroup, nil
+}
+
+// return sorted list of elements common to s1 and s2
+func intersection(s1 []string, s2 []string) []string {
+	count := make(map[string]int)
+
+	for _, v := range s1 {
+		count[v]++
+	}
+
+	foundInBoth := map[string]bool{}
+	for _, v := range s2 {
+		if count[v] > 0 {
+			foundInBoth[v] = true
+		}
+	}
+	is := maps.Keys(foundInBoth)
+	slices.Sort(is)
+	return is
+}
+
 func intersectMapKeys[K comparable, T any](s []K, m map[K]T) map[K]T {
 	intersection := make(map[K]T)
 	for _, e := range s {
@@ -72,6 +116,14 @@ func intersectMapKeys[K comparable, T any](s []K, m map[K]T) map[K]T {
 		}
 	}
 	return intersection
+}
+
+func mergeMapsWithoutLoss[K comparable, V any](m1 map[K]V, m2 map[K]V) {
+	expectedLength := len(m1) + len(m2)
+	maps.Copy(m1, m2)
+	if len(m1) != expectedLength {
+		panic(fmt.Errorf("unexpected key collision in maps"))
+	}
 }
 
 // DirInfo reports if path is a directory and new files can be written in it

--- a/pkg/shell/common_test.go
+++ b/pkg/shell/common_test.go
@@ -22,6 +22,26 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+func (s *MySuite) TestIntersection(c *C) {
+	is := intersection([]string{"A", "B", "C"}, []string{"A", "B", "C"})
+	c.Assert(is, DeepEquals, []string{"A", "B", "C"})
+
+	is = intersection([]string{"A", "B", "C"}, []string{"C", "B", "A"})
+	c.Assert(is, DeepEquals, []string{"A", "B", "C"})
+
+	is = intersection([]string{"C", "B", "A"}, []string{"A", "B", "C", "C"})
+	c.Assert(is, DeepEquals, []string{"A", "B", "C"})
+
+	is = intersection([]string{"A", "B", "C"}, []string{"D", "C", "B", "A"})
+	c.Assert(is, DeepEquals, []string{"A", "B", "C"})
+
+	is = intersection([]string{"A", "C"}, []string{"D", "C", "B", "A"})
+	c.Assert(is, DeepEquals, []string{"A", "C"})
+
+	is = intersection([]string{"A", "C"}, []string{})
+	c.Assert(is, DeepEquals, []string{})
+}
+
 func (s *MySuite) TestIntersectMapKeys(c *C) {
 	// test map whose keys completely overlap with slice
 	a := []string{"key0", "key1", "key2"}


### PR DESCRIPTION
Initial implementation of import-inputs

- read metadata to identify intergroup outputs necessary for target
  deployment group
- collect output values from prior groups and combine into a single file
  in the target deployment group directory

Does not yet support the evaluation of module settings that is necessary for writing to Packer deployment groups. This is anticipated in a follow-up PR now that #1205 has been merged.

Suggest testing with `igc_tf_test.yaml` under tools directory. With this approach one would run:

```shell
terraform -chdir=igc-tf-test/zero init
terraform -chdir=igc-tf-test/zero validate
terraform -chdir=igc-tf-test/zero apply
ghpc export-outputs igc-tf-test/zero

ghpc import-inputs igc-tf-test/one
terraform -chdir=igc-tf-test/one init
terraform -chdir=igc-tf-test/one validate
terraform -chdir=igc-tf-test/one apply
```

Edge cases to consider (among others):

- forget to run export-outputs (or any of the commands for first group) before import-inputs on second group
- attempt to run export-outputs without having run apply
- delete deployment metadata

None of these failures are able to be automatically recovered but the user shouldn't be left helpless.