### PR TITLE
Disable release tests

### DIFF
--- a/tools/cloud-build/provision/release-tests.tf
+++ b/tools/cloud-build/provision/release-tests.tf
@@ -17,6 +17,7 @@ resource "google_cloudbuild_trigger" "release_test" {
   name        = "RELEASE-test-${each.key}"
   description = "Runs the '${each.key}' integration test against `release-candidate`"
   tags        = [local.notify_chat_tag]
+  disabled    = true
 
   git_file_source {
     path      = "tools/cloud-build/daily-tests/builds/${each.key}.yaml"


### PR DESCRIPTION
```shell
...
 # google_cloudbuild_trigger.release_test["spack-gromacs"] will be updated in-place
  ~ resource "google_cloudbuild_trigger" "release_test" {
      ~ disabled       = false -> true
        id             = "projects/hpc-toolkit-dev/triggers/e9cc5014-09e6-44be-8cc6-61cfa4df3bd8"
        name           = "RELEASE-test-spack-gromacs"
        tags           = [
            "notify_chat_on_failure",
        ]
        # (8 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 19 to change, 0 to destroy.
...
```