### PR TITLE
Add pre-commit to check for ghpc_module label

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,14 @@ repos:
     files: '.*(\.sh|\.tf)$'
     pass_filenames: true
     require_serial: true
+  - id: module-label-check
+    name: module-label-check
+    entry: python3 tools/label-check.py
+    language: python
+    language_version: python3
+    files: '.*\.tf$'
+    pass_filenames: false
+    require_serial: true
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1
   hooks:

--- a/tools/label-check.py
+++ b/tools/label-check.py
@@ -1,0 +1,182 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import glob
+import sys
+
+
+LOCALS_TEMPLATE = '''
+locals {{
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, {{ ghpc_module = \"{module_label}\" }})
+}}
+'''
+
+
+class ModulePath:
+    """Convenience class to get various path related information about a module"""
+    MAIN_FILENAME = "main.tf"
+    VARS_FILENAME = "variables.tf"
+    VERSIONS_FILENAME = "versions.tf"
+    OUTPUT_FILENAME = "outputs.tf"
+
+    def __init__(self, module_path: str):
+        self.module_path = module_path
+
+    def has_main(self) -> str:
+        return os.path.isfile(os.path.join(self.module_path, self.MAIN_FILENAME))
+
+    def has_vars(self) -> str:
+        return os.path.isfile(os.path.join(self.module_path, self.VARS_FILENAME))
+
+    def has_outputs(self) -> str:
+        return os.path.isfile(os.path.join(self.module_path, self.OUTPUT_FILENAME))
+
+    def main(self) -> str:
+        return self._filepath(self.MAIN_FILENAME)
+
+    def vars(self) -> str:
+        return self._filepath(self.VARS_FILENAME)
+
+    def versions(self) -> str:
+        return self._filepath(self.VERSIONS_FILENAME)
+
+    def outputs(self) -> str:
+        return self._filepath(self.OUTPUT_FILENAME)
+
+    def primary_file(self) -> str:
+        """The file that should contain the labels definition"""
+        return self.main() if self.has_main() else self.outputs()
+
+    def name(self) -> str:
+        return os.path.basename(self.module_path)
+
+    def name_label(self) -> str:
+        return self.name().lower()
+
+    def _filepath(self, name: str) -> str:
+        return os.path.join(self.module_path, name)
+
+
+def get_module_paths(root_dir="./") -> list[str]:
+    community_modules_glob = os.path.join(
+        root_dir, "community/modules", "*", "*")
+    community_modules = glob.glob(community_modules_glob)
+    core_modules_glob = os.path.join(root_dir, "modules", "*", "*")
+    core_modules = glob.glob(core_modules_glob)
+    return community_modules + core_modules
+
+
+def has_labels_variable(module_path: ModulePath) -> bool:
+    if not module_path.has_vars():
+        return False
+    with open(module_path.vars()) as var_file:
+        return 'variable "labels"' in var_file.read()
+
+
+def check_for_labels_local_block(module_path: ModulePath) -> bool:
+    check_string = LOCALS_TEMPLATE.format(
+        module_label=module_path.name_label())
+    file_to_check = module_path.primary_file()
+    with open(file_to_check) as file:
+        return check_string in file.read()
+
+
+def add_labels_local_block(module_path: ModulePath):
+    file_to_write = module_path.primary_file()
+    with open(file_to_write, 'r') as main_file:
+        insert_at = -1
+        lines = main_file.readlines()
+        for num, line in enumerate(lines):
+            if '*/' in line:
+                insert_at = num + 1
+                break
+        if insert_at < 0:
+            print('Could not find "*/" in {}'.format(file_to_write))
+            sys.exit(1)
+
+    lines.insert(insert_at, LOCALS_TEMPLATE.format(
+        module_label=module_path.name_label()))
+
+    with open(file_to_write, 'w') as main_file:
+        main_file.writelines(lines)
+
+
+def check_label_usage(module_path: ModulePath) -> bool:
+    passed = True
+    with open(module_path.primary_file()) as file:
+        if file.read().count('var.labels') > 1:  # there will be one reference in local block
+            print("{} contains references to var.labels instead of local.labels".format(
+                module_path.primary_file()))
+            passed = False
+
+    if module_path.primary_file() != module_path.outputs() and module_path.has_outputs():
+        with open(module_path.outputs()) as outputs:
+            if outputs.read().count('var.labels') > 0:
+                print("{} contains references to var.labels instead of local.labels".format(
+                    module_path.outputs()))
+                passed = False
+    return passed
+
+
+def check_provider_meta(module_path: ModulePath) -> bool:
+    """This is enforcing that the provider meta name matches the module name"""
+    version_file_path = module_path.versions()
+    module_name = module_path.name()
+    with open(version_file_path) as version_file:
+        s = version_file.read()
+        if s.count('provider_meta "google') == s.count(
+                'blueprints/terraform/hpc-toolkit:{}'.format(module_name)):
+            return True
+        else:
+            print('{} provider meta does not match module name'.format(
+                version_file_path))
+            return False
+
+
+def check_module(module_path: ModulePath) -> bool:
+    passed = True
+    if not has_labels_variable(module_path):
+        return passed
+    if not check_for_labels_local_block(module_path):
+        passed = False
+        add_labels_local_block(module_path)
+    passed = check_label_usage(module_path) and passed
+    return check_provider_meta(module_path) and passed
+
+
+def main() -> bool:
+    """Performs some basic checks on all modules.
+
+    This function will check that every module with a var.labels is merging in a
+    `ghpc_module` label. If missing, the locals block will be added. It will
+    check that all other references to labels points to the merged local.labels.
+    
+    This function also checks that the provider meta name matches the module
+    name
+    
+    Returns: True if checks passed
+    """
+
+    module_paths = get_module_paths()
+    passed = True
+    for module_path in module_paths:
+        passed = check_module(ModulePath(module_path)) and passed
+    return passed
+
+
+if __name__ == "__main__":
+    if not main():
+        sys.exit(1)


### PR DESCRIPTION
This change:
- Adds a stand alone python tool to validate consistency of `ghpc_module` label that can be used for billing filtering
- Adds a check that provider-meta block is consistent with module naming
- Adds pre-commit to run the above check

```
$ time python3 tools/label-check.py
real    0m0.072s
user    0m0.052s
sys     0m0.026s
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
