### PR TITLE
Add all Ansible binaries to default PATH

### DIFF
--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -205,7 +205,21 @@ main() {
 		[ "${ansible_minor_vers}" -lt "${ansible_req_minor_vers}" ]; then
 		${venv_python_path} -m pip install ansible=="${REQ_ANSIBLE_PIP_VERSION}"
 	fi
-	ln -s "${venv_path}/bin/ansible-playbook" /usr/bin/ansible-playbook
+	while read -r cmd; do
+		ln -s "${venv_path}/bin/${cmd}" "/usr/bin/${cmd}"
+	done <<-EOF
+		ansible
+		ansible-config
+		ansible-connection
+		ansible-console
+		ansible-doc
+		ansible-galaxy
+		ansible-inventory
+		ansible-playbook
+		ansible-pull
+		ansible-test
+		ansible-vault
+	EOF
 }
 
 main "$@"


### PR DESCRIPTION
These binaries were chosen as the ones created in `~/.local/bin` by `pip install --user ansible`. The objective is to ensure that Ansible is in PATH for any tool that wishes to invoke it. #1352  already ensures that any invocation of ansible will use the virtualenv copy of Python for its interpreter.

Implemented retaining POSIX sh compatibility, which was probably chosen to maximize portability. This script is often the very first to run in our startup-scripts.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
