### PR TITLE
Add ramble-setup module

### DIFF
--- a/community/examples/ramble.yaml
+++ b/community/examples/ramble.yaml
@@ -1,0 +1,52 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+blueprint_name: ramble
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: ramble-01
+  region: us-central1
+  zone: us-central1-c
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network1
+    source: modules/network/pre-existing-vpc
+
+  - id: spack
+    source: community/modules/scripts/spack-install
+    settings:
+      install_dir: /spack
+
+  - id: ramble-setup
+    source: community/modules/scripts/ramble-setup
+    settings:
+      install_dir: /ramble
+
+  - id: vm-startup
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - $(spack.install_spack_deps_runner)
+      - $(spack.install_spack_runner)
+      - $(ramble-setup.ramble_runner)
+
+  - id: ramble-vm
+    source: modules/compute/vm-instance
+    use: [network1, vm-startup]
+    settings:
+      name_prefix: ramble-vm

--- a/community/modules/scripts/ramble-setup/README.md
+++ b/community/modules/scripts/ramble-setup/README.md
@@ -1,0 +1,107 @@
+## Description
+
+This module will create a set of startup-script runners that will setup Ramble,
+and install Ramble’s dependencies.
+
+Ramble is a multi-platform experimentation framework capable of driving
+software installation, acquiring input files, configuring experiments, and
+extracting results. For more information about ramble, see:
+https://github.com/GoogleCloudPlatform/ramble
+
+This module outputs two startup script runners, which can be added to startup
+scripts to setup, ramble and its dependencies.
+
+For this module to be completely functionaly, it depends on a spack
+installation. For more information, see HPC-Toolkit’s Spack module.
+
+> **_NOTE:_** This is an experimental module and the functionality and
+> documentation will likely be updated in the near future. This module has only
+> been tested in limited capacity.
+
+# Examples
+
+## Basic Example
+
+```yaml
+- id: ramble-setup
+  source: community/modules/scripts/ramble-setup
+```
+
+This example simply installs ramble on a VM.
+
+## Full Example
+
+```yaml
+- id: ramble-setup
+  source: community/modules/scripts/ramble-setup
+  settings:
+    install_dir: /ramble
+    ramble_url: https://github.com/GoogleCloudPlatform/ramble
+    ramble_ref: v0.2.1
+    log_file: /var/log/ramble.log
+    chown_owner: “owner”
+    chgrp_group: “user_group”
+    chmod_mode: “a+r”
+```
+
+This example simply installs ramble into a VM at the location `/ramble`, checks
+out the v0.2.1 tag, changes the owner and group to “owner” and “user_group”,
+and chmod’s the clone to make it world readable.
+
+Also see a more complete [Ramble example blueprint](../../../examples/ramble.yaml).
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_chgrp_group"></a> [chgrp\_group](#input\_chgrp\_group) | Group to chgrp the Ramble clone to. Default will not modify the clone. | `string` | `null` | no |
+| <a name="input_chmod_mode"></a> [chmod\_mode](#input\_chmod\_mode) | Mode to chmod the Ramble clone to. Defaults to null (i.e. do not modify).<br>For usage information see:<br>https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html#parameter-mode | `string` | `null` | no |
+| <a name="input_chown_owner"></a> [chown\_owner](#input\_chown\_owner) | Owner to chown the Ramble clone to. Default will not modify the clone. | `string` | `null` | no |
+| <a name="input_install_dir"></a> [install\_dir](#input\_install\_dir) | Destination directory of installation of Ramble. | `string` | `"/apps/ramble"` | no |
+| <a name="input_log_file"></a> [log\_file](#input\_log\_file) | Log file to write output from ramble setup steps into. | `string` | `"/var/log/ramble-setup.log"` | no |
+| <a name="input_ramble_ref"></a> [ramble\_ref](#input\_ramble\_ref) | Git ref to checkout for Ramble. | `string` | `"develop"` | no |
+| <a name="input_ramble_url"></a> [ramble\_url](#input\_ramble\_url) | URL for Ramble repository to clone. | `string` | `"https://github.com/GoogleCloudPlatform/ramble"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ramble_path"></a> [ramble\_path](#output\_ramble\_path) | Location ramble is installed into. |
+| <a name="output_ramble_ref"></a> [ramble\_ref](#output\_ramble\_ref) | Git ref the ramble install is checked out to use |
+| <a name="output_ramble_runner"></a> [ramble\_runner](#output\_ramble\_runner) | Runner to setup Ramble using an ansible playbook. The startup-script module<br>will automatically handle installation of ansible.<br>- id: example-startup-script<br>  source: modules/scripts/startup-script<br>  settings:<br>    runners:<br>    - $(your-ramble-id.ramble\_setup\_runner)<br>... |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/ramble-setup/main.tf
+++ b/community/modules/scripts/ramble-setup/main.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  setup_file = templatefile(
+    "${path.module}/templates/ramble_setup.tpl",
+    {
+      install_dir = var.install_dir
+      ramble_url  = var.ramble_url
+      ramble_ref  = var.ramble_ref
+      chown_owner = var.chown_owner == null ? "" : var.chown_owner
+      chgrp_group = var.chgrp_group == null ? "" : var.chgrp_group
+      chmod_mode  = var.chmod_mode == null ? "" : var.chmod_mode
+      log_file    = var.log_file
+    }
+  )
+
+  deps_file = templatefile(
+    "${path.module}/templates/install_ramble_deps.yml",
+    {
+      ramble_ref = var.ramble_ref
+    }
+  )
+
+  ramble_runner_content = <<-EOT
+   ${local.setup_file}
+   ${local.deps_file}
+  EOT
+
+  ramble_setup_runner = {
+    "type"        = "ansible-local"
+    "content"     = local.ramble_runner_content
+    "destination" = "ramble_setup.yml"
+  }
+}

--- a/community/modules/scripts/ramble-setup/outputs.tf
+++ b/community/modules/scripts/ramble-setup/outputs.tf
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "ramble_runner" {
+  description = <<-EOT
+  Runner to setup Ramble using an ansible playbook. The startup-script module
+  will automatically handle installation of ansible.
+  - id: example-startup-script
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - $(your-ramble-id.ramble_setup_runner)
+  ...
+  EOT
+  value       = local.ramble_setup_runner
+}
+
+output "ramble_path" {
+  description = "Location ramble is installed into."
+  value       = var.install_dir
+}
+
+output "ramble_ref" {
+  description = "Git ref the ramble install is checked out to use"
+  value       = var.ramble_ref
+}

--- a/community/modules/scripts/ramble-setup/templates/install_ramble_deps.yml
+++ b/community/modules/scripts/ramble-setup/templates/install_ramble_deps.yml
@@ -1,0 +1,45 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install dependencies for ramble installation
+  become: yes
+  hosts: localhost
+  vars:
+    ramble_ref: ${ramble_ref}
+  tasks:
+  - name: Install dependencies through system package manager
+    ansible.builtin.package:
+      name:
+      - python3-pip
+      - git
+
+  - name: Gather the package facts
+    ansible.builtin.package_facts:
+      manager: auto
+
+  - name: Install protobuf for old releases of Python
+    when: ansible_facts.packages["python3"][0].version is version("3.7", "<") and ansible_facts.packages["python3"][0].version is version("3.5", ">=")
+    ansible.builtin.pip:
+      name: protobuf
+      version: 3.19.4
+      executable: pip3
+
+  - name: Download ramble requirements file
+    ansible.builtin.get_url:
+      url: "https://raw.githubusercontent.com/GoogleCloudPlatform/ramble/{{ ramble_ref }}/requirements.txt"
+      dest: /tmp/requirements.txt
+
+  - name: Install ramble dependencies
+    ansible.builtin.pip:
+      requirements: /tmp/requirements.txt

--- a/community/modules/scripts/ramble-setup/templates/ramble_setup.tpl
+++ b/community/modules/scripts/ramble-setup/templates/ramble_setup.tpl
@@ -1,0 +1,68 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install necessary dependencies
+  hosts: localhost
+  tasks:
+  - name: Install git
+    ansible.builtin.package:
+      name:
+      - git
+      state: latest
+
+  - name: Install python
+    ansible.builtin.package:
+      name:
+      - python
+
+- name: Install Ramble
+  hosts: localhost
+  vars:
+    install_dir: ${install_dir}
+    ramble_url: ${ramble_url}
+    ramble_ref: ${ramble_ref}
+    chmod_mode: ${chmod_mode}
+    chown_owner: ${chown_owner}
+    chgrp_group: ${chgrp_group}
+  tasks:
+  - name: Clones ramble into installation directory
+    ansible.builtin.git:
+      repo: "{{ ramble_url }}"
+      dest: "{{ install_dir }}"
+      version: "{{ ramble_ref }}"
+
+  - name: chgrp ramble installation
+    ansible.builtin.file:
+      path: "{{ install_dir }}"
+      group: "{{ chgrp_group }}"
+      recurse: true
+    when: chgrp_group != ""
+
+  - name: chown ramble installation
+    ansible.builtin.file:
+      path: "{{ install_dir }}"
+      owner: "{{ chown_owner }}"
+      recurse: true
+    when: chown_owner != ""
+
+  - name: chmod ramble installation
+    ansible.builtin.file:
+      path: "{{ install_dir }}"
+      mode: "{{ chmod_mode }}"
+      recurse: true
+    when: chmod_mode != ""
+
+  - name: Add ramble to profile
+    ansible.builtin.shell:
+      echo ". {{ install_dir }}/share/ramble/setup-env.sh" > /etc/profile.d/ramble.sh

--- a/community/modules/scripts/ramble-setup/variables.tf
+++ b/community/modules/scripts/ramble-setup/variables.tf
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "install_dir" {
+  description = "Destination directory of installation of Ramble."
+  default     = "/apps/ramble"
+  type        = string
+}
+
+variable "ramble_url" {
+  description = "URL for Ramble repository to clone."
+  default     = "https://github.com/GoogleCloudPlatform/ramble"
+  type        = string
+}
+
+variable "ramble_ref" {
+  description = "Git ref to checkout for Ramble."
+  default     = "develop"
+  type        = string
+}
+
+variable "log_file" {
+  description = "Log file to write output from ramble setup steps into."
+  default     = "/var/log/ramble-setup.log"
+  type        = string
+}
+
+variable "chown_owner" {
+  description = "Owner to chown the Ramble clone to. Default will not modify the clone."
+  default     = null
+  type        = string
+}
+
+variable "chgrp_group" {
+  description = "Group to chgrp the Ramble clone to. Default will not modify the clone."
+  default     = null
+  type        = string
+}
+
+variable "chmod_mode" {
+  description = <<-EOT
+    Mode to chmod the Ramble clone to. Defaults to null (i.e. do not modify).
+    For usage information see:
+    https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html#parameter-mode
+    EOT
+  default     = null
+  type        = string
+}

--- a/community/modules/scripts/ramble-setup/versions.tf
+++ b/community/modules/scripts/ramble-setup/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.0"
+}

--- a/community/modules/scripts/spack-install/README.md
+++ b/community/modules/scripts/spack-install/README.md
@@ -215,5 +215,6 @@ No resources.
 | <a name="output_install_spack_deps_runner"></a> [install\_spack\_deps\_runner](#output\_install\_spack\_deps\_runner) | Runner to install dependencies for spack using an ansible playbook. The<br>startup-script module will automatically handle installation of ansible.<br>- id: example-startup-script<br>  source: modules/scripts/startup-script<br>  settings:<br>    runners:<br>    - $(your-spack-id.install\_spack\_deps\_runner)<br>... |
 | <a name="output_install_spack_runner"></a> [install\_spack\_runner](#output\_install\_spack\_runner) | Runner to install Spack using the startup-script module |
 | <a name="output_setup_spack_runner"></a> [setup\_spack\_runner](#output\_setup\_spack\_runner) | Adds Spack setup-env.sh script to /etc/profile.d so that it is called at shell startup. Among other things this adds Spack binary to user PATH. |
+| <a name="output_spack_path"></a> [spack\_path](#output\_spack\_path) | Path to the root of the spack installation |
 | <a name="output_startup_script"></a> [startup\_script](#output\_startup\_script) | Path to the Spack installation script. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/spack-install/outputs.tf
+++ b/community/modules/scripts/spack-install/outputs.tf
@@ -56,3 +56,8 @@ output "setup_spack_runner" {
       EOT
   }
 }
+
+output "spack_path" {
+  description = "Path to the root of the spack installation"
+  value       = var.install_dir
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -710,6 +710,15 @@ bucket:
 > manually mount as the user using the bucket
 > ([Read more](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/mounting.md#access-permissions)).
 
+### [ramble.yaml] ![community-badge] ![experimental-badge]
+
+This blueprint provisions a single VM, installs spack using the
+[spack-install module](../community/modules/scripts/spack-install/README.md),
+and then installs ramble using the
+[ramble-setup module](../community/modules/scripts/ramble-setup/README.md).
+
+[ramble.yaml]: ../community/examples/ramble.yaml
+
 ### [spack-gromacs.yaml] ![community-badge] ![experimental-badge]
 
 Spack is an HPC software package manager. This example creates a small Slurm

--- a/modules/README.md
+++ b/modules/README.md
@@ -196,6 +196,10 @@ Modules that are still in development and less stable are labeled with the
 * **[spack-install]** ![community-badge] ![experimental-badge] : Creates a
   startup script to install [Spack](https://github.com/spack/spack) on an
   instance or a slurm login or controller.
+* **[ramble-setup]** ![community-badge] ![experimental-badge] : Creates a
+  startup script to install
+  [Ramble](https://github.com/GoogleCloudPlatform/ramble) on an instance or a
+  slurm login or controller.
 * **[wait-for-startup]** ![community-badge] ![experimental-badge] : Waits for
   successful completion of a startup script on a compute VM.
 
@@ -203,6 +207,7 @@ Modules that are still in development and less stable are labeled with the
 [htcondor-install]: ../community/modules/scripts/htcondor-install/README.md
 [omnia-install]: ../community/modules/scripts/omnia-install/README.md
 [spack-install]: ../community/modules/scripts/spack-install/README.md
+[ramble-setup]: ../community/modules/scripts/ramble-setup/README.md
 [wait-for-startup]: ../community/modules/scripts/wait-for-startup/README.md
 [pbspro-install]: ../community/modules/scripts/pbspro-install/README.md
 [pbspro-preinstall]: ../community/modules/scripts/pbspro-preinstall/README.md


### PR DESCRIPTION
This merge adds a new community module for installing the ramble experimentation framework.

It also adds `spack_path` as an output to the spack-install module.