### PR TITLE
Ensure that all modules take labels if they create resources

### DIFF
--- a/community/modules/compute/gke-job-template/README.md
+++ b/community/modules/compute/gke-job-template/README.md
@@ -89,6 +89,7 @@ No modules.
 | <a name="input_command"></a> [command](#input\_command) | The command and arguments for the container that run in the Pod. The command field corresponds to entrypoint in some container runtimes. | `list(string)` | <pre>[<br>  "hostname"<br>]</pre> | no |
 | <a name="input_has_gpu"></a> [has\_gpu](#input\_has\_gpu) | Indicates that the job should request nodes with GPUs. Typically supplied by a gke-node-pool module. | `list(bool)` | <pre>[<br>  false<br>]</pre> | no |
 | <a name="input_image"></a> [image](#input\_image) | The container image the job should use. | `string` | `"debian"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the GKE job template. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_machine_family"></a> [machine\_family](#input\_machine\_family) | The machine family to use in the node selector (example: `n2`). If null then machine family will not be used as selector criteria. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the job. | `string` | `"my-job"` | no |
 | <a name="input_node_count"></a> [node\_count](#input\_node\_count) | How many nodes the job should run in parallel. | `number` | `1` | no |

--- a/community/modules/compute/gke-job-template/main.tf
+++ b/community/modules/compute/gke-job-template/main.tf
@@ -15,6 +15,11 @@
   */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "gke-job-template" })
+}
+
+locals {
   # Start with the minimum cpu available of used node pools
   min_allocatable_cpu = min(var.allocatable_cpu_per_node...)
   full_node_cpu_request = (
@@ -62,6 +67,7 @@ locals {
       restart_policy     = var.restart_policy
       backoff_limit      = var.backoff_limit
       tolerations        = distinct(var.tolerations)
+      labels             = local.labels
     }
   )
 

--- a/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
+++ b/community/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
@@ -3,6 +3,10 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ${name}${suffix}
+  labels:
+  %{~ for key, val in labels ~}
+    ${key}: ${val}
+  %{~ endfor ~}
 spec:
   parallelism: ${node_count}
   completions: ${node_count}

--- a/community/modules/compute/gke-job-template/variables.tf
+++ b/community/modules/compute/gke-job-template/variables.tf
@@ -112,3 +112,8 @@ variable "random_name_sufix" {
   type        = bool
   default     = true
 }
+
+variable "labels" {
+  description = "Labels to add to the GKE job template. Key-value pairs."
+  type        = map(string)
+}

--- a/community/modules/scripts/pbspro-preinstall/README.md
+++ b/community/modules/scripts/pbspro-preinstall/README.md
@@ -126,6 +126,7 @@ limitations under the License.
 | <a name="input_devel_rpm"></a> [devel\_rpm](#input\_devel\_rpm) | Absolute path to PBS Pro Development RPM file | `string` | n/a | yes |
 | <a name="input_execution_rpm"></a> [execution\_rpm](#input\_execution\_rpm) | Absolute path to PBS Pro Execution Host RPM file | `string` | n/a | yes |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Set to true if object versioning is enabled and you are certain that you want to destroy the bucket. | `bool` | `false` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the created bucket. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_license_file"></a> [license\_file](#input\_license\_file) | Path to PBS Pro license file | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | Google Cloud Storage bucket location (defaults to var.region if not set) | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which Google Cloud Storage bucket will be created | `string` | n/a | yes |

--- a/community/modules/scripts/pbspro-preinstall/main.tf
+++ b/community/modules/scripts/pbspro-preinstall/main.tf
@@ -15,6 +15,11 @@
  */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "pbspro-preinstall" })
+}
+
+locals {
   location = coalesce(var.location, var.region)
 
   bucket_name = "pbspro-packages"
@@ -49,6 +54,7 @@ module "pbspro_bucket" {
   prefix           = var.deployment_name
   names            = [local.bucket_name]
   randomize_suffix = true
+  labels           = local.labels
 
   bucket_viewers   = local.bucket_viewers
   set_viewer_roles = local.set_viewer_roles

--- a/community/modules/scripts/pbspro-preinstall/variables.tf
+++ b/community/modules/scripts/pbspro-preinstall/variables.tf
@@ -148,3 +148,8 @@ variable "bucket_viewers" {
     ])
   }
 }
+
+variable "labels" {
+  description = "Labels to add to the created bucket. Key-value pairs."
+  type        = map(string)
+}

--- a/modules/monitoring/dashboard/README.md
+++ b/modules/monitoring/dashboard/README.md
@@ -73,6 +73,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_base_dashboard"></a> [base\_dashboard](#input\_base\_dashboard) | Baseline dashboard template, select from HPC or Empty | `string` | `"HPC"` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the monitoring dashboard instance. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_title"></a> [title](#input\_title) | Title of the created dashboard | `string` | `"HPC Toolkit Dashboard"` | no |
 | <a name="input_widgets"></a> [widgets](#input\_widgets) | List of additional widgets to add to the base dashboard. | `list(string)` | `[]` | no |

--- a/modules/monitoring/dashboard/dashboards/HPC.json.tpl
+++ b/modules/monitoring/dashboard/dashboards/HPC.json.tpl
@@ -1,5 +1,6 @@
 {
   "displayName": "${title}: ${deployment_name}",
+  "labels": ${jsonencode(labels)},
   "gridLayout": {
     "columns": 2,
     "widgets": [

--- a/modules/monitoring/dashboard/main.tf
+++ b/modules/monitoring/dashboard/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "dashboard" })
+}
 
 locals {
   dash_path = "${path.module}/dashboards/${var.base_dashboard}.json.tpl"
@@ -24,6 +28,7 @@ resource "google_monitoring_dashboard" "dashboard" {
     widgets         = var.widgets
     deployment_name = var.deployment_name
     title           = var.title
+    labels          = local.labels
     }
   )
   project = var.project_id

--- a/modules/monitoring/dashboard/variables.tf
+++ b/modules/monitoring/dashboard/variables.tf
@@ -45,3 +45,8 @@ variable "widgets" {
   type        = list(string)
   default     = []
 }
+
+variable "labels" {
+  description = "Labels to add to the monitoring dashboard instance. Key-value pairs."
+  type        = map(string)
+}


### PR DESCRIPTION
A "labels" variable was added to the following modules:

- community/modules/compute/gke-job-template/variables.tf
- community/modules/scripts/pbspro-preinstall/variables.tf
- modules/monitoring/dashboard/variables.tf

The following modules do not create resources that take labels, and so a "labels" variable was not added:

- community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
- community/modules/project/service-account/variables.tf
- community/modules/project/service-enablement/variables.tf
- community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/variables.tf
- community/modules/scripts/htcondor-install/variables.tf
- community/modules/scripts/omnia-install/variables.tf
- community/modules/scripts/pbspro-install/variables.tf
- community/modules/scripts/pbspro-qmgr/variables.tf
- community/modules/scripts/spack-install/variables.tf
- community/modules/scripts/wait-for-startup/variables.tf
- modules/file-system/pre-existing-network-storage/variables.tf
- modules/network/pre-existing-vpc/variables.tf
- modules/network/vpc/variables.tf