### PR TITLE
Use dedicated dtype ModuleID and GroupName instead of string

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -75,7 +75,7 @@ func setArtifactsDir(cmd *cobra.Command, args []string) {
 	}
 }
 
-func verifyDeploymentAgainstBlueprint(expandedBlueprintFile string, group string, deploymentRoot string) (config.ModuleKind, error) {
+func verifyDeploymentAgainstBlueprint(expandedBlueprintFile string, group config.GroupName, deploymentRoot string) (config.ModuleKind, error) {
 	groupKinds, err := shell.GetDeploymentKinds(expandedBlueprintFile)
 	if err != nil {
 		return config.UnknownKind, err
@@ -94,7 +94,7 @@ func verifyDeploymentAgainstBlueprint(expandedBlueprintFile string, group string
 
 func runExportCmd(cmd *cobra.Command, args []string) error {
 	workingDir := filepath.Clean(args[0])
-	deploymentGroup := filepath.Base(workingDir)
+	deploymentGroup := config.GroupName(filepath.Base(workingDir))
 	deploymentRoot := filepath.Clean(filepath.Join(workingDir, ".."))
 
 	if err := shell.CheckWritableDir(artifactsDir); err != nil {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/shell"
 	"path/filepath"
 
@@ -44,7 +45,7 @@ var (
 
 func runImportCmd(cmd *cobra.Command, args []string) error {
 	workingDir := filepath.Clean(args[0])
-	deploymentGroup := filepath.Base(workingDir)
+	deploymentGroup := config.GroupName(filepath.Base(workingDir))
 	deploymentRoot := filepath.Clean(filepath.Join(workingDir, ".."))
 
 	if err := shell.CheckWritableDir(workingDir); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,14 +166,14 @@ func getDeploymentConfigForTest() DeploymentConfig {
 		Source:           "testSource",
 		Kind:             TerraformKind,
 		ID:               "testModule",
-		Use:              []string{},
+		Use:              []ModuleID{},
 		WrapSettingsWith: make(map[string][]string),
 	}
 	testModuleWithLabels := Module{
 		Source:           "./role/source",
 		ID:               "testModuleWithLabels",
 		Kind:             TerraformKind,
-		Use:              []string{},
+		Use:              []ModuleID{},
 		WrapSettingsWith: make(map[string][]string),
 		Settings: NewDict(map[string]cty.Value{
 			"moduleLabel": cty.StringVal("moduleLabelValue"),
@@ -319,7 +319,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 			matchingIntragroupName1: cty.StringVal("explicit-intra-value"),
 			matchingIntragroupName2: ModuleRef(mod0.ID, matchingIntragroupName2).AsExpression().AsValue(),
 		}),
-		Use: []string{mod0.ID},
+		Use: []ModuleID{mod0.ID},
 	}
 	setTestModuleInfo(mod1, testModuleInfo1)
 
@@ -332,7 +332,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 		ID:     "TestModule2",
 		Kind:   TerraformKind,
 		Source: testModuleSource2,
-		Use:    []string{mod0.ID},
+		Use:    []ModuleID{mod0.ID},
 	}
 	setTestModuleInfo(mod2, testModuleInfo2)
 
@@ -418,25 +418,25 @@ func (s *MySuite) TestCheckModuleAndGroupNames(c *C) {
 func (s *MySuite) TestListUnusedModules(c *C) {
 	{ // No modules in "use"
 		m := Module{ID: "m"}
-		c.Check(m.listUnusedModules(), DeepEquals, []string{})
+		c.Check(m.listUnusedModules(), DeepEquals, []ModuleID{})
 	}
 
 	{ // Useful
 		m := Module{
 			ID:  "m",
-			Use: []string{"w"},
+			Use: []ModuleID{"w"},
 			Settings: NewDict(map[string]cty.Value{
 				"x": cty.True.Mark(ProductOfModuleUse{"w"})})}
-		c.Check(m.listUnusedModules(), DeepEquals, []string{})
+		c.Check(m.listUnusedModules(), DeepEquals, []ModuleID{})
 	}
 
 	{ // Unused
 		m := Module{
 			ID:  "m",
-			Use: []string{"w", "u"},
+			Use: []ModuleID{"w", "u"},
 			Settings: NewDict(map[string]cty.Value{
 				"x": cty.True.Mark(ProductOfModuleUse{"w"})})}
-		c.Check(m.listUnusedModules(), DeepEquals, []string{"u"})
+		c.Check(m.listUnusedModules(), DeepEquals, []ModuleID{"u"})
 	}
 }
 
@@ -478,7 +478,7 @@ func (s *MySuite) TestAddKindToModules(c *C) {
 	c.Assert(testMod.Kind, Equals, expected)
 
 	/* Test addKindToModules() does nothing to packer types*/
-	moduleID := "packerModule"
+	moduleID := ModuleID("packerModule")
 	expected = PackerKind
 	dc = getDeploymentConfigWithTestModuleEmptyKind()
 	dc.Config.DeploymentGroups[0].Modules = append(dc.Config.DeploymentGroups[0].Modules, Module{ID: moduleID, Kind: expected})

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -128,7 +128,7 @@ func (dc *DeploymentConfig) expandBackends() error {
 				if deployment, err := blueprint.DeploymentName(); err == nil {
 					prefix += "/" + deployment
 				}
-				prefix += "/" + grp.Name
+				prefix += "/" + string(grp.Name)
 				be.Configuration.Set("prefix", cty.StringVal(prefix))
 			}
 		}
@@ -376,15 +376,15 @@ func (dc *DeploymentConfig) applyGlobalVariables() error {
 }
 
 // AutomaticOutputName generates unique deployment-group-level output names
-func AutomaticOutputName(outputName string, moduleID string) string {
-	return outputName + "_" + moduleID
+func AutomaticOutputName(outputName string, moduleID ModuleID) string {
+	return outputName + "_" + string(moduleID)
 }
 
 // Checks validity of reference to a module:
 // * module exists;
 // * module is not a Packer module;
 // * module is not in a later deployment group.
-func validateModuleReference(bp Blueprint, from Module, toID string) error {
+func validateModuleReference(bp Blueprint, from Module, toID ModuleID) error {
 	to, err := bp.Module(toID)
 	if err != nil {
 		return err

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -227,7 +227,7 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 		using := Module{
 			ID:     "usingModule",
 			Source: "path/using",
-			Use:    []string{"usedModule"},
+			Use:    []ModuleID{"usedModule"},
 		}
 		used := Module{ID: "usedModule", Source: "path/used"}
 

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -29,8 +29,8 @@ import (
 // representation of a reference text
 type Reference struct {
 	GlobalVar bool
-	Module    string // should be empty if GlobalVar. otherwise required
-	Name      string // required
+	Module    ModuleID // should be empty if GlobalVar. otherwise required
+	Name      string   // required
 }
 
 // GlobalRef returns a reference to a global variable
@@ -39,7 +39,7 @@ func GlobalRef(n string) Reference {
 }
 
 // ModuleRef returns a reference to a module output
-func ModuleRef(m string, n string) Reference {
+func ModuleRef(m ModuleID, n string) Reference {
 	return Reference{Module: m, Name: n}
 }
 
@@ -91,7 +91,7 @@ func SimpleVarToReference(s string) (Reference, error) {
 			Name:      components[1]}, nil
 	}
 	return Reference{
-		Module: components[0],
+		Module: ModuleID(components[0]),
 		Name:   components[1]}, nil
 }
 
@@ -140,7 +140,7 @@ func TraversalToReference(t hcl.Traversal) (Reference, error) {
 		if err != nil {
 			return Reference{}, fmt.Errorf("expected third component of module var reference to be a variable name, got %w", err)
 		}
-		return ModuleRef(m, n), nil
+		return ModuleRef(ModuleID(m), n), nil
 	default:
 		return Reference{}, fmt.Errorf("unexpected first component of reference: %#v", root)
 	}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -456,7 +456,12 @@ func (dc *DeploymentConfig) testModuleNotUsed(c validatorConfig) error {
 
 	acc := map[string][]string{}
 	dc.Config.WalkModules(func(m *Module) error {
-		acc[m.ID] = m.listUnusedModules()
+		ids := m.listUnusedModules()
+		sids := make([]string, len(ids))
+		for i, id := range ids {
+			sids[i] = string(id)
+		}
+		acc[string(m.ID)] = sids
 		return nil
 	})
 

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -132,7 +132,7 @@ func WriteDeployment(dc config.DeploymentConfig, outputDir string, overwriteFlag
 
 func createGroupDirs(deploymentPath string, deploymentGroups *[]config.DeploymentGroup) error {
 	for _, grp := range *deploymentGroups {
-		groupPath := filepath.Join(deploymentPath, grp.Name)
+		groupPath := filepath.Join(deploymentPath, string(grp.Name))
 		// Create the deployment group directory if not already created.
 		if _, err := os.Stat(groupPath); errors.Is(err, os.ErrNotExist) {
 			if err := os.Mkdir(groupPath, 0755); err != nil {
@@ -159,7 +159,7 @@ func deploymentSource(mod config.Module) (string, error) {
 		return mod.Source, nil
 	}
 	if mod.Kind == config.PackerKind {
-		return mod.ID, nil
+		return string(mod.ID), nil
 	}
 	if mod.Kind != config.TerraformKind {
 		return "", fmt.Errorf("unexpected module kind %#v", mod.Kind)
@@ -204,7 +204,7 @@ func copyEmbeddedModules(base string) error {
 func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGroup) error {
 	for iGrp := range *deploymentGroups {
 		grp := &(*deploymentGroups)[iGrp]
-		basePath := filepath.Join(deploymentPath, grp.Name)
+		basePath := filepath.Join(deploymentPath, string(grp.Name))
 
 		var copyEmbedded = false
 		for iMod := range grp.Modules {
@@ -269,7 +269,7 @@ func isOverwriteAllowed(depDir string, overwritingConfig *config.Blueprint, over
 
 	var curGroups []string
 	for _, group := range overwritingConfig.DeploymentGroups {
-		curGroups = append(curGroups, group.Name)
+		curGroups = append(curGroups, string(group.Name))
 	}
 
 	return isSubset(prevGroups, curGroups)

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -255,7 +255,7 @@ func (s *MySuite) TestCreateGroupDirs(c *C) {
 	if err := os.Mkdir(testDeployDir, 0755); err != nil {
 		log.Fatal("Failed to create test deployment directory for createGroupDirs")
 	}
-	groupNames := []string{"group0", "group1", "group2"}
+	groupNames := []config.GroupName{"group0", "group1", "group2"}
 
 	// No deployment groups
 	testDepGroups := []config.DeploymentGroup{}
@@ -266,7 +266,7 @@ func (s *MySuite) TestCreateGroupDirs(c *C) {
 	testDepGroups = []config.DeploymentGroup{{Name: groupNames[0]}}
 	err = createGroupDirs(testDeployDir, &testDepGroups)
 	c.Check(err, IsNil)
-	grp0Path := filepath.Join(testDeployDir, groupNames[0])
+	grp0Path := filepath.Join(testDeployDir, string(groupNames[0]))
 	_, err = os.Stat(grp0Path)
 	c.Check(errors.Is(err, os.ErrNotExist), Equals, false)
 	c.Check(err, IsNil)
@@ -288,14 +288,14 @@ func (s *MySuite) TestCreateGroupDirs(c *C) {
 	err = os.Remove(grp0Path)
 	c.Check(err, IsNil)
 	// Check for group 1
-	grp1Path := filepath.Join(testDeployDir, groupNames[1])
+	grp1Path := filepath.Join(testDeployDir, string(groupNames[1]))
 	_, err = os.Stat(grp1Path)
 	c.Check(errors.Is(err, os.ErrNotExist), Equals, false)
 	c.Check(err, IsNil)
 	err = os.Remove(grp1Path)
 	c.Check(err, IsNil)
 	// Check for group 2
-	grp2Path := filepath.Join(testDeployDir, groupNames[2])
+	grp2Path := filepath.Join(testDeployDir, string(groupNames[2]))
 	_, err = os.Stat(grp2Path)
 	c.Check(errors.Is(err, os.ErrNotExist), Equals, false)
 	c.Check(err, IsNil)

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -40,8 +40,8 @@ func (w *PackerWriter) addNumModules(value int) {
 	w.numModules += value
 }
 
-func printPackerInstructions(modPath string, moduleName string, printIntergroupWarning bool) {
-	printInstructionsPreamble("Packer", modPath, moduleName)
+func printPackerInstructions(modPath string, mod config.ModuleID, printIntergroupWarning bool) {
+	printInstructionsPreamble("Packer", modPath, string(mod))
 	if printIntergroupWarning {
 		fmt.Print(intergroupWarning)
 	}
@@ -66,7 +66,7 @@ func (w PackerWriter) writeDeploymentGroup(
 	deployDir string,
 ) error {
 	depGroup := dc.Config.DeploymentGroups[grpIdx]
-	groupPath := filepath.Join(deployDir, depGroup.Name)
+	groupPath := filepath.Join(deployDir, string(depGroup.Name))
 	igcInputs := map[string]bool{}
 
 	for _, mod := range depGroup.Modules {

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -220,7 +220,7 @@ func writeMain(
 	for _, mod := range modules {
 		hclBody.AppendNewline()
 		// Add block
-		moduleBlock := hclBody.AppendNewBlock("module", []string{mod.ID})
+		moduleBlock := hclBody.AppendNewBlock("module", []string{string(mod.ID)})
 		moduleBody := moduleBlock.Body()
 
 		// Add source attribute
@@ -331,8 +331,8 @@ func writeVersions(dst string) error {
 	return nil
 }
 
-func printTerraformInstructions(grpPath string, moduleName string, printIntergroupWarning bool) {
-	printInstructionsPreamble("Terraform", grpPath, moduleName)
+func printTerraformInstructions(grpPath string, group config.GroupName, printIntergroupWarning bool) {
+	printInstructionsPreamble("Terraform", grpPath, string(group))
 	if printIntergroupWarning {
 		fmt.Print(intergroupWarning)
 	}
@@ -360,7 +360,7 @@ func (w TFWriter) writeDeploymentGroup(
 		intergroupInputs[igVar.Name] = true
 	}
 
-	writePath := filepath.Join(deploymentDir, depGroup.Name)
+	writePath := filepath.Join(deploymentDir, string(depGroup.Name))
 
 	// Write main.tf file
 	doctoredModules := substituteIgcReferences(depGroup.Modules, intergroupVars)

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -148,14 +148,14 @@ func getOutputs(tf *tfexec.Terraform) (map[string]cty.Value, error) {
 	return outputValues, nil
 }
 
-func outputsFile(artifactsDir string, groupName string) string {
-	return filepath.Join(artifactsDir, fmt.Sprintf("%s_outputs.tfvars", groupName))
+func outputsFile(artifactsDir string, group config.GroupName) string {
+	return filepath.Join(artifactsDir, fmt.Sprintf("%s_outputs.tfvars", string(group)))
 }
 
 // ExportOutputs will run terraform output and capture data needed for
 // subsequent deployment groups
 func ExportOutputs(tf *tfexec.Terraform, artifactsDir string) error {
-	thisGroup := filepath.Base(tf.WorkingDir())
+	thisGroup := config.GroupName(filepath.Base(tf.WorkingDir()))
 	filepath := outputsFile(artifactsDir, thisGroup)
 
 	outputValues, err := getOutputs(tf)
@@ -184,7 +184,7 @@ func ExportOutputs(tf *tfexec.Terraform, artifactsDir string) error {
 // working directory
 func ImportInputs(deploymentGroupDir string, artifactsDir string, expandedBlueprintFile string) error {
 	deploymentRoot := filepath.Clean(filepath.Join(deploymentGroupDir, ".."))
-	thisGroup := filepath.Base(deploymentGroupDir)
+	thisGroup := config.GroupName(filepath.Base(deploymentGroupDir))
 
 	outputNamesByGroup, err := getIntergroupOutputNamesByGroup(thisGroup, expandedBlueprintFile)
 	if err != nil {


### PR DESCRIPTION
Rationale:
* To bolster interfaces;
* To enable move of validations to unmarshaling stage;