### PR TITLE
Ensure that terraform cleanup always runs

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -150,13 +150,14 @@
 
     ## Cleanup and fail gracefully
     rescue:
+    - name: Capture terraform stderr
+      ansible.builtin.set_fact:
+        terraform_apply_stderr_one_line: "{{ terraform_output.results.1.stderr | replace('\n',' ') }}"
     - name: Gather logs
       ansible.builtin.include_tasks:
         file: tasks/gather_startup_script_logs.yml
         apply:
           delegate_to: localhost
-      vars:
-        terraform_apply_stderr: "{{ terraform_output.results.1.stderr }}"
     - name: Cleanup firewall and infrastructure
       ansible.builtin.include_tasks:
         file: tasks/rescue_terraform_failure.yml

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -150,12 +150,25 @@
 
     ## Cleanup and fail gracefully
     rescue:
-    - name: Include rescue from terraform failure
-      ansible.builtin.include_tasks: "tasks/rescue_terraform_failure.yml"
+    - name: Gather logs
+      ansible.builtin.include_tasks:
+        file: tasks/gather_startup_script_logs.yml
+        apply:
+          delegate_to: localhost
+      vars:
+        terraform_apply_stderr: "{{ terraform_output.results.1.stderr }}"
+    - name: Cleanup firewall and infrastructure
+      ansible.builtin.include_tasks:
+        file: tasks/rescue_terraform_failure.yml
+        apply:
+          delegate_to: localhost
       vars:
         deployment_name: "{{ deployment_name }}"
         workspace: "{{ workspace }}"
-        terraform_apply_stderr: "{{ terraform_output.results.1.stderr }}"
+    - name: Trigger failure (rescue blocks otherwise revert failures)
+      ansible.builtin.fail:
+        msg: "Failed while setting up test infrastructure"
+      when: true
 
 - name: Run Integration Tests
   hosts: remote_host
@@ -178,28 +191,12 @@
       loop: "{{ post_deploy_tests }}"
       loop_control:
         loop_var: test
-
-    ## Always cleanup, even on failure
     always:
-    - name: Delete Firewall Rule
-      register: fw_deleted
-      changed_when: fw_deleted.rc == 0
-      failed_when: false
-      run_once: true
-      delegate_to: localhost
-      ansible.builtin.command:
-        argv:
-        - gcloud
-        - compute
-        - firewall-rules
-        - delete
-        - "{{ deployment_name }}"
-    - name: Tear Down Cluster
-      run_once: true
-      changed_when: true # assume something got destroyed
-      delegate_to: localhost
-      environment:
-        TF_IN_AUTOMATION: "TRUE"
-      ansible.builtin.command:
-        cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
+    - name: Cleanup firewall and infrastructure
+      ansible.builtin.include_tasks:
+        file: tasks/rescue_terraform_failure.yml
+        apply:
+          delegate_to: localhost
+      vars:
+        deployment_name: "{{ deployment_name }}"
+        workspace: "{{ workspace }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -155,12 +155,21 @@
 
     ## Cleanup and fail gracefully
     rescue:
+    - name: Gather logs
+      ansible.builtin.include_tasks:
+        file: tasks/gather_startup_script_logs.yml
+        apply:
+          delegate_to: localhost
+      vars:
+        terraform_apply_stderr: "{{ terraform_output.results.1.stderr }}"
     - name: Include rescue from terraform failure
-      ansible.builtin.include_tasks: "tasks/rescue_terraform_failure.yml"
+      ansible.builtin.include_tasks:
+        file: tasks/rescue_terraform_failure.yml
+        apply:
+          delegate_to: localhost
       vars:
         deployment_name: "{{ deployment_name }}"
         workspace: "{{ workspace }}"
-        terraform_apply_stderr: "{{ terraform_output.results.1.stderr }}"
 
 - name: Run Integration Tests
   hosts: remote_host

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -155,13 +155,14 @@
 
     ## Cleanup and fail gracefully
     rescue:
+    - name: Capture terraform stderr
+      ansible.builtin.set_fact:
+        terraform_apply_stderr_one_line: "{{ terraform_output.results.1.stderr | replace('\n',' ') }}"
     - name: Gather logs
       ansible.builtin.include_tasks:
         file: tasks/gather_startup_script_logs.yml
         apply:
           delegate_to: localhost
-      vars:
-        terraform_apply_stderr: "{{ terraform_output.results.1.stderr }}"
     - name: Include rescue from terraform failure
       ansible.builtin.include_tasks:
         file: tasks/rescue_terraform_failure.yml
@@ -170,6 +171,10 @@
       vars:
         deployment_name: "{{ deployment_name }}"
         workspace: "{{ workspace }}"
+    - name: Trigger failure (rescue blocks otherwise revert failures)
+      ansible.builtin.fail:
+        msg: "Failed while setting up test infrastructure"
+      when: true
 
 - name: Run Integration Tests
   hosts: remote_host
@@ -233,25 +238,11 @@
     - name: Print Slurm suspend.log
       ansible.builtin.debug:
         var: suspend_output.stdout_lines
-    - name: Delete Firewall Rule
-      register: fw_deleted
-      changed_when: fw_deleted.rc == 0
-      failed_when: false  # keep cleaning up
-      run_once: true
-      delegate_to: localhost
-      ansible.builtin.command:
-        argv:
-        - gcloud
-        - compute
-        - firewall-rules
-        - delete
-        - "{{ deployment_name }}"
-    - name: Tear Down Cluster
-      changed_when: true  # assume something destroyed
-      run_once: true
-      delegate_to: localhost
-      environment:
-        TF_IN_AUTOMATION: "TRUE"
-      ansible.builtin.command:
-        cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
+    - name: Cleanup firewall and infrastructure
+      ansible.builtin.include_tasks:
+        file: tasks/rescue_terraform_failure.yml
+        apply:
+          delegate_to: localhost
+      vars:
+        deployment_name: "{{ deployment_name }}"
+        workspace: "{{ workspace }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,26 +15,20 @@
 - name: Assert variables are defined
   ansible.builtin.assert:
     that:
-    - deployment_name is defined
-    - workspace is defined
+    - terraform_apply_stderr is defined
 
-- name: Delete Firewall Rule
-  register: fw_deleted
-  changed_when: fw_deleted.rc == 0
+- name: Remove New Lines From Terraform Apply STDERR
+  ansible.builtin.set_fact:
+    terraform_apply_stderr_one_line: "{{ terraform_apply_stderr | replace('\n',' ') }}"
+
+- name: Get Startup Script Logs
+  changed_when: false
   failed_when: false
-  ansible.builtin.command:
-    argv:
-    - gcloud
-    - compute
-    - firewall-rules
-    - delete
-    - "{{ deployment_name }}"
+  ansible.builtin.command: "{{ terraform_apply_stderr_one_line | regex_search('please run: (.+)', '\\1') | first }}"
 
-- name: Tear Down Cluster
-  changed_when: true  # assume something destroyed
-  run_once: true
-  environment:
-    TF_IN_AUTOMATION: "TRUE"
-  ansible.builtin.command:
-    cmd: terraform destroy -auto-approve
-    chdir: "{{ workspace }}/{{ deployment_name }}/primary"
+- name: Log Startup Script Failure
+  changed_when: false
+  failed_when: false
+  ansible.builtin.debug:
+    var: serial_port_1_output
+  when: serial_port_1_output is defined

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
@@ -11,20 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 ---
 - name: Assert variables are defined
   ansible.builtin.assert:
     that:
-    - terraform_apply_stderr is defined
-
-- name: Remove New Lines From Terraform Apply STDERR
-  ansible.builtin.set_fact:
-    terraform_apply_stderr_one_line: "{{ terraform_apply_stderr | replace('\n',' ') }}"
+    - terraform_apply_stderr_one_line is defined
 
 - name: Get Startup Script Logs
+  when: 'terraform_apply_stderr_one_line | regex_findall("please run: (.+)", "\\1") | list | length > 0'
   changed_when: false
   failed_when: false
-  ansible.builtin.command: "{{ terraform_apply_stderr_one_line | regex_search('please run: (.+)', '\\1') | first }}"
+  ansible.builtin.command: '{{ terraform_apply_stderr_one_line | regex_findall("please run: (.+)", "\\1") | first }}'
+  register: serial_port_1_output
 
 - name: Log Startup Script Failure
   changed_when: false


### PR DESCRIPTION
The current position of "terraform destroy" within the rescue block positions it to not run when previous steps in the rescue block fail. This will leak infrastructure into our build project. Additionally, this PR reduces code duplication by splitting out the terraform cleanup into its own task file and include that in another place cleanup is necessary.