### PR TITLE
Create a gke-job-template module, which creates a Kubernetes job file

### DIFF
--- a/community/examples/gke.yaml
+++ b/community/examples/gke.yaml
@@ -49,6 +49,8 @@ deployment_groups:
     use: [compute_pool]
     settings:
       image: busybox
-      command: [echo, Hello World]
+      command:
+      - echo
+      - Hello World
       node_count: 3
     outputs: [instructions]

--- a/community/examples/gke.yaml
+++ b/community/examples/gke.yaml
@@ -43,3 +43,12 @@ deployment_groups:
   - id: compute_pool
     source: community/modules/compute/gke-node-pool
     use: [gke_cluster]
+
+  - id: job-template
+    source: community/modules/compute/gke-job-template
+    use: [compute_pool]
+    settings:
+      image: busybox
+      command: [echo, Hello World]
+      node_count: 3
+    outputs: [instructions]

--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -1,0 +1,98 @@
+## Description
+
+This module is used to create a Kubernetes job template file.
+
+The job template file can be submitted as is or used as a template for further
+customization. Add the `instructions` output to a blueprint (as shown below) to
+get instructions on how to use `kubectl` to submit the job.
+
+This module is designed to`use` a `gke-node-pool` module.
+
+that can be submitted to a GKE cluster
+using `kubectl` and will run on the specified node pool.
+
+> **_NOTE:_** This is an experimental module and the functionality and
+> documentation will likely be updated in the near future. This module has only
+> been tested in limited capacity.
+
+### Example
+
+The following example creates a GKE node group.
+
+```yaml
+  - id: job-template
+    source: community/modules/compute/gke-job-template
+    use: [compute_pool]
+    settings:
+      node_count: 3
+    outputs: [instructions]
+```
+
+Also see a full [GKE example blueprint](../../../examples/gke.yaml).
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [local_file.job_template](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_backoff_limit"></a> [backoff\_limit](#input\_backoff\_limit) | Controls the number of retries before considering a Job as failed. | `number` | `3` | no |
+| <a name="input_command"></a> [command](#input\_command) | A list of strings that will be joined to create the job command. | `list(string)` | <pre>[<br>  "hostname"<br>]</pre> | no |
+| <a name="input_cpu_per_node"></a> [cpu\_per\_node](#input\_cpu\_per\_node) | The number of CPUs per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field. | `number` | `null` | no |
+| <a name="input_image"></a> [image](#input\_image) | The container image the job should use. | `string` | `"debian"` | no |
+| <a name="input_machine_family"></a> [machine\_family](#input\_machine\_family) | The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the job. | `string` | `"my-job"` | no |
+| <a name="input_node_count"></a> [node\_count](#input\_node\_count) | How many nodes the job should run in parallel. | `number` | `1` | no |
+| <a name="input_node_pool_name"></a> [node\_pool\_name](#input\_node\_pool\_name) | The name of the node pool on which to run the job. Can be populated via `use` feild. | `string` | `null` | no |
+| <a name="input_node_selectors"></a> [node\_selectors](#input\_node\_selectors) | A list of node selectors to use to place the job. | <pre>list(object({<br>    key   = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| <a name="input_random_name_sufix"></a> [random\_name\_sufix](#input\_random\_name\_sufix) | Appends a random suffix to the job name to avoid clashes. | `bool` | `false` | no |
+| <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | Job restart policy. Only a RestartPolicy equal to `Never` or `OnFailure` is allowed. | `string` | `"Never"` | no |
+| <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | value | <pre>list(object({<br>    key      = string<br>    operator = string<br>    value    = string<br>    effect   = string<br>  }))</pre> | <pre>[<br>  {<br>    "effect": "NoSchedule",<br>    "key": "user-workload",<br>    "operator": "Equal",<br>    "value": "true"<br>  }<br>]</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions for submitting the GKE job. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -17,7 +17,7 @@ using `kubectl` and will run on the specified node pool.
 
 ### Example
 
-The following example creates a GKE node group.
+The following example creates a GKE job template file.
 
 ```yaml
   - id: job-template
@@ -60,7 +60,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
@@ -88,17 +88,17 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#input\_allocatable\_cpu\_per\_node) | The allocatable cpu per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field. | `list(number)` | <pre>[<br>  -1<br>]</pre> | no |
 | <a name="input_backoff_limit"></a> [backoff\_limit](#input\_backoff\_limit) | Controls the number of retries before considering a Job as failed. | `number` | `3` | no |
-| <a name="input_command"></a> [command](#input\_command) | A list of strings that will be joined to create the job command. | `list(string)` | <pre>[<br>  "hostname"<br>]</pre> | no |
+| <a name="input_command"></a> [command](#input\_command) | The command and arguments for the container that run in the Pod. The command field corresponds to entrypoint in some container runtimes. | `list(string)` | <pre>[<br>  "hostname"<br>]</pre> | no |
 | <a name="input_image"></a> [image](#input\_image) | The container image the job should use. | `string` | `"debian"` | no |
 | <a name="input_machine_family"></a> [machine\_family](#input\_machine\_family) | The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the job. | `string` | `"my-job"` | no |
 | <a name="input_node_count"></a> [node\_count](#input\_node\_count) | How many nodes the job should run in parallel. | `number` | `1` | no |
-| <a name="input_node_pool_name"></a> [node\_pool\_name](#input\_node\_pool\_name) | A list of node pool names on which to run the job. Can be populated via `use` feild. | `list(string)` | `null` | no |
+| <a name="input_node_pool_name"></a> [node\_pool\_name](#input\_node\_pool\_name) | A list of node pool names on which to run the job. Can be populated via `use` feild. | `list(string)` | `[]` | no |
 | <a name="input_node_selectors"></a> [node\_selectors](#input\_node\_selectors) | A list of node selectors to use to place the job. | <pre>list(object({<br>    key   = string<br>    value = string<br>  }))</pre> | `[]` | no |
-| <a name="input_random_name_sufix"></a> [random\_name\_sufix](#input\_random\_name\_sufix) | Appends a random suffix to the job name to avoid clashes. | `bool` | `false` | no |
+| <a name="input_random_name_sufix"></a> [random\_name\_sufix](#input\_random\_name\_sufix) | Appends a random suffix to the job name to avoid clashes. | `bool` | `true` | no |
 | <a name="input_requested_cpu_per_pod"></a> [requested\_cpu\_per\_pod](#input\_requested\_cpu\_per\_pod) | The requested cpu per pod. If null, allocatable\_cpu\_per\_node will be used to claim whole nodes. If provided will override allocatable\_cpu\_per\_node. | `number` | `-1` | no |
 | <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | Job restart policy. Only a RestartPolicy equal to `Never` or `OnFailure` is allowed. | `string` | `"Never"` | no |
-| <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | value | <pre>list(object({<br>    key      = string<br>    operator = string<br>    value    = string<br>    effect   = string<br>  }))</pre> | <pre>[<br>  {<br>    "effect": "NoSchedule",<br>    "key": "user-workload",<br>    "operator": "Equal",<br>    "value": "true"<br>  }<br>]</pre> | no |
+| <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations allow the scheduler to schedule pods with matching taints. Generally populated from gke-node-pool via `use` field. | <pre>list(object({<br>    key      = string<br>    operator = string<br>    value    = string<br>    effect   = string<br>  }))</pre> | <pre>[<br>  {<br>    "effect": "NoSchedule",<br>    "key": "user-workload",<br>    "operator": "Equal",<br>    "value": "true"<br>  }<br>]</pre> | no |
 
 ## Outputs
 

--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -30,6 +30,15 @@ The following example creates a GKE node group.
 
 Also see a full [GKE example blueprint](../../../examples/gke.yaml).
 
+### Requested Resources
+
+When one or more `gke-node-pool` modules are referenced with the `use` field.
+The requested resources will be populated to achieve a 1 pod per node packing
+while still leaving some headroom for required system pods.
+
+This functionality can be overridden by specifying the desired cpu requirement
+using the `requested_cpu_per_pod` setting.
+
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -77,9 +86,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#input\_allocatable\_cpu\_per\_node) | The allocatable cpu per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field. | `list(number)` | <pre>[<br>  -1<br>]</pre> | no |
 | <a name="input_backoff_limit"></a> [backoff\_limit](#input\_backoff\_limit) | Controls the number of retries before considering a Job as failed. | `number` | `3` | no |
 | <a name="input_command"></a> [command](#input\_command) | A list of strings that will be joined to create the job command. | `list(string)` | <pre>[<br>  "hostname"<br>]</pre> | no |
-| <a name="input_cpu_per_node"></a> [cpu\_per\_node](#input\_cpu\_per\_node) | The number of CPUs per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field. | `number` | `null` | no |
 | <a name="input_image"></a> [image](#input\_image) | The container image the job should use. | `string` | `"debian"` | no |
 | <a name="input_machine_family"></a> [machine\_family](#input\_machine\_family) | The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the job. | `string` | `"my-job"` | no |
@@ -87,6 +96,7 @@ No modules.
 | <a name="input_node_pool_name"></a> [node\_pool\_name](#input\_node\_pool\_name) | A list of node pool names on which to run the job. Can be populated via `use` feild. | `list(string)` | `null` | no |
 | <a name="input_node_selectors"></a> [node\_selectors](#input\_node\_selectors) | A list of node selectors to use to place the job. | <pre>list(object({<br>    key   = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_random_name_sufix"></a> [random\_name\_sufix](#input\_random\_name\_sufix) | Appends a random suffix to the job name to avoid clashes. | `bool` | `false` | no |
+| <a name="input_requested_cpu_per_pod"></a> [requested\_cpu\_per\_pod](#input\_requested\_cpu\_per\_pod) | The requested cpu per pod. If null, allocatable\_cpu\_per\_node will be used to claim whole nodes. If provided will override allocatable\_cpu\_per\_node. | `number` | `-1` | no |
 | <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | Job restart policy. Only a RestartPolicy equal to `Never` or `OnFailure` is allowed. | `string` | `"Never"` | no |
 | <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | value | <pre>list(object({<br>    key      = string<br>    operator = string<br>    value    = string<br>    effect   = string<br>  }))</pre> | <pre>[<br>  {<br>    "effect": "NoSchedule",<br>    "key": "user-workload",<br>    "operator": "Equal",<br>    "value": "true"<br>  }<br>]</pre> | no |
 

--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -6,7 +6,7 @@ The job template file can be submitted as is or used as a template for further
 customization. Add the `instructions` output to a blueprint (as shown below) to
 get instructions on how to use `kubectl` to submit the job.
 
-This module is designed to`use` a `gke-node-pool` module.
+This module is designed to`use` one or more `gke-node-pool` modules.
 
 that can be submitted to a GKE cluster
 using `kubectl` and will run on the specified node pool.
@@ -84,7 +84,7 @@ No modules.
 | <a name="input_machine_family"></a> [machine\_family](#input\_machine\_family) | The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the job. | `string` | `"my-job"` | no |
 | <a name="input_node_count"></a> [node\_count](#input\_node\_count) | How many nodes the job should run in parallel. | `number` | `1` | no |
-| <a name="input_node_pool_name"></a> [node\_pool\_name](#input\_node\_pool\_name) | The name of the node pool on which to run the job. Can be populated via `use` feild. | `string` | `null` | no |
+| <a name="input_node_pool_name"></a> [node\_pool\_name](#input\_node\_pool\_name) | A list of node pool names on which to run the job. Can be populated via `use` feild. | `list(string)` | `null` | no |
 | <a name="input_node_selectors"></a> [node\_selectors](#input\_node\_selectors) | A list of node selectors to use to place the job. | <pre>list(object({<br>    key   = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_random_name_sufix"></a> [random\_name\_sufix](#input\_random\_name\_sufix) | Appends a random suffix to the job name to avoid clashes. | `bool` | `false` | no |
 | <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | Job restart policy. Only a RestartPolicy equal to `Never` or `OnFailure` is allowed. | `string` | `"Never"` | no |

--- a/community/modules/compute/gke-job-template/main.tf
+++ b/community/modules/compute/gke-job-template/main.tf
@@ -15,29 +15,46 @@
   */
 
 locals {
-  should_set_resources = var.cpu_per_node != null
-  cpu_limit            = local.should_set_resources ? var.cpu_per_node : 0
-  cpu_request          = local.cpu_limit > 2 ? local.cpu_limit - 1 : "${local.cpu_limit * 1000 / 2 + 10}m"
+  # Start with the minimum cpu available of used node pools
+  min_allocatable_cpu = min(var.allocatable_cpu_per_node...)
+  full_node_cpu_request = (
+    local.min_allocatable_cpu > 2 ?     # if large enough
+    local.min_allocatable_cpu - 1 :     # leave headroom for 1 cpu
+    local.min_allocatable_cpu / 2 + 0.1 # else take just over half
+  )
+
+  cpu_request = (
+    var.requested_cpu_per_pod >= 0 ?   # if user supplied requested cpu
+    var.requested_cpu_per_pod :        # then honor it
+    (                                  # else
+      local.min_allocatable_cpu >= 0 ? # if allocatable cpu was supplied
+      local.full_node_cpu_request :    # then claim the full node
+      -1                               # else do not set a limit
+    )
+  )
+  millicpu           = floor(local.cpu_request * 1000)
+  should_request_cpu = local.millicpu >= 0
+  full_node_request  = local.min_allocatable_cpu >= 0 && var.requested_cpu_per_pod < 0
 
   suffix = var.random_name_sufix ? "-${random_id.resource_name_suffix.hex}" : ""
 
   job_template_contents = templatefile(
     "${path.module}/templates/gke-job-base.yaml.tftpl",
     {
-      name                 = var.name
-      suffix               = local.suffix
-      image                = var.image
-      command              = var.command
-      node_count           = var.node_count
-      machine_family       = var.machine_family
-      node_pool_names      = var.node_pool_name
-      node_selectors       = var.node_selectors
-      should_set_resources = local.should_set_resources
-      cpu_request          = local.cpu_request
-      cpu_limit            = local.cpu_limit
-      restart_policy       = var.restart_policy
-      backoff_limit        = var.backoff_limit
-      tolerations          = distinct(var.tolerations)
+      name               = var.name
+      suffix             = local.suffix
+      image              = var.image
+      command            = var.command
+      node_count         = var.node_count
+      machine_family     = var.machine_family
+      node_pool_names    = var.node_pool_name
+      node_selectors     = var.node_selectors
+      should_request_cpu = local.should_request_cpu
+      full_node_request  = local.full_node_request
+      millicpu_request   = "${local.millicpu}m"
+      restart_policy     = var.restart_policy
+      backoff_limit      = var.backoff_limit
+      tolerations        = distinct(var.tolerations)
     }
   )
 

--- a/community/modules/compute/gke-job-template/main.tf
+++ b/community/modules/compute/gke-job-template/main.tf
@@ -58,7 +58,7 @@ locals {
     }
   )
 
-  job_template_output_path = "${path.root}/gke-job.yaml"
+  job_template_output_path = "${path.root}/${var.name}${local.suffix}.yaml"
 
 }
 

--- a/community/modules/compute/gke-job-template/main.tf
+++ b/community/modules/compute/gke-job-template/main.tf
@@ -30,14 +30,14 @@ locals {
       command              = var.command
       node_count           = var.node_count
       machine_family       = var.machine_family
-      node_pool_name       = var.node_pool_name
+      node_pool_names      = var.node_pool_name
       node_selectors       = var.node_selectors
       should_set_resources = local.should_set_resources
       cpu_request          = local.cpu_request
       cpu_limit            = local.cpu_limit
       restart_policy       = var.restart_policy
       backoff_limit        = var.backoff_limit
-      tolerations          = var.tolerations
+      tolerations          = distinct(var.tolerations)
     }
   )
 

--- a/community/modules/compute/gke-job-template/main.tf
+++ b/community/modules/compute/gke-job-template/main.tf
@@ -1,0 +1,58 @@
+/**
+  * Copyright 2023 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+locals {
+  should_set_resources = var.cpu_per_node != null
+  cpu_limit            = local.should_set_resources ? var.cpu_per_node : 0
+  cpu_request          = local.cpu_limit > 2 ? local.cpu_limit - 1 : "${local.cpu_limit * 1000 / 2 + 10}m"
+
+  suffix = var.random_name_sufix ? "-${random_id.resource_name_suffix.hex}" : ""
+
+  job_template_contents = templatefile(
+    "${path.module}/templates/gke-job-base.yaml.tftpl",
+    {
+      name                 = var.name
+      suffix               = local.suffix
+      image                = var.image
+      command              = var.command
+      node_count           = var.node_count
+      machine_family       = var.machine_family
+      node_pool_name       = var.node_pool_name
+      node_selectors       = var.node_selectors
+      should_set_resources = local.should_set_resources
+      cpu_request          = local.cpu_request
+      cpu_limit            = local.cpu_limit
+      restart_policy       = var.restart_policy
+      backoff_limit        = var.backoff_limit
+      tolerations          = var.tolerations
+    }
+  )
+
+  job_template_output_path = "${path.root}/gke-job.yaml"
+
+}
+
+resource "random_id" "resource_name_suffix" {
+  byte_length = 2
+  keepers = {
+    timestamp = timestamp()
+  }
+}
+
+resource "local_file" "job_template" {
+  content  = local.job_template_contents
+  filename = local.job_template_output_path
+}

--- a/community/modules/compute/gke-job-template/outputs.tf
+++ b/community/modules/compute/gke-job-template/outputs.tf
@@ -1,0 +1,27 @@
+/**
+  * Copyright 2023 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+output "instructions" {
+  description = "Instructions for submitting the GKE job."
+  value       = <<-EOT
+    A GKE job file has been created locally at:
+      ${abspath(local.job_template_output_path)}
+    
+    Use the following commands to:
+    Submit your job:
+      kubectl create -f ${abspath(local.job_template_output_path)}
+  EOT
+}

--- a/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
+++ b/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
@@ -39,13 +39,13 @@ spec:
       - name: ${name}-container
         image: ${image}
         command: [%{~ for s in command ~}"${s}",%{~ endfor ~}]
-        %{~ if should_set_resources ~}
-        # resource requirements: ~full node per pod
+        %{~ if should_request_cpu ~}
         resources:
           requests:
-            cpu: ${cpu_request}
-          limits:
-            cpu: ${cpu_limit}
+            %{~ if full_node_request ~}
+            # cpu request attempts full node per pod
+            %{~ endif ~}
+            cpu: ${millicpu_request}
         %{~ endif ~}
       restartPolicy: ${restart_policy}
   backoffLimit: ${backoff_limit}

--- a/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
+++ b/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
@@ -8,12 +8,22 @@ spec:
   completions: ${node_count}
   template:
     spec:
+      %{~ if length(node_pool_names) > 0 ~}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                %{~ for node_pool in node_pool_names ~}
+                - ${node_pool}
+                %{~ endfor ~}
+      %{~ endif ~}
       nodeSelector:
       %{~ if machine_family != null ~}
         cloud.google.com/machine-family: ${machine_family}
-      %{~ endif ~}
-      %{~ if node_pool_name != null ~}
-        cloud.google.com/gke-nodepool: ${node_pool_name}
       %{~ endif ~}
       %{~ for key, val in node_selectors ~}
         ${key}: ${val}

--- a/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
+++ b/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
@@ -1,0 +1,41 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${name}${suffix}
+spec:
+  parallelism: ${node_count}
+  completions: ${node_count}
+  template:
+    spec:
+      nodeSelector:
+      %{~ if machine_family != null ~}
+        cloud.google.com/machine-family: ${machine_family}
+      %{~ endif ~}
+      %{~ if node_pool_name != null ~}
+        cloud.google.com/gke-nodepool: ${node_pool_name}
+      %{~ endif ~}
+      %{~ for key, val in node_selectors ~}
+        ${key}: ${val}
+      %{~ endfor ~}
+      tolerations:
+      %{~ for toleration in tolerations ~}
+      - key: ${toleration.key}
+        operator: ${toleration.operator}
+        value: "${toleration.value}"
+        effect: ${toleration.effect}
+      %{~ endfor ~}
+      containers:
+      - name: ${name}-container
+        image: ${image}
+        command: [%{~ for s in command ~}"${s}",%{~ endfor ~}]
+        %{~ if should_set_resources ~}
+        # resource requirements: ~full node per pod
+        resources:
+          requests:
+            cpu: ${cpu_request}
+          limits:
+            cpu: ${cpu_limit}
+        %{~ endif ~}
+      restartPolicy: ${restart_policy}
+  backoffLimit: ${backoff_limit}

--- a/community/modules/compute/gke-job-template/variables.tf
+++ b/community/modules/compute/gke-job-template/variables.tf
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+variable "name" {
+  description = "The name of the job."
+  type        = string
+  default     = "my-job"
+}
+
+variable "node_count" {
+  description = "How many nodes the job should run in parallel."
+  type        = number
+  default     = 1
+}
+
+variable "command" {
+  description = "A list of strings that will be joined to create the job command."
+  type        = list(string)
+  default     = ["hostname"]
+}
+
+variable "image" {
+  description = "The container image the job should use."
+  type        = string
+  default     = "debian"
+}
+
+variable "node_pool_name" {
+  description = "The name of the node pool on which to run the job. Can be populated via `use` feild."
+  type        = string
+  default     = null
+}
+
+variable "cpu_per_node" {
+  description = "The number of CPUs per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field."
+  type        = number
+  default     = null
+}
+
+variable "tolerations" {
+  description = "value"
+  type = list(object({
+    key      = string
+    operator = string
+    value    = string
+    effect   = string
+  }))
+  default = [
+    {
+      key      = "user-workload"
+      operator = "Equal"
+      value    = "true"
+      effect   = "NoSchedule"
+    }
+  ]
+}
+
+variable "machine_family" {
+  description = "The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria."
+  type        = string
+  default     = null
+}
+
+variable "node_selectors" {
+  description = "A list of node selectors to use to place the job."
+  type = list(object({
+    key   = string
+    value = string
+  }))
+  default = []
+}
+
+variable "restart_policy" {
+  description = "Job restart policy. Only a RestartPolicy equal to `Never` or `OnFailure` is allowed."
+  type        = string
+  default     = "Never"
+}
+
+variable "backoff_limit" {
+  description = "Controls the number of retries before considering a Job as failed."
+  type        = number
+  default     = 3
+}
+
+variable "random_name_sufix" {
+  description = "Appends a random suffix to the job name to avoid clashes."
+  type        = bool
+  default     = false
+}

--- a/community/modules/compute/gke-job-template/variables.tf
+++ b/community/modules/compute/gke-job-template/variables.tf
@@ -27,7 +27,7 @@ variable "node_count" {
 }
 
 variable "command" {
-  description = "A list of strings that will be joined to create the job command."
+  description = "The command and arguments for the container that run in the Pod. The command field corresponds to entrypoint in some container runtimes."
   type        = list(string)
   default     = ["hostname"]
 }
@@ -41,7 +41,7 @@ variable "image" {
 variable "node_pool_name" {
   description = "A list of node pool names on which to run the job. Can be populated via `use` feild."
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "allocatable_cpu_per_node" {
@@ -57,7 +57,7 @@ variable "requested_cpu_per_pod" {
 }
 
 variable "tolerations" {
-  description = "value"
+  description = "Tolerations allow the scheduler to schedule pods with matching taints. Generally populated from gke-node-pool via `use` field."
   type = list(object({
     key      = string
     operator = string
@@ -104,5 +104,5 @@ variable "backoff_limit" {
 variable "random_name_sufix" {
   description = "Appends a random suffix to the job name to avoid clashes."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/community/modules/compute/gke-job-template/variables.tf
+++ b/community/modules/compute/gke-job-template/variables.tf
@@ -39,8 +39,8 @@ variable "image" {
 }
 
 variable "node_pool_name" {
-  description = "The name of the node pool on which to run the job. Can be populated via `use` feild."
-  type        = string
+  description = "A list of node pool names on which to run the job. Can be populated via `use` feild."
+  type        = list(string)
   default     = null
 }
 

--- a/community/modules/compute/gke-job-template/variables.tf
+++ b/community/modules/compute/gke-job-template/variables.tf
@@ -44,10 +44,16 @@ variable "node_pool_name" {
   default     = null
 }
 
-variable "cpu_per_node" {
-  description = "The number of CPUs per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field."
+variable "allocatable_cpu_per_node" {
+  description = "The allocatable cpu per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field."
+  type        = list(number)
+  default     = [-1]
+}
+
+variable "requested_cpu_per_pod" {
+  description = "The requested cpu per pod. If null, allocatable_cpu_per_node will be used to claim whole nodes. If provided will override allocatable_cpu_per_node."
   type        = number
-  default     = null
+  default     = -1
 }
 
 variable "tolerations" {

--- a/community/modules/compute/gke-job-template/versions.tf
+++ b/community/modules/compute/gke-job-template/versions.tf
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/community/modules/compute/gke-job-template/versions.tf
+++ b/community/modules/compute/gke-job-template/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     random = {

--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -98,5 +98,9 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_cpu_per_node"></a> [cpu\_per\_node](#output\_cpu\_per\_node) | Number of CPUs available |
+| <a name="output_node_pool_name"></a> [node\_pool\_name](#output\_node\_pool\_name) | Name of the node pool. |
+| <a name="output_tolerations"></a> [tolerations](#output\_tolerations) | value |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -100,7 +100,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_cpu_per_node"></a> [cpu\_per\_node](#output\_cpu\_per\_node) | Number of CPUs available |
+| <a name="output_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#output\_allocatable\_cpu\_per\_node) | Number of CPUs available for scheduling pods on each node. |
 | <a name="output_node_pool_name"></a> [node\_pool\_name](#output\_node\_pool\_name) | Name of the node pool. |
 | <a name="output_tolerations"></a> [tolerations](#output\_tolerations) | value |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/gke-node-pool/outputs.tf
+++ b/community/modules/compute/gke-node-pool/outputs.tf
@@ -1,0 +1,55 @@
+/**
+  * Copyright 2023 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+output "node_pool_name" {
+  description = "Name of the node pool."
+  value       = google_container_node_pool.node_pool.name
+}
+
+locals {
+  is_single_shared_core = contains(["g1", "f1"], local.machine_family) # note GKE does not support f1 machines
+  is_double_shared_core = local.machine_family == "e2" && !local.machine_not_shared_core
+  is_a_series           = local.machine_family == "a2"
+  last_digit            = try(local.machine_vals[2], 0)
+
+  vcpu        = local.is_single_shared_core ? 1 : local.is_double_shared_core ? 2 : local.is_a_series ? local.last_digit * 12 : local.last_digit
+  useable_cpu = local.set_threads_per_core ? local.threads_per_core * local.vcpu / 2 : local.vcpu
+}
+
+output "cpu_per_node" {
+  description = "Number of CPUs available"
+  value       = local.useable_cpu
+}
+
+locals {
+  translate_toleration = {
+    PREFER_NO_SCHEDULE = "PreferNoSchedule"
+    NO_SCHEDULE        = "NoSchedule"
+    NO_EXECUTE         = "NoExecute"
+  }
+  taints = google_container_node_pool.node_pool.node_config[0].taint
+  tolerations = [for taint in local.taints : {
+    key      = taint.key
+    operator = "Equal"
+    value    = taint.value
+    effect   = lookup(local.translate_toleration, taint.effect, null)
+  }]
+}
+
+output "tolerations" {
+  description = "value"
+  value       = local.tolerations
+}

--- a/community/modules/compute/gke-node-pool/outputs.tf
+++ b/community/modules/compute/gke-node-pool/outputs.tf
@@ -21,7 +21,7 @@ output "node_pool_name" {
 
 locals {
   is_single_shared_core = contains(["g1", "f1"], local.machine_family) # note GKE does not support f1 machines
-  is_double_shared_core = local.machine_family == "e2" && !local.machine_not_shared_core
+  is_double_shared_core = local.machine_family == "e2" && local.machine_shared_core
   is_a_series           = local.machine_family == "a2"
   last_digit            = try(local.machine_vals[2], 0)
 

--- a/community/modules/compute/gke-node-pool/threads_per_core_calc.tf
+++ b/community/modules/compute/gke-node-pool/threads_per_core_calc.tf
@@ -28,15 +28,15 @@
 # local.threads_per_core: actual threads_per_core to be used.
 
 locals {
-  machine_vals            = split("-", var.machine_type)
-  machine_family          = local.machine_vals[0]
-  machine_not_shared_core = length(local.machine_vals) > 2
-  machine_vcpus           = try(parseint(local.machine_vals[2], 10), 1)
+  machine_vals        = split("-", var.machine_type)
+  machine_family      = local.machine_vals[0]
+  machine_shared_core = length(local.machine_vals) <= 2
+  machine_vcpus       = try(parseint(local.machine_vals[2], 10), 1)
 
   smt_capable_family = !contains(["t2d", "t2a"], local.machine_family)
   smt_capable_vcpu   = local.machine_vcpus >= 2
 
-  smt_capable          = local.smt_capable_family && local.smt_capable_vcpu && local.machine_not_shared_core
+  smt_capable          = local.smt_capable_family && local.smt_capable_vcpu && !local.machine_shared_core
   set_threads_per_core = var.threads_per_core != null && (var.threads_per_core == 0 && local.smt_capable || try(var.threads_per_core >= 1, false))
   threads_per_core     = var.threads_per_core == 2 ? 2 : 1
 }

--- a/community/modules/compute/gke-node-pool/versions.tf
+++ b/community/modules/compute/gke-node-pool/versions.tf
@@ -26,6 +26,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:k8s-cluster/v1.15.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.15.0"
   }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -755,8 +755,11 @@ walks through the use of this blueprint.
 
 This blueprint uses GKE to provision a Kubernetes cluster with a system node
 pool (included in gke-cluster module) and an autoscaling compute node pool. It
-also creates a VPC configured to be used by a VPC native GKE cluster with subnet
+creates a VPC configured to be used by a VPC native GKE cluster with subnet
 secondary IP ranges defined.
+
+The `gke-job-template` module is used to create a job file that can be submitted
+to the cluster using `kubectl` and will run on the specified node pool.
 
 [gke.yaml]: ../community/examples/gke.yaml
 

--- a/modules/compute/vm-instance/threads_per_core_calc.tf
+++ b/modules/compute/vm-instance/threads_per_core_calc.tf
@@ -28,15 +28,15 @@
 # local.threads_per_core: actual threads_per_core to be used.
 
 locals {
-  machine_vals            = split("-", var.machine_type)
-  machine_family          = local.machine_vals[0]
-  machine_not_shared_core = length(local.machine_vals) > 2
-  machine_vcpus           = try(parseint(local.machine_vals[2], 10), 1)
+  machine_vals        = split("-", var.machine_type)
+  machine_family      = local.machine_vals[0]
+  machine_shared_core = length(local.machine_vals) <= 2
+  machine_vcpus       = try(parseint(local.machine_vals[2], 10), 1)
 
   smt_capable_family = !contains(["t2d", "t2a"], local.machine_family)
   smt_capable_vcpu   = local.machine_vcpus >= 2
 
-  smt_capable          = local.smt_capable_family && local.smt_capable_vcpu && local.machine_not_shared_core
+  smt_capable          = local.smt_capable_family && local.smt_capable_vcpu && !local.machine_shared_core
   set_threads_per_core = var.threads_per_core != null && (var.threads_per_core == 0 && local.smt_capable || try(var.threads_per_core >= 1, false))
   threads_per_core     = var.threads_per_core == 2 ? 2 : 1
 }


### PR DESCRIPTION
This change:
- Creates a GKE job module to be used with gke-node-pool
- Updates the GKE example blueprint to include a GKE job
- fixes an typo in gke-node-pool provider meta

Manually tested.