### PR TITLE
Filter blueprint autocompletion on YAML files

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -66,11 +66,12 @@ var (
 	skipValidatorsDesc  = "Validators to skip"
 
 	createCmd = &cobra.Command{
-		Use:   "create BLUEPRINT_NAME",
-		Short: "Create a new deployment.",
-		Long:  "Create a new deployment based on a provided blueprint.",
-		Run:   runCreateCmd,
-		Args:  cobra.ExactArgs(1),
+		Use:               "create BLUEPRINT_NAME",
+		Short:             "Create a new deployment.",
+		Long:              "Create a new deployment based on a provided blueprint.",
+		Run:               runCreateCmd,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: filterYaml,
 	}
 )
 
@@ -185,4 +186,11 @@ func skipValidators(dc *config.DeploymentConfig) error {
 		}
 	}
 	return nil
+}
+
+func filterYaml(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
 }

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -38,11 +38,12 @@ func init() {
 var (
 	outputFilename string
 	expandCmd      = &cobra.Command{
-		Use:   "expand BLUEPRINT_NAME",
-		Short: "Expand the Environment Blueprint.",
-		Long:  "Updates the Environment Blueprint in the same way as create, but without writing the deployment.",
-		Run:   runExpandCmd,
-		Args:  cobra.ExactArgs(1),
+		Use:               "expand BLUEPRINT_NAME",
+		Short:             "Expand the Environment Blueprint.",
+		Long:              "Updates the Environment Blueprint in the same way as create, but without writing the deployment.",
+		Run:               runExpandCmd,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: filterYaml,
 	}
 )
 


### PR DESCRIPTION
Cause tab completion when the user has typed `ghpc create` to filter on directories and files with the extension `yaml` or `yml`. For bash, this requires that the user install bash-completion and generate a ghpc-specific autocompletion configuration following steps in `ghpc completion --help`

The `fish` shell does not support this feature.