### PR TITLE
Add destroy command for deployments

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -1,0 +1,110 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd defines command line utilities for ghpc
+package cmd
+
+import (
+	"fmt"
+	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/modulewriter"
+	"hpc-toolkit/pkg/shell"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	artifactsFlag := "artifacts"
+	destroyCmd.Flags().StringVarP(&artifactsDir, artifactsFlag, "a", "", "Artifacts output directory (automatically configured if unset)")
+	destroyCmd.MarkFlagDirname(artifactsFlag)
+
+	destroyCmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Automatically approve proposed changes")
+
+	rootCmd.AddCommand(destroyCmd)
+}
+
+var (
+	destroyCmd = &cobra.Command{
+		Use:               "destroy DEPLOYMENT_DIRECTORY",
+		Short:             "destroy all resources in a Toolkit deployment directory.",
+		Long:              "destroy all resources in a Toolkit deployment directory.",
+		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkDir),
+		ValidArgsFunction: matchDirs,
+		PreRunE:           parseDestroyArgs,
+		RunE:              runDestroyCmd,
+		SilenceUsage:      true,
+	}
+)
+
+func parseDestroyArgs(cmd *cobra.Command, args []string) error {
+	applyBehavior = getApplyBehavior(autoApprove)
+
+	deploymentRoot = args[0]
+	artifactsDir = getArtifactsDir(deploymentRoot)
+
+	if isDir, _ := shell.DirInfo(artifactsDir); !isDir {
+		return fmt.Errorf("artifacts path %s is not a directory", artifactsDir)
+	}
+
+	return nil
+}
+
+func runDestroyCmd(cmd *cobra.Command, args []string) error {
+	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
+	dc, err := config.NewDeploymentConfig(expandedBlueprintFile)
+	if err != nil {
+		return err
+	}
+
+	if err := shell.ValidateDeploymentDirectory(dc.Config.DeploymentGroups, deploymentRoot); err != nil {
+		return err
+	}
+
+	// destroy in reverse order of creation!
+	packerManifests := []string{}
+	for i := len(dc.Config.DeploymentGroups) - 1; i >= 0; i-- {
+		group := dc.Config.DeploymentGroups[i]
+		groupDir := filepath.Join(deploymentRoot, string(group.Name))
+
+		var err error
+		switch group.Kind {
+		case config.PackerKind:
+			// Packer groups are enforced to have length 1
+			// TODO: destroyPackerGroup(moduleDir)
+			moduleDir := filepath.Join(groupDir, string(group.Modules[0].ID))
+			packerManifests = append(packerManifests, filepath.Join(moduleDir, "packer-manifest.json"))
+		case config.TerraformKind:
+			err = destroyTerraformGroup(groupDir)
+		default:
+			err = fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind.String())
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	modulewriter.WritePackerDestroyInstructions(os.Stdout, packerManifests)
+	return nil
+}
+
+func destroyTerraformGroup(groupDir string) error {
+	tf, err := shell.ConfigureTerraform(groupDir)
+	if err != nil {
+		return err
+	}
+
+	return shell.Destroy(tf, applyBehavior)
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -37,17 +37,16 @@ var (
 		Long:              "Import input values from previous deployment groups upon which this group depends.",
 		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkDir),
 		ValidArgsFunction: matchDirs,
-		PreRun:            setArtifactsDir,
+		PreRun:            parseExportImportArgs,
 		RunE:              runImportCmd,
 		SilenceUsage:      true,
 	}
 )
 
 func runImportCmd(cmd *cobra.Command, args []string) error {
-	workingDir := filepath.Clean(args[0])
-	deploymentRoot := filepath.Clean(filepath.Join(workingDir, ".."))
+	groupDir := filepath.Clean(args[0])
 
-	if err := shell.CheckWritableDir(workingDir); err != nil {
+	if err := shell.CheckWritableDir(groupDir); err != nil {
 		return err
 	}
 
@@ -61,7 +60,7 @@ func runImportCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := shell.ImportInputs(workingDir, artifactsDir, expandedBlueprintFile); err != nil {
+	if err := shell.ImportInputs(groupDir, artifactsDir, expandedBlueprintFile); err != nil {
 		return err
 	}
 

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -415,6 +415,13 @@ func writeDestroyInstructions(w io.Writer, dc config.DeploymentConfig, deploymen
 	fmt.Fprintln(w, "Destroying infrastructure when no longer needed")
 	fmt.Fprintln(w, "===============================================")
 	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Automated")
+	fmt.Fprintln(w, "---------")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "./ghpc destroy %s\n", deploymentDir)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Advanced / Manual")
+	fmt.Fprintln(w, "-----------------")
 	fmt.Fprintln(w, "Infrastructure should be destroyed in reverse order of creation:")
 	fmt.Fprintln(w)
 	for grpIdx := len(dc.Config.DeploymentGroups) - 1; grpIdx >= 0; grpIdx-- {
@@ -429,15 +436,22 @@ func writeDestroyInstructions(w io.Writer, dc config.DeploymentConfig, deploymen
 		}
 	}
 
-	if len(packerManifests) > 0 {
-		fmt.Fprintln(w)
-		fmt.Fprintf(w, "Please browse to the Cloud Console to remove VM images produced by Packer.\n")
-		fmt.Fprintln(w, "By default, the names of images can be found in these files:")
-		fmt.Fprintln(w)
-		for _, manifest := range packerManifests {
-			fmt.Fprintln(w, manifest)
-		}
-		fmt.Fprintln(w)
-		fmt.Fprintln(w, "https://console.cloud.google.com/compute/images")
+	WritePackerDestroyInstructions(w, packerManifests)
+}
+
+// WritePackerDestroyInstructions prints our best effort guidance to the user on
+// deleting images produced by Packer; must improve definition of Packer outputs
+func WritePackerDestroyInstructions(w io.Writer, manifests []string) {
+	if len(manifests) == 0 {
+		return
 	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Please browse to the Cloud Console to remove VM images produced by Packer.\n")
+	fmt.Fprintln(w, "If this file is present, the names of images can be read from it:")
+	fmt.Fprintln(w)
+	for _, manifest := range manifests {
+		fmt.Fprintln(w, manifest)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "https://console.cloud.google.com/compute/images")
 }

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -105,7 +105,7 @@ func (w PackerWriter) writeDeploymentGroup(
 }
 
 func (w PackerWriter) restoreState(deploymentDir string) error {
-	// TODO: implement state restoration for Packer
+	// TODO: restore packer-manifest.json if it exists
 	return nil
 }
 

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -74,7 +74,7 @@ func DirInfo(path string) (isDir bool, isWritable bool) {
 	}
 
 	isDir = p.Mode().IsDir()
-	isWritable = unix.Access(path, unix.W_OK|unix.X_OK) == nil
+	isWritable = unix.Access(path, unix.W_OK|unix.R_OK|unix.X_OK) == nil
 
 	return isDir, isWritable
 }

--- a/pkg/shell/common_test.go
+++ b/pkg/shell/common_test.go
@@ -74,7 +74,7 @@ func (s *MySuite) TestCheckWritableDir(c *C) {
 	// and in MacOS. TODO: investigate why
 	// err = os.Chmod(dir, 0600)
 	// if err != nil {
-	// 	c.Error(err)
+	//      c.Error(err)
 	// }
 	// err = CheckWritableDir(dir)
 	// c.Assert(err, NotNil)

--- a/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
@@ -32,18 +32,15 @@
       environment:
         TF_IN_AUTOMATION: "TRUE"
     always:
-    - name: Destroy cluster deployment group
-      register: terraform_destroy_cluster
-      changed_when: terraform_destroy_cluster.changed
+    - name: Destroy deployment
+      register: ghpc_destroy
+      changed_when: ghpc_destroy.changed
       ignore_errors: true
-      ansible.builtin.command: "{{ item }}"
+      ansible.builtin.command: ./ghpc destroy {{ deployment_name }} --auto-approve
       args:
-        chdir: "{{ workspace }}/{{ deployment_name }}/cluster"
+        chdir: "{{ workspace }}"
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      loop:
-      - terraform init
-      - terraform destroy -auto-approve -no-color
     - name: Delete VM Image
       register: image_deletion
       changed_when: image_deletion.changed
@@ -54,15 +51,3 @@
       args:
         chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
         executable: /bin/bash
-    - name: Destroy primary deployment group
-      register: terraform_destroy_primary
-      changed_when: terraform_destroy_primary.changed
-      ignore_errors: true
-      ansible.builtin.command: "{{ item }}"
-      args:
-        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
-      environment:
-        TF_IN_AUTOMATION: "TRUE"
-      loop:
-      - terraform init
-      - terraform destroy -auto-approve -no-color

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/instructions.txt
@@ -22,12 +22,19 @@ cd -
 Destroying infrastructure when no longer needed
 ===============================================
 
+Automated
+---------
+
+./ghpc destroy golden_copy_deployment
+
+Advanced / Manual
+-----------------
 Infrastructure should be destroyed in reverse order of creation:
 
 terraform -chdir=golden_copy_deployment/zero destroy
 
 Please browse to the Cloud Console to remove VM images produced by Packer.
-By default, the names of images can be found in these files:
+If this file is present, the names of images can be read from it:
 
 golden_copy_deployment/one/image/packer-manifest.json
 

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/instructions.txt
@@ -20,6 +20,13 @@ terraform -chdir=golden_copy_deployment/one apply
 Destroying infrastructure when no longer needed
 ===============================================
 
+Automated
+---------
+
+./ghpc destroy golden_copy_deployment
+
+Advanced / Manual
+-----------------
 Infrastructure should be destroyed in reverse order of creation:
 
 terraform -chdir=golden_copy_deployment/one destroy

--- a/tools/validate_configs/golden_copies/expectations/text_escape/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/instructions.txt
@@ -13,11 +13,18 @@ cd -
 Destroying infrastructure when no longer needed
 ===============================================
 
+Automated
+---------
+
+./ghpc destroy golden_copy_deployment
+
+Advanced / Manual
+-----------------
 Infrastructure should be destroyed in reverse order of creation:
 
 
 Please browse to the Cloud Console to remove VM images produced by Packer.
-By default, the names of images can be found in these files:
+If this file is present, the names of images can be read from it:
 
 golden_copy_deployment/zero/lime/packer-manifest.json
 


### PR DESCRIPTION
Mimic functionality of existing deploy command with a destroy command. Refactor existing code so that the generation and application of a plan uses the same code for apply or destroy, because destroy is an alias for "apply -destroy".

Examples
--

If you destroy a deployment you created, but have not yet deployed:

```text
❯❯❯ ghpc destroy dev
2023/05/30 17:17:00 testing if module in image-builder-001/cluster requires destroying cloud infrastructure
2023/05/30 17:17:02 cloud infrastructure in image-builder-001/cluster is already destroyed
2023/05/30 17:17:04 testing if module in image-builder-001/primary requires destroying cloud infrastructure
2023/05/30 17:17:05 cloud infrastructure in image-builder-001/primary is already destroyed

Please browse to the Cloud Console to remove VM images produced by Packer.
If this file is present, the names of images can be read from it:

image-builder-001/packer/custom-image/packer-manifest.json

https://console.cloud.google.com/compute/images
```

If you destroy a deployment you've already deployed:

```sh
❯❯❯ ghpc destroy image-builder-001
2023/05/30 17:09:53 testing if module in image-builder-001/cluster requires destroying cloud infrastructure
2023/05/30 17:09:58 module in image-builder-001/cluster requires destroying cloud infrastructure
2023/05/30 17:09:59 Summary of proposed changes: Plan: 0 to add, 0 to change, 17 to destroy.
Display full proposed changes, Apply proposed changes, Stop and exit, Continue without applying? [d,a,s,c]: a
2023/05/30 17:10:02 running terraform apply on group image-builder-001/cluster
module.compute_partition.module.slurm_partition.null_resource.partition: Destroying... [id=5869856706865772036]```
...
... TERRAFORM OUTPUT
...
2023/05/30 17:15:42 testing if module in image-builder-001/primary requires destroying cloud infrastructure
2023/05/30 17:15:45 module in image-builder-001/primary requires destroying cloud infrastructure
2023/05/30 17:15:46 Summary of proposed changes: Plan: 0 to add, 0 to change, 11 to destroy.
Display full proposed changes, Apply proposed changes, Stop and exit, Continue without applying? [d,a,s,c]: a
2023/05/30 17:15:49 running terraform apply on group image-builder-001/primary
module.network1.module.vpc.module.subnets.google_compute_subnetwork.subnetwork["us-central1/image-builder-001-primary-subnet"]: Destroying... [id=projects/toolkit-demo-zero-e913/regions/us-central1/subnetworks/image-builder-001-primary-subnet]
...
... TERRAFORM OUTPUT
...

Apply complete! Resources: 0 added, 0 changed, 11 destroyed.

Please browse to the Cloud Console to remove VM images produced by Packer.
If this file is present, the names of images can be read from it:

image-builder-001/packer/custom-image/packer-manifest.json

https://console.cloud.google.com/compute/images
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
