### PR TITLE
Fix retry configuration for daily integration tests

### DIFF
--- a/tools/cloud-build/provision/trigger-schedule/main.tf
+++ b/tools/cloud-build/provision/trigger-schedule/main.tf
@@ -20,6 +20,7 @@ resource "google_cloud_scheduler_job" "schedule" {
   attempt_deadline = "180s"
   retry_config {
     max_backoff_duration = "1200s"
+    max_retry_duration   = "3600s"
     max_doublings        = 2
     min_backoff_duration = "300s"
     retry_count          = var.retry_count


### PR DESCRIPTION
Add max_retry_duration to retry_config for daily integration tests to encourage retry attempts upon failures.