### PR TITLE
Change default gke-job-template.backoff_limit to have shared fate

### DIFF
--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -87,7 +87,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#input\_allocatable\_cpu\_per\_node) | The allocatable cpu per node. Used to claim whole nodes. Generally populated from gke-node-pool via `use` field. | `list(number)` | <pre>[<br>  -1<br>]</pre> | no |
-| <a name="input_backoff_limit"></a> [backoff\_limit](#input\_backoff\_limit) | Controls the number of retries before considering a Job as failed. | `number` | `3` | no |
+| <a name="input_backoff_limit"></a> [backoff\_limit](#input\_backoff\_limit) | Controls the number of retries before considering a Job as failed. Set to zero for shared fate. | `number` | `0` | no |
 | <a name="input_command"></a> [command](#input\_command) | The command and arguments for the container that run in the Pod. The command field corresponds to entrypoint in some container runtimes. | `list(string)` | <pre>[<br>  "hostname"<br>]</pre> | no |
 | <a name="input_image"></a> [image](#input\_image) | The container image the job should use. | `string` | `"debian"` | no |
 | <a name="input_machine_family"></a> [machine\_family](#input\_machine\_family) | The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria. | `string` | `null` | no |

--- a/community/modules/compute/gke-job-template/variables.tf
+++ b/community/modules/compute/gke-job-template/variables.tf
@@ -96,9 +96,9 @@ variable "restart_policy" {
 }
 
 variable "backoff_limit" {
-  description = "Controls the number of retries before considering a Job as failed."
+  description = "Controls the number of retries before considering a Job as failed. Set to zero for shared fate."
   type        = number
-  default     = 3
+  default     = 0
 }
 
 variable "random_name_sufix" {


### PR DESCRIPTION
`backoff_limit` controls retries for rescheduling a pod when it fails. It does not restart all of the pods in a job, just the one that failed. To achieve shared fate between all of the pods in a job this must be set to zero. Then when any pod fails the whole job will be killed.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
