### PR TITLE
Fix link in image builder example

### DIFF
--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -57,7 +57,7 @@ deployment_groups:
     kind: packer
     settings:
       source_image_project_id: [schedmd-slurm-public]
-      # see latest in https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
+      # see latest in https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#published-image-family
       source_image_family: schedmd-v5-slurm-22-05-8-hpc-centos-7
       # You can find size of source image by using following command
       # gcloud compute images describe-from-family <source_image_family> --project schedmd-slurm-public


### PR DESCRIPTION
The current link points to image families on which one an build Slurm; we want users to discover the Slurm image families published by SchedMD