### PR TITLE
Fix Ansible panic when IP address not found

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,20 +3,20 @@ skip_list:
 - jinja[invalid]
 
 exclude_paths:
-  - .cache/ # implicit unless exclude_paths is defined in config
-  - .github/
-  - cmd/
-  - docs/
-  - examples/
-  - community/examples/
-  - pkg/
+- .cache/ # implicit unless exclude_paths is defined in config
+- .github/
+- cmd/
+- docs/
+- examples/
+- community/examples/
+- pkg/
 
 mock_roles:
 - googlecloudplatform.google_cloud_ops_agents
 
 kinds:
-  - playbook: "**/ansible_playbooks/*test.{yml,yaml}"
-  - playbook: "**/files/*.{yml,yaml}"
-  - playbook: "**/scripts/*.{yml,yaml}"
-  - tasks: "**/ansible_playbooks/test*.{yml,yaml}"
-  - tasks: "**/tasks/*"
+- playbook: "**/ansible_playbooks/*test.{yml,yaml}"
+- playbook: "**/files/*.{yml,yaml}"
+- playbook: "**/scripts/*.{yml,yaml}"
+- tasks: "**/ansible_playbooks/test*.{yml,yaml}"
+- tasks: "**/tasks/*"

--- a/tools/cloud-build/Dockerfile
+++ b/tools/cloud-build/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     dnsutils \
     shellcheck && \
     apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com bullseye main" && \
-    apt-get -y update && apt-get install -y unzip python3-pip python3-venv terraform packer jq && \
+    apt-get -y update && apt-get install -y unzip python3-pip python3-venv python3-netaddr terraform packer jq && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
       | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -130,6 +130,7 @@
       ansible.builtin.add_host:
         hostname: "{{ remote_ip }}"
         groups: [remote_host]
+      when: remote_ip | ansible.utils.ipaddr
     - name: Wait for cluster
       ansible.builtin.wait_for_connection:
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -58,6 +58,7 @@
       ansible.builtin.add_host:
         hostname: "{{ access_ip.stdout }}"
         groups: [remote_host]
+      when: access_ip.stdout | ansible.utils.ipaddr
     ## Setup firewall for cloud build
     - name: Get Builder IP
       register: build_ip

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -136,6 +136,7 @@
       ansible.builtin.add_host:
         hostname: "{{ login_ip }}"
         groups: [remote_host]
+      when: login_ip | ansible.utils.ipaddr
 
     ## Cleanup and fail gracefully
     rescue:


### PR DESCRIPTION
This change enables Ansible to fail, rather than panic, when the IP address of the newly-created remote host is not found. Failure enables the rescue block to run, which will allow terraform destroy to execute.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
