### PR TITLE
Add community wrapper blueprint for LLNL flux-framework

### DIFF
--- a/community/examples/flux-framework/README.md
+++ b/community/examples/flux-framework/README.md
@@ -36,11 +36,11 @@ This will create a directory containing Terraform modules.
 
 Follow `ghpc` instructions to deploy the cluster
 
-  ```text
-  terraform -chdir=flux-fw-cluster/primary init
-  terraform -chdir=flux-fw-cluster/primary validate
-  terraform -chdir=flux-fw-cluster/primary apply
-  ```
+```text
+terraform -chdir=flux-fw-cluster/primary init
+terraform -chdir=flux-fw-cluster/primary validate
+terraform -chdir=flux-fw-cluster/primary apply
+```
   
 ### Connect to the login node
 
@@ -60,8 +60,7 @@ Or via the Google Cloud Console
 
    Select the project in which the flux-framework cluster was provisioned.
 
-2. Click on the **SSH** button associated with the **gfluxfw-login-001**
-   instance to open a window with a terminal into the cluster login node.
+2. Click on the **SSH** button associated with the **gfluxfw-login-001** instance to open a window with a terminal into the cluster login node.
 
 ### Verify the flux-framework Cluster
 

--- a/community/examples/flux-framework/README.md
+++ b/community/examples/flux-framework/README.md
@@ -4,6 +4,7 @@ The [flux-cluster.yaml](flux-cluster.yaml) blueprint describes a flux-framework 
 is deployed as the native resource manager as described in the [Flux Administrator's Guide](https://flux-framework.readthedocs.io/en/latest/guides/admin-guide.html).
 
 The cluster includes
+
 - A management node
 - A login node
 - Four compute nodes each of which is an instance of the c2-standard-16 machine type
@@ -138,4 +139,3 @@ Use `^d` to release the resources in the allocation and return to the login node
 
 To learn how to make the best use of flux follow the [Introduction to Flux](https://hpc-tutorials.llnl.gov/flux/)
 tutorial.
-

--- a/community/examples/flux-framework/README.md
+++ b/community/examples/flux-framework/README.md
@@ -1,0 +1,141 @@
+## [flux-framework](https://flux-framework.org/) Cluster
+
+The [flux-cluster.yaml](flux-cluster.yaml) blueprint describes a flux-framework cluster where flux
+is deployed as the native resource manager as described in the [Flux Administrator's Guide](https://flux-framework.readthedocs.io/en/latest/guides/admin-guide.html).
+
+The cluster includes
+- A management node
+- A login node
+- Four compute nodes each of which is an instance of the c2-standard-16 machine type
+
+> **_NOTE:_** prior to running this HPC Toolkit example the [Flux Framework GCP Images](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/img#flux-framework-gcp-images)
+> must be created in your project.
+
+### Intial Setup for flux-framework Cluster
+
+Before provisioning any infrastructure in this project you should follow the
+Toolkit guidance to enable [APIs][apis] and establish minimum resource
+[quotas][quotas]. In particular, the following APIs should be enabled
+
+- [compute.googleapis.com](https://cloud.google.com/compute/docs/reference/rest/v1#service:-compute.googleapis.com) (Google Compute Engine)
+- [secretmanager.googleapis.com](https://cloud.google.com/secret-manager/docs/reference/rest#service:-secretmanager.googleapis.com) (Secret manager, for secure mode)
+
+[apis]: ../../../README.md#enable-gcp-apis
+[quotas]: ../../../README.md#gcp-quotas
+
+### Deploy the flux-framework Cluster
+
+Use `ghcp` to provision the blueprint
+
+```bash
+ghpc create community/examples/flux-framework --vars project_id=<<PROJECT_ID>>
+```
+
+This will create a directory containing Terraform modules.
+
+Follow `ghpc` instructions to deploy the cluster
+
+  ```text
+  terraform -chdir=flux-fw-cluster/primary init
+  terraform -chdir=flux-fw-cluster/primary validate
+  terraform -chdir=flux-fw-cluster/primary apply
+  ```
+  
+### Connect to the login node
+
+Access the cluster via the login node from the command line.
+
+```bash
+gcloud compute ssh gfluxfw-login-001
+```
+
+Or via the Google Cloud Console
+
+1. Open the following URL in a new tab.
+
+   https://console.cloud.google.com/compute
+
+   This will take you to **Compute Engine > VM instances** in the Google Cloud Console.
+
+   Select the project in which the flux-framework cluster was provisioned.
+
+2. Click on the **SSH** button associated with the **gfluxfw-login-001**
+   instance to open a window with a terminal into the cluster login node.
+
+### Verify the flux-framework Cluster
+
+View the cluster resources
+
+```bash
+flux resource list
+```
+
+The output will look similar to
+
+```text
+     STATE PROPERTIES NNODES   NCORES NODELIST
+      free x86-64,e2       1        2 gfluxfw-login-001
+      free x86-64,c2       4       32 gfluxfw-compute-[001-004]
+ allocated                 0        0 
+      down                 0        0 
+```
+
+Run a simple job that executes the `hostname` command on each of the cluster compute nodes
+
+```bash
+flux run -N4 --requires=c2 hostname
+```
+
+The output will be something like
+
+```text
+gfluxfw-compute-001
+gfluxfw-compute-004
+gfluxfw-compute-003
+gfluxfw-compute-002
+```
+
+Create a two node allocation
+
+```bash
+flux alloc -N2 --requires=c2
+```
+
+View the resources associated with the allocation
+
+```bash
+flux resource list
+```
+
+The output will look similar to
+
+```text
+     STATE PROPERTIES NNODES   NCORES NODELIST
+      free x86-64,c2       2       16 gfluxfw-compute-[003-004]
+ allocated                 0        0 
+      down                 0        0 
+```
+
+Observe the impact on cluster resources
+
+```bash
+flux --parent resource list
+```
+
+Yields output like
+
+```text
+     STATE PROPERTIES NNODES   NCORES NODELIST
+      free x86-64,e2       1        2 gfluxfw-login-001
+      free x86-64,c2       2       16 gfluxfw-compute-[001-002]
+ allocated x86-64,c2       2       16 gfluxfw-compute-[003-004]
+      down                 0        0 
+```
+
+Use `^d` to release the resources in the allocation and return to the login node.
+
+### Next Steps
+
+To learn how to make the best use of flux follow the [Introduction to Flux](https://hpc-tutorials.llnl.gov/flux/)
+tutorial.
+

--- a/community/examples/flux-framework/flux-cluster.yaml
+++ b/community/examples/flux-framework/flux-cluster.yaml
@@ -37,15 +37,15 @@ deployment_groups:
     source: github.com/GoogleCloudPlatform/scientific-computing-examples.git/fluxfw-gcp/tf
     settings:
       compute_node_specs:
-        - name_prefix: gfluxfw-compute
-          machine_arch: x86-64
-          machine_type: c2-standard-16
-          gpu_type: null
-          gpu_count: 0
-          compact: true
-          instances: 4
-          properties: ["c2"]
-          boot_script: null
+      - name_prefix: gfluxfw-compute
+        machine_arch: x86-64
+        machine_type: c2-standard-16
+        gpu_type: null
+        gpu_count: 0
+        compact: true
+        instances: 4
+        properties: ["c2"]
+        boot_script: null
       login_node_specs:
       - name_prefix: gfluxfw-login
         machine_arch: x86-64
@@ -62,7 +62,7 @@ deployment_groups:
         manager: null
         login: null
         compute: null
- 
+
       cluster_storage:
         mountpoint: $(homefs.network_storage.local_mount)
         share_ip: $(homefs.network_storage.server_ip)

--- a/community/examples/flux-framework/flux-cluster.yaml
+++ b/community/examples/flux-framework/flux-cluster.yaml
@@ -1,3 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
 blueprint_name: flux-fw-cluster
 
 vars:
@@ -49,6 +64,6 @@ deployment_groups:
         compute: null
  
       cluster_storage:
-        mountpoint: ((module.homefs.network_storage.local_mount))
-        share_ip: ((module.homefs.network_storage.server_ip))
-        share_name: ((module.homefs.network_storage.remote_mount))
+        mountpoint: $(homefs.network_storage.local_mount)
+        share_ip: $(homefs.network_storage.server_ip)
+        share_name: $(homefs.network_storage.remote_mount)

--- a/community/examples/flux-framework/flux-cluster.yaml
+++ b/community/examples/flux-framework/flux-cluster.yaml
@@ -1,0 +1,54 @@
+blueprint_name: flux-fw-cluster
+
+vars:
+  project_id: ## set GCP Project ID Here ##
+  deployment_name: flux-fw-cluster
+  region: us-central1
+  zone: us-central1-a
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: flux-net
+    source: modules/network/vpc
+    settings:
+      network_name: flux-net-01
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [flux-net]
+    settings:
+      local_mount: /home
+  - id: fluxfw-gcp
+    source: github.com/GoogleCloudPlatform/scientific-computing-examples.git/fluxfw-gcp/tf
+    settings:
+      compute_node_specs:
+        - name_prefix: gfluxfw-compute
+          machine_arch: x86-64
+          machine_type: c2-standard-16
+          gpu_type: null
+          gpu_count: 0
+          compact: true
+          instances: 4
+          properties: ["c2"]
+          boot_script: null
+      login_node_specs:
+      - name_prefix: gfluxfw-login
+        machine_arch: x86-64
+        machine_type: e2-standard-4
+        instances: 1
+        properties: []
+        boot_script: null
+      manager_name_prefix: gfluxfw
+      manager_machine_type: e2-standard-8
+
+      subnetwork: $(flux-net.subnetwork_self_link)
+
+      service_account_emails:
+        manager: null
+        login: null
+        compute: null
+ 
+      cluster_storage:
+        mountpoint: ((module.homefs.network_storage.local_mount))
+        share_ip: ((module.homefs.network_storage.server_ip))
+        share_name: ((module.homefs.network_storage.remote_mount))


### PR DESCRIPTION
This PR adds a community "wrapper" blueprint for the LLNL [flux-framework](flux-framework.org)

The blueprint wraps the fluxfw-gcp module found [here](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp). It implements the approach described in [Flux support on the Cloud HPC Toolkit](https://docs.google.com/document/d/1QTsolSTvyXG_Xvr9geK_ZFAvhO6nQh5TmWRmcIND_9E/edit?usp=sharing&resourcekey=0-R3o3Se5THn5ohq-trDXwmA)