### PR TITLE
Deprecating Slurm-gcp-V4, removing experimental from V5

### DIFF
--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
@@ -1,7 +1,8 @@
 ## Description
 
 > **Warning**: this module is now deprecated. We recommend using the Slurm on GCP V5
-> [schedmd-slurm-gcp-v5-partition](../schedmd-slurm-gcp-v5-partition/README.md) instead.
+> [schedmd-slurm-gcp-v5-partition](../schedmd-slurm-gcp-v5-partition/README.md) and
+> [schedmd-slurm-gcp-v5-node-group](../schedmd-slurm-gcp-v5-node-group/README.md) instead.
 
 This module creates a compute partition that be can used as input to
 [SchedMD-slurm-on-gcp-controller](../../scheduler/SchedMD-slurm-on-gcp-controller/README.md).

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
@@ -1,5 +1,8 @@
 ## Description
 
+> **Warning**: this module is now deprecated. We recommend using the Slurm on GCP V5
+> [schedmd-slurm-gcp-v5-partition](../schedmd-slurm-gcp-v5-partition/README.md) instead.
+
 This module creates a compute partition that be can used as input to
 [SchedMD-slurm-on-gcp-controller](../../scheduler/SchedMD-slurm-on-gcp-controller/README.md).
 

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
@@ -1,9 +1,5 @@
 ## Description
 
-> **_WARNING:_** This module is in active development and is therefore not
-> guaranteed to work consistently. Expect the interface to change rapidly while
-> warning exists.
-
 This module creates a node group data structure intended to be input to the
 [schedmd-slurm-gcp-v5-partition](../schedmd-slurm-gcp-v5-partition/) module.
 

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/README.md
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/README.md
@@ -1,5 +1,8 @@
 ## Description
 
+> **Warning**: this module is now deprecated. We recommend using the Slurm on GCP V5
+> [schedmd-slurm-gcp-v5-controller](../schedmd-slurm-gcp-v5-controller/README.md) instead.
+
 This module creates a slurm controller node via the SchedMD/slurm-gcp
 [controller] module.
 

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/README.md
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/README.md
@@ -1,5 +1,8 @@
 ## Description
 
+> **Warning**: this module is now deprecated. We recommend using the Slurm on GCP V5
+> [schedmd-slurm-gcp-v5-login](../schedmd-slurm-gcp-v5-login/README.md) instead.
+
 This module creates a login node for a Slurm cluster based on the
 [Slurm on GCP][slurm-on-gcp] terraform [login module][login-module]. The login
 node is used in conjunction with the

--- a/modules/README.md
+++ b/modules/README.md
@@ -20,6 +20,9 @@ Modules labeled with the ![community-badge] badge are contributed by
 the community (including the HPC Toolkit team, partners, etc.). Community modules
 are located in the [community folder](../community/modules/README.md).
 
+Modules labeled with the ![deprecated-badge] badge are now deprecated and may be
+removed in the future. Customers are advised to transition to alternatives.
+
 Modules that are still in development and less stable are labeled with the
 ![experimental-badge] badge.
 
@@ -27,15 +30,16 @@ Modules that are still in development and less stable are labeled with the
 [community-badge]: https://img.shields.io/badge/-community-%23b8def4?style=plastic
 [stable-badge]: https://img.shields.io/badge/-stable-lightgrey?style=plastic
 [experimental-badge]: https://img.shields.io/badge/-experimental-%23febfa2?style=plastic
+[deprecated-badge]: https://img.shields.io/badge/-deprecated-%23fea2a2?style=plastic
 
 ### Compute
 
 * **[vm-instance]** ![core-badge] : Creates one or more VM instances.
-* **[SchedMD-slurm-on-gcp-partition]** ![community-badge] : Creates a partition
+* **[SchedMD-slurm-on-gcp-partition]** ![community-badge] ![deprecated-badge] : Creates a partition
   to be used by a [slurm-controller][schedmd-slurm-on-gcp-controller].
-* **[schedmd-slurm-gcp-v5-partition]** ![community-badge] ![experimental-badge] :
+* **[schedmd-slurm-gcp-v5-partition]** ![community-badge] :
   Creates a partition to be used by a [slurm-controller][schedmd-slurm-gcp-v5-controller].
-* **[schedmd-slurm-gcp-v5-node-group]** ![community-badge] ![experimental-badge] :
+* **[schedmd-slurm-gcp-v5-node-group]** ![community-badge] :
   Creates a node group to be used by the [schedmd-slurm-gcp-v5-partition] module.
 * **[gke-node-pool]** ![community-badge] ![experimental-badge] : Creates a
   Kubernetes node pool using GKE.
@@ -141,15 +145,15 @@ Modules that are still in development and less stable are labeled with the
   submission of Google Cloud Batch jobs.
 * **[gke-cluster]** ![community-badge] ![experimental-badge] : Creates a
   Kubernetes cluster using GKE.
-* **[schedmd-slurm-gcp-v5-controller]** ![community-badge] ![experimental-badge] :
+* **[schedmd-slurm-gcp-v5-controller]** ![community-badge] :
   Creates a Slurm controller node using [slurm-gcp-version-5].
-* **[schedmd-slurm-gcp-v5-login]** ![community-badge] ![experimental-badge] :
+* **[schedmd-slurm-gcp-v5-login]** ![community-badge] :
   Creates a Slurm login node using [slurm-gcp-version-5].
 * **[schedmd-slurm-gcp-v5-hybrid]** ![community-badge] ![experimental-badge] :
   Creates hybrid Slurm partition configuration files using [slurm-gcp-version-5].
-* **[SchedMD-slurm-on-gcp-controller]** ![community-badge] : Creates a Slurm
+* **[SchedMD-slurm-on-gcp-controller]** ![community-badge] ![deprecated-badge] : Creates a Slurm
   controller node using [slurm-gcp].
-* **[SchedMD-slurm-on-gcp-login-node]** ![community-badge] : Creates a Slurm
+* **[SchedMD-slurm-on-gcp-login-node]** ![community-badge] ![deprecated-badge] : Creates a Slurm
   login node using [slurm-gcp].
 * **[htcondor-configure]** ![community-badge] ![experimental-badge] : Creates
   Toolkit runners and service accounts to configure an HTCondor pool.

--- a/modules/README.md
+++ b/modules/README.md
@@ -35,8 +35,6 @@ Modules that are still in development and less stable are labeled with the
 ### Compute
 
 * **[vm-instance]** ![core-badge] : Creates one or more VM instances.
-* **[SchedMD-slurm-on-gcp-partition]** ![community-badge] ![deprecated-badge] : Creates a partition
-  to be used by a [slurm-controller][schedmd-slurm-on-gcp-controller].
 * **[schedmd-slurm-gcp-v5-partition]** ![community-badge] :
   Creates a partition to be used by a [slurm-controller][schedmd-slurm-gcp-v5-controller].
 * **[schedmd-slurm-gcp-v5-node-group]** ![community-badge] :
@@ -50,6 +48,8 @@ Modules that are still in development and less stable are labeled with the
   pool][htcondor-configure].
 * **[pbspro-execution]** ![community-badge] ![experimental-badge] :
   Creates execution hosts for use in a PBS Professional cluster.
+* **[SchedMD-slurm-on-gcp-partition]** ![community-badge] ![deprecated-badge] : Creates a partition
+  to be used by a [slurm-controller][schedmd-slurm-on-gcp-controller].
 
 [vm-instance]: compute/vm-instance/README.md
 [gke-node-pool]: ../community/modules/compute/gke-node-pool/README.md
@@ -151,16 +151,16 @@ Modules that are still in development and less stable are labeled with the
   Creates a Slurm login node using [slurm-gcp-version-5].
 * **[schedmd-slurm-gcp-v5-hybrid]** ![community-badge] ![experimental-badge] :
   Creates hybrid Slurm partition configuration files using [slurm-gcp-version-5].
-* **[SchedMD-slurm-on-gcp-controller]** ![community-badge] ![deprecated-badge] : Creates a Slurm
-  controller node using [slurm-gcp].
-* **[SchedMD-slurm-on-gcp-login-node]** ![community-badge] ![deprecated-badge] : Creates a Slurm
-  login node using [slurm-gcp].
 * **[htcondor-configure]** ![community-badge] ![experimental-badge] : Creates
   Toolkit runners and service accounts to configure an HTCondor pool.
 * **[pbspro-client]** ![community-badge] ![experimental-badge] : Creates
   a client host for submitting jobs to a PBS Professional cluster.
 * **[pbspro-server]** ![community-badge] ![experimental-badge] : Creates
   a server host for operating a PBS Professional cluster.
+* **[SchedMD-slurm-on-gcp-controller]** ![community-badge] ![deprecated-badge] : Creates a Slurm
+  controller node using [slurm-gcp].
+* **[SchedMD-slurm-on-gcp-login-node]** ![community-badge] ![deprecated-badge] : Creates a Slurm
+  login node using [slurm-gcp].
 
 [batch-job-template]: ../modules/scheduler/batch-job-template/README.md
 [batch-login-node]: ../modules/scheduler/batch-login-node/README.md


### PR DESCRIPTION
Removing the experimental tag from Slurm on GCP V5 modules. Marking V4 as deprecated. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
