### PR TITLE
Creates GPU GKE example, waiting for operations module

### DIFF
--- a/community/examples/ml-gke.yaml
+++ b/community/examples/ml-gke.yaml
@@ -11,15 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 ---
 
-blueprint_name: small-gke
+blueprint_name: gke-ml
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: cluster-01
+  deployment_name: ml-01
   region: us-central1
+
+  authorized_cidr:  ## Cidr block containing the IP of the machine calling terraform. Ex: <your-ip-address>/32
 
 deployment_groups:
 - group: primary
@@ -40,19 +41,29 @@ deployment_groups:
     use: [network1]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
+      master_authorized_networks:
+      - display_name: deployment-machine
+        cidr_block: $(vars.authorized_cidr)
     outputs: [instructions]
 
-  - id: compute_pool
+  - id: install-nvidia-drivers
+    source: github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning//aiinfra-cluster/modules/kubernetes-operations?ref=v0.6.0
+    use: [gke_cluster]
+    settings:
+      install_nvidia_driver: true
+
+  - id: a2-pool
     source: community/modules/compute/gke-node-pool
     use: [gke_cluster]
+    settings:
+      machine_type: a2-highgpu-8g
 
   - id: job-template
     source: community/modules/compute/gke-job-template
-    use: [compute_pool]
+    use: [a2-pool]
     settings:
-      image: busybox
+      image: nvidia/cuda:11.0.3-runtime-ubuntu20.04
       command:
-      - echo
-      - Hello World
-      node_count: 3
+      - nvidia-smi
+      node_count: 1
     outputs: [instructions]

--- a/community/examples/ml-gke.yaml
+++ b/community/examples/ml-gke.yaml
@@ -13,14 +13,16 @@
 # limitations under the License.
 ---
 
-blueprint_name: gke-ml
+blueprint_name: ml-gke
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: ml-01
   region: us-central1
 
-  authorized_cidr:  ## Cidr block containing the IP of the machine calling terraform. Ex: <your-ip-address>/32
+  # Cidr block containing the IP of the machine calling terraform.
+  # The following line must be updated for this example to work.
+  authorized_cidr: <your-ip-address>/32
 
 deployment_groups:
 - group: primary
@@ -46,6 +48,7 @@ deployment_groups:
         cidr_block: $(vars.authorized_cidr)
     outputs: [instructions]
 
+  # Docs at https://github.com/GoogleCloudPlatform/hpc-toolkit/tree/main/community/modules/scripts/kubernetes-operations
   - id: install-nvidia-drivers
     source: github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning//aiinfra-cluster/modules/kubernetes-operations?ref=v0.6.0
     use: [gke_cluster]

--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -89,6 +89,7 @@ No modules.
 | <a name="input_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#input\_allocatable\_cpu\_per\_node) | The allocatable cpu per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field. | `list(number)` | <pre>[<br>  -1<br>]</pre> | no |
 | <a name="input_backoff_limit"></a> [backoff\_limit](#input\_backoff\_limit) | Controls the number of retries before considering a Job as failed. Set to zero for shared fate. | `number` | `0` | no |
 | <a name="input_command"></a> [command](#input\_command) | The command and arguments for the container that run in the Pod. The command field corresponds to entrypoint in some container runtimes. | `list(string)` | <pre>[<br>  "hostname"<br>]</pre> | no |
+| <a name="input_has_gpu"></a> [has\_gpu](#input\_has\_gpu) | Do nodes have GPUs attached. Generally populated from gke-node-pool via `use` field. | `list(bool)` | <pre>[<br>  false<br>]</pre> | no |
 | <a name="input_image"></a> [image](#input\_image) | The container image the job should use. | `string` | `"debian"` | no |
 | <a name="input_machine_family"></a> [machine\_family](#input\_machine\_family) | The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the job. | `string` | `"my-job"` | no |

--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -6,10 +6,8 @@ The job template file can be submitted as is or used as a template for further
 customization. Add the `instructions` output to a blueprint (as shown below) to
 get instructions on how to use `kubectl` to submit the job.
 
-This module is designed to`use` one or more `gke-node-pool` modules.
-
-that can be submitted to a GKE cluster
-using `kubectl` and will run on the specified node pool.
+This module is designed to `use` one or more `gke-node-pool` modules. The job
+will be configured to run on any of the specified node pools.
 
 > **_NOTE:_** This is an experimental module and the functionality and
 > documentation will likely be updated in the near future. This module has only
@@ -89,7 +87,7 @@ No modules.
 | <a name="input_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#input\_allocatable\_cpu\_per\_node) | The allocatable cpu per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field. | `list(number)` | <pre>[<br>  -1<br>]</pre> | no |
 | <a name="input_backoff_limit"></a> [backoff\_limit](#input\_backoff\_limit) | Controls the number of retries before considering a Job as failed. Set to zero for shared fate. | `number` | `0` | no |
 | <a name="input_command"></a> [command](#input\_command) | The command and arguments for the container that run in the Pod. The command field corresponds to entrypoint in some container runtimes. | `list(string)` | <pre>[<br>  "hostname"<br>]</pre> | no |
-| <a name="input_has_gpu"></a> [has\_gpu](#input\_has\_gpu) | Do nodes have GPUs attached. Generally populated from gke-node-pool via `use` field. | `list(bool)` | <pre>[<br>  false<br>]</pre> | no |
+| <a name="input_has_gpu"></a> [has\_gpu](#input\_has\_gpu) | Indicates that the job should request nodes with GPUs. Typically supplied by a gke-node-pool module. | `list(bool)` | <pre>[<br>  false<br>]</pre> | no |
 | <a name="input_image"></a> [image](#input\_image) | The container image the job should use. | `string` | `"debian"` | no |
 | <a name="input_machine_family"></a> [machine\_family](#input\_machine\_family) | The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the job. | `string` | `"my-job"` | no |

--- a/community/modules/compute/gke-job-template/main.tf
+++ b/community/modules/compute/gke-job-template/main.tf
@@ -36,7 +36,7 @@ locals {
   should_request_cpu = local.millicpu >= 0
   full_node_request  = local.min_allocatable_cpu >= 0 && var.requested_cpu_per_pod < 0
 
-  should_request_gpu = anytrue(var.has_gpu)
+  should_request_gpu = alltrue(var.has_gpu)
   # arbitrarily, user can edit in template.
   # May come from node pool in future.
   gpu_limit = 1

--- a/community/modules/compute/gke-job-template/main.tf
+++ b/community/modules/compute/gke-job-template/main.tf
@@ -36,6 +36,11 @@ locals {
   should_request_cpu = local.millicpu >= 0
   full_node_request  = local.min_allocatable_cpu >= 0 && var.requested_cpu_per_pod < 0
 
+  should_request_gpu = anytrue(var.has_gpu)
+  # arbitrarily, user can edit in template.
+  # May come from node pool in future.
+  gpu_limit = 1
+
   suffix = var.random_name_sufix ? "-${random_id.resource_name_suffix.hex}" : ""
 
   job_template_contents = templatefile(
@@ -52,6 +57,8 @@ locals {
       should_request_cpu = local.should_request_cpu
       full_node_request  = local.full_node_request
       millicpu_request   = "${local.millicpu}m"
+      should_request_gpu = local.should_request_gpu
+      gpu_limit          = local.gpu_limit
       restart_policy     = var.restart_policy
       backoff_limit      = var.backoff_limit
       tolerations        = distinct(var.tolerations)

--- a/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
+++ b/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
@@ -39,13 +39,19 @@ spec:
       - name: ${name}-container
         image: ${image}
         command: [%{~ for s in command ~}"${s}",%{~ endfor ~}]
-        %{~ if should_request_cpu ~}
+        %{~ if should_request_cpu || should_request_gpu ~}
         resources:
+          %{~ if should_request_gpu ~}
+          limits:
+            nvidia.com/gpu: ${gpu_limit}
+          %{~ endif ~}
+          %{~ if should_request_cpu ~}
           requests:
             %{~ if full_node_request ~}
             # cpu request attempts full node per pod
             %{~ endif ~}
             cpu: ${millicpu_request}
+          %{~ endif ~}
         %{~ endif ~}
       restartPolicy: ${restart_policy}
   backoffLimit: ${backoff_limit}

--- a/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
+++ b/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
@@ -43,6 +43,8 @@ spec:
         resources:
           %{~ if should_request_gpu ~}
           limits:
+            # GPUs should only be specified as limits
+            # https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/
             nvidia.com/gpu: ${gpu_limit}
           %{~ endif ~}
           %{~ if should_request_cpu ~}

--- a/community/modules/compute/gke-job-template/variables.tf
+++ b/community/modules/compute/gke-job-template/variables.tf
@@ -50,6 +50,12 @@ variable "allocatable_cpu_per_node" {
   default     = [-1]
 }
 
+variable "has_gpu" {
+  description = "Do nodes have GPUs attached. Generally populated from gke-node-pool via `use` field."
+  type        = list(bool)
+  default     = [false]
+}
+
 variable "requested_cpu_per_pod" {
   description = "The requested cpu per pod. If null, allocatable_cpu_per_node will be used to claim whole nodes. If provided will override allocatable_cpu_per_node."
   type        = number

--- a/community/modules/compute/gke-job-template/variables.tf
+++ b/community/modules/compute/gke-job-template/variables.tf
@@ -51,7 +51,7 @@ variable "allocatable_cpu_per_node" {
 }
 
 variable "has_gpu" {
-  description = "Do nodes have GPUs attached. Generally populated from gke-node-pool via `use` field."
+  description = "Indicates that the job should request nodes with GPUs. Typically supplied by a gke-node-pool module."
   type        = list(bool)
   default     = [false]
 }

--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -197,7 +197,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#output\_allocatable\_cpu\_per\_node) | Number of CPUs available for scheduling pods on each node. |
-| <a name="output_has_gpu"></a> [has\_gpu](#output\_has\_gpu) | Do nodes in this node pool have GPUs attached. |
+| <a name="output_has_gpu"></a> [has\_gpu](#output\_has\_gpu) | Boolean value indicating whether nodes in the pool are configured with GPUs. |
 | <a name="output_node_pool_name"></a> [node\_pool\_name](#output\_node\_pool\_name) | Name of the node pool. |
 | <a name="output_tolerations"></a> [tolerations](#output\_tolerations) | Tolerations needed for a pod to be scheduled on this node pool. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -197,6 +197,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#output\_allocatable\_cpu\_per\_node) | Number of CPUs available for scheduling pods on each node. |
+| <a name="output_has_gpu"></a> [has\_gpu](#output\_has\_gpu) | Do nodes in this node pool have GPUs attached. |
 | <a name="output_node_pool_name"></a> [node\_pool\_name](#output\_node\_pool\_name) | Name of the node pool. |
 | <a name="output_tolerations"></a> [tolerations](#output\_tolerations) | Tolerations needed for a pod to be scheduled on this node pool. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/gke-node-pool/outputs.tf
+++ b/community/modules/compute/gke-node-pool/outputs.tf
@@ -40,6 +40,11 @@ output "allocatable_cpu_per_node" {
   value       = local.allocatable_cpu
 }
 
+output "has_gpu" {
+  description = "Do nodes in this node pool have GPUs attached."
+  value       = local.has_gpu
+}
+
 locals {
   translate_toleration = {
     PREFER_NO_SCHEDULE = "PreferNoSchedule"

--- a/community/modules/compute/gke-node-pool/outputs.tf
+++ b/community/modules/compute/gke-node-pool/outputs.tf
@@ -41,7 +41,7 @@ output "allocatable_cpu_per_node" {
 }
 
 output "has_gpu" {
-  description = "Do nodes in this node pool have GPUs attached."
+  description = "Boolean value indicating whether nodes in the pool are configured with GPUs."
   value       = local.has_gpu
 }
 

--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -139,6 +139,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | an identifier for the resource with format projects/<project\_id>/locations/<region>/clusters/<name>. |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | An identifier for the resource with format projects/<project\_id>/locations/<region>/clusters/<name>. |
+| <a name="output_gke_cluster_exists"></a> [gke\_cluster\_exists](#output\_gke\_cluster\_exists) | A static flag that signals to downstream modules that a cluster has been created. Needed by community/modules/scripts/kubernetes-operations. |
 | <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions on how to connect to the created cluster. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/gke-cluster/outputs.tf
+++ b/community/modules/scheduler/gke-cluster/outputs.tf
@@ -15,8 +15,16 @@
   */
 
 output "cluster_id" {
-  description = "an identifier for the resource with format projects/<project_id>/locations/<region>/clusters/<name>."
+  description = "An identifier for the resource with format projects/<project_id>/locations/<region>/clusters/<name>."
   value       = google_container_cluster.gke_cluster.id
+}
+
+output "gke_cluster_exists" {
+  description = "A static flag that signals to downstream modules that a cluster has been created. Needed by community/modules/scripts/kubernetes-operations."
+  value       = true
+  depends_on = [
+    google_container_cluster.gke_cluster
+  ]
 }
 
 locals {

--- a/community/modules/scripts/kubernetes-operations/README.md
+++ b/community/modules/scripts/kubernetes-operations/README.md
@@ -1,0 +1,43 @@
+## Description
+
+This module performs pre-defined operations on Kubernetes resources that would
+otherwise be executed using `kubectl`.
+
+The `kubernetes-operations` module is owned and maintained by the
+[ai-infra-cluster-provisioning] Github project. Full documentation of the module
+interface can be found in that project on the [`kubernetes-operations`] page.
+
+### Examples
+
+The following example will use the [`kubernetes-operations`] module to create a
+DaemonSet that will install Nvidia drivers on GPU nodes.
+
+```yaml
+  - id: gke_cluster
+    source: community/modules/scheduler/gke-cluster
+    use: [network1]
+    settings:
+      enable_private_endpoint: false  # Allows for access from authorized public IPs
+      master_authorized_networks:
+      - display_name: deployment-machine
+        cidr_block: <your-ip-address>/32
+    outputs: [instructions]
+
+  - id: install-nvidia-drivers
+    source: github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning//aiinfra-cluster/modules/kubernetes-operations?ref=v0.6.0
+    use: [gke_cluster]
+    settings:
+      install_nvidia_driver: true
+```
+
+> **Note**: The IP address of the machine calling Terraform must be listed as a
+> `master_authorized_network` otherwise the [`kubernetes-operations`] module
+> will not be able to communicate with the cluster.
+
+### Version Compatibility
+
+Only version [v0.6.0] of this module has been tested for compatibility with the HPC Toolkit. Older versions will not work and newer versions are untested.
+
+[v0.6.0]: https://github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning/releases/tag/v0.6.0
+[`kubernetes-operations`]: https://github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning/tree/v0.6.0/aiinfra-cluster/modules/kubernetes-operations
+[ai-infra-cluster-provisioning]: https://github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning/tree/v0.6.0

--- a/examples/README.md
+++ b/examples/README.md
@@ -826,26 +826,31 @@ to the cluster using `kubectl` and will run on the specified node pool.
 This blueprint demonstrates how to set up a GPU GKE cluster using the HPC
 Toolkit. It includes:
 
+> **Warning**: `authorized_cidr` variable must be entered for this example to
+> work. See note below.
+
 * Creation of a regional GKE cluster.
 * Creation of an autoscaling GKE node pool with `a2` machines each with 8
   attached A100 GPUs.
-* Configuration of the cluster using the `kubernetes-operations` module to
+* Configuration of the cluster using the [`kubernetes-operations`] module to
   install nvidia drivers.
 * Creation of a job template yaml file that can be used to submit jobs to the
   GPU node pool.
 
 > **Note**: The Kubernetes API server will only allow requests from authorized
 > networks. Nvidia drivers are installed on GPU nodes by a DaemonSet created by
-> the `kubernetes-operations` Terraform module. **You must use the
+> the [`kubernetes-operations`] Terraform module. **You must use the
 > `authorized_cidr` variable to supply an authorized network which contains the
 > IP address of the machine deploying the blueprint, for example
 > `--vars authorized_cidr=<your-ip-address>/32`.** This will allow Terraform to
-> create the necessary DaemonSet on the cluster.
+> create the necessary DaemonSet on the cluster. You can use a service like
+> [whatismyip.com](https://whatismyip.com) to determine your IP address.
 
 Once you have deployed the blueprint, follow output instructions to _fetch
 credentials for the created cluster_ and _submit a job calling `nvidia_smi`_.
 
 [ml-gke.yaml]: ../community/examples/ml-gke.yaml
+[`kubernetes-operations`]: ../community/modules/scripts/kubernetes-operations/README.md
 
 ### [starccm-tutorial.yaml] ![community-badge] ![experimental-badge]
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [hpc-cluster-localssd.yaml](#hpc-cluster-localssdyaml--) ![community-badge] ![experimental-badge]
   * [htcondor-pool.yaml](#htcondor-poolyaml--) ![community-badge] ![experimental-badge]
   * [gke.yaml](#gkeyaml--) ![community-badge] ![experimental-badge]
+  * [ml-gke](#mlgkeyaml--) ![community-badge] ![experimental-badge]
   * [starccm-tutorial.yaml](#starccm-tutorialyaml--) ![community-badge] ![experimental-badge]
   * [fluent-tutorial.yaml](#fluent-tutorialyaml--) ![community-badge] ![experimental-badge]
 * [Blueprint Schema](#blueprint-schema)
@@ -819,6 +820,32 @@ The `gke-job-template` module is used to create a job file that can be submitted
 to the cluster using `kubectl` and will run on the specified node pool.
 
 [gke.yaml]: ../community/examples/gke.yaml
+
+### [ml-gke.yaml] ![community-badge] ![experimental-badge]
+
+This blueprint demonstrates how to set up a GPU GKE cluster using the HPC
+Toolkit. It includes:
+
+* Creation of a regional GKE cluster.
+* Creation of an autoscaling GKE node pool with `a2` machines each with 8
+  attached A100 GPUs.
+* Configuration of the cluster using the `kubernetes-operations` module to
+  install nvidia drivers.
+* Creation of a job template yaml file that can be used to submit jobs to the
+  GPU node pool.
+
+> **Note**: The Kubernetes API server will only allow requests from authorized
+> networks. Nvidia drivers are installed on GPU nodes by a DaemonSet created by
+> the `kubernetes-operations` Terraform module. **You must use the
+> `authorized_cidr` variable to supply an authorized network which contains the
+> IP address of the machine deploying the blueprint, for example
+> `--vars authorized_cidr=<your-ip-address>/32`.** This will allow Terraform to
+> create the necessary DaemonSet on the cluster.
+
+Once you have deployed the blueprint, follow output instructions to _fetch
+credentials for the created cluster_ and _submit a job calling `nvidia_smi`_.
+
+[ml-gke.yaml]: ../community/examples/ml-gke.yaml
 
 ### [starccm-tutorial.yaml] ![community-badge] ![experimental-badge]
 


### PR DESCRIPTION
This change:
- Adds a GKE GPU example
- Documents the `kubernetes-operations` module
- Adds `enable_private_endpoint: false` to GKE examples.
  - For best security this variable should be true but it restricts access from the public internet and provides a poor first time user experience as the cluster is unreachable in many cases. Decision leave default to true but show it off in examples so user is aware.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
