### PR TITLE
Adds a basic gke test which provisions and destroys a cluster

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -1,0 +1,64 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+timeout: 14400s  # 4hr
+
+steps:
+## Test simple golang build
+- id: build_ghpc
+  waitFor: ["-"]
+  name: golang
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    cd /workspace
+    make
+- id: fetch_builder
+  waitFor: ["-"]
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - echo "done fetching builder"
+
+## Test GKE
+- id: gke
+  waitFor: ["fetch_builder", "build_ghpc"]
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    SG_EXAMPLE=community/examples/gke.yaml
+
+    # adding vm to act as remote node
+    echo '  - id: remote-node'                     >> $${SG_EXAMPLE}
+    echo '    source: modules/compute/vm-instance' >> $${SG_EXAMPLE}
+    echo '    use: [network1]'                     >> $${SG_EXAMPLE}
+    echo '    settings:'                           >> $${SG_EXAMPLE}
+    echo '      machine_type: e2-standard-2'       >> $${SG_EXAMPLE}
+    echo '      zone: us-central1-a'               >> $${SG_EXAMPLE}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/gke.yml"

--- a/tools/cloud-build/daily-tests/tests/gke.yml
+++ b/tools/cloud-build/daily-tests/tests/gke.yml
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+test_name: gke
+deployment_name: gke-{{ build }}
+zone: us-central1-a  # for remote node
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/community/examples/gke.yaml"
+network: "{{ deployment_name }}-net"
+remote_node: "{{ deployment_name }}-0"
+post_deploy_tests: []


### PR DESCRIPTION
At this time, the test simply deploys and then destroys the blueprint and does not submit a job.

The blueprint is edited for the test to add a standalone vm-instance. Our current test structure requires that there is a remote node that can be connected to. This VM acts as the remote node. 

Trigger has been deployed.