### PR TITLE
add config-ssh as a startup script option

### DIFF
--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -229,8 +229,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_configure_ssh"></a> [configure\_ssh](#input\_configure\_ssh) | If set to true, it will automate ssh configuration by setting StrictHostKeyChecking to no and, the first fine users log-in, creating ssh keys that are added to the authorized keys list . This requires a shared /home filesystem. | `bool` | `false` | no |
 | <a name="input_ansible_virtualenv_path"></a> [ansible\_virtualenv\_path](#input\_ansible\_virtualenv\_path) | Virtual environment path in which to install Ansible | `string` | `"/usr/local/ghpc-venv"` | no |
+| <a name="input_configure_ssh"></a> [configure\_ssh](#input\_configure\_ssh) | If set to true, it will automate ssh configuration by:<br>  - Setting StrictHostKeyChecking to 'No' when hosts start with the same "deployment\_name"<br>  - The first time users log-in, it will create ssh keys that are added to the authorized keys list<br>  This requires a shared /home filesystem and implies on using the deployment name as prefix. | `string` | `false` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |
 | <a name="input_gcs_bucket_path"></a> [gcs\_bucket\_path](#input\_gcs\_bucket\_path) | The GCS path for storage bucket and the object. | `string` | `null` | no |

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -229,6 +229,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_configure_ssh"></a> [configure\_ssh](#input\_configure\_ssh) | If set to true, it will automate ssh configuration by setting StrictHostKeyChecking to no and, the first fine users log-in, creating ssh keys that are added to the authorized keys list . This requires a shared /home filesystem. | `bool` | `false` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |
 | <a name="input_gcs_bucket_path"></a> [gcs\_bucket\_path](#input\_gcs\_bucket\_path) | The GCS path for storage bucket and the object. | `string` | `null` | no |

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -181,7 +181,7 @@ they are able to do so by using the `gcs_bucket_path` as shown in the below exam
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-Copyright 2022 Google LLC
+Copyright 2023 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -230,7 +230,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ansible_virtualenv_path"></a> [ansible\_virtualenv\_path](#input\_ansible\_virtualenv\_path) | Virtual environment path in which to install Ansible | `string` | `"/usr/local/ghpc-venv"` | no |
-| <a name="input_configure_ssh"></a> [configure\_ssh](#input\_configure\_ssh) | If set to true, it will automate ssh configuration by:<br>  - Setting StrictHostKeyChecking to 'No' when hosts start with the same "deployment\_name"<br>  - The first time users log-in, it will create ssh keys that are added to the authorized keys list<br>  This requires a shared /home filesystem and implies on using the deployment name as prefix. | `string` | `false` | no |
+| <a name="input_configure_ssh_host_patterns"></a> [configure\_ssh\_host\_patterns](#input\_configure\_ssh\_host\_patterns) | If specified, it will automate ssh configuration by:<br>  - Defining a Host block for every element of this variable and setting StrictHostKeyChecking to 'No'.<br>  Ex: "hpc*", "hpc01*", "ml*"<br>  - The first time users log-in, it will create ssh keys that are added to the authorized keys list<br>  This requires a shared /home filesystem and relies on specifying the right prefix. | `list(string)` | `[]` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |
 | <a name="input_gcs_bucket_path"></a> [gcs\_bucket\_path](#input\_gcs\_bucket\_path) | The GCS path for storage bucket and the object. | `string` | `null` | no |

--- a/modules/scripts/startup-script/files/configure-ssh.yml
+++ b/modules/scripts/startup-script/files/configure-ssh.yml
@@ -1,0 +1,35 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Configure ssh between nodes
+  become: true
+  hosts: localhost
+  vars:
+    ssh_config_path: "/etc/ssh/ssh_config"
+    bashrc: "{{ '/etc/bashrc' if ansible_facts['os_family'] == 'RedHat' else '/etc/bash.bashrc' }}"
+    setup_ssh_script: "/bin/bash /usr/local/ghpc/setup-ssh-keys.sh"
+  tasks:
+  - name: "Set StrictHostKeyChecking to no"
+    ansible.builtin.blockinfile:
+      path: "{{ ssh_config_path }}"
+      block: |
+        Host {{ host_name_prefix }}*
+          StrictHostKeyChecking no
+  - name: "Create ssh keys in .bashrc if not alrady done"
+    ansible.builtin.lineinfile:
+      path: "{{ bashrc }}"
+      regexp: '^{{ setup_ssh_script }}'
+      line: "{{ setup_ssh_script }}"

--- a/modules/scripts/startup-script/files/configure-ssh.yml
+++ b/modules/scripts/startup-script/files/configure-ssh.yml
@@ -26,8 +26,10 @@
     ansible.builtin.blockinfile:
       path: "{{ ssh_config_path }}"
       block: |
-        Host {{ host_name_prefix }}*
+        Host "{{ item }}"
           StrictHostKeyChecking no
+      marker: "# {mark} ANSIBLE MANAGED BLOCK {{item}}"
+    loop: "{{ host_name_prefix }}"
   - name: "Create ssh keys in .bashrc if not alrady done"
     ansible.builtin.lineinfile:
       path: "{{ bashrc }}"

--- a/modules/scripts/startup-script/files/setup-ssh-keys.sh
+++ b/modules/scripts/startup-script/files/setup-ssh-keys.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ ! -d ~/.ssh/ ]; then
+	source /usr/local/ghpc-venv/bin/activate
+	ansible-playbook /usr/local/ghpc/setup-ssh-keys.yml
+fi

--- a/modules/scripts/startup-script/files/setup-ssh-keys.yml
+++ b/modules/scripts/startup-script/files/setup-ssh-keys.yml
@@ -1,0 +1,40 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Setup SSH Keys for user
+  become: false
+  hosts: localhost
+  vars:
+    pub_key_path: "{{ ansible_env.HOME }}/.ssh"
+    pub_key_file: "{{ pub_key_path }}/id_rsa"
+    auth_key_file: "{{ pub_key_path }}/authorized_keys"
+  tasks:
+  - name: "Create .ssh folder"
+    ansible.builtin.file:
+      path: "{{ pub_key_path }}"
+      state: directory
+      mode: 0700
+      owner: "{{ ansible_user_id }}"
+  - name: Create keys
+    community.crypto.openssh_keypair:
+      path: "{{ pub_key_file }}"
+      owner: "{{ ansible_user_id }}"
+  - name: Copy public key to authorized keys
+    ansible.builtin.copy:
+      src: "{{ pub_key_file }}.pub"
+      dest: "{{ auth_key_file }}"
+      owner: "{{ ansible_user_id }}"
+      mode: 0644

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,15 +112,16 @@ variable "install_ansible" {
   default     = null
 }
 
-variable "configure_ssh" {
+variable "configure_ssh_host_patterns" {
   description = <<EOT
-  If set to true, it will automate ssh configuration by:
-  - Setting StrictHostKeyChecking to 'No' when hosts start with the same "deployment_name"
+  If specified, it will automate ssh configuration by:
+  - Defining a Host block for every element of this variable and setting StrictHostKeyChecking to 'No'.
+  Ex: "hpc*", "hpc01*", "ml*"
   - The first time users log-in, it will create ssh keys that are added to the authorized keys list
-  This requires a shared /home filesystem and implies on using the deployment name as prefix.
+  This requires a shared /home filesystem and relies on specifying the right prefix.
   EOT
-  type        = string
-  default     = false
+  type        = list(string)
+  default     = []
 }
 
 variable "prepend_ansible_installer" {

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -112,6 +112,12 @@ variable "install_ansible" {
   default     = null
 }
 
+variable "configure_ssh" {
+  description = "If set to true, it will automate ssh configuration by setting StrictHostKeyChecking to no and, the first fine users log-in, creating ssh keys that are added to the authorized keys list . This requires a shared /home filesystem."
+  type        = bool
+  default     = false
+}
+
 variable "prepend_ansible_installer" {
   description = <<EOT
   DEPRECATED. Use `install_ansible=false` to prevent ansible installation.

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -113,8 +113,13 @@ variable "install_ansible" {
 }
 
 variable "configure_ssh" {
-  description = "If set to true, it will automate ssh configuration by setting StrictHostKeyChecking to no and, the first fine users log-in, creating ssh keys that are added to the authorized keys list . This requires a shared /home filesystem."
-  type        = bool
+  description = <<EOT
+  If set to true, it will automate ssh configuration by:
+  - Setting StrictHostKeyChecking to 'No' when hosts start with the same "deployment_name"
+  - The first time users log-in, it will create ssh keys that are added to the authorized keys list
+  This requires a shared /home filesystem and implies on using the deployment name as prefix.
+  EOT
+  type        = string
   default     = false
 }
 

--- a/tools/validate_configs/test_configs/config-ssh.yaml
+++ b/tools/validate_configs/test_configs/config-ssh.yaml
@@ -1,0 +1,99 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: config-ssh
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: hpc-small
+  region: us-west4
+  zone: us-west4-c
+
+# Documentation for each of the modules used below can be found at
+# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
+
+deployment_groups:
+- group: primary
+  modules:
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network1]
+    settings:
+      local_mount: /home
+
+  - id: script
+    source: modules/scripts/startup-script
+    settings:
+      configure_ssh_host_patterns: ['10.182.0.*', 'hpcsm*']
+
+  - id: debug_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      node_count_dynamic_max: 4
+      machine_type: n2-standard-2
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - homefs
+    - debug_node_group
+    settings:
+      partition_name: debug
+      exclusive: false # allows nodes to stay up after jobs are done
+      enable_placement: false # the default is: true
+      is_default: true
+
+  - id: compute_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      node_count_dynamic_max: 20
+
+  - id: compute_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - homefs
+    - compute_node_group
+    settings:
+      partition_name: compute
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    use:
+    - network1
+    - debug_partition
+    - compute_partition
+    - homefs
+    - script
+    settings:
+      disable_controller_public_ips: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    use:
+    - network1
+    - slurm_controller
+    - script
+    settings:
+      machine_type: n2-standard-4
+      disable_login_public_ips: false


### PR DESCRIPTION
With this change, a user could specify `configure_ssh_host_prefix` on a startup script and that would configure SSH for users in the deployed system. Example: 

```
  - id: script
    source: modules/scripts/startup-script
    settings:
      configure_ssh_host_patterns: ['10.182.0.*', 'clustername*']
``` 

It will automate ssh configuration by:
- Defining a Host block for every element of this variable and setting StrictHostKeyChecking to 'No' for the specified block.
  Ex: "10.182.0.*", "hpc*", "hpc01*", "ml*"
- The first time users log-in, it will create ssh keys that are added to the authorized keys list
  This requires a shared /home filesystem and relies on specifying the right prefix.
  
### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
