### PR TITLE
Remove unused zone policy settings from Slurm v5 node group module

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
@@ -161,8 +161,6 @@ No modules.
 | <a name="input_source_image_project"></a> [source\_image\_project](#input\_source\_image\_project) | The hosting the custom VM image. It is recommended to use `instance_image` instead. | `string` | `""` | no |
 | <a name="input_spot_instance_config"></a> [spot\_instance\_config](#input\_spot\_instance\_config) | Configuration for spot VMs. | <pre>object({<br>    termination_action = string<br>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
-| <a name="input_zone_policy_allow"></a> [zone\_policy\_allow](#input\_zone\_policy\_allow) | Partition nodes will prefer to be created in the listed zones. If a zone appears<br>in both zone\_policy\_allow and zone\_policy\_deny, then zone\_policy\_deny will take<br>priority for that zone. | `set(string)` | `[]` | no |
-| <a name="input_zone_policy_deny"></a> [zone\_policy\_deny](#input\_zone\_policy\_deny) | Partition nodes will not be created in the listed zones. If a zone appears in<br>both zone\_policy\_allow and zone\_policy\_deny, then zone\_policy\_deny will take<br>priority for that zone. | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
@@ -344,40 +344,6 @@ variable "bandwidth_tier" {
   }
 }
 
-variable "zone_policy_allow" {
-  description = <<-EOD
-    Partition nodes will prefer to be created in the listed zones. If a zone appears
-    in both zone_policy_allow and zone_policy_deny, then zone_policy_deny will take
-    priority for that zone.
-    EOD
-  type        = set(string)
-  default     = []
-
-  validation {
-    condition = alltrue([
-      for x in var.zone_policy_allow : length(regexall("^[a-z]+-[a-z]+[0-9]-[a-z]$", x)) > 0
-    ])
-    error_message = "A provided zone in zone_policy_allow is not a valid zone (Regexp: '^[a-z]+-[a-z]+[0-9]-[a-z]$')."
-  }
-}
-
-variable "zone_policy_deny" {
-  description = <<-EOD
-    Partition nodes will not be created in the listed zones. If a zone appears in
-    both zone_policy_allow and zone_policy_deny, then zone_policy_deny will take
-    priority for that zone.
-    EOD
-  type        = set(string)
-  default     = []
-
-  validation {
-    condition = alltrue([
-      for x in var.zone_policy_deny : length(regexall("^[a-z]+-[a-z]+[0-9]-[a-z]$", x)) > 0
-    ])
-    error_message = "A provided zone in zone_policy_deny is not a valid zone (Regexp '^[a-z]+-[a-z]+[0-9]-[a-z]$')."
-  }
-}
-
 variable "access_config" {
   description = "Access configurations, i.e. IPs via which the node group instances can be accessed via the internet."
   type = list(object({


### PR DESCRIPTION
Two unused variables were found in the Slurm v5 node group module. These were not caught by TFLint due to https://github.com/terraform-linters/tflint-ruleset-terraform/issues/94.

I have manually checked that the remaining input variables in the node group module are used by removing all validation blocks and manually running `tflint --only=terraform_unused_declarations --chdir=.`.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
