### PR TITLE
Don't perform file-wide text substitutions

### DIFF
--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -115,9 +115,6 @@ func writeOutputs(
 		return nil
 	}
 	hclBytes := hclFile.Bytes()
-	hclBytes = escapeLiteralVariables(hclBytes)
-	hclBytes = escapeBlueprintVariables(hclBytes)
-
 	outputsPath := filepath.Join(dst, "outputs.tf")
 	if err := createBaseFile(outputsPath); err != nil {
 		return fmt.Errorf("error creating outputs.tf file: %v", err)
@@ -247,8 +244,6 @@ func writeMain(
 	}
 	// Write file
 	hclBytes := hclFile.Bytes()
-	hclBytes = escapeLiteralVariables(hclBytes)
-	hclBytes = escapeBlueprintVariables(hclBytes)
 	hclBytes = hclwrite.Format(hclBytes)
 	if err := appendHCLToFile(mainPath, hclBytes); err != nil {
 		return fmt.Errorf("error writing HCL to main.tf file: %v", err)
@@ -310,8 +305,6 @@ func writeProviders(vars map[string]cty.Value, dst string) error {
 
 	// Write file
 	hclBytes := hclFile.Bytes()
-	hclBytes = escapeLiteralVariables(hclBytes)
-	hclBytes = escapeBlueprintVariables(hclBytes)
 	if err := appendHCLToFile(providersPath, hclBytes); err != nil {
 		return fmt.Errorf("error writing HCL to providers.tf file: %v", err)
 	}


### PR DESCRIPTION
Don't perform file-wide text substitutions, limit scope to string literals in variables values
