### PR TITLE
Rename multiple slurm examples

### DIFF
--- a/community/examples/AMD/README.md
+++ b/community/examples/AMD/README.md
@@ -52,7 +52,7 @@ using the `compute` partition, you may ignore its quota requirements.
 Use `ghpc` to provision the blueprint, supplying your project ID:
 
 ```shell
-ghpc create --vars project_id=<<PROJECT_ID>> hpc-cluster-amd-slurmv5.yaml
+ghpc create --vars project_id=<<PROJECT_ID>> hpc-amd-slurm.yaml
 ```
 
 It will create a directory containing a Terraform module. Follow the printed

--- a/community/examples/AMD/hpc-amd-slurm.yaml
+++ b/community/examples/AMD/hpc-amd-slurm.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-blueprint_name: hpc-cluster-amd
+blueprint_name: hpc-amd-slurm
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/community/examples/hpc-slurm-gromacs.yaml
+++ b/community/examples/hpc-slurm-gromacs.yaml
@@ -14,11 +14,11 @@
 
 ---
 
-blueprint_name: spack-gromacs
+blueprint_name: hpc-slurm-gromacs
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: spack-gromacs
+  deployment_name: hpc-slurm-gromacs
   region: us-central1
   zone: us-central1-c
 

--- a/community/examples/intel/README.md
+++ b/community/examples/intel/README.md
@@ -75,7 +75,7 @@ And the following available quota is required in the region used by the cluster:
 Use `ghpc` to provision the blueprint, supplying your project ID
 
 ```text
-ghpc create --vars project_id=<<PROJECT_ID>> community/examples/intel/hpc-cluster-intel-select.yaml
+ghpc create --vars project_id=<<PROJECT_ID>> community/examples/intel/hpc-intel-select-slurm.yaml
 ```
 
 This will create a set of directories containing Terraform modules and Packer
@@ -401,7 +401,7 @@ terraform -chdir=pfs-daos/primary destroy
 
 ## DAOS Server with Slurm cluster
 
-The [daos-slurm.yaml](daos-slurm.yaml) blueprint describes an environment with a Slurm cluster and four DAOS server instances. The compute nodes are configured as DAOS clients and have the ability to use the DAOS filesystem on the DAOS server instances.
+The [hpc-slurm-daos.yaml](hpc-slurm-daos.yaml) blueprint describes an environment with a Slurm cluster and four DAOS server instances. The compute nodes are configured as DAOS clients and have the ability to use the DAOS filesystem on the DAOS server instances.
 
 The blueprint uses modules from
 - [google-cloud-daos][google-cloud-daos]
@@ -453,7 +453,7 @@ For Slurm:
 Use `ghpc` to provision the blueprint, supplying your project ID
 
 ```text
-ghpc create community/examples/intel/daos-slurm.yaml \
+ghpc create community/examples/intel/hpc-slurm-daos.yaml \
   --vars project_id=<<PROJECT_ID>> \
   [--backend-config bucket=<GCS tf backend bucket>]
 ```
@@ -494,7 +494,7 @@ Once the startup script has completed and Slurm reports readiness, connect to th
 
 ### Create and Mount a DAOS Container
 
-The [community/examples/intel/daos-slurm.yaml](daos-slurm.yaml) blueprint defines a single DAOS pool named `pool1`. The pool will be created when the *daos-server* instances are provisioned.
+The [community/examples/intel/hpc-slurm-daos.yaml](hpc-slurm-daos.yaml) blueprint defines a single DAOS pool named `pool1`. The pool will be created when the *daos-server* instances are provisioned.
 
 You will need to create your own DAOS container in the pool that can be used by your Slurm jobs.
 

--- a/community/examples/intel/hpc-intel-select-slurm.yaml
+++ b/community/examples/intel/hpc-intel-select-slurm.yaml
@@ -14,7 +14,7 @@
 
 ---
 
-blueprint_name: hpc-cluster-intel-select
+blueprint_name: hpc-intel-select-slurm
 
 vars:
   deployment_name: hpc-intel-select

--- a/community/examples/intel/hpc-slurm-daos.yaml
+++ b/community/examples/intel/hpc-slurm-daos.yaml
@@ -14,7 +14,7 @@
 
 ---
 
-blueprint_name: daos-slurm
+blueprint_name: hpc-slurm-daos
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/community/modules/scripts/spack-install/README.md
+++ b/community/modules/scripts/spack-install/README.md
@@ -27,7 +27,7 @@ share a software stack.
 ## Example
 
 As an example, the below is a possible definition of a spack installation. To
-see this module used in a full blueprint, see the [spack-gromacs.yaml] example.
+see this module used in a full blueprint, see the [hpc-slurm-gromacs.yaml] example.
 
 ```yaml
   - id: spack
@@ -115,7 +115,7 @@ Alternatively, it can be added as a startup script via:
       - $(spack.install_spack_runner)
 ```
 
-[spack-gromacs.yaml]: ../../../examples/spack-gromacs.yaml
+[hpc-slurm-gromacs.yaml]: ../../../examples/hpc-slurm-gromacs.yaml
 
 ## Environment Setup
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,13 +19,13 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [lustre.yaml](#lustreyaml-) ![core-badge]
   * [slurm-gcp-v5-ubuntu2004.yaml](#slurm-gcp-v5-ubuntu2004yaml-) ![community-badge]
   * [slurm-gcp-v5-high-io.yaml](#slurm-gcp-v5-high-ioyaml-) ![community-badge]
-  * [hpc-cluster-intel-select.yaml](#hpc-cluster-intel-selectyaml-) ![community-badge]
+  * [hpc-intel-select-slurm.yaml](#hpc-intel-select-slurmyaml-) ![community-badge]
   * [pfs-daos.yaml](#pfs-daosyaml-) ![community-badge]
-  * [daos-slurm.yaml](#daos-slurmyaml-) ![community-badge]
-  * [hpc-cluster-amd-slurmv5.yaml](#hpc-cluster-amd-slurmv5yaml-) ![community-badge]
+  * [hpc-slurm-daos.yaml](#hpc-slurm-daosyaml-) ![community-badge]
+  * [hpc-amd-slurm.yaml](#hpc-amd-slurmyaml-) ![community-badge]
   * [quantum-circuit-simulator.yaml](#quantum-circuit-simulatoryaml-) ![community-badge]
   * [client-google-cloud-storage.yaml](#client-google-cloud-storageyaml--) ![community-badge] ![experimental-badge]
-  * [spack-gromacs.yaml](#spack-gromacsyaml--) ![community-badge] ![experimental-badge]
+  * [hpc-slurm-gromacs.yaml](#hpc-slurm-gromacsyaml--) ![community-badge] ![experimental-badge]
   * [omnia-cluster.yaml](#omnia-clusteryaml--) ![community-badge] ![experimental-badge]
   * [hpc-cluster-small-sharedvpc.yaml](#hpc-cluster-small-sharedvpcyaml--) ![community-badge] ![experimental-badge]
   * [hpc-cluster-localssd.yaml](#hpc-cluster-localssdyaml--) ![community-badge] ![experimental-badge]
@@ -576,14 +576,14 @@ For this example the following is needed in the selected region:
 * Compute Engine API: Resource policies: **one for each job in parallel** -
   _only needed for `compute` partition_
 
-### [hpc-cluster-intel-select.yaml] ![community-badge]
+### [hpc-intel-select-slurm.yaml] ![community-badge]
 
 This example provisions a Slurm cluster automating the [steps to comply to the
 Intel Select Solutions for Simulation & Modeling Criteria][intelselect]. It is
 more extensively discussed in a dedicated [README for Intel
 examples][intel-examples-readme].
 
-[hpc-cluster-intel-select.yaml]: ../community/examples/intel/hpc-cluster-intel-select.yaml
+[hpc-intel-select-slurm.yaml]: ../community/examples/intel/hpc-intel-select-slurm.yaml
 [intel-examples-readme]: ../community/examples/intel/README.md
 [intelselect]: https://cloud.google.com/compute/docs/instances/create-intel-select-solution-hpc-clusters
 
@@ -595,15 +595,15 @@ examples][intel-examples-readme].
 [pfs-daos.yaml]: ../community/examples/intel/pfs-daos.yaml
 [migs]: https://cloud.google.com/compute/docs/instance-groups
 
-### [daos-slurm.yaml] ![community-badge]
+### [hpc-slurm-daos.yaml] ![community-badge]
 
 This example provisions DAOS servers and a Slurm cluster. It is
 more extensively discussed in a dedicated [README for Intel
 examples][intel-examples-readme].
 
-[daos-slurm.yaml]: ../community/examples/intel/daos-slurm.yaml
+[hpc-slurm-daos.yaml]: ../community/examples/intel/hpc-slurm-daos.yaml
 
-### [hpc-cluster-amd-slurmv5.yaml] ![community-badge]
+### [hpc-amd-slurm.yaml] ![community-badge]
 
 This example provisions a Slurm cluster using AMD VM machine types. It
 automates the initial setup of Spack, including a script that can be used to
@@ -611,7 +611,7 @@ install the AMD Optimizing C/C++ Compiler ([AOCC]) and compile OpenMPI with
 AOCC. It is more extensively discussed in a dedicated [README for AMD
 examples][amd-examples-readme].
 
-[hpc-cluster-amd-slurmv5.yaml]: ../community/examples/AMD/hpc-cluster-amd-slurmv5.yaml
+[hpc-amd-slurm.yaml]: ../community/examples/AMD/hpc-amd-slurm.yaml
 [AOCC]: https://developer.amd.com/amd-aocc/
 [amd-examples-readme]: ../community/examples/AMD/README.md
 
@@ -685,7 +685,7 @@ and then installs ramble using the
 
 [ramble.yaml]: ../community/examples/ramble.yaml
 
-### [spack-gromacs.yaml] ![community-badge] ![experimental-badge]
+### [hpc-slurm-gromacs.yaml] ![community-badge] ![experimental-badge]
 
 Spack is an HPC software package manager. This example creates a small Slurm
 cluster with software installed using the
@@ -731,7 +731,7 @@ spack load gromacs
 > hours to run on startup. To decrease this time in future deployments, consider
 > including a spack build cache as described in the comments of the example.
 
-[spack-gromacs.yaml]: ../community/examples/spack-gromacs.yaml
+[hpc-slurm-gromacs.yaml]: ../community/examples/hpc-slurm-gromacs.yaml
 
 ### [omnia-cluster.yaml] ![community-badge] ![experimental-badge]
 

--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -47,7 +47,7 @@ Please review the [examples README] for usage instructions.
 
 ### Intel-Optimized Slurm Cluster
 
-The [Intel-Optimized] Slurm Cluster [blueprint](../../../community/examples/intel/hpc-cluster-intel-select.yaml)
+The [Intel-Optimized] Slurm Cluster [blueprint](../../../community/examples/intel/hpc-intel-select-slurm.yaml)
 adds the Intel compliance software on top of a Slurm on GCP image.
 
 [Image Builder]: ../../../examples/image-builder.yaml

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -53,7 +53,7 @@ steps:
     set -x -e
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
-    SG_EXAMPLE=community/examples/spack-gromacs.yaml
+    SG_EXAMPLE=community/examples/hpc-slurm-gromacs.yaml
 
     sed -i "s/# spack_cache_url:/spack_cache_url:/" $${SG_EXAMPLE}
     sed -i "s/# - mirror_name: gcs_cache/- mirror_name: gcs_cache/" $${SG_EXAMPLE}

--- a/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
+++ b/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
@@ -18,7 +18,7 @@ test_name: spack-gromacs
 deployment_name: "spack-gromacs-{{ build }}"
 zone: us-central1-c
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/community/examples/spack-gromacs.yaml"
+blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-gromacs.yaml"
 network: "default"
 max_nodes: 5
 login_node: slurm-{{ deployment_name }}-login0


### PR DESCRIPTION
Just renaming and docs updates, no other changes
* `hpc-cluster-amd-slurmv5.yaml` -> `hpc-amd-slurm.yaml`;
* `spack-gromacs.yaml` -> `hpc-slurm-gromacs.yaml`;
* `hpc-cluster-intel-select.yaml` -> `hpc-intel-select-slurm.yaml`;
* `daos-slurm.yaml` -> `hpc-slurm-daos.yaml`.
