### PR TITLE
Eliminate need to activate virtual environment to run Ansible

### DIFF
--- a/community/modules/scripts/ramble-setup/templates/install_ramble_deps.yml
+++ b/community/modules/scripts/ramble-setup/templates/install_ramble_deps.yml
@@ -24,16 +24,9 @@
       - python3-pip
       - git
 
-  - name: Gather the package facts
-    ansible.builtin.package_facts:
-      manager: auto
-
-  - name: Install protobuf for old releases of Python
-    when: ansible_facts.packages["python3"][0].version is version("3.7", "<") and ansible_facts.packages["python3"][0].version is version("3.5", ">=")
+  - name: Ensure a recent copy of pip
     ansible.builtin.pip:
-      name: protobuf
-      version: 3.19.4
-      executable: pip3
+      name: pip>=21.3.1
 
   - name: Download ramble requirements file
     ansible.builtin.get_url:

--- a/community/modules/scripts/spack-install/templates/install_spack.tpl
+++ b/community/modules/scripts/spack-install/templates/install_spack.tpl
@@ -12,6 +12,18 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
+# create an /etc/profile.d file that sources the Spack environment; it safely
+# skips sourcing when Spack has not yet been installed
+if [ ! -f /etc/profile.d/spack.sh ]; then
+        cat <<EOF > /etc/profile.d/spack.sh
+SPACK_PYTHON=${SPACK_PYTHON_VENV}/bin/python3
+if [ -f ${INSTALL_DIR}/share/spack/setup-env.sh ]; then
+        . ${INSTALL_DIR}/share/spack/setup-env.sh
+fi
+EOF
+        chmod 0644 /etc/profile.d/spack.sh
+fi
+
 # Only install and configure spack if ${INSTALL_DIR} doesn't exist
 if [ ! -d ${INSTALL_DIR} ]; then
 
@@ -151,15 +163,5 @@ echo "$PREFIX Populating defined buildcaches"
     } >> ${LOG_FILE}
   %{endif ~}
 %{endfor ~}
-
-if [ ! -f /etc/profile.d/spack.sh ]; then
-        cat <<EOF > /etc/profile.d/spack.sh
-SPACK_PYTHON=${SPACK_PYTHON_VENV}/bin/python3
-if [ -f ${INSTALL_DIR}/share/spack/setup-env.sh ]; then
-        . ${INSTALL_DIR}/share/spack/setup-env.sh
-fi
-EOF
-        chmod 0644 /etc/profile.d/spack.sh
-fi
 
 echo "$PREFIX Setup complete..."

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -229,6 +229,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_ansible_virtualenv_path"></a> [ansible\_virtualenv\_path](#input\_ansible\_virtualenv\_path) | Virtual environment path in which to install Ansible | `string` | `"/usr/local/ghpc-venv"` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |
 | <a name="input_gcs_bucket_path"></a> [gcs\_bucket\_path](#input\_gcs\_bucket\_path) | The GCS path for storage bucket and the object. | `string` | `null` | no |

--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -15,7 +15,7 @@
 
 REQ_ANSIBLE_VERSION=2.11
 REQ_ANSIBLE_PIP_VERSION=4.10.0
-REQ_PIP_MINOR_VERSION=18
+REQ_PIP_MAJOR_VERSION=21
 REQ_PYTHON3_VERSION=6
 
 apt_wait() {
@@ -165,7 +165,7 @@ main() {
 	fi
 	pip_version=$(${python_path} -m pip --version | sed -nr 's/^pip ([0-9]+\.[0-9]+).*$/\1/p')
 	pip_major_version=$(echo "${pip_version}" | cut -d '.' -f 1)
-	if [ "${pip_major_version}" -lt "${REQ_PIP_MINOR_VERSION}" ]; then
+	if [ "${pip_major_version}" -lt "${REQ_PIP_MAJOR_VERSION}" ]; then
 		${python_path} -m pip install --upgrade pip
 	fi
 

--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -47,10 +47,10 @@ install_python_deps() {
 # checking python. Sets the variable to an empty string if neither are found.
 get_python_path() {
 	python_path=""
-	if which python3 2>/dev/null; then
-		python_path=$(which python3 2>/dev/null)
-	elif which python 2>/dev/null; then
-		python_path=$(which python 2>/dev/null)
+	if command -v python3 1>/dev/null; then
+		python_path=$(command -v python3)
+	elif command -v python 1>/dev/null; then
+		python_path=$(command -v python)
 	fi
 }
 
@@ -81,7 +81,7 @@ install_python3_yum() {
 		echo "Unsupported version of centos/RHEL/Rocky"
 		return 1
 	fi
-	yum install --disablerepo="*" --enablerepo=${enable_repo} -y python3 python3-pip
+	yum install --disablerepo="*" --enablerepo="${enable_repo}" -y python3 python3-pip
 	python_path=$(rpm -ql python3 | grep 'bin/python3$')
 }
 
@@ -90,7 +90,7 @@ install_python3_yum() {
 install_python3_apt() {
 	apt_wait
 	apt-get install -y python3 python3-distutils python3-pip
-	python_path=$(which python3)
+	python_path=$(command -v python3)
 }
 
 install_python3() {
@@ -119,7 +119,7 @@ install_pip3_yum() {
 		echo "Unsupported version of centos/RHEL/Rocky"
 		return 1
 	fi
-	yum install --disablerepo="*" --enablerepo=${enable_repo} -y python3-pip
+	yum install --disablerepo="*" --enablerepo="${enable_repo}" -y python3-pip
 }
 
 # Install python3 with the apt package manager. Updates python_path to the
@@ -194,7 +194,7 @@ main() {
 
 	# Install ansible
 	ansible_version=""
-	if which ansible-playbook 2>/dev/null; then
+	if command -v ansible-playbook 1>/dev/null; then
 		ansible_version=$(ansible-playbook --version 2>/dev/null | sed -nr 's/^ansible-playbook.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
 		ansible_major_vers=$(echo "${ansible_version}" | cut -d '.' -f 1)
 		ansible_minor_vers=$(echo "${ansible_version}" | cut -d '.' -f 2)

--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -143,6 +143,13 @@ install_pip3() {
 }
 
 main() {
+	if [ $# -gt 1 ]; then
+		echo "Error: provide only 1 optional argument identifying virtual environment path for Ansible"
+		return 1
+	fi
+
+	venv_path="${1:-/usr/local/ghpc-venv}"
+
 	# Get the python3 executable, or install it if not found
 	get_python_path
 	get_python_major_version "${python_path}"
@@ -171,13 +178,10 @@ main() {
 
 	# Create pip virtual environment for HPC Toolkit
 	${python_path} -m pip install virtualenv
-	${python_path} -m virtualenv /usr/local/ghpc-venv
-	venv_python_path=/usr/local/ghpc-venv/bin/python3
+	${python_path} -m virtualenv "${venv_path}"
+	venv_python_path=${venv_path}/bin/python3
 
-	# when Ansible creates virtual environments, it defaults to virtualenv
-	# these steps install virtualenv in the Ansible virtual environment and
-	# ensures that it will be found
-	${venv_python_path} -m pip install virtualenv
+	# configure ansible to always use correct Python binary
 	if [ ! -f /etc/ansible/ansible.cfg ]; then
 		mkdir /etc/ansible
 		cat <<-EOF >/etc/ansible/ansible.cfg
@@ -199,8 +203,9 @@ main() {
 	fi
 	if [ -z "${ansible_version}" ] || [ "${ansible_major_vers}" -ne "${ansible_req_major_vers}" ] ||
 		[ "${ansible_minor_vers}" -lt "${ansible_req_minor_vers}" ]; then
-		${venv_python_path} -m pip install ansible==${REQ_ANSIBLE_PIP_VERSION}
+		${venv_python_path} -m pip install ansible=="${REQ_ANSIBLE_PIP_VERSION}"
 	fi
+	ln -s "${venv_path}/bin/ansible-playbook" /usr/bin/ansible-playbook
 }
 
-main
+main "$@"

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -32,6 +32,7 @@ locals {
     type        = "shell"
     source      = "${path.module}/files/install_ansible.sh"
     destination = "install_ansible_automatic.sh"
+    args        = var.ansible_virtualenv_path
   }] : []
 
   runners = concat(local.ops_agent_installer, local.ansible_installer, var.runners)

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -1,21 +1,13 @@
 
 
 stdlib::run_playbook() {
-  python_interpreter_flag=""
-  if [ -d /usr/local/ghpc-venv ]; then
-    . /usr/local/ghpc-venv/bin/activate
-    python_interpreter_flag="-e ansible_python_interpreter=/usr/local/ghpc-venv/bin/python3"
-  fi
   if [ ! "$(which ansible-playbook)" ]; then
     stdlib::error "ansible-playbook not found"\
     "Please install ansible before running ansible-local runners."
     exit 1
   fi
-  ansible-playbook $${python_interpreter_flag} --connection=local --inventory=localhost, --limit localhost $1 $2
+  ansible-playbook --connection=local --inventory=localhost, --limit localhost $1 $2
   ret_code=$?
-  if [ -d /usr/local/ghpc-venv ]; then
-    deactivate
-  fi
   return $${ret_code}
 }
 

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -122,5 +122,14 @@ variable "prepend_ansible_installer" {
     condition     = var.prepend_ansible_installer == null
     error_message = "The variable prepend_ansible_installer has been removed. Use install_ansible instead"
   }
+}
 
+variable "ansible_virtualenv_path" {
+  description = "Virtual environment path in which to install Ansible"
+  type        = string
+  default     = "/usr/local/ghpc-venv"
+  validation {
+    condition     = can(regex("^(/[\\w-]+)+$", var.ansible_virtualenv_path))
+    error_message = "var.ansible_virtualenv_path must be an absolute path to a directory without spaces or special characters"
+  }
 }

--- a/tools/validate_configs/test_configs/startup-options.yaml
+++ b/tools/validate_configs/test_configs/startup-options.yaml
@@ -31,6 +31,7 @@ deployment_groups:
   - id: startup
     source: ./modules/scripts/startup-script
     settings:
+      ansible_virtualenv_path: /usr/local/ghpc
       runners:
       - type: data
         source: /tmp/foo.tgz
@@ -42,6 +43,9 @@ deployment_groups:
           echo $2
           tar zxvf /tmp/$1 -C /
         args: "foo.tgz 'Expanding the file'"
+      - type: ansible-local
+        content: "--- {}"
+        destination: empty_tasks.yaml
 
   - id: instance-explicit-startup
     source: ./modules/compute/vm-instance


### PR DESCRIPTION
Combined with #1352, the impact of this PR is that the Ansible installation script will:

- install Python3 at the system level
- ensures that the copy of pip in system and in GHPC virtual environment is, at least, 21.3.1 (maximum allowed by Python 3.6)
- by default, when Ansible installs a pip package, it will use pip **from** the GHPC virtual environment, but the package will be installed system-wide (unless actively configured to install into a virtualenv)

Consequently, Ansible management of pip packages is predictable and intuitive.

If one uses the `community/examples/ramble.yaml` example, one can `pip list` a long list of packages installed for Ramble at the system level.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
