### PR TITLE
Add documentation warning about lustre license cost

### DIFF
--- a/community/examples/slurm-gcp-v5-high-io.yaml
+++ b/community/examples/slurm-gcp-v5-high-io.yaml
@@ -57,6 +57,8 @@ deployment_groups:
       size_gb: 10240
       local_mount: /projects
 
+  # This file system has an associated license cost.
+  # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
   - id: scratchfs
     source: community/modules/file-system/DDN-EXAScaler
     use: [network1]

--- a/community/modules/file-system/DDN-EXAScaler/README.md
+++ b/community/modules/file-system/DDN-EXAScaler/README.md
@@ -9,16 +9,16 @@ More information about the architecture can be found at
 For more information on this and other network storage options in the Cloud HPC
 Toolkit, see the extended [Network Storage documentation](../../../../docs/network_storage.md).
 
-> **_NOTE:_** By default security.public_key is set to `null`, therefore the
+> **Warning**: This file system has a license cost as described in the pricing
+> section of the [DDN EXAScaler Cloud Marketplace Solution][marketplace].
+>
+> **Note**: By default security.public_key is set to `null`, therefore the
 > admin user is not created. To ensure the admin user is created, provide a
 > public key via the security setting.
 >
-> **_NOTE:_** This module's instances require access to Google APIs and
+> **Note**: This module's instances require access to Google APIs and
 > therefore, instances must have public IP address or it must be used in a
 > subnetwork where [Private Google Access][private-google-access] is enabled.
->
-> **_WARNING:_** This file system has a license cost as described in the pricing
-> section of the [DDN EXAScaler Cloud Marketplace Solution][marketplace].
 
 [private-google-access]: https://cloud.google.com/vpc/docs/configure-private-google-access
 [marketplace]: https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
@@ -40,6 +40,8 @@ module outputs runners that can be used with the startup-script module to
 install the client and mount the file system. See the following example:
 
 ```yaml
+  # This file system has an associated license cost.
+  # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
   - id: lustrefs
     source: community/modules/file-system/DDN-EXAScaler
     use: [network1]

--- a/examples/README.md
+++ b/examples/README.md
@@ -158,6 +158,10 @@ File systems:
   [DDN Exascaler Lustre](../community/modules/file-system/DDN-EXAScaler/README.md)
   file system designed for high IO performance. The capacity is ~10TiB.
 
+> **Warning**: The DDN Exascaler Lustre file system has a license cost as
+> described in the pricing section of the
+> [DDN EXAScaler Cloud Marketplace Solution](https://console.developers.google.com/marketplace/product/ddnstorage/).
+
 There are two partitions in this example: `low_cost` and `compute`. The
 `low_cost` partition uses `n2-standard-4` VMs. This partition can be used for
 debugging and workloads that do not require high performance.
@@ -413,6 +417,10 @@ Creates a DDN EXAScaler lustre file-system that is mounted in two client instanc
 The [DDN Exascaler Lustre](../community/modules/file-system/DDN-EXAScaler/README.md)
 file system is designed for high IO performance. It has a default capacity of ~10TiB and is mounted at `/lustre`.
 
+> **Warning**: The DDN Exascaler Lustre file system has a license cost as
+> described in the pricing section of the
+> [DDN EXAScaler Cloud Marketplace Solution](https://console.developers.google.com/marketplace/product/ddnstorage/).
+
 After the creation of the file-system and the client instances, the lustre drivers will be automatically installed and the mount-point configured on the VMs. This may take a few minutes after the VMs are created and can be verified by running:
 
 ```sh
@@ -518,6 +526,10 @@ This blueprint will create a cluster with the following storage tiers:
 * The scratchfs is mounted at `/scratch` and is a
   [DDN Exascaler Lustre](../community/modules/file-system/DDN-EXAScaler/README.md)
   file system designed for high IO performance. The capacity is ~10TiB.
+
+> **Warning**: The DDN Exascaler Lustre file system has a license cost as
+> described in the pricing section of the
+> [DDN EXAScaler Cloud Marketplace Solution](https://console.developers.google.com/marketplace/product/ddnstorage/).
 
 The cluster will support 2 partitions:
 

--- a/examples/hpc-cluster-high-io.yaml
+++ b/examples/hpc-cluster-high-io.yaml
@@ -48,6 +48,8 @@ deployment_groups:
       size_gb: 10240
       local_mount: /projects
 
+  # This file system has an associated license cost.
+  # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
   - id: scratchfs
     source: community/modules/file-system/DDN-EXAScaler
     use: [network1]

--- a/examples/lustre.yaml
+++ b/examples/lustre.yaml
@@ -30,6 +30,8 @@ deployment_groups:
   - id: network1
     source: modules/network/pre-existing-vpc
 
+  # This file system has an associated license cost.
+  # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
   - id: lustre
     source: community/modules/file-system/DDN-EXAScaler
     use: [network1]


### PR DESCRIPTION
Documentation changes only.

This change:
- Adds comments to lustre examples with link to marketplace
- Adds warning to example descriptions where lustre is used
- Reorders notes on lustre module to put cost warning at top
- Change format of warning label to use github md highlighting

> **_WARNING:_** Old

> **Warning**: New