### PR TITLE
Update Django to 4.1.9 to address CVE-2023-31047

### DIFF
--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -16,7 +16,7 @@ dill==0.3.6
 distlib==0.3.6
 # django-revproxy==0.11.0 released but not yet in pypi
 git+https://github.com/jazzband/django-revproxy.git@d2234005135dc0771b7c4e0bb0465664ccfa5787
-Django==4.1.7
+Django==4.1.9
 django-allauth==0.54.0
 django-extensions==3.2.1
 djangorestframework==3.14.0


### PR DESCRIPTION
Address CVE-2023-31047 by upgrading Django to 4.1.9. Deliberately do _not_ upgrade to 4.2.1 because [release notes](https://docs.djangoproject.com/en/4.2/releases/4.2/) indicate backward-incompatible changes. A subsequent PR should upgrade to 4.2.x because it is describes as an LTS release with 3 years of support.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
