### PR TITLE
Resolve destroy/create race in vm-instance

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -165,7 +165,6 @@ limitations under the License.
 | Name | Type |
 |------|------|
 | [google-beta_google_compute_instance.compute_vm](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance) | resource |
-| [google_compute_disk.boot_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [google_compute_resource_policy.placement_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy) | resource |
 | [google_compute_image.compute_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -85,19 +85,6 @@ data "google_compute_image" "compute_image" {
   project = var.instance_image.project
 }
 
-resource "google_compute_disk" "boot_disk" {
-  project = var.project_id
-
-  count = var.instance_count
-
-  name   = "${local.resource_prefix}-boot-disk-${count.index}"
-  image  = data.google_compute_image.compute_image.self_link
-  type   = var.disk_type
-  size   = var.disk_size_gb
-  labels = local.labels
-  zone   = var.zone
-}
-
 resource "google_compute_resource_policy" "placement_policy" {
   project = var.project_id
 
@@ -128,9 +115,13 @@ resource "google_compute_instance" "compute_vm" {
   labels = local.labels
 
   boot_disk {
-    source      = google_compute_disk.boot_disk[count.index].self_link
-    device_name = google_compute_disk.boot_disk[count.index].name
     auto_delete = var.auto_delete_boot_disk
+    initialize_params {
+      size   = var.disk_size_gb
+      type   = var.disk_type
+      image  = data.google_compute_image.compute_image.self_link
+      labels = local.labels
+    }
   }
 
   dynamic "scratch_disk" {


### PR DESCRIPTION
If one changes a VM parameter that requires destruction and replacement of the VM (e.g. `local_ssd_count: 0` &rarr; `1`) but does not change the zone of the VM, then there is a race condition which causes the disk to be deleted along with the VM (when `var.auto_delete_boot_disk` is its default value of `true`) but not re-created because the explicit Terraform resource was not deleted. Thus the new VM cannot be created until a 2nd Terraform apply refreshes state with the now-deleted disk.

Resolve by using the initialize_params block instead of an explicit google_compute_disk resource. Preserves behavior that setting `var.auto_delete_boot_disk=false` allows a disk to be re-used when the VM is destroyed and replaced (e.g. changing `local_ssd_count`). Additionally, this PR preserves the behavior of labeling disks at creation for cost-tracking.

Example blueprint:

```yaml
---
blueprint_name: simple

vars:
  project_id:  ## Set project id here
  deployment_name: simple
  region: us-central1
  zone: us-central1-c

deployment_groups:
- group: primary
  modules:
  - id: network1
    source: modules/network/pre-existing-vpc
  - id: simplevm
    source: modules/compute/vm-instance
    use:
    - network1
    settings:
      auto_delete_boot_disk: false
      machine_type: c2-standard-4
      add_deployment_name_before_prefix: true
      local_ssd_count: 0
```

After this PR, there is a new edge case. If one simultaneously changes `local_ssd_count:0` &rarr; `1` AND changes `zone: us-central1-c` &rarr; `-b`, then a re-apply succeeds although a new disk is created in `-b` and the disk in `-c` is orphaned. I consider this behavior acceptable given that the user is opting into a behavior which suggests retaining the disk (and cost). The user should also not expect a zonal disk to follow the VM to a new zone.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
