### PR TITLE
Remove `modulereader.ModuleFS` use `sourcereader.ModuleFS` instead.

### DIFF
--- a/ghpc.go
+++ b/ghpc.go
@@ -18,7 +18,6 @@ package main
 import (
 	"embed"
 	"hpc-toolkit/cmd"
-	"hpc-toolkit/pkg/modulereader"
 	"hpc-toolkit/pkg/sourcereader"
 	"os"
 )
@@ -35,7 +34,6 @@ var gitInitialHash string
 
 func main() {
 	sourcereader.ModuleFS = moduleFS
-	modulereader.ModuleFS = moduleFS
 	cmd.GitTagVersion = gitTagVersion
 	cmd.GitBranch = gitBranch
 	cmd.GitCommitInfo = gitCommitInfo

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -36,10 +36,11 @@ func getHCLInfo(source string) (ModuleInfo, error) {
 	ret := ModuleInfo{}
 
 	if sourcereader.IsEmbeddedPath(source) {
-		if !tfconfig.IsModuleDirOnFilesystem(tfconfig.WrapFS(ModuleFS), source) {
+		wrapFS := tfconfig.WrapFS(sourcereader.ModuleFS)
+		if !tfconfig.IsModuleDirOnFilesystem(wrapFS, source) {
 			return ret, fmt.Errorf("Source is not a terraform or packer module: %s", source)
 		}
-		module, _ = tfconfig.LoadModuleFromFilesystem(tfconfig.WrapFS(ModuleFS), source)
+		module, _ = tfconfig.LoadModuleFromFilesystem(wrapFS, source)
 	} else {
 		fileInfo, err := os.Stat(source)
 		if os.IsNotExist(err) {

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -18,7 +18,6 @@
 package modulereader
 
 import (
-	"embed"
 	"fmt"
 	"hpc-toolkit/pkg/sourcereader"
 	"io/ioutil"
@@ -28,9 +27,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
-
-// ModuleFS contains embedded modules (./modules) for use in building
-var ModuleFS embed.FS
 
 // VarInfo stores information about a module input variables
 type VarInfo struct {

--- a/pkg/modulereader/resreader_test.go
+++ b/pkg/modulereader/resreader_test.go
@@ -16,6 +16,7 @@ package modulereader
 
 import (
 	"embed"
+	"hpc-toolkit/pkg/sourcereader"
 	"io/ioutil"
 	"log"
 	"os"
@@ -104,7 +105,7 @@ func (s *MySuite) TestFactory(c *C) {
 }
 
 func (s *MySuite) TestGetModuleInfo_Embedded(c *C) {
-	ModuleFS = testModuleFS
+	sourcereader.ModuleFS = testModuleFS
 
 	// Success
 	moduleInfo, err := GetModuleInfo("modules/test_role/test_module", tfKindString)

--- a/pkg/sourcereader/embedded.go
+++ b/pkg/sourcereader/embedded.go
@@ -28,9 +28,10 @@ import (
 // hpc-toolkit/modules are not accessible at the package level.
 var ModuleFS BaseFS
 
-// BaseFS is an extension of the io.fs interface with the functionality needed
+// BaseFS is an extension of the fs.FS interface with the functionality needed
 // in CopyDirFromModules. Works with embed.FS and afero.FS
 type BaseFS interface {
+	fs.FS
 	ReadDir(string) ([]fs.DirEntry, error)
 	ReadFile(string) ([]byte, error)
 }

--- a/pkg/sourcereader/embedded.go
+++ b/pkg/sourcereader/embedded.go
@@ -39,8 +39,8 @@ type BaseFS interface {
 // EmbeddedSourceReader reads modules from a local directory
 type EmbeddedSourceReader struct{}
 
-func copyFileOut(fs BaseFS, src string, dst string) error {
-	content, err := fs.ReadFile(src)
+func copyFileOut(bfs BaseFS, src string, dst string) error {
+	content, err := bfs.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("failed to read embedded %#v: %v", src, err)
 	}
@@ -56,8 +56,8 @@ func copyFileOut(fs BaseFS, src string, dst string) error {
 }
 
 // copyDirFromModules copies an FS directory to a local path
-func copyDirFromModules(fs BaseFS, source string, dest string) error {
-	dirEntries, err := fs.ReadDir(source)
+func copyDirFromModules(bfs BaseFS, source string, dest string) error {
+	dirEntries, err := bfs.ReadDir(source)
 	if err != nil {
 		return err
 	}
@@ -72,11 +72,11 @@ func copyDirFromModules(fs BaseFS, source string, dest string) error {
 			if err := os.Mkdir(entryDest, 0755); err != nil {
 				return err
 			}
-			if err = copyDirFromModules(fs, entrySource, entryDest); err != nil {
+			if err = copyDirFromModules(bfs, entrySource, entryDest); err != nil {
 				return err
 			}
 		} else {
-			if err := copyFileOut(fs, entrySource, entryDest); err != nil {
+			if err := copyFileOut(bfs, entrySource, entryDest); err != nil {
 				return err
 			}
 
@@ -88,12 +88,12 @@ func copyDirFromModules(fs BaseFS, source string, dest string) error {
 // copyFSToTempDir is a temporary workaround until tfconfig.ReadFromFilesystem
 // works against embed.FS.
 // Open Issue: https://github.com/hashicorp/terraform-config-inspect/issues/68
-func copyFSToTempDir(fs BaseFS, modulePath string) (string, error) {
+func copyFSToTempDir(bfs BaseFS, modulePath string) (string, error) {
 	tmpDir, err := ioutil.TempDir("", "tfconfig-module-*")
 	if err != nil {
 		return tmpDir, err
 	}
-	err = copyDirFromModules(fs, modulePath, tmpDir)
+	err = copyDirFromModules(bfs, modulePath, tmpDir)
 	return tmpDir, err
 }
 


### PR DESCRIPTION
Motivation: reduce duplication in initialization logic.