### PR TITLE
Disable auto_activate_base in conda examples

### DIFF
--- a/community/examples/quantum-circuit-simulator.yaml
+++ b/community/examples/quantum-circuit-simulator.yaml
@@ -47,6 +47,7 @@ deployment_groups:
           bash Miniconda3-py39_4.12.0-Linux-x86_64.sh -b -p /opt/conda
           source /opt/conda/bin/activate base
           conda init --system
+          conda config --system --set auto_activate_base False
           # following channel ordering is important! use strict_priority!
           # cuquantum comes from cuquantum label in nvidia channel
           # libcutensor comes from main (default) label in nvidia channel

--- a/examples/ml-slurm.yaml
+++ b/examples/ml-slurm.yaml
@@ -75,6 +75,7 @@ deployment_groups:
 
           source $CONDA_BASE/bin/activate base
           conda init --system
+          conda config --system --set auto_activate_base False
           # following channel ordering is important! use strict_priority!
           conda config --system --set channel_priority strict
           conda config --system --remove channels defaults


### PR DESCRIPTION
This change will allow users to explicitly run "conda" but will disable activation of the "base" conda environment which may prepend unexpected executables to the user's PATH.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
