### PR TITLE
Rename example blueprints

### DIFF
--- a/community/examples/hpc-gke.yaml
+++ b/community/examples/hpc-gke.yaml
@@ -14,7 +14,7 @@
 
 ---
 
-blueprint_name: small-gke
+blueprint_name: hpc-gke
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/community/examples/hpc-slurm-local-ssd.yaml
+++ b/community/examples/hpc-slurm-local-ssd.yaml
@@ -14,7 +14,7 @@
 
 ---
 
-blueprint_name: hpc-cluster-localssd
+blueprint_name: hpc-slurm-local-ssd
 
 vars:
   project_id: ## Set GCP Project ID Here ##

--- a/community/examples/tutorial-fluent.yaml
+++ b/community/examples/tutorial-fluent.yaml
@@ -14,7 +14,7 @@
 
 ---
 
-blueprint_name: ansys-fluent
+blueprint_name: tutorial-fluent
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/community/examples/tutorial-starccm.yaml
+++ b/community/examples/tutorial-starccm.yaml
@@ -14,7 +14,7 @@
 
 ---
 
-blueprint_name: starccm
+blueprint_name: tutorial-starccm
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -26,7 +26,7 @@ The following example creates a GKE job template file.
     outputs: [instructions]
 ```
 
-Also see a full [GKE example blueprint](../../../examples/gke.yaml).
+Also see a full [GKE example blueprint](../../../examples/hpc-gke.yaml).
 
 ### Requested Resources
 

--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -17,7 +17,7 @@ The following example creates a GKE node group.
     use: [gke_cluster]
 ```
 
-Also see a full [GKE example blueprint](../../../examples/gke.yaml).
+Also see a full [GKE example blueprint](../../../examples/hpc-gke.yaml).
 
 ### Taints and Tolerations
 

--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -30,7 +30,7 @@ requirements.
     use: [network1]
 ```
 
-Also see a full [GKE example blueprint](../../../examples/gke.yaml).
+Also see a full [GKE example blueprint](../../../examples/hpc-gke.yaml).
 
 ### VPC Network
 

--- a/docs/cloud-batch.md
+++ b/docs/cloud-batch.md
@@ -25,9 +25,9 @@ contained in the `community` folder of the HPC Toolkit repo and are marked as
 
 ## Example
 
-[cloud-batch.yaml](../examples/cloud-batch.yaml) contains an example
+[serverless-batch.yaml](../examples/serverless-batch.yaml) contains an example
 of how to use Google Cloud Batch with the HPC Toolkit
-([example documentation](../examples/README.md#cloud-batchyaml--)).
+([example documentation](../examples/README.md#serverless-batchyaml--)).
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,8 +14,8 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [hpc-slurm.yaml](#hpc-slurmyaml-) ![core-badge]
   * [hpc-cluster-high-io.yaml](#hpc-cluster-high-ioyaml-) ![core-badge]
   * [image-builder.yaml](#image-builderyaml-) ![core-badge]
-  * [cloud-batch.yaml](#cloud-batchyaml-) ![core-badge]
-  * [batch-mpi.yaml](#batch-mpiyaml-) ![core-badge]
+  * [serverless-batch.yaml](#serverless-batchyaml-) ![core-badge]
+  * [serverless-batch-mpi.yaml](#serverless-batch-mpiyaml-) ![core-badge]
   * [pfs-lustre.yaml](#pfs-lustreyaml-) ![core-badge]
   * [slurm-gcp-v5-ubuntu2004.yaml](#slurm-gcp-v5-ubuntu2004yaml-) ![community-badge]
   * [slurm-gcp-v5-high-io.yaml](#slurm-gcp-v5-high-ioyaml-) ![community-badge]
@@ -28,12 +28,12 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [hpc-slurm-gromacs.yaml](#hpc-slurm-gromacsyaml--) ![community-badge] ![experimental-badge]
   * [omnia-cluster.yaml](#omnia-clusteryaml--) ![community-badge] ![experimental-badge]
   * [hpc-cluster-small-sharedvpc.yaml](#hpc-cluster-small-sharedvpcyaml--) ![community-badge] ![experimental-badge]
-  * [hpc-cluster-localssd.yaml](#hpc-cluster-localssdyaml--) ![community-badge] ![experimental-badge]
+  * [hpc-slurm-local-ssd.yaml](#hpc-slurm-local-ssdyaml--) ![community-badge] ![experimental-badge]
   * [hpc-htcondor.yaml](#hpc-htcondoryaml--) ![community-badge] ![experimental-badge]
-  * [gke.yaml](#gkeyaml--) ![community-badge] ![experimental-badge]
+  * [hpc-gke.yaml](#hpc-gkeyaml--) ![community-badge] ![experimental-badge]
   * [ml-gke](#mlgkeyaml--) ![community-badge] ![experimental-badge]
-  * [starccm-tutorial.yaml](#starccm-tutorialyaml--) ![community-badge] ![experimental-badge]
-  * [fluent-tutorial.yaml](#fluent-tutorialyaml--) ![community-badge] ![experimental-badge]
+  * [tutorial-starccm.yaml](#tutorial-starccmyaml--) ![community-badge] ![experimental-badge]
+  * [tutorial-fluent.yaml](#tutorial-fluentyaml--) ![community-badge] ![experimental-badge]
 * [Blueprint Schema](#blueprint-schema)
 * [Writing an HPC Blueprint](#writing-an-hpc-blueprint)
   * [Blueprint Boilerplate](#blueprint-boilerplate)
@@ -328,7 +328,7 @@ For this example the following is needed in the selected region:
 * Compute Engine API: Resource policies: **one for each job in parallel** -
   _only needed for `compute` partition_
 
-### [cloud-batch.yaml] ![core-badge]
+### [serverless-batch.yaml] ![core-badge]
 
 This example demonstrates how to use the HPC Toolkit to set up a Google Cloud Batch job
 that mounts a Filestore instance and runs startup scripts.
@@ -340,9 +340,9 @@ renders a Google Cloud Batch job template. A login node VM is created with
 instructions on how to SSH to the login node and submit the Google Cloud Batch
 job.
 
-[cloud-batch.yaml]: ../examples/cloud-batch.yaml
+[serverless-batch.yaml]: ../examples/serverless-batch.yaml
 
-### [batch-mpi.yaml] ![core-badge]
+### [serverless-batch-mpi.yaml] ![core-badge]
 
 This blueprint demonstrates how to use Spack to run a real MPI job on Batch.
 
@@ -396,7 +396,7 @@ The blueprint contains the following:
     job has finished this folder will contain the results of the job. You can
     inspect the `rsl.out.0000` file for a summary of the job.
 
-[batch-mpi.yaml]: ../examples/batch-mpi.yaml
+[serverless-batch-mpi.yaml]: ../examples/serverless-batch-mpi.yaml
 
 ### [pfs-lustre.yaml] ![core-badge]
 
@@ -760,7 +760,7 @@ a Shared VPC service project][fs-shared-vpc].
 [hpc-cluster-small-sharedvpc.yaml]: ../community/examples/hpc-cluster-small-sharedvpc.yaml
 [fs-shared-vpc]: https://cloud.google.com/filestore/docs/shared-vpc
 
-### [hpc-cluster-localssd.yaml] ![community-badge] ![experimental-badge]
+### [hpc-slurm-local-ssd.yaml] ![community-badge] ![experimental-badge]
 
 This blueprint demonstrates the use of Slurm and Filestore, with the definition
 of a partition which deploys compute nodes that have local ssd drives deployed.
@@ -769,7 +769,7 @@ properly configured (allowing Internet access and allowing inter virtual
 machine communications, for NFS and also for communications between the Slurm
 nodes)
 
-[hpc-cluster-localssd.yaml]: ../community/examples/hpc-cluster-localssd.yaml
+[hpc-slurm-local-ssd.yaml]: ../community/examples/hpc-slurm-local-ssd.yaml
 
 ### [hpc-htcondor.yaml] ![community-badge] ![experimental-badge]
 
@@ -783,7 +783,7 @@ walks through the use of this blueprint.
 [hpc-htcondor.yaml]: ../community/examples/hpc-htcondor.yaml
 [hpcvmimage]: https://cloud.google.com/compute/docs/instances/create-hpc-vm
 
-### [gke.yaml] ![community-badge] ![experimental-badge]
+### [hpc-gke.yaml] ![community-badge] ![experimental-badge]
 
 This blueprint uses GKE to provision a Kubernetes cluster with a system node
 pool (included in gke-cluster module) and an autoscaling compute node pool. It
@@ -793,7 +793,7 @@ secondary IP ranges defined.
 The `gke-job-template` module is used to create a job file that can be submitted
 to the cluster using `kubectl` and will run on the specified node pool.
 
-[gke.yaml]: ../community/examples/gke.yaml
+[hpc-gke.yaml]: ../community/examples/hpc-gke.yaml
 
 ### [ml-gke.yaml] ![community-badge] ![experimental-badge]
 
@@ -826,23 +826,23 @@ credentials for the created cluster_ and _submit a job calling `nvidia_smi`_.
 [ml-gke.yaml]: ../community/examples/ml-gke.yaml
 [`kubernetes-operations`]: ../community/modules/scripts/kubernetes-operations/README.md
 
-### [starccm-tutorial.yaml] ![community-badge] ![experimental-badge]
+### [tutorial-starccm.yaml] ![community-badge] ![experimental-badge]
 
 This blueprint provisions a simple cluster for use with a Simcenter StarCCM+
 tutorial.
 
 > The main tutorial is described on the [HPC Toolkit website](https://cloud.google.com/hpc-toolkit/docs/simcenter-star-ccm/run-workload).
 
-[starccm-tutorial.yaml]: ../community/examples/starccm-tutorial.yaml
+[tutorial-starccm.yaml]: ../community/examples/tutorial-starccm.yaml
 
-### [fluent-tutorial.yaml] ![community-badge] ![experimental-badge]
+### [tutorial-fluent.yaml] ![community-badge] ![experimental-badge]
 
 This blueprint provisions a simple cluster for use with an Ansys Fluent
 tutorial.
 
 > The main tutorial is described on the [HPC Toolkit website](https://cloud.google.com/hpc-toolkit/docs/tutorials/ansys-fluent).
 
-[fluent-tutorial.yaml]: ../community/examples/fluent-tutorial.yaml
+[tutorial-fluent.yaml]: ../community/examples/tutorial-fluent.yaml
 
 ## Blueprint Schema
 

--- a/examples/serverless-batch-mpi.yaml
+++ b/examples/serverless-batch-mpi.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 
-blueprint_name: batch-wrf-mpi
+blueprint_name: serverless-batch-mpi
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/examples/serverless-batch.yaml
+++ b/examples/serverless-batch.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-blueprint_name: cloud-batch
+blueprint_name: serverless-batch
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -32,7 +32,7 @@ user will modify the template after running the HPC Toolkit.
 ```
 
 See the
-[Google Cloud Batch Example](../../../../examples/README.md#cloud-batchyaml--)
+[Google Cloud Batch Example](../../../../examples/README.md#serverless-batchyaml--)
 for how to use the `batch-job-template` module with other HPC Toolkit modules such
 as `filestore` and `startup-script`.
 

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -54,7 +54,7 @@ steps:
     set -x -e
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
-    SG_EXAMPLE=examples/batch-mpi.yaml
+    SG_EXAMPLE=examples/serverless-batch-mpi.yaml
 
     sed -i "s/# spack_cache_url:/spack_cache_url:/" $${SG_EXAMPLE}
     sed -i "s/# - mirror_name: gcs_cache/- mirror_name: gcs_cache/" $${SG_EXAMPLE}

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -49,7 +49,7 @@ steps:
     set -x -e
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
-    SG_EXAMPLE=community/examples/gke.yaml
+    SG_EXAMPLE=community/examples/hpc-gke.yaml
 
     # adding vm to act as remote node
     echo '  - id: remote-node'                     >> $${SG_EXAMPLE}

--- a/tools/cloud-build/daily-tests/tests/batch-mpi.yml
+++ b/tools/cloud-build/daily-tests/tests/batch-mpi.yml
@@ -16,7 +16,7 @@ test_name: batch-mpi
 deployment_name: batch-mpi-{{ build }}
 zone: us-central1-c
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/examples/batch-mpi.yaml"
+blueprint_yaml: "{{ workspace }}/examples/serverless-batch-mpi.yaml"
 network: "default"
 remote_node: "{{ deployment_name }}-batch-login"
 post_deploy_tests:

--- a/tools/cloud-build/daily-tests/tests/cloud-batch.yml
+++ b/tools/cloud-build/daily-tests/tests/cloud-batch.yml
@@ -16,7 +16,7 @@ test_name: cloud-batch
 deployment_name: cloud-batch-{{ build }}
 zone: us-central1-c
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/examples/cloud-batch.yaml"
+blueprint_yaml: "{{ workspace }}/examples/serverless-batch.yaml"
 network: "default"
 remote_node: "{{ deployment_name }}-batch-login"
 post_deploy_tests:

--- a/tools/cloud-build/daily-tests/tests/gke.yml
+++ b/tools/cloud-build/daily-tests/tests/gke.yml
@@ -16,7 +16,7 @@ test_name: gke
 deployment_name: gke-{{ build }}
 zone: us-central1-a  # for remote node
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/community/examples/gke.yaml"
+blueprint_yaml: "{{ workspace }}/community/examples/hpc-gke.yaml"
 network: "{{ deployment_name }}-net"
 remote_node: "{{ deployment_name }}-0"
 post_deploy_tests: []


### PR DESCRIPTION
No changes, other than renaming and docs update
* `gke` -> `hpc-gke`;
* `hpc-cluster-localssd` -> `hpc-slurm-local-ssd`;
* `fluent-tutorial` -> `tutorial-fluent`;
* `starccm-tutorial` -> `tutorial-starccm`;
* `batch-mpi` -> `serverless-batch-mpi`;
* `cloud-batch` -> `serverless-batch`.