### PR TITLE
Add Terraform state download command to stdout of integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -54,3 +54,7 @@
     cmd: gsutil cp "{{ deployment_name }}.tgz" "gs://{{ state_bucket }}/{{ test_name }}/"
     chdir: "{{ workspace }}"
   changed_when: True
+
+- name: Print download command
+  ansible.builtin.debug:
+    msg: gcloud storage cp gs://{{ state_bucket }}/{{ test_name }}/{{ deployment_name }}.tgz .


### PR DESCRIPTION
Add debug statement that, for each integration tests, will print a `gcloud` command to download the deployment with Terraform backend configured. Useful for debugging failed tests and was lost during the transition from bash to Ansible.