### PR TITLE
Expose disk_size_gb, disk_type, & guest_accelerator on gke-node-pool

### DIFF
--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -84,6 +84,9 @@ No modules.
 | <a name="input_auto_upgrade"></a> [auto\_upgrade](#input\_auto\_upgrade) | Whether the nodes will be automatically upgraded. | `bool` | `false` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | projects/{{project}}/locations/{{location}}/clusters/{{cluster}} | `string` | n/a | yes |
 | <a name="input_compact_placement"></a> [compact\_placement](#input\_compact\_placement) | Places node pool's nodes in a closer physical proximity in order to reduce network latency between nodes. | `bool` | `false` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of disk for each node. | `number` | `100` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Disk type for each node. | `string` | `"pd-standard"` | no |
+| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br>    type               = string<br>    count              = number<br>    gpu_partition_size = string<br>    gpu_sharing_config = list(object({<br>      gpu_sharing_strategy       = string<br>      max_shared_clients_per_gpu = number<br>    }))<br>  }))</pre> | `null` | no |
 | <a name="input_image_type"></a> [image\_type](#input\_image\_type) | The default image type used by NAP once a new node pool is being created. Use either COS\_CONTAINERD or UBUNTU\_CONTAINERD. | `string` | `"COS_CONTAINERD"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | GCE resource labels to be applied to resources. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The name of a Google Compute Engine machine type. | `string` | `"c2-standard-60"` | no |
@@ -103,5 +106,5 @@ No modules.
 |------|-------------|
 | <a name="output_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#output\_allocatable\_cpu\_per\_node) | Number of CPUs available for scheduling pods on each node. |
 | <a name="output_node_pool_name"></a> [node\_pool\_name](#output\_node\_pool\_name) | Name of the node pool. |
-| <a name="output_tolerations"></a> [tolerations](#output\_tolerations) | value |
+| <a name="output_tolerations"></a> [tolerations](#output\_tolerations) | Tolerations needed for a pod to be scheduled on this node pool. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/gke-node-pool/outputs.tf
+++ b/community/modules/compute/gke-node-pool/outputs.tf
@@ -21,7 +21,7 @@ output "node_pool_name" {
 
 locals {
   is_a_series = local.machine_family == "a2"
-  last_digit  = try(local.machine_vals[2], 0)
+  last_digit  = trimsuffix(try(local.machine_vals[2], 0), "g")
 
   # Shared core machines only have 1 cpu allocatable, even if they have 2 cpu capacity
   vcpu        = local.machine_shared_core ? 1 : local.is_a_series ? local.last_digit * 12 : local.last_digit
@@ -56,6 +56,6 @@ locals {
 }
 
 output "tolerations" {
-  description = "value"
+  description = "Tolerations needed for a pod to be scheduled on this node pool."
   value       = local.tolerations
 }

--- a/community/modules/compute/gke-node-pool/variables.tf
+++ b/community/modules/compute/gke-node-pool/variables.tf
@@ -42,6 +42,32 @@ variable "machine_type" {
   default     = "c2-standard-60"
 }
 
+variable "disk_size_gb" {
+  description = "Size of disk for each node."
+  type        = number
+  default     = 100
+}
+
+variable "disk_type" {
+  description = "Disk type for each node."
+  type        = string
+  default     = "pd-standard"
+}
+
+variable "guest_accelerator" {
+  description = "List of the type and count of accelerator cards attached to the instance."
+  type = list(object({
+    type               = string
+    count              = number
+    gpu_partition_size = string
+    gpu_sharing_config = list(object({
+      gpu_sharing_strategy       = string
+      max_shared_clients_per_gpu = number
+    }))
+  }))
+  default = null
+}
+
 variable "image_type" {
   description = "The default image type used by NAP once a new node pool is being created. Use either COS_CONTAINERD or UBUNTU_CONTAINERD."
   type        = string

--- a/community/modules/scheduler/gke-cluster/versions.tf
+++ b/community/modules/scheduler/gke-cluster/versions.tf
@@ -26,6 +26,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:k8s-cluster/v1.17.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.17.0"
   }
 }


### PR DESCRIPTION
In addition to exposing the 3 vars listed in the title this PR does some additional cleanup:
- Trims the g off of the end of a2 machine types when calculating vCPU (ie. `a2-highgpu-1g`)
- Adds a taint for GPU node pools. If we do not add this taint then GKE automatically will. This is problematic for re-apply as it will try to destroy the node pool to remove the automatically added taint. By adding it ourself we avoid this problem. 

Tested manually: 
```yaml
  - id: t4-pool
    source: community/modules/compute/gke-node-pool
    use: [gke_cluster]
    settings:
      machine_type: n1-standard-4
      guest_accelerator:
      - type: nvidia-tesla-t4
        count: 2
        gpu_partition_size: null
        gpu_sharing_config: null

...

  - id: simple-a2-pool
    source: community/modules/compute/gke-node-pool
    use: [gke_cluster]
    settings:
      machine_type: a2-highgpu-1g

...

  - id: multi-instance-gpu-pool
    source: community/modules/compute/gke-node-pool
    use: [gke_cluster]
    settings:
      machine_type: a2-highgpu-1g
      guest_accelerator:
      - type: nvidia-tesla-a100
        count: 1
        gpu_partition_size: 1g.5gb
        gpu_sharing_config: null

...

  - id: time-sharing-gpu-pool
    source: community/modules/compute/gke-node-pool
    use: [gke_cluster]
    settings:
      machine_type: a2-highgpu-1g
      guest_accelerator:
      - type: nvidia-tesla-a100
        count: 1
        gpu_partition_size: 1g.5gb
        gpu_sharing_config:
        - gpu_sharing_strategy: TIME_SHARING
          max_shared_clients_per_gpu: 3
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
