### PR TITLE
Modify instructions to user

### DIFF
--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -184,7 +184,7 @@ func (s *MySuite) TestPrepDepDir_OverwriteRealDep(c *C) {
 	c.Check(len(files1) > 0, Equals, true)
 
 	files2, _ := ioutil.ReadDir(realDepDir)
-	c.Check(len(files2), Equals, 2) // .ghpc and .gitignore
+	c.Check(len(files2), Equals, 3) // .ghpc, .gitignore, and instructions file
 }
 
 func (s *MySuite) TestIsSubset(c *C) {
@@ -707,9 +707,13 @@ func (s *MySuite) TestWriteDeploymentGroup_PackerWriter(c *C) {
 			},
 		},
 	}
-
-	testWriter.writeDeploymentGroup(testDC, 0, deploymentDir)
-	_, err := os.Stat(filepath.Join(moduleDir, packerAutoVarFilename))
+	f, err := os.CreateTemp("", "tmpf")
+	if err != nil {
+		c.Fatal()
+	}
+	defer os.Remove(f.Name())
+	testWriter.writeDeploymentGroup(testDC, 0, deploymentDir, f)
+	_, err = os.Stat(filepath.Join(moduleDir, packerAutoVarFilename))
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -18,7 +18,7 @@ package modulewriter
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"path/filepath"
 
 	"hpc-toolkit/pkg/config"
@@ -41,20 +41,20 @@ func (w *PackerWriter) addNumModules(value int) {
 	w.numModules += value
 }
 
-func printPackerInstructions(f *os.File, modPath string, modID config.ModuleID, printImportInputs bool) {
-	fmt.Fprintln(f)
-	fmt.Fprintf(f, "Packer group '%s' was successfully created in directory %s\n", modID, modPath)
-	fmt.Fprintln(f, "To deploy, run the following commands:")
-	fmt.Fprintln(f)
+func printPackerInstructions(w io.Writer, modPath string, modID config.ModuleID, printImportInputs bool) {
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Packer group '%s' was successfully created in directory %s\n", modID, modPath)
+	fmt.Fprintln(w, "To deploy, run the following commands:")
+	fmt.Fprintln(w)
 	grpPath := filepath.Clean(filepath.Join(modPath, ".."))
 	if printImportInputs {
-		fmt.Fprintf(f, "ghpc import-inputs %s\n", grpPath)
+		fmt.Fprintf(w, "ghpc import-inputs %s\n", grpPath)
 	}
-	fmt.Fprintf(f, "cd %s\n", modPath)
-	fmt.Fprintln(f, "packer init .")
-	fmt.Fprintln(f, "packer validate .")
-	fmt.Fprintln(f, "packer build .")
-	fmt.Fprintln(f, "cd -")
+	fmt.Fprintf(w, "cd %s\n", modPath)
+	fmt.Fprintln(w, "packer init .")
+	fmt.Fprintln(w, "packer validate .")
+	fmt.Fprintln(w, "packer build .")
+	fmt.Fprintln(w, "cd -")
 }
 
 func writePackerAutovars(vars map[string]cty.Value, dst string) error {
@@ -69,7 +69,7 @@ func (w PackerWriter) writeDeploymentGroup(
 	dc config.DeploymentConfig,
 	grpIdx int,
 	deployDir string,
-	instructionsFile *os.File,
+	instructionsFile io.Writer,
 ) error {
 	depGroup := dc.Config.DeploymentGroups[grpIdx]
 	groupPath := filepath.Join(deployDir, string(depGroup.Name))

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -18,6 +18,7 @@ package modulewriter
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -324,19 +325,19 @@ func writeVersions(dst string) error {
 	return nil
 }
 
-func writeTerraformInstructions(f *os.File, grpPath string, n config.GroupName, printExportOutputs bool, printImportInputs bool) {
-	fmt.Fprintln(f)
-	fmt.Fprintf(f, "Terraform group '%s' was successfully created in directory %s\n", n, grpPath)
-	fmt.Fprintln(f, "To deploy, run the following commands:")
-	fmt.Fprintln(f)
+func writeTerraformInstructions(w io.Writer, grpPath string, n config.GroupName, printExportOutputs bool, printImportInputs bool) {
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Terraform group '%s' was successfully created in directory %s\n", n, grpPath)
+	fmt.Fprintln(w, "To deploy, run the following commands:")
+	fmt.Fprintln(w)
 	if printImportInputs {
-		fmt.Fprintf(f, "ghpc import-inputs %s\n", grpPath)
+		fmt.Fprintf(w, "ghpc import-inputs %s\n", grpPath)
 	}
-	fmt.Fprintf(f, "terraform -chdir=%s init\n", grpPath)
-	fmt.Fprintf(f, "terraform -chdir=%s validate\n", grpPath)
-	fmt.Fprintf(f, "terraform -chdir=%s apply\n", grpPath)
+	fmt.Fprintf(w, "terraform -chdir=%s init\n", grpPath)
+	fmt.Fprintf(w, "terraform -chdir=%s validate\n", grpPath)
+	fmt.Fprintf(w, "terraform -chdir=%s apply\n", grpPath)
 	if printExportOutputs {
-		fmt.Fprintf(f, "ghpc export-outputs %s\n", grpPath)
+		fmt.Fprintf(w, "ghpc export-outputs %s\n", grpPath)
 	}
 }
 
@@ -350,7 +351,7 @@ func (w TFWriter) writeDeploymentGroup(
 	dc config.DeploymentConfig,
 	groupIndex int,
 	deploymentDir string,
-	instructionsFile *os.File,
+	instructionsFile io.Writer,
 ) error {
 	depGroup := dc.Config.DeploymentGroups[groupIndex]
 	deploymentVars := getUsedDeploymentVars(depGroup, dc.Config)

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/instructions.txt
@@ -1,4 +1,5 @@
-# Advanced Deployment Instructions
+Advanced Deployment Instructions
+================================
 
 Terraform group 'zero' was successfully created in directory golden_copy_deployment/zero
 To deploy, run the following commands:
@@ -18,7 +19,8 @@ packer validate .
 packer build .
 cd -
 
-# Destroying infrastructure when no longer needed
+Destroying infrastructure when no longer needed
+===============================================
 
 Infrastructure should be destroyed in reverse order of creation:
 

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/instructions.txt
@@ -1,0 +1,32 @@
+# Advanced Deployment Instructions
+
+Terraform group 'zero' was successfully created in directory golden_copy_deployment/zero
+To deploy, run the following commands:
+
+terraform -chdir=golden_copy_deployment/zero init
+terraform -chdir=golden_copy_deployment/zero validate
+terraform -chdir=golden_copy_deployment/zero apply
+ghpc export-outputs golden_copy_deployment/zero
+
+Packer group 'image' was successfully created in directory golden_copy_deployment/one/image
+To deploy, run the following commands:
+
+ghpc import-inputs golden_copy_deployment/one
+cd golden_copy_deployment/one/image
+packer init .
+packer validate .
+packer build .
+cd -
+
+# Destroying infrastructure when no longer needed
+
+Infrastructure should be destroyed in reverse order of creation:
+
+terraform -chdir=golden_copy_deployment/zero destroy
+
+Please browse to the Cloud Console to remove VM images produced by Packer.
+By default, the names of images can be found in these files:
+
+golden_copy_deployment/one/image/packer-manifest.json
+
+https://console.cloud.google.com/compute/images

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/instructions.txt
@@ -1,4 +1,5 @@
-# Advanced Deployment Instructions
+Advanced Deployment Instructions
+================================
 
 Terraform group 'zero' was successfully created in directory golden_copy_deployment/zero
 To deploy, run the following commands:
@@ -16,7 +17,8 @@ terraform -chdir=golden_copy_deployment/one init
 terraform -chdir=golden_copy_deployment/one validate
 terraform -chdir=golden_copy_deployment/one apply
 
-# Destroying infrastructure when no longer needed
+Destroying infrastructure when no longer needed
+===============================================
 
 Infrastructure should be destroyed in reverse order of creation:
 

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/instructions.txt
@@ -1,0 +1,24 @@
+# Advanced Deployment Instructions
+
+Terraform group 'zero' was successfully created in directory golden_copy_deployment/zero
+To deploy, run the following commands:
+
+terraform -chdir=golden_copy_deployment/zero init
+terraform -chdir=golden_copy_deployment/zero validate
+terraform -chdir=golden_copy_deployment/zero apply
+ghpc export-outputs golden_copy_deployment/zero
+
+Terraform group 'one' was successfully created in directory golden_copy_deployment/one
+To deploy, run the following commands:
+
+ghpc import-inputs golden_copy_deployment/one
+terraform -chdir=golden_copy_deployment/one init
+terraform -chdir=golden_copy_deployment/one validate
+terraform -chdir=golden_copy_deployment/one apply
+
+# Destroying infrastructure when no longer needed
+
+Infrastructure should be destroyed in reverse order of creation:
+
+terraform -chdir=golden_copy_deployment/one destroy
+terraform -chdir=golden_copy_deployment/zero destroy

--- a/tools/validate_configs/golden_copies/expectations/text_escape/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/instructions.txt
@@ -1,4 +1,5 @@
-# Advanced Deployment Instructions
+Advanced Deployment Instructions
+================================
 
 Packer group 'lime' was successfully created in directory golden_copy_deployment/zero/lime
 To deploy, run the following commands:
@@ -9,7 +10,8 @@ packer validate .
 packer build .
 cd -
 
-# Destroying infrastructure when no longer needed
+Destroying infrastructure when no longer needed
+===============================================
 
 Infrastructure should be destroyed in reverse order of creation:
 

--- a/tools/validate_configs/golden_copies/expectations/text_escape/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/instructions.txt
@@ -1,0 +1,22 @@
+# Advanced Deployment Instructions
+
+Packer group 'lime' was successfully created in directory golden_copy_deployment/zero/lime
+To deploy, run the following commands:
+
+cd golden_copy_deployment/zero/lime
+packer init .
+packer validate .
+packer build .
+cd -
+
+# Destroying infrastructure when no longer needed
+
+Infrastructure should be destroyed in reverse order of creation:
+
+
+Please browse to the Cloud Console to remove VM images produced by Packer.
+By default, the names of images can be found in these files:
+
+golden_copy_deployment/zero/lime/packer-manifest.json
+
+https://console.cloud.google.com/compute/images

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -51,7 +51,7 @@ run_test() {
 		echo "*** ERROR: can't cd into the deployment folder ${DEPLOYMENT}"
 		exit 1
 	}
-	for folder in ./*; do
+	for folder in */; do
 		cd "$folder"
 		pkrdirs=()
 		while IFS= read -r -d $'\n'; do


### PR DESCRIPTION
- remove series of terraform and packer commands in favor of new "ghpc deploy" command
- advise user to find "advanced manual deployment instructions" in a file named instructions.txt in the root of the deployment folder
- add instructions to file for running "terraform destroy" and removing VM images when no longer needed

Instructions printed to screen are now:

```text
❯❯❯ ghpc create --vars project_id=example examples/image-builder.yaml
To deploy your infrastructure please run:

./ghpc deploy image-builder-001

Please find instructions for cleanly destroying infrastructure and advanced
advanced manual deployment instructions at:

image-builder-001/instructions.txt
```

And the contents of the above file are:

```text
Advanced Deployment Instructions
================================

Terraform group 'builder-env' was successfully created in directory image-builder-001/builder-env
To deploy, run the following commands:

terraform -chdir=image-builder-001/builder-env init
terraform -chdir=image-builder-001/builder-env validate
terraform -chdir=image-builder-001/builder-env apply
ghpc export-outputs image-builder-001/builder-env

Packer group 'custom-image' was successfully created in directory image-builder-001/packer/custom-image
To deploy, run the following commands:

ghpc import-inputs image-builder-001/packer
cd image-builder-001/packer/custom-image
packer init .
packer validate .
packer build .
cd -

Terraform group 'cluster' was successfully created in directory image-builder-001/cluster
To deploy, run the following commands:

ghpc import-inputs image-builder-001/cluster
terraform -chdir=image-builder-001/cluster init
terraform -chdir=image-builder-001/cluster validate
terraform -chdir=image-builder-001/cluster apply

Destroying infrastructure when no longer needed
===============================================

Infrastructure should be destroyed in reverse order of creation:

terraform -chdir=image-builder-001/cluster destroy
terraform -chdir=image-builder-001/builder-env destroy

Please browse to the Cloud Console to remove VM images produced by Packer.
By default, the names of images can be found in these files:

image-builder-001/packer/custom-image/packer-manifest.json

https://console.cloud.google.com/compute/images
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
