### PR TITLE
Unify shared code of create and expand commands

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -24,16 +24,18 @@ import (
 	"hpc-toolkit/pkg/modulewriter"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/yaml.v3"
 )
 
 const msgCLIVars = "Comma-separated list of name=value variables to override YAML configuration. Can be used multiple times."
 const msgCLIBackendConfig = "Comma-separated list of name=value variables to set Terraform backend configuration. Can be used multiple times."
 
 func init() {
-	createCmd.Flags().StringVarP(&bpFilename, "config", "c", "",
-		"HPC Environment Blueprint file to be used to create an HPC deployment dir.")
+	createCmd.Flags().StringVarP(&bpFilenameDeprecated, "config", "c", "", "")
 	cobra.CheckErr(createCmd.Flags().MarkDeprecated("config",
 		"please see the command usage for more details."))
 
@@ -52,9 +54,9 @@ func init() {
 }
 
 var (
-	bpFilename   string
-	outputDir    string
-	cliVariables []string
+	bpFilenameDeprecated string
+	outputDir            string
+	cliVariables         []string
 
 	cliBEConfigVars     []string
 	overwriteDeployment bool
@@ -73,35 +75,8 @@ var (
 )
 
 func runCreateCmd(cmd *cobra.Command, args []string) {
-	if bpFilename == "" {
-		if len(args) == 0 {
-			fmt.Println(cmd.UsageString())
-			return
-		}
-
-		bpFilename = args[0]
-	}
-
-	deploymentConfig, err := config.NewDeploymentConfig(bpFilename)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if err := deploymentConfig.SetCLIVariables(cliVariables); err != nil {
-		log.Fatalf("Failed to set the variables at CLI: %v", err)
-	}
-	if err := deploymentConfig.SetBackendConfig(cliBEConfigVars); err != nil {
-		log.Fatalf("Failed to set the backend config at CLI: %v", err)
-	}
-	if err := deploymentConfig.SetValidationLevel(validationLevel); err != nil {
-		log.Fatal(err)
-	}
-	if err := skipValidators(&deploymentConfig); err != nil {
-		log.Fatal(err)
-	}
-	if err := deploymentConfig.ExpandConfig(); err != nil {
-		log.Fatal(err)
-	}
-	if err := modulewriter.WriteDeployment(deploymentConfig, outputDir, overwriteDeployment); err != nil {
+	dc := expandOrDie(args[0])
+	if err := modulewriter.WriteDeployment(dc, outputDir, overwriteDeployment); err != nil {
 		var target *modulewriter.OverwriteDeniedError
 		if errors.As(err, &target) {
 			fmt.Printf("\n%s\n", err.Error())
@@ -110,6 +85,94 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 	}
+}
+
+func expandOrDie(path string) config.DeploymentConfig {
+	dc, err := config.NewDeploymentConfig(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Set properties from CLI
+	if err := setCLIVariables(&dc.Config); err != nil {
+		log.Fatalf("Failed to set the variables at CLI: %v", err)
+	}
+	if err := setBackendConfig(&dc.Config); err != nil {
+		log.Fatalf("Failed to set the backend config at CLI: %v", err)
+	}
+	if err := setValidationLevel(&dc.Config); err != nil {
+		log.Fatal(err)
+	}
+	if err := skipValidators(&dc); err != nil {
+		log.Fatal(err)
+	}
+	if dc.Config.GhpcVersion != "" {
+		fmt.Printf("ghpc_version setting is ignored.")
+	}
+	dc.Config.GhpcVersion = GitCommitInfo
+
+	// Expand the blueprint
+	if err := dc.ExpandConfig(); err != nil {
+		log.Fatal(err)
+	}
+
+	return dc
+}
+
+func setCLIVariables(bp *config.Blueprint) error {
+	for _, cliVar := range cliVariables {
+		arr := strings.SplitN(cliVar, "=", 2)
+
+		if len(arr) != 2 {
+			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", cliVar)
+		}
+		// Convert the variable's string literal to its equivalent default type.
+		key := arr[0]
+		var v config.YamlValue
+		if err := yaml.Unmarshal([]byte(arr[1]), &v); err != nil {
+			return fmt.Errorf("invalid input: unable to convert '%s' value '%s' to known type", key, arr[1])
+		}
+		bp.Vars.Set(key, v.Unwrap())
+	}
+	return nil
+}
+
+func setBackendConfig(bp *config.Blueprint) error {
+	if len(cliBEConfigVars) == 0 {
+		return nil // no op
+	}
+	be := config.TerraformBackend{Type: "gcs"}
+	for _, config := range cliBEConfigVars {
+		arr := strings.SplitN(config, "=", 2)
+
+		if len(arr) != 2 {
+			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", config)
+		}
+
+		key, value := arr[0], arr[1]
+		switch key {
+		case "type":
+			be.Type = value
+		default:
+			be.Configuration.Set(key, cty.StringVal(value))
+		}
+	}
+	bp.TerraformBackendDefaults = be
+	return nil
+}
+
+// SetValidationLevel allows command-line tools to set the validation level
+func setValidationLevel(bp *config.Blueprint) error {
+	switch validationLevel {
+	case "ERROR":
+		bp.ValidationLevel = config.ValidationError
+	case "WARNING":
+		bp.ValidationLevel = config.ValidationWarning
+	case "IGNORE":
+		bp.ValidationLevel = config.ValidationIgnore
+	default:
+		return fmt.Errorf("invalid validation level (\"ERROR\", \"WARNING\", \"IGNORE\")")
+	}
+	return nil
 }
 
 func skipValidators(dc *config.DeploymentConfig) error {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -93,13 +93,13 @@ func expandOrDie(path string) config.DeploymentConfig {
 		log.Fatal(err)
 	}
 	// Set properties from CLI
-	if err := setCLIVariables(&dc.Config); err != nil {
+	if err := setCLIVariables(&dc.Config, cliVariables); err != nil {
 		log.Fatalf("Failed to set the variables at CLI: %v", err)
 	}
-	if err := setBackendConfig(&dc.Config); err != nil {
+	if err := setBackendConfig(&dc.Config, cliBEConfigVars); err != nil {
 		log.Fatalf("Failed to set the backend config at CLI: %v", err)
 	}
-	if err := setValidationLevel(&dc.Config); err != nil {
+	if err := setValidationLevel(&dc.Config, validationLevel); err != nil {
 		log.Fatal(err)
 	}
 	if err := skipValidators(&dc); err != nil {
@@ -118,8 +118,8 @@ func expandOrDie(path string) config.DeploymentConfig {
 	return dc
 }
 
-func setCLIVariables(bp *config.Blueprint) error {
-	for _, cliVar := range cliVariables {
+func setCLIVariables(bp *config.Blueprint, s []string) error {
+	for _, cliVar := range s {
 		arr := strings.SplitN(cliVar, "=", 2)
 
 		if len(arr) != 2 {
@@ -136,12 +136,12 @@ func setCLIVariables(bp *config.Blueprint) error {
 	return nil
 }
 
-func setBackendConfig(bp *config.Blueprint) error {
-	if len(cliBEConfigVars) == 0 {
+func setBackendConfig(bp *config.Blueprint, s []string) error {
+	if len(s) == 0 {
 		return nil // no op
 	}
 	be := config.TerraformBackend{Type: "gcs"}
-	for _, config := range cliBEConfigVars {
+	for _, config := range s {
 		arr := strings.SplitN(config, "=", 2)
 
 		if len(arr) != 2 {
@@ -161,8 +161,8 @@ func setBackendConfig(bp *config.Blueprint) error {
 }
 
 // SetValidationLevel allows command-line tools to set the validation level
-func setValidationLevel(bp *config.Blueprint) error {
-	switch validationLevel {
+func setValidationLevel(bp *config.Blueprint, s string) error {
+	switch s {
 	case "ERROR":
 		bp.ValidationLevel = config.ValidationError
 	case "WARNING":

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,0 +1,135 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"hpc-toolkit/pkg/config"
+
+	"github.com/zclconf/go-cty/cty"
+	. "gopkg.in/check.v1"
+)
+
+func (s *MySuite) TestSetCLIVariables(c *C) {
+	bp := config.Blueprint{}
+	bp.Vars.Set("deployment_name", cty.StringVal("bush"))
+
+	cliVariables = []string{
+		"project_id=cli_test_project_id",
+		"deployment_name=cli_deployment_name",
+		"region=cli_region",
+		"zone=cli_zone",
+		"kv=key=val",
+		"keyBool=true",
+		"keyInt=15",
+		"keyFloat=15.43",
+		"keyMap={bar: baz, qux: 1}",
+		"keyArray=[1, 2, 3]",
+		"keyArrayOfMaps=[foo, {bar: baz, qux: 1}]",
+		"keyMapOfArrays={foo: [1, 2, 3], bar: [a, b, c]}",
+	}
+	c.Assert(setCLIVariables(&bp), IsNil)
+	c.Check(
+		bp.Vars.Items(), DeepEquals, map[string]cty.Value{
+			"project_id":      cty.StringVal("cli_test_project_id"),
+			"deployment_name": cty.StringVal("cli_deployment_name"),
+			"region":          cty.StringVal("cli_region"),
+			"zone":            cty.StringVal("cli_zone"),
+			"kv":              cty.StringVal("key=val"),
+			"keyBool":         cty.True,
+			"keyInt":          cty.NumberIntVal(15),
+			"keyFloat":        cty.NumberFloatVal(15.43),
+			"keyMap": cty.ObjectVal(map[string]cty.Value{
+				"bar": cty.StringVal("baz"),
+				"qux": cty.NumberIntVal(1)}),
+			"keyArray": cty.TupleVal([]cty.Value{
+				cty.NumberIntVal(1), cty.NumberIntVal(2), cty.NumberIntVal(3)}),
+			"keyArrayOfMaps": cty.TupleVal([]cty.Value{
+				cty.StringVal("foo"),
+				cty.ObjectVal(map[string]cty.Value{
+					"bar": cty.StringVal("baz"),
+					"qux": cty.NumberIntVal(1)})}),
+			"keyMapOfArrays": cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.TupleVal([]cty.Value{
+					cty.NumberIntVal(1), cty.NumberIntVal(2), cty.NumberIntVal(3)}),
+				"bar": cty.TupleVal([]cty.Value{
+					cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c")}),
+			}),
+		})
+
+	// Failure: Variable without '='
+	bp = config.Blueprint{}
+	cliVariables = []string{"project_idcli_test_project_id"}
+
+	c.Assert(setCLIVariables(&bp), ErrorMatches, "invalid format: .*")
+	c.Check(bp.Vars, DeepEquals, config.Dict{})
+}
+
+func (s *MySuite) TestSetBackendConfig(c *C) {
+	// Success
+	cliBEConfigVars = []string{
+		"taste=sweet",
+		"type=green",
+		"odor=strong",
+	}
+
+	bp := config.Blueprint{}
+	c.Assert(setBackendConfig(&bp), IsNil)
+
+	be := bp.TerraformBackendDefaults
+	c.Check(be.Type, Equals, "green")
+	c.Check(be.Configuration.Items(), DeepEquals, map[string]cty.Value{
+		"taste": cty.StringVal("sweet"),
+		"odor":  cty.StringVal("strong"),
+	})
+}
+
+func (s *MySuite) TestSetBackendConfig_Invalid(c *C) {
+	// Failure: Variable without '='
+	cliBEConfigVars = []string{
+		"typegreen",
+	}
+	bp := config.Blueprint{}
+	c.Assert(setBackendConfig(&bp), ErrorMatches, "invalid format: .*")
+}
+
+func (s *MySuite) TestSetBackendConfig_NoOp(c *C) {
+	cliBEConfigVars = []string{}
+	bp := config.Blueprint{
+		TerraformBackendDefaults: config.TerraformBackend{
+			Type: "green"}}
+
+	c.Assert(setBackendConfig(&bp), IsNil)
+	c.Check(bp.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{
+		Type: "green"})
+}
+
+func (s *MySuite) TestValidationLevels(c *C) {
+	bp := config.Blueprint{}
+
+	validationLevel = "ERROR"
+	c.Check(setValidationLevel(&bp), IsNil)
+	c.Check(bp.ValidationLevel, Equals, config.ValidationError)
+
+	validationLevel = "WARNING"
+	c.Check(setValidationLevel(&bp), IsNil)
+	c.Check(bp.ValidationLevel, Equals, config.ValidationWarning)
+
+	validationLevel = "IGNORE"
+	c.Check(setValidationLevel(&bp), IsNil)
+	c.Check(bp.ValidationLevel, Equals, config.ValidationIgnore)
+
+	validationLevel = "INVALID"
+	c.Check(setValidationLevel(&bp), NotNil)
+}

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -17,15 +17,12 @@ package cmd
 
 import (
 	"fmt"
-	"hpc-toolkit/pkg/config"
-	"log"
 
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	expandCmd.Flags().StringVarP(&bpFilename, "config", "c", "",
-		"HPC Environment Blueprint file to be expanded.")
+	expandCmd.Flags().StringVarP(&bpFilenameDeprecated, "config", "c", "", "")
 	cobra.CheckErr(expandCmd.Flags().MarkDeprecated("config",
 		"please see the command usage for more details."))
 
@@ -50,36 +47,7 @@ var (
 )
 
 func runExpandCmd(cmd *cobra.Command, args []string) {
-	if bpFilename == "" {
-		if len(args) == 0 {
-			fmt.Println(cmd.UsageString())
-			return
-		}
-
-		bpFilename = args[0]
-	}
-
-	deploymentConfig, err := config.NewDeploymentConfig(bpFilename)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if err := deploymentConfig.SetCLIVariables(cliVariables); err != nil {
-		log.Fatalf("Failed to set the variables at CLI: %v", err)
-	}
-	if err := deploymentConfig.SetBackendConfig(cliBEConfigVars); err != nil {
-		log.Fatalf("Failed to set the backend config at CLI: %v", err)
-	}
-	if err := deploymentConfig.SetValidationLevel(validationLevel); err != nil {
-		log.Fatal(err)
-	}
-	if err := skipValidators(&deploymentConfig); err != nil {
-		log.Fatal(err)
-	}
-	if err := deploymentConfig.ExpandConfig(); err != nil {
-		log.Fatal(err)
-	}
-	deploymentConfig.Config.GhpcVersion = GitCommitInfo
-	deploymentConfig.ExportBlueprint(outputFilename)
-	fmt.Printf(
-		"Expanded Environment Definition created successfully, saved as %s.\n", outputFilename)
+	dc := expandOrDie(args[0])
+	dc.ExportBlueprint(outputFilename)
+	fmt.Printf("Expanded Environment Definition created successfully, saved as %s.\n", outputFilename)
 }

--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -85,13 +85,18 @@ func (d *Dict) AsObject() cty.Value {
 	return cty.ObjectVal(d.Items())
 }
 
-// yamlValue is wrapper around cty.Value to handle YAML unmarshal.
-type yamlValue struct {
+// YamlValue is wrapper around cty.Value to handle YAML unmarshal.
+type YamlValue struct {
 	v cty.Value
 }
 
+// Unwrap returns wrapped cty.Value.
+func (y YamlValue) Unwrap() cty.Value {
+	return y.v
+}
+
 // UnmarshalYAML implements custom YAML unmarshaling.
-func (y *yamlValue) UnmarshalYAML(n *yaml.Node) error {
+func (y *YamlValue) UnmarshalYAML(n *yaml.Node) error {
 	var err error
 	switch n.Kind {
 	case yaml.ScalarNode:
@@ -106,7 +111,7 @@ func (y *yamlValue) UnmarshalYAML(n *yaml.Node) error {
 	return err
 }
 
-func (y *yamlValue) unmarshalScalar(n *yaml.Node) error {
+func (y *YamlValue) unmarshalScalar(n *yaml.Node) error {
 	var s interface{}
 	if err := n.Decode(&s); err != nil {
 		return err
@@ -135,8 +140,8 @@ func (y *yamlValue) unmarshalScalar(n *yaml.Node) error {
 	return nil
 }
 
-func (y *yamlValue) unmarshalObject(n *yaml.Node) error {
-	var my map[string]yamlValue
+func (y *YamlValue) unmarshalObject(n *yaml.Node) error {
+	var my map[string]YamlValue
 	if err := n.Decode(&my); err != nil {
 		return err
 	}
@@ -148,8 +153,8 @@ func (y *yamlValue) unmarshalObject(n *yaml.Node) error {
 	return nil
 }
 
-func (y *yamlValue) unmarshalTuple(n *yaml.Node) error {
-	var ly []yamlValue
+func (y *YamlValue) unmarshalTuple(n *yaml.Node) error {
+	var ly []YamlValue
 	if err := n.Decode(&ly); err != nil {
 		return err
 	}
@@ -163,7 +168,7 @@ func (y *yamlValue) unmarshalTuple(n *yaml.Node) error {
 
 // UnmarshalYAML implements custom YAML unmarshaling.
 func (d *Dict) UnmarshalYAML(n *yaml.Node) error {
-	var m map[string]yamlValue
+	var m map[string]YamlValue
 	if err := n.Decode(&m); err != nil {
 		return err
 	}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -74,7 +74,7 @@ func (dc DeploymentConfig) executeValidators() error {
 	var errored, warned bool
 	implementedValidators := dc.getValidators()
 
-	if dc.Config.ValidationLevel == validationIgnore {
+	if dc.Config.ValidationLevel == ValidationIgnore {
 		return nil
 	}
 
@@ -93,7 +93,7 @@ func (dc DeploymentConfig) executeValidators() error {
 		if err := f(validator); err != nil {
 			var prefix string
 			switch dc.Config.ValidationLevel {
-			case validationWarning:
+			case ValidationWarning:
 				warned = true
 				prefix = "warning: "
 			default:

--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -18,7 +18,7 @@ use warnings;
 
 # TODO: raise ./cmd min coverage to 80% after tests are written
 my $min = 80;
-my $cmdmin = 40;
+my $cmdmin = 50;
 my $shellmin = 15;
 my $failed_coverage = 0;
 my $failed_tests = 0;


### PR DESCRIPTION
* Unify shared code of create and expand commands;
* Move CLI args parsing methods from pkg/config to cmd;
* Clean up around deprecated `--config` argument;
* Bump cmd test coverage threshold 40 -> 50.

