### PR TITLE
Expose csi driver addons in gke-cluster

### DIFF
--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -75,14 +75,14 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.51.0, < 5.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.51.0, < 5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.65.0, < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.51.0, < 5.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.51.0, < 5.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.65.0, < 5.0 |
 
 ## Modules
 
@@ -110,7 +110,10 @@ No modules.
 | <a name="input_autoscaling_profile"></a> [autoscaling\_profile](#input\_autoscaling\_profile) | (Beta) Optimize for utilization or availability when deciding to remove nodes. Can be BALANCED or OPTIMIZE\_UTILIZATION. | `string` | `"OPTIMIZE_UTILIZATION"` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment. Used in the GKE cluster name by default and can be configured with `prefix_with_deployment_name`. | `string` | n/a | yes |
 | <a name="input_enable_dataplane_v2"></a> [enable\_dataplane\_v2](#input\_enable\_dataplane\_v2) | Enables [Dataplane v2](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2). This setting is immutable on clusters. | `bool` | `false` | no |
+| <a name="input_enable_filestore_csi"></a> [enable\_filestore\_csi](#input\_enable\_filestore\_csi) | The status of the Filestore Container Storage Interface (CSI) driver addon, which allows the usage of filestore instance as volumes. | `bool` | `false` | no |
+| <a name="input_enable_gcsfuse_csi"></a> [enable\_gcsfuse\_csi](#input\_enable\_gcsfuse\_csi) | The status of the GCSFuse Filestore Container Storage Interface (CSI) driver addon, which allows the usage of a gcs bucket as volumes. | `bool` | `false` | no |
 | <a name="input_enable_master_global_access"></a> [enable\_master\_global\_access](#input\_enable\_master\_global\_access) | Whether the cluster master is accessible globally (from any region) or only within the same region as the private endpoint. | `bool` | `false` | no |
+| <a name="input_enable_persistent_disk_csi"></a> [enable\_persistent\_disk\_csi](#input\_enable\_persistent\_disk\_csi) | The status of the Google Compute Engine Persistent Disk Container Storage Interface (CSI) driver addon, which allows the usage of a PD as volumes. | `bool` | `true` | no |
 | <a name="input_enable_private_endpoint"></a> [enable\_private\_endpoint](#input\_enable\_private\_endpoint) | (Beta) Whether the master's internal IP address is used as the cluster endpoint. | `bool` | `true` | no |
 | <a name="input_enable_private_ipv6_google_access"></a> [enable\_private\_ipv6\_google\_access](#input\_enable\_private\_ipv6\_google\_access) | The private IPv6 google access type for the VMs in this subnet. | `bool` | `true` | no |
 | <a name="input_enable_private_nodes"></a> [enable\_private\_nodes](#input\_enable\_private\_nodes) | (Beta) Whether nodes have internal IP addresses only. | `bool` | `true` | no |

--- a/community/modules/scheduler/gke-cluster/main.tf
+++ b/community/modules/scheduler/gke-cluster/main.tf
@@ -143,8 +143,14 @@ resource "google_container_cluster" "gke_cluster" {
   }
 
   addons_config {
+    gcp_filestore_csi_driver_config {
+      enabled = var.enable_filestore_csi
+    }
+    gcs_fuse_csi_driver_config {
+      enabled = var.enable_gcsfuse_csi
+    }
     gce_persistent_disk_csi_driver_config {
-      enabled = true
+      enabled = var.enable_persistent_disk_csi
     }
   }
 

--- a/community/modules/scheduler/gke-cluster/variables.tf
+++ b/community/modules/scheduler/gke-cluster/variables.tf
@@ -109,6 +109,24 @@ variable "maintenance_exclusions" {
   }
 }
 
+variable "enable_filestore_csi" {
+  description = "The status of the Filestore Container Storage Interface (CSI) driver addon, which allows the usage of filestore instance as volumes."
+  type        = bool
+  default     = false
+}
+
+variable "enable_gcsfuse_csi" {
+  description = "The status of the GCSFuse Filestore Container Storage Interface (CSI) driver addon, which allows the usage of a gcs bucket as volumes."
+  type        = bool
+  default     = false
+}
+
+variable "enable_persistent_disk_csi" {
+  description = "The status of the Google Compute Engine Persistent Disk Container Storage Interface (CSI) driver addon, which allows the usage of a PD as volumes."
+  type        = bool
+  default     = true
+}
+
 variable "system_node_pool_name" {
   description = "Name of the system node pool."
   type        = string

--- a/community/modules/scheduler/gke-cluster/versions.tf
+++ b/community/modules/scheduler/gke-cluster/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.51.0, < 5.0"
+      version = ">= 4.65.0, < 5.0"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
Expose Container Storage Interface drivers addons for several different storage types.

Note: none of the defaults change with this PR.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
