### PR TITLE
Initial implementation of deploy command

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,144 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd defines command line utilities for ghpc
+package cmd
+
+import (
+	"fmt"
+	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/shell"
+	"log"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	artifactsFlag := "artifacts"
+
+	deployCmd.Flags().StringVarP(&artifactsDir, artifactsFlag, "a", "", "Artifacts output directory (automatically configured if unset)")
+	deployCmd.MarkFlagDirname(artifactsFlag)
+
+	autoApproveFlag := "auto-approve"
+	deployCmd.Flags().BoolVarP(&autoApprove, autoApproveFlag, "", false, "Automatically approve proposed changes")
+
+	// anticipate mutually exclusive flags from-directory, from-group, from-blueprint
+	deploymentFlag := "from-directory"
+	deployCmd.Flags().StringVarP(&deploymentRoot, deploymentFlag, "d", "", "Deployment root directory")
+	deployCmd.MarkFlagDirname(deploymentFlag)
+	deployCmd.MarkFlagRequired(deploymentFlag)
+	rootCmd.AddCommand(deployCmd)
+}
+
+var (
+	deploymentRoot string
+	autoApprove    bool
+	applyBehavior  shell.ApplyBehavior
+	deployCmd      = &cobra.Command{
+		Use:          "deploy -d DEPLOYMENT_DIRECTORY",
+		Short:        "deploy all resources in a Toolkit deployment directory.",
+		Long:         "deploy all resources in a Toolkit deployment directory.",
+		Args:         cobra.ExactArgs(0),
+		PreRun:       setApplyBehavior,
+		RunE:         runDeployCmd,
+		SilenceUsage: true,
+	}
+)
+
+func setApplyBehavior(cmd *cobra.Command, args []string) {
+	if autoApprove {
+		applyBehavior = shell.AutomaticApply
+	} else {
+		applyBehavior = shell.PromptBeforeApply
+	}
+}
+
+func runDeployCmd(cmd *cobra.Command, args []string) error {
+	if artifactsDir == "" {
+		artifactsDir = filepath.Clean(filepath.Join(deploymentRoot, defaultArtifactsDir))
+	}
+
+	if err := shell.CheckWritableDir(artifactsDir); err != nil {
+		return err
+	}
+
+	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
+	dc, err := config.NewDeploymentConfig(expandedBlueprintFile)
+	if err != nil {
+		return err
+	}
+
+	if err := shell.ValidateDeploymentDirectory(dc.Config.DeploymentGroups, deploymentRoot); err != nil {
+		return err
+	}
+
+	for _, group := range dc.Config.DeploymentGroups {
+		groupDir := filepath.Join(deploymentRoot, string(group.Name))
+		if err = shell.ImportInputs(groupDir, artifactsDir, expandedBlueprintFile); err != nil {
+			return err
+		}
+
+		var err error
+		switch group.Kind {
+		case config.PackerKind:
+			// Packer groups are enforced to have length 1
+			moduleDir := filepath.Join(groupDir, string(group.Modules[0].ID))
+			err = deployPackerGroup(moduleDir)
+		case config.TerraformKind:
+			err = deployTerraformGroup(groupDir)
+		default:
+			err = fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind.String())
+		}
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func deployPackerGroup(moduleDir string) error {
+	if err := shell.TestPacker(); err != nil {
+		return err
+	}
+	buildImage := applyBehavior == shell.AutomaticApply || shell.AskForConfirmation("Build Packer image?")
+	if buildImage {
+		log.Printf("initializing packer module at %s", moduleDir)
+		if err := shell.ExecPackerCmd(moduleDir, false, "init", "."); err != nil {
+			return err
+		}
+		log.Printf("validating packer module at %s", moduleDir)
+		if err := shell.ExecPackerCmd(moduleDir, false, "validate", "."); err != nil {
+			return err
+		}
+		log.Printf("building image using packer module at %s", moduleDir)
+		if err := shell.ExecPackerCmd(moduleDir, true, "build", "."); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deployTerraformGroup(groupDir string) error {
+	tf, err := shell.ConfigureTerraform(groupDir)
+	if err != nil {
+		return err
+	}
+
+	if err = shell.ExportOutputs(tf, artifactsDir, applyBehavior); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -111,8 +111,11 @@ func deployPackerGroup(moduleDir string) error {
 	if err := shell.ConfigurePacker(); err != nil {
 		return err
 	}
-	proposedChange := fmt.Sprintf("Proposed change: use packer to build image in %s", moduleDir)
-	buildImage := applyBehavior == shell.AutomaticApply || shell.ApplyChangesChoice(proposedChange)
+	c := shell.ProposedChanges{
+		Summary: fmt.Sprintf("Proposed change: use packer to build image in %s", moduleDir),
+		Full:    fmt.Sprintf("Proposed change: use packer to build image in %s", moduleDir),
+	}
+	buildImage := applyBehavior == shell.AutomaticApply || shell.ApplyChangesChoice(c)
 	if buildImage {
 		log.Printf("initializing packer module at %s", moduleDir)
 		if err := shell.ExecPackerCmd(moduleDir, false, "init", "."); err != nil {

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"hpc-toolkit/pkg/shell"
+	"os"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *MySuite) TestDeployGroups(c *C) {
+	applyBehavior = shell.NeverApply
+	var err error
+	pathEnv := os.Getenv("PATH")
+	os.Setenv("PATH", "")
+	err = deployTerraformGroup(".")
+	c.Assert(err, NotNil)
+	err = deployPackerGroup(".")
+	c.Assert(err, NotNil)
+	os.Setenv("PATH", pathEnv)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -143,9 +143,9 @@ func (bp Blueprint) ModuleGroupOrDie(mod ModuleID) DeploymentGroup {
 
 // GroupIndex returns the index of the input group in the blueprint
 // return -1 if not found
-func (bp Blueprint) GroupIndex(groupName GroupName) int {
+func (bp Blueprint) GroupIndex(n GroupName) int {
 	for i, g := range bp.DeploymentGroups {
-		if g.Name == groupName {
+		if g.Name == n {
 			return i
 		}
 	}
@@ -153,10 +153,10 @@ func (bp Blueprint) GroupIndex(groupName GroupName) int {
 }
 
 // Group returns the deployment group with a given name
-func (bp Blueprint) Group(groupName GroupName) (DeploymentGroup, error) {
-	idx := bp.GroupIndex(groupName)
+func (bp Blueprint) Group(n GroupName) (DeploymentGroup, error) {
+	idx := bp.GroupIndex(n)
 	if idx == -1 {
-		return DeploymentGroup{}, fmt.Errorf("could not find group %s in blueprint", groupName)
+		return DeploymentGroup{}, fmt.Errorf("could not find group %s in blueprint", n)
 	}
 	return bp.DeploymentGroups[idx], nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,6 +152,15 @@ func (bp Blueprint) GroupIndex(groupName GroupName) int {
 	return -1
 }
 
+// Group returns the deployment group with a given name
+func (bp Blueprint) Group(groupName GroupName) (DeploymentGroup, error) {
+	idx := bp.GroupIndex(groupName)
+	if idx == -1 {
+		return DeploymentGroup{}, fmt.Errorf("could not find group %s in blueprint", groupName)
+	}
+	return bp.DeploymentGroups[idx], nil
+}
+
 // TerraformBackend defines the configuration for the terraform state backend
 type TerraformBackend struct {
 	Type          string

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -145,10 +145,12 @@ func getIntergroupPackerSettings(dc config.DeploymentConfig, packerModule config
 	return packerSettings
 }
 
-// AskForConfirmation prompts the user with a question; it returns true if and
+// ApplyChangesChoice prompts the user to decide whether they want to approve
+// changes to cloud configuration, to stop execution of ghpc entirely, or to
+// skip making the proposed changes and continue execution (in deploy command)
 // only if the user responds with "y" or "yes" (case-insensitive)
-func AskForConfirmation(prompt string) bool {
-	fmt.Printf("%s [y/n]: ", prompt)
+func ApplyChangesChoice(proposedChanges string) bool {
+	fmt.Print("Display proposed changes, Apply proposed changes, Stop and exit, Continue without applying? [d,a,s,c]: ")
 
 	var userResponse string
 	_, err := fmt.Scanln(&userResponse)
@@ -157,11 +159,14 @@ func AskForConfirmation(prompt string) bool {
 	}
 
 	switch strings.ToLower(strings.TrimSpace(userResponse)) {
-	case "y":
+	case "a":
 		return true
-	case "yes":
-		return true
-	default:
+	case "c":
 		return false
+	case "d":
+		fmt.Println(proposedChanges)
+	case "s":
+		log.Fatal("user chose to stop execution of ghpc rather than make proposed changes to infrastructure")
 	}
+	return ApplyChangesChoice(proposedChanges)
 }

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -30,6 +30,13 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// ProposedChanges provides summary and full description of proposed changes
+// to cloud infrastructure
+type ProposedChanges struct {
+	Summary string
+	Full    string
+}
+
 // ValidateDeploymentDirectory ensures that the deployment directory structure
 // appears valid given a mapping of group names to module kinds
 // TODO: verify kind fully by auto-detecting type from group directory
@@ -149,24 +156,27 @@ func getIntergroupPackerSettings(dc config.DeploymentConfig, packerModule config
 // changes to cloud configuration, to stop execution of ghpc entirely, or to
 // skip making the proposed changes and continue execution (in deploy command)
 // only if the user responds with "y" or "yes" (case-insensitive)
-func ApplyChangesChoice(proposedChanges string) bool {
-	fmt.Print("Display proposed changes, Apply proposed changes, Stop and exit, Continue without applying? [d,a,s,c]: ")
-
+func ApplyChangesChoice(c ProposedChanges) bool {
+	log.Printf("Summary of proposed changes: %s", strings.TrimSpace(c.Summary))
 	var userResponse string
-	_, err := fmt.Scanln(&userResponse)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	switch strings.ToLower(strings.TrimSpace(userResponse)) {
-	case "a":
-		return true
-	case "c":
-		return false
-	case "d":
-		fmt.Println(proposedChanges)
-	case "s":
-		log.Fatal("user chose to stop execution of ghpc rather than make proposed changes to infrastructure")
+	for {
+		fmt.Print("Display full proposed changes, Apply proposed changes, Stop and exit, Continue without applying? [d,a,s,c]: ")
+
+		_, err := fmt.Scanln(&userResponse)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		switch strings.ToLower(strings.TrimSpace(userResponse)) {
+		case "a":
+			return true
+		case "c":
+			return false
+		case "d":
+			fmt.Println(c.Full)
+		case "s":
+			log.Fatal("user chose to stop execution of ghpc rather than make proposed changes to infrastructure")
+		}
 	}
-	return ApplyChangesChoice(proposedChanges)
 }

--- a/pkg/shell/packer.go
+++ b/pkg/shell/packer.go
@@ -21,8 +21,8 @@ import (
 	"os/exec"
 )
 
-// TestPacker errors if packer is not in the user PATH
-func TestPacker() error {
+// ConfigurePacker errors if packer is not in the user PATH
+func ConfigurePacker() error {
 	_, err := exec.LookPath("packer")
 	if err != nil {
 		return &TfError{

--- a/pkg/shell/packer.go
+++ b/pkg/shell/packer.go
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shell
+
+import (
+	"os"
+	"os/exec"
+)
+
+// TestPacker errors if packer is not in the user PATH
+func TestPacker() error {
+	_, err := exec.LookPath("packer")
+	if err != nil {
+		return &TfError{
+			help: "must have a copy of packer installed in PATH",
+			err:  err,
+		}
+	}
+	return nil
+}
+
+// ExecPackerCmd runs packer with arguments in the given working directory
+// optionally prints to stdout/stderr
+func ExecPackerCmd(workingDir string, printToScreen bool, args ...string) error {
+	cmd := exec.Command("packer", args...)
+	cmd.Dir = workingDir
+	if printToScreen {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/shell/packer_test.go
+++ b/pkg/shell/packer_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shell
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *MySuite) TestPacker(c *C) {
+	if _, err := exec.LookPath("packer"); err != nil {
+		c.Skip("packer not found in PATH")
+	}
+
+	err := ConfigurePacker()
+	c.Assert(err, IsNil)
+
+	// test failure when terraform cannot be found in PATH
+	pathEnv := os.Getenv("PATH")
+	os.Setenv("PATH", "")
+	err = ConfigurePacker()
+	os.Setenv("PATH", pathEnv)
+	c.Assert(err, NotNil)
+
+	var tfe *TfError
+	c.Assert(errors.As(err, &tfe), Equals, true)
+
+	// executing with help argument (safe against RedHat binary named packer)
+	err = ExecPackerCmd(".", true, "-h")
+	c.Assert(err, IsNil)
+	// executing with arguments will error
+	err = ExecPackerCmd(".", false)
+	c.Assert(err, NotNil)
+}

--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -18,7 +18,7 @@ use warnings;
 
 # TODO: raise ./cmd min coverage to 80% after tests are written
 my $min = 80;
-my $cmdmin = 50;
+my $cmdmin = 40;
 my $shellmin = 15;
 my $failed_coverage = 0;
 my $failed_tests = 0;


### PR DESCRIPTION
Support workflows for deploying single- or multi-group blueprints via the following sequence of commands:

```text
ghpc create blueprint.yaml
ghpc deploy deployment_root_directory
```

No direct user execution of Terraform or Packer is necessary. If the optional `--auto-approve` flag is supplied to `deploy`, then changes to cloud infrastructure are automatically applied. If not supplied, the user must approve every deployment group separately.

In this initial implementation, `ghpc` blindly iterates over all deployment groups in-order. It will only attempt to run "terraform apply" if "terraform plan -detailed-exitcode" returns code 2. It will always attempt to build Packer images. For each group, it will always attempt to invoke "import-inputs" and "export-outputs". These are operationally harmless on groups without inputs or exports, but may print log entries to stdout.

Example output:

```text
❯❯❯ ghpc create -w --vars project_id=project examples/hpc-cluster-small.yaml
Terraform group 'primary' was successfully created in directory hpc-small/primary
To deploy, run the following commands:

terraform -chdir=hpc-small/primary init
terraform -chdir=hpc-small/primary validate
terraform -chdir=hpc-small/primary apply

❯❯❯ ghpc deploy hpc-small
2023/05/10 14:31:05 initializing terraform directory hpc-small/primary
2023/05/10 14:31:23 testing if terraform state of hpc-small/primary is in sync with cloud infrastructure
2023/05/10 14:31:30 cloud infrastructure requires changes
2023/05/10 14:31:30 Summary of proposed changes: Plan: 13 to add, 0 to change, 0 to destroy.
Display full proposed changes, Apply proposed changes, Stop and exit, Continue without applying? [d,a,s,c]: a
2023/05/10 14:31:35 running terraform apply on group hpc-small/primary
module.slurm_login.module.slurm_cluster_login_node.data.google_compute_default_service_account.default: Reading...
##
## MANY LINES OF TERRAFORM APPLY OUTPUT
##
Apply complete! Resources: 13 added, 0 changed, 0 destroyed.
2023/05/10 14:36:22 collecting terraform outputs from hpc-small/primary
2023/05/10 14:36:23 group primary contains no artifacts to export
❯❯❯ ghpc deploy hpc-small --auto-approve
2023/05/10 14:45:04 testing if terraform state of hpc-small/primary is in sync with cloud infrastructure
2023/05/10 14:45:08 cloud infrastructure requires no changes
2023/05/10 14:45:08 collecting terraform outputs from hpc-small/primary
2023/05/10 14:45:08 group primary contains no artifacts to export
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
