### PR TITLE
DAOSGCP-175 Updates for google-cloud-daos v0.4.0

### DIFF
--- a/community/examples/intel/README.md
+++ b/community/examples/intel/README.md
@@ -501,13 +501,10 @@ You will need to create your own DAOS container in the pool that can be used by 
 While logged into the login node create a container named `cont1` in the `pool1` pool:
 
 ```bash
-daos cont create pool1 \
-  --label cont1 \
-  --type POSIX \
-  --properties rf:0
+daos cont create --type=POSIX --properties=rf:0 --label=cont1 pool1
 ```
 
-The `cont1` container is owned by your account and therefore your Slurm jobs will need to run with your user account in order to access the container.
+Since the `cont1` container is owned by your account, your Slurm jobs will need to run as your user account in order to access the container.
 
 Create a mount point for the container and mount it with dfuse (DAOS Fuse)
 
@@ -612,5 +609,5 @@ have been shutdown and deleted by the Slurm autoscaler. Delete the remaining
 infrastructure with `terraform`:
 
 ```shell
-terraform -chdir=pfs-daos/primary destroy
+terraform -chdir=daos-slurm/primary destroy
 ```

--- a/community/examples/intel/hpc-slurm-daos.yaml
+++ b/community/examples/intel/hpc-slurm-daos.yaml
@@ -41,7 +41,7 @@ deployment_groups:
   # https://github.com/daos-stack/google-cloud-daos/tree/main/images
   # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server
   - id: daos
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.3.0
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.4.0
     use: [network1]
     settings:
       labels: {ghpc_role: file-system}

--- a/community/examples/intel/pfs-daos.yaml
+++ b/community/examples/intel/pfs-daos.yaml
@@ -35,17 +35,17 @@ deployment_groups:
   # https://github.com/daos-stack/google-cloud-daos/tree/main/images
   # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server
   - id: daos-server
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.3.0
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.4.0
     use: [network1]
     settings:
       number_of_instances: 2
       labels: {ghpc_role: file-system}
 
-  # This module creates a MIG with DAOS clients. Client images MUST be created before running this.
+  # This module creates DAOS clients. Client images MUST be created before running this.
   # https://github.com/daos-stack/google-cloud-daos/tree/main/images
   # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_client
   - id: daos-client
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_client?ref=v0.3.0
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_client?ref=v0.4.0
     use: [network1, daos-server]
     settings:
       number_of_instances: 2


### PR DESCRIPTION
The google-cloud-daos repository which contains the DAOS Server and Client terraform modules has been tagged v0.4.0. The new version now uses the Google HPC Rocky Linux 8 image by default.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
