### PR TITLE
Add module labels for billing filtering

### DIFF
--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/outputs.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/outputs.tf
@@ -14,6 +14,11 @@
 # limitations under the License.
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "SchedMD-slurm-on-gcp-partition" })
+}
+
+locals {
   instance_name   = lookup(var.instance_image, "name", null)
   instance_family = lookup(var.instance_image, "family", null)
   instance_image = (
@@ -36,7 +41,7 @@ output "partition" {
     image_hyperthreads : var.image_hyperthreads
     compute_disk_type : var.compute_disk_type
     compute_disk_size_gb : var.compute_disk_size_gb
-    compute_labels : var.labels
+    compute_labels : local.labels
     cpu_platform : var.cpu_platform
     gpu_count : var.gpu_count
     gpu_type : var.gpu_type

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/outputs.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/outputs.tf
@@ -15,7 +15,7 @@
 
 locals {
   # This label allows for billing report tracking based on module.
-  labels = merge(var.labels, { ghpc_module = "SchedMD-slurm-on-gcp-partition" })
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-on-gcp-partition" })
 }
 
 locals {

--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -15,6 +15,11 @@
   */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "gke-node-pool" })
+}
+
+locals {
   sa_email = var.service_account.email != null ? var.service_account.email : data.google_compute_default_service_account.default_sa.email
 
   has_gpu = var.guest_accelerator != null || contains(["g2", "a2"], local.machine_family)
@@ -62,7 +67,7 @@ resource "google_container_node_pool" "node_pool" {
   node_config {
     disk_size_gb      = var.disk_size_gb
     disk_type         = var.disk_type
-    resource_labels   = var.labels
+    resource_labels   = local.labels
     service_account   = var.service_account.email
     oauth_scopes      = var.service_account.scopes
     machine_type      = var.machine_type

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "htcondor-execute-point" })
+}
 
 locals {
   network_storage_metadata = var.network_storage == null ? {} : { network_storage = jsonencode(var.network_storage) }
@@ -52,7 +56,7 @@ module "execute_point_instance_template" {
   network         = var.network_self_link
   subnetwork      = var.subnetwork_self_link
   service_account = var.service_account
-  labels          = var.labels
+  labels          = local.labels
 
   machine_type         = var.machine_type
   disk_size_gb         = var.disk_size_gb

--- a/community/modules/compute/pbspro-execution/main.tf
+++ b/community/modules/compute/pbspro-execution/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "pbspro-execution" })
+}
+
+locals {
   resource_prefix = var.name_prefix != null ? var.name_prefix : "${var.deployment_name}-exec"
   # PBS Pro Big Book 2021.3 Sec. 15.6.2.1 says that mountpoints in $usecp
   # configuration need trailing slashes
@@ -73,7 +78,7 @@ module "pbs_execution" {
   project_id      = var.project_id
   region          = var.region
   zone            = var.zone
-  labels          = var.labels
+  labels          = local.labels
 
   machine_type    = var.machine_type
   service_account = var.service_account

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v5-node-group" })
+}
+
+locals {
 
   # Handle VM image format from 2 sources, prioritize source_image* variables
   # over instance_image
@@ -32,7 +37,7 @@ locals {
       device_name  = ad.device_name
       disk_type    = ad.disk_type
       disk_size_gb = ad.disk_size_gb
-      disk_labels  = merge(ad.disk_labels, var.labels)
+      disk_labels  = merge(ad.disk_labels, local.labels)
       auto_delete  = ad.auto_delete
       boot         = ad.boot
     }
@@ -51,14 +56,14 @@ locals {
     can_ip_forward           = var.can_ip_forward
     disable_smt              = !var.enable_smt
     disk_auto_delete         = var.disk_auto_delete
-    disk_labels              = merge(var.labels, var.disk_labels)
+    disk_labels              = merge(local.labels, var.disk_labels)
     disk_size_gb             = var.disk_size_gb
     disk_type                = var.disk_type
     enable_confidential_vm   = var.enable_confidential_vm
     enable_oslogin           = var.enable_oslogin
     enable_shielded_vm       = var.enable_shielded_vm
     gpu                      = var.gpu != null ? var.gpu : one(local.guest_accelerator)
-    labels                   = var.labels
+    labels                   = local.labels
     machine_type             = var.machine_type
     metadata                 = var.metadata
     min_cpu_platform         = var.min_cpu_platform

--- a/community/modules/database/slurm-cloudsql-federation/main.tf
+++ b/community/modules/database/slurm-cloudsql-federation/main.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
 */
 
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "slurm-cloudsql-federation" })
+}
+
 resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }
@@ -37,7 +42,7 @@ resource "google_sql_database_instance" "instance" {
   database_version    = "MYSQL_5_7"
 
   settings {
-    user_labels = var.labels
+    user_labels = local.labels
     tier        = var.tier
     ip_configuration {
 

--- a/community/modules/file-system/DDN-EXAScaler/main.tf
+++ b/community/modules/file-system/DDN-EXAScaler/main.tf
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "DDN-EXAScaler" })
+}
+
 locals {
 
   network_id = var.network_self_link != null ? regex("https://www.googleapis.com/compute/v\\d/(.*)", var.network_self_link)[0] : null
@@ -41,7 +47,7 @@ module "ddn_exascaler" {
   zone            = var.zone
   project         = var.project_id
   prefix          = var.prefix
-  labels          = var.labels
+  labels          = local.labels
   security        = var.security
   service_account = var.service_account
   waiter          = var.waiter

--- a/community/modules/file-system/DDN-EXAScaler/main.tf
+++ b/community/modules/file-system/DDN-EXAScaler/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   # This label allows for billing report tracking based on module.
-  labels = merge(var.labels, { ghpc_module = "DDN-EXAScaler" })
+  labels = merge(var.labels, { ghpc_module = "ddn-exascaler" })
 }
 
 locals {

--- a/community/modules/file-system/cloud-storage-bucket/main.tf
+++ b/community/modules/file-system/cloud-storage-bucket/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "cloud-storage-bucket" })
+}
+
+locals {
   prefix         = var.name_prefix != null ? var.name_prefix : ""
   deployment     = var.use_deployment_name_in_bucket_name ? var.deployment_name : ""
   suffix         = var.random_suffix ? random_id.resource_name_suffix.hex : ""
@@ -34,5 +39,5 @@ resource "google_storage_bucket" "bucket" {
   uniform_bucket_level_access = true
   location                    = var.region
   storage_class               = "REGIONAL"
-  labels                      = var.labels
+  labels                      = local.labels
 }

--- a/community/modules/file-system/nfs-server/main.tf
+++ b/community/modules/file-system/nfs-server/main.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
 */
 
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "nfs-server" })
+}
+
 resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }
@@ -54,7 +59,7 @@ resource "google_compute_disk" "attached_disk" {
   size    = var.disk_size
   type    = var.type
   zone    = var.zone
-  labels  = var.labels
+  labels  = local.labels
 }
 
 resource "google_compute_instance" "compute_instance" {
@@ -87,5 +92,5 @@ resource "google_compute_instance" "compute_instance" {
   metadata                = var.metadata
   metadata_startup_script = templatefile("${path.module}/scripts/install-nfs-server.sh.tpl", { local_mounts = var.local_mounts })
 
-  labels = var.labels
+  labels = local.labels
 }

--- a/community/modules/project/new-project/main.tf
+++ b/community/modules/project/new-project/main.tf
@@ -15,6 +15,11 @@
 */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "new-project" })
+}
+
+locals {
   name = var.name != null ? var.name : var.project_id
 }
 
@@ -41,7 +46,7 @@ module "project_factory" {
   usage_bucket_name                       = var.usage_bucket_name
   usage_bucket_prefix                     = var.usage_bucket_prefix
   shared_vpc_subnets                      = var.shared_vpc_subnets
-  labels                                  = var.labels
+  labels                                  = local.labels
   bucket_project                          = var.bucket_project
   bucket_name                             = var.bucket_name
   bucket_location                         = var.bucket_location

--- a/community/modules/remote-desktop/chrome-remote-desktop/main.tf
+++ b/community/modules/remote-desktop/chrome-remote-desktop/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "chrome-remote-desktop" })
+}
 
 locals {
 
@@ -56,7 +60,7 @@ module "client_startup_script" {
   deployment_name = var.deployment_name
   project_id      = var.project_id
   region          = var.region
-  labels          = var.labels
+  labels          = local.labels
 
   runners = flatten([
     local.user_startup_script_runners,
@@ -77,7 +81,7 @@ module "instances" {
   project_id      = var.project_id
   region          = var.region
   zone            = var.zone
-  labels          = var.labels
+  labels          = local.labels
 
   machine_type    = var.machine_type
   service_account = var.service_account

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/main.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/main.tf
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "SchedMD-slurm-on-gcp-controller" })
+}
+
 locals {
   controller_startup_script = var.controller_startup_script != null ? var.controller_startup_script : var.startup_script
   compute_startup_script    = var.compute_startup_script != null ? var.compute_startup_script : var.startup_script
@@ -38,7 +44,7 @@ module "slurm_cluster_controller" {
   compute_node_service_account  = var.compute_node_service_account
   disable_compute_public_ips    = var.disable_compute_public_ips
   disable_controller_public_ips = var.disable_controller_public_ips
-  labels                        = var.labels
+  labels                        = local.labels
   login_network_storage         = var.network_storage
   login_node_count              = var.login_node_count
   machine_type                  = var.controller_machine_type

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/main.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   # This label allows for billing report tracking based on module.
-  labels = merge(var.labels, { ghpc_module = "SchedMD-slurm-on-gcp-controller" })
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-on-gcp-controller" })
 }
 
 locals {

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/main.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/main.tf
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "SchedMD-slurm-on-gcp-login-node" })
+}
+
 locals {
   login_startup_script = var.login_startup_script != null ? var.login_startup_script : var.startup_script
 
@@ -39,7 +45,7 @@ module "slurm_cluster_login_node" {
   controller_name           = var.controller_name
   controller_secondary_disk = var.controller_secondary_disk
   disable_login_public_ips  = var.disable_login_public_ips
-  labels                    = var.labels
+  labels                    = local.labels
   login_network_storage     = var.network_storage
   machine_type              = var.login_machine_type
   munge_key                 = var.munge_key

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/main.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   # This label allows for billing report tracking based on module.
-  labels = merge(var.labels, { ghpc_module = "SchedMD-slurm-on-gcp-login-node" })
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-on-gcp-login-node" })
 }
 
 locals {

--- a/community/modules/scheduler/gke-cluster/main.tf
+++ b/community/modules/scheduler/gke-cluster/main.tf
@@ -15,6 +15,11 @@
   */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "gke-cluster" })
+}
+
+locals {
   dash             = var.prefix_with_deployment_name && var.name_suffix != "" ? "-" : ""
   prefix           = var.prefix_with_deployment_name ? var.deployment_name : ""
   name_maybe_empty = "${local.prefix}${local.dash}${var.name_suffix}"
@@ -37,7 +42,7 @@ resource "google_container_cluster" "gke_cluster" {
   project         = var.project_id
   name            = local.name
   location        = var.region
-  resource_labels = var.labels
+  resource_labels = local.labels
 
   # decouple node pool lifecyle from cluster life cycle
   remove_default_node_pool = true
@@ -178,7 +183,7 @@ resource "google_container_node_pool" "system_node_pools" {
   }
 
   node_config {
-    resource_labels = var.labels
+    resource_labels = local.labels
     service_account = var.service_account.email
     oauth_scopes    = var.service_account.scopes
     machine_type    = var.system_node_pool_machine_type

--- a/community/modules/scheduler/htcondor-configure/main.tf
+++ b/community/modules/scheduler/htcondor-configure/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "htcondor-configure" })
+}
+
+locals {
   execute_point_display_name   = "HTCondor Execute Point (${var.deployment_name})"
   execute_point_roles          = [for role in var.execute_point_roles : "${var.project_id}=>${role}"]
   access_point_display_name    = "HTCondor Access Point (${var.deployment_name})"
@@ -108,7 +113,7 @@ resource "random_password" "pool" {
 resource "google_secret_manager_secret" "pool_password" {
   secret_id = "${var.deployment_name}-pool-password"
 
-  labels = var.labels
+  labels = local.labels
 
   replication {
     automatic = true

--- a/community/modules/scheduler/pbspro-client/main.tf
+++ b/community/modules/scheduler/pbspro-client/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "pbspro-client" })
+}
+
+locals {
   resource_prefix = var.name_prefix != null ? var.name_prefix : "${var.deployment_name}-client"
 
   user_startup_script_runners = var.startup_script == null ? [] : [
@@ -43,7 +48,7 @@ module "client_startup_script" {
   deployment_name = var.deployment_name
   project_id      = var.project_id
   region          = var.region
-  labels          = var.labels
+  labels          = local.labels
 
   runners = flatten([
     local.user_startup_script_runners,
@@ -62,7 +67,7 @@ module "pbs_client" {
   project_id      = var.project_id
   region          = var.region
   zone            = var.zone
-  labels          = var.labels
+  labels          = local.labels
 
   machine_type    = var.machine_type
   service_account = var.service_account

--- a/community/modules/scheduler/pbspro-server/main.tf
+++ b/community/modules/scheduler/pbspro-server/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "pbspro-server" })
+}
+
+locals {
   resource_prefix = var.name_prefix != null ? var.name_prefix : "${var.deployment_name}-server"
 
   user_startup_script_runners = var.startup_script == null ? [] : [
@@ -75,7 +80,7 @@ module "pbs_server" {
   project_id      = var.project_id
   region          = var.region
   zone            = var.zone
-  labels          = var.labels
+  labels          = local.labels
 
   machine_type    = var.machine_type
   service_account = var.service_account

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
@@ -15,6 +15,11 @@
 */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v5-controller" })
+}
+
+locals {
   ghpc_startup_script_controller = [{
     filename = "ghpc_startup.sh"
     content  = var.controller_startup_script
@@ -44,7 +49,7 @@ locals {
       device_name  = ad.device_name
       disk_type    = ad.disk_type
       disk_size_gb = ad.disk_size_gb
-      disk_labels  = merge(ad.disk_labels, var.labels)
+      disk_labels  = merge(ad.disk_labels, local.labels)
       auto_delete  = ad.auto_delete
       boot         = ad.boot
     }
@@ -99,14 +104,14 @@ module "slurm_controller_template" {
   slurm_cluster_name       = local.slurm_cluster_name
   disable_smt              = var.disable_smt
   disk_auto_delete         = var.disk_auto_delete
-  disk_labels              = merge(var.disk_labels, var.labels)
+  disk_labels              = merge(var.disk_labels, local.labels)
   disk_size_gb             = var.disk_size_gb
   disk_type                = var.disk_type
   enable_confidential_vm   = var.enable_confidential_vm
   enable_oslogin           = var.enable_oslogin
   enable_shielded_vm       = var.enable_shielded_vm
   gpu                      = var.gpu != null ? var.gpu : one(local.guest_accelerator)
-  labels                   = var.labels
+  labels                   = local.labels
   machine_type             = var.machine_type
   metadata                 = var.metadata
   min_cpu_platform         = var.min_cpu_platform

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v5-login" })
+}
+
+locals {
   ghpc_startup_script = [{
     filename = "ghpc_startup.sh"
     content  = var.startup_script
@@ -40,7 +45,7 @@ locals {
       device_name  = ad.device_name
       disk_type    = ad.disk_type
       disk_size_gb = ad.disk_size_gb
-      disk_labels  = merge(ad.disk_labels, var.labels)
+      disk_labels  = merge(ad.disk_labels, local.labels)
       auto_delete  = ad.auto_delete
       boot         = ad.boot
     }
@@ -59,14 +64,14 @@ module "slurm_login_template" {
   slurm_cluster_name       = local.slurm_cluster_name
   disable_smt              = var.disable_smt
   disk_auto_delete         = var.disk_auto_delete
-  disk_labels              = merge(var.disk_labels, var.labels)
+  disk_labels              = merge(var.disk_labels, local.labels)
   disk_size_gb             = var.disk_size_gb
   disk_type                = var.disk_type
   enable_confidential_vm   = var.enable_confidential_vm
   enable_oslogin           = var.enable_oslogin
   enable_shielded_vm       = var.enable_shielded_vm
   gpu                      = var.gpu != null ? var.gpu : one(local.guest_accelerator)
-  labels                   = var.labels
+  labels                   = local.labels
   machine_type             = var.machine_type
   metadata                 = var.metadata
   min_cpu_platform         = var.min_cpu_platform

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -15,6 +15,11 @@
 */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "vm-instance" })
+}
+
+locals {
   native_fstype = []
   startup_script = local.startup_from_network_storage != null ? (
   { startup-script = local.startup_from_network_storage }) : {}
@@ -89,7 +94,7 @@ resource "google_compute_disk" "boot_disk" {
   image  = data.google_compute_image.compute_image.self_link
   type   = var.disk_type
   size   = var.disk_size_gb
-  labels = var.labels
+  labels = local.labels
   zone   = var.zone
 }
 
@@ -120,7 +125,7 @@ resource "google_compute_instance" "compute_vm" {
   resource_policies = google_compute_resource_policy.placement_policy[*].self_link
 
   tags   = var.tags
-  labels = var.labels
+  labels = local.labels
 
   boot_disk {
     source      = google_compute_disk.boot_disk[count.index].self_link

--- a/modules/compute/vm-instance/startup_from_network_storage.tf
+++ b/modules/compute/vm-instance/startup_from_network_storage.tf
@@ -57,7 +57,7 @@ locals {
 module "netstorage_startup_script" {
   source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=34bb7250"
 
-  labels          = var.labels
+  labels          = local.labels
   project_id      = var.project_id
   deployment_name = var.deployment_name
   region          = var.region

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "filestore" })
+}
+
 resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }
@@ -56,7 +61,7 @@ resource "google_filestore_instance" "filestore_instance" {
     name        = var.filestore_share_name
   }
 
-  labels = var.labels
+  labels = local.labels
 
   networks {
     network      = local.shared_vpc ? var.network_id : local.network_name

--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "batch-job-template" })
+}
+
+locals {
   instance_template = var.instance_template != null ? var.instance_template : module.instance_template.self_link
 
   tasks_per_node = var.task_count_per_node != null ? var.task_count_per_node : (var.mpi_mode ? 1 : null)
@@ -74,7 +79,7 @@ module "instance_template" {
   subnetwork_project = local.subnetwork_project
   service_account    = var.service_account
   access_config      = var.enable_public_ips ? [{ nat_ip = null, network_tier = null }] : []
-  labels             = var.labels
+  labels             = local.labels
 
   machine_type         = var.machine_type
   startup_script       = local.startup_from_network_storage

--- a/modules/scheduler/batch-job-template/startup_from_network_storage.tf
+++ b/modules/scheduler/batch-job-template/startup_from_network_storage.tf
@@ -57,7 +57,7 @@ locals {
 module "netstorage_startup_script" {
   source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=34bb7250"
 
-  labels          = var.labels
+  labels          = local.labels
   project_id      = var.project_id
   deployment_name = var.deployment_name
   region          = var.region

--- a/modules/scheduler/batch-login-node/main.tf
+++ b/modules/scheduler/batch-login-node/main.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "batch-login-node" })
+}
+
 data "google_compute_instance_template" "batch_instance_template" {
   name = var.instance_template
 }
@@ -100,7 +105,7 @@ locals {
 
 module "login_startup_script" {
   source          = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=34bb7250"
-  labels          = var.labels
+  labels          = local.labels
   project_id      = var.project_id
   deployment_name = var.deployment_name
   region          = var.region

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "startup-script" })
+}
+
+locals {
   ops_agent_installer = var.install_cloud_ops_agent ? [{
     type        = "shell"
     source      = "${path.module}/files/install_cloud_ops_agent.sh"
@@ -88,7 +93,7 @@ resource "google_storage_bucket" "configs_bucket" {
   uniform_bucket_level_access = true
   location                    = var.region
   storage_class               = "REGIONAL"
-  labels                      = var.labels
+  labels                      = local.labels
 }
 
 resource "google_storage_bucket_object" "scripts" {


### PR DESCRIPTION
Adds a label with the format `ghpc_module: <module name>`. This will allow users to [filter billing reports](https://github.com/GoogleCloudPlatform/hpc-toolkit#billing-reports) based on the module that is creating the resource.

In subsequent change I will add a pre-submit to verify this block is accurate. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
