### PR TITLE
Write Packer intergroup input values

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -76,7 +76,12 @@ func setArtifactsDir(cmd *cobra.Command, args []string) {
 }
 
 func verifyDeploymentAgainstBlueprint(expandedBlueprintFile string, group config.GroupName, deploymentRoot string) (config.ModuleKind, error) {
-	groupKinds, err := shell.GetDeploymentKinds(expandedBlueprintFile)
+	dc, err := config.NewDeploymentConfig(expandedBlueprintFile)
+	if err != nil {
+		return config.UnknownKind, err
+	}
+
+	groupKinds, err := shell.GetDeploymentKinds(dc)
 	if err != nil {
 		return config.UnknownKind, err
 	}

--- a/community/examples/intel/README.md
+++ b/community/examples/intel/README.md
@@ -95,18 +95,18 @@ templates. **Please ignore the printed instructions** in favor of the following:
     ```shell
     terraform -chdir=hpc-intel-select/primary output \
       -raw startup_script_startup_controller > \
-      hpc-intel-select/packer/controller-image/startup_script.sh
+      hpc-intel-select/build1/controller-image/startup_script.sh
 
     terraform -chdir=hpc-intel-select/primary output \
       -raw startup_script_startup_compute > \
-      hpc-intel-select/packer/compute-image/startup_script.sh
+      hpc-intel-select/build2/compute-image/startup_script.sh
     ```
 
 3. Build the custom Slurm controller image. While this step is executing, you
    may begin the next step in parallel.
 
     ```shell
-    cd hpc-intel-select/packer/controller-image
+    cd hpc-intel-select/build1/controller-image
     packer init .
     packer validate .
     packer build -var startup_script_file=startup_script.sh .
@@ -116,7 +116,7 @@ templates. **Please ignore the printed instructions** in favor of the following:
 
     ```shell
     cd -
-    cd hpc-intel-select/packer/compute-image
+    cd hpc-intel-select/build2/compute-image
     packer init .
     packer validate .
     packer build -var startup_script_file=startup_script.sh .

--- a/community/examples/intel/hpc-cluster-intel-select.yaml
+++ b/community/examples/intel/hpc-cluster-intel-select.yaml
@@ -73,7 +73,7 @@ deployment_groups:
           clck -D ${FWD}.db -F ${FWD} -l debug
     outputs:
     - startup_script
-- group: packer
+- group: build1
   modules:
   - id: controller-image
     source: modules/packer/custom-image
@@ -83,6 +83,8 @@ deployment_groups:
       source_image_project_id: [schedmd-slurm-public]
       source_image_family: schedmd-slurm-21-08-8-hpc-centos-7
       image_family: $(vars.controller_image_family)
+- group: build2
+  modules:
   - id: compute-image
     source: modules/packer/custom-image
     kind: packer

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -141,6 +141,17 @@ func (bp Blueprint) ModuleGroupOrDie(mod ModuleID) DeploymentGroup {
 	return g
 }
 
+// GroupIndex returns the index of the input group in the blueprint
+// return -1 if not found
+func (bp Blueprint) GroupIndex(groupName GroupName) int {
+	for i, g := range bp.DeploymentGroups {
+		if g.Name == groupName {
+			return i
+		}
+	}
+	return -1
+}
+
 // TerraformBackend defines the configuration for the terraform state backend
 type TerraformBackend struct {
 	Type          string
@@ -500,13 +511,13 @@ func (bp *Blueprint) checkModulesInfo() error {
 }
 
 // checkModulesAndGroups ensures:
-// - all module IDs are unique across all groups
-// - if deployment group kind is unknown (not explicit in blueprint), then it is
-//   set to th kind of the first module that has a known kind (a prior func sets
-//   module kind to Terraform if unset)
-// - all modules must be of the same kind and all modules must be of the same
-//   kind as the group
-// - all group names are unique and do not have illegal characters
+//   - all module IDs are unique across all groups
+//   - if deployment group kind is unknown (not explicit in blueprint), then it is
+//     set to th kind of the first module that has a known kind (a prior func sets
+//     module kind to Terraform if unset)
+//   - all modules must be of the same kind and all modules must be of the same
+//     kind as the group
+//   - all group names are unique and do not have illegal characters
 func checkModulesAndGroups(groups []DeploymentGroup) error {
 	seenMod := map[ModuleID]bool{}
 	seenGroups := map[GroupName]bool{}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -393,16 +393,16 @@ func (s *MySuite) TestExpandConfig(c *C) {
 	dc.ExpandConfig()
 }
 
-func (s *MySuite) TestCheckModuleAndGroupNames(c *C) {
+func (s *MySuite) TestCheckModulesAndGroups(c *C) {
 	{ // Duplicate module name same group
 		g := DeploymentGroup{Name: "ice", Modules: []Module{{ID: "pony"}, {ID: "pony"}}}
-		err := checkModuleAndGroupNames([]DeploymentGroup{g})
+		err := checkModulesAndGroups([]DeploymentGroup{g})
 		c.Check(err, ErrorMatches, "module IDs must be unique: pony used more than once")
 	}
 	{ // Duplicate module name different groups
 		ice := DeploymentGroup{Name: "ice", Modules: []Module{{ID: "pony"}}}
 		fire := DeploymentGroup{Name: "fire", Modules: []Module{{ID: "pony"}}}
-		err := checkModuleAndGroupNames([]DeploymentGroup{ice, fire})
+		err := checkModulesAndGroups([]DeploymentGroup{ice, fire})
 		c.Check(err, ErrorMatches, "module IDs must be unique: pony used more than once")
 	}
 	{ // Mixing module kinds
@@ -410,7 +410,7 @@ func (s *MySuite) TestCheckModuleAndGroupNames(c *C) {
 			{ID: "pony", Kind: PackerKind},
 			{ID: "zebra", Kind: TerraformKind},
 		}}
-		err := checkModuleAndGroupNames([]DeploymentGroup{g})
+		err := checkModulesAndGroups([]DeploymentGroup{g})
 		c.Check(err, ErrorMatches, "mixing modules of differing kinds in a deployment group is not supported: deployment group ice, got packer and terraform")
 	}
 }

--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -67,6 +67,14 @@ func (d *Dict) Set(k string, v cty.Value) *Dict {
 	return d
 }
 
+// Unset removes a key from dictionary, if it is present
+func (d *Dict) Unset(k string) *Dict {
+	if d.Has(k) {
+		delete(d.m, k)
+	}
+	return d
+}
+
 // Items returns instance of map[string]cty.Value
 // will same set of key-value pairs as stored in Dict.
 // This map is a copy, changes to returned map have no effect on the Dict.

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -354,7 +354,7 @@ func (w TFWriter) writeDeploymentGroup(
 ) error {
 	depGroup := dc.Config.DeploymentGroups[groupIndex]
 	deploymentVars := getUsedDeploymentVars(depGroup, dc.Config)
-	intergroupVars := findIntergroupVariables(depGroup, dc.Config)
+	intergroupVars := FindIntergroupVariables(depGroup, dc.Config)
 	intergroupInputs := make(map[string]bool)
 	for _, igVar := range intergroupVars {
 		intergroupInputs[igVar.Name] = true
@@ -473,13 +473,14 @@ func getUsedDeploymentVars(group config.DeploymentGroup, bp config.Blueprint) ma
 func substituteIgcReferences(mods []config.Module, igcRefs map[config.Reference]modulereader.VarInfo) []config.Module {
 	doctoredMods := make([]config.Module, len(mods))
 	for i, mod := range mods {
-		doctoredMods[i] = substituteIgcReferencesInModule(mod, igcRefs)
+		doctoredMods[i] = SubstituteIgcReferencesInModule(mod, igcRefs)
 	}
 	return doctoredMods
 }
 
-// Updates expressions in Module settings to use special IGC var name instead of the module reference
-func substituteIgcReferencesInModule(mod config.Module, igcRefs map[config.Reference]modulereader.VarInfo) config.Module {
+// SubstituteIgcReferencesInModule updates expressions in Module settings to use
+// special IGC var name instead of the module reference
+func SubstituteIgcReferencesInModule(mod config.Module, igcRefs map[config.Reference]modulereader.VarInfo) config.Module {
 	v, _ := cty.Transform(mod.Settings.AsObject(), func(p cty.Path, v cty.Value) (cty.Value, error) {
 		e, is := config.IsExpressionValue(v)
 		if !is {
@@ -501,7 +502,9 @@ func substituteIgcReferencesInModule(mod config.Module, igcRefs map[config.Refer
 	return mod
 }
 
-func findIntergroupVariables(group config.DeploymentGroup, bp config.Blueprint) map[config.Reference]modulereader.VarInfo {
+// FindIntergroupVariables returns all unique intergroup references made by
+// each module settings in a group
+func FindIntergroupVariables(group config.DeploymentGroup, bp config.Blueprint) map[config.Reference]modulereader.VarInfo {
 	res := map[config.Reference]modulereader.VarInfo{}
 	igcRefs := group.FindAllIntergroupReferences(bp)
 	for _, r := range igcRefs {


### PR DESCRIPTION
- ensure Packer deployment groups are always 1-module long
- modify location to match Packer module destination directory
- evaluate the Packer settings using deployment variables and intergroup output values from prior groups