### PR TITLE
Add intergroup instructions to output of create

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -192,9 +192,11 @@ For this example the following is needed in the selected region:
 
 ### [image-builder.yaml] ![core-badge]
 
-This Blueprint uses the [Packer template module][pkr] to create custom VM images
-by applying software and configurations to existing images. This example takes
-the following steps:
+This blueprint uses the [Packer template module][pkr] to create a custom VM
+image and uses it to provision an HPC cluster using the Slurm scheduler. By
+using a custom image, the cluster is able to begin running jobs sooner and more
+reliably because there is no need to install applications as VMs boot. This
+example takes the following steps:
 
 1. Creates a network with outbound internet access in which to build the image (see
 [Custom Network](#custom-network-deployment-group-1)).
@@ -205,9 +207,11 @@ the following steps:
 4. Deploys a Slurm cluster using the custom image (see
 [Slurm Cluster Based on Custom Image](#slurm-cluster-based-on-custom-image-deployment-group-3)).
 
+#### Building and using the custom image
+
 Create the deployment folder from the blueprint:
 
-```shell
+```text
 ./ghpc create examples/image-builder.yaml --vars "project_id=${GOOGLE_CLOUD_PROJECT}"
 ```
 
@@ -219,9 +223,9 @@ example, the network is created in the first deployment group and its name
 must be supplied to both the Packer and Slurm cluster deployment groups. These
 sub-commands automate steps that might otherwise require manual copying.
 
-When you are done, clean up the resources in reverse order of creation
+When you are done, clean up the resources in reverse order of creation:
 
-```shell
+```text
 terraform -chdir=image-builder-001/cluster destroy --auto-approve
 terraform -chdir=image-builder-001/builder-env destroy --auto-approve
 ```

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -26,8 +26,6 @@ vars:
   region: us-central1
   zone: us-central1-c
   new_image_family: my-slurm-image
-  network_name: image-builder
-  subnetwork_name: image-builder-us-central1
   disk_size: 32
 
 # Documentation for each of the modules used below can be found at
@@ -48,13 +46,15 @@ deployment_groups:
         content: |
           #!/bin/sh
           echo "Hello World" > /home/hello.txt
-    outputs: [startup_script]
 
 - group: packer
   modules:
   - id: custom-image
     source: modules/packer/custom-image
     kind: packer
+    use:
+    - network1
+    - scripts_for_image
     settings:
       source_image_project_id: [schedmd-slurm-public]
       # see latest in https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#published-image-family
@@ -67,9 +67,6 @@ deployment_groups:
 
 - group: cluster
   modules:
-  - id: cluster-network
-    source: modules/network/pre-existing-vpc
-
   - id: compute_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
@@ -82,7 +79,7 @@ deployment_groups:
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
     use:
-    - cluster-network
+    - network1
     - compute_node_group
     settings:
       partition_name: compute
@@ -90,7 +87,9 @@ deployment_groups:
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
-    use: [cluster-network, compute_partition]
+    use:
+    - network1
+    - compute_partition
     settings:
       disable_controller_public_ips: false
       disk_size_gb: $(vars.disk_size)
@@ -100,7 +99,9 @@ deployment_groups:
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
-    use: [cluster-network, slurm_controller]
+    use:
+    - network1
+    - slurm_controller
     settings:
       disable_login_public_ips: false
       disk_size_gb: $(vars.disk_size)

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -43,13 +43,6 @@ const (
 	expandedBlueprintName      = "expanded_blueprint.yaml"
 )
 
-const intergroupWarning string = `
-WARNING: this deployment group requires outputs from previous groups!
-This is an advanced feature under active development. The automatically generated
-instructions for executing terraform or packer below will not work as shown.
-
-`
-
 // ModuleWriter interface for writing modules to a deployment
 type ModuleWriter interface {
 	getNumModules() int

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -40,16 +40,20 @@ func (w *PackerWriter) addNumModules(value int) {
 	w.numModules += value
 }
 
-func printPackerInstructions(modPath string, mod config.ModuleID, printIntergroupWarning bool) {
+func printPackerInstructions(modPath string, mod config.ModuleID, printImportInputs bool) {
 	printInstructionsPreamble("Packer", modPath, string(mod))
-	if printIntergroupWarning {
-		fmt.Print(intergroupWarning)
+
+	fmt.Println()
+	grpPath := filepath.Clean(filepath.Join(modPath, ".."))
+	if printImportInputs {
+		fmt.Printf("ghpc import-inputs %s\n", grpPath)
 	}
-	fmt.Printf("  cd %s\n", modPath)
-	fmt.Println("  packer init .")
-	fmt.Println("  packer validate .")
-	fmt.Println("  packer build .")
-	fmt.Printf("  cd -\n\n")
+	fmt.Printf("cd %s\n", modPath)
+	fmt.Println("packer init .")
+	fmt.Println("packer validate .")
+	fmt.Println("packer build .")
+	fmt.Println("cd -")
+	fmt.Println()
 }
 
 func writePackerAutovars(vars map[string]cty.Value, dst string) error {

--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -24,44 +24,55 @@
   - name: Create Infrastructure and test
     block:
     - name: Create Network with Terraform
-      ansible.builtin.command:
-        cmd: "{{ item }}"
-        chdir: "{{ workspace }}/{{ deployment_name }}/builder-env"
+      register: network
+      changed_when: network.changed
+      ansible.builtin.command: "{{ item }}"
       args:
+        chdir: "{{ workspace }}/{{ deployment_name }}/builder-env"
         creates: "{{ workspace }}/{{ deployment_name }}/.terraform"
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      with_items:
+      loop:
       - terraform init
       - terraform validate
       - terraform apply -auto-approve -no-color
+    - name: Apply terraform startup-script to packer module
+      register: export_import
+      changed_when: export_import.changed
+      ansible.builtin.command: "{{ item }}"
+      args:
+        chdir: "{{ workspace }}"
+      loop:
+      - ./ghpc export-outputs {{ deployment_name }}/builder-env
+      - ./ghpc import-inputs {{ deployment_name }}/packer
     - name: Create VM image with Packer
-      register: image_created
-      changed_when: image_created.rc == 0
-      ansible.builtin.shell: |
-        set -e -o pipefail
-        packer init .
-        packer validate .
-        packer build .
+      register: image_creation
+      changed_when: image_creation.changed
+      ansible.builtin.command: "{{ item }}"
       args:
         chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
-        executable: /bin/bash
-    - name: Delete VM Image
-      register: image_deleted
-      changed_when: image_deleted.rc == 0
-      when: image_created.rc == 0
-      ansible.builtin.shell: |
-        gcloud compute images delete --project={{ project }} --quiet $(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d ":" -f2)
-      args:
-        chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
-    ## Always cleanup network
+      loop:
+      - packer init .
+      - packer validate .
+      - packer build .
+      notify:
+      - Delete VM Image
     always:
     - name: Tear Down Network
-      changed_when: true # assume something destroyed
-      run_once: true
-      delegate_to: localhost
+      register: terraform_destroy
+      changed_when: terraform_destroy.changed
+      ansible.builtin.command: terraform destroy -auto-approve -no-color
+      args:
+        chdir: "{{ workspace }}/{{ deployment_name }}/builder-env"
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      ansible.builtin.command:
-        cmd: terraform destroy -auto-approve -no-color
-        chdir: "{{ workspace }}/{{ deployment_name }}/builder-env"
+  handlers:
+  - name: Delete VM Image
+    register: image_deletion
+    changed_when: image_deletion.changed
+    ansible.builtin.shell: |
+      set -e -o pipefail
+      gcloud compute images delete --project={{ project }} --quiet $(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d ":" -f2)
+    args:
+      chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
+      executable: /bin/bash


### PR DESCRIPTION
- Replace intergroup warning with instructions to the user for executing export-outputs and import-inputs.
- Remove indentation from instructions to improve cut-and-pastability
- Update packer integration test to use export-outputs/import-inputs commands
- Modify image-builder example to adopt intergroup references

### Printed instructions for modified image-builder.yaml

```text
❯❯❯ ghpc create -w --vars project_id=test-project examples/image-builder.yaml
Terraform group 'builder-env' was successfully created in directory image-builder-001/builder-env
To deploy, run the following commands:

terraform -chdir=image-builder-001/builder-env init
terraform -chdir=image-builder-001/builder-env validate
terraform -chdir=image-builder-001/builder-env apply
ghpc export-outputs image-builder-001/builder-env

Packer group 'custom-image' was successfully created in directory image-builder-001/packer/custom-image
To deploy, run the following commands:

ghpc import-inputs image-builder-001/packer
cd image-builder-001/packer/custom-image
packer init .
packer validate .
packer build .
cd -

Terraform group 'cluster' was successfully created in directory image-builder-001/cluster
To deploy, run the following commands:

ghpc import-inputs image-builder-001/cluster
terraform -chdir=image-builder-001/cluster init
terraform -chdir=image-builder-001/cluster validate
terraform -chdir=image-builder-001/cluster apply

❯❯❯
```

### Old instructions (no intergroup references)

```text
❯❯❯ ghpc create -w --vars project_id=toolkit-demo-zero-e913 examples/image-builder.yaml
Terraform group 'builder-env' was successfully created in directory image-builder-001/builder-env
To deploy, run the following commands:
  terraform -chdir=image-builder-001/builder-env init
  terraform -chdir=image-builder-001/builder-env validate
  terraform -chdir=image-builder-001/builder-env apply

Packer group 'custom-image' was successfully created in directory image-builder-001/packer/custom-image
To deploy, run the following commands:
  cd image-builder-001/packer/custom-image
  packer init .
  packer validate .
  packer build .
  cd -

Terraform group 'cluster' was successfully created in directory image-builder-001/cluster
To deploy, run the following commands:
  terraform -chdir=image-builder-001/cluster init
  terraform -chdir=image-builder-001/cluster validate
  terraform -chdir=image-builder-001/cluster apply

❯❯❯
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
