### PR TITLE
Ensure local users are not present in final image

### DIFF
--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -247,7 +247,7 @@ No resources.
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the short-lived VM | `map(string)` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2-standard-4"` | no |
 | <a name="input_manifest_file"></a> [manifest\_file](#input\_manifest\_file) | File to which to write Packer build manifest | `string` | `"packer-manifest.json"` | no |
-| <a name="input_metadata"></a> [metadata](#input\_metadata) | Instance metadata to attach to the build VM (startup-script key overridden by var.startup\_script and var.startup\_script\_file if either is set) | `map(string)` | `{}` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Instance metadata for the builder VM (use var.startup\_script or var.startup\_script\_file to set startup-script metadata) | `map(string)` | `{}` | no |
 | <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | Project ID of Shared VPC network | `string` | `null` | no |
 | <a name="input_omit_external_ip"></a> [omit\_external\_ip](#input\_omit\_external\_ip) | Provision the image building VM without a public IP address | `bool` | `true` | no |
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Describes maintenance behavior for the instance. If left blank this will default to `MIGRATE` except the use of GPUs requires it to be `TERMINATE` | `string` | `null` | no |

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -204,7 +204,7 @@ variable "state_timeout" {
 }
 
 variable "metadata" {
-  description = "Instance metadata to attach to the build VM (startup-script key overridden by var.startup_script and var.startup_script_file if either is set)"
+  description = "Instance metadata for the builder VM (use var.startup_script or var.startup_script_file to set startup-script metadata)"
   type        = map(string)
   default     = {}
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/variables.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/variables.pkr.hcl
@@ -204,7 +204,7 @@ variable "state_timeout" {
 }
 
 variable "metadata" {
-  description = "Instance metadata to attach to the build VM (startup-script key overridden by var.startup_script and var.startup_script_file if either is set)"
+  description = "Instance metadata for the builder VM (use var.startup_script or var.startup_script_file to set startup-script metadata)"
   type        = map(string)
   default     = {}
 }

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/variables.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/variables.pkr.hcl
@@ -204,7 +204,7 @@ variable "state_timeout" {
 }
 
 variable "metadata" {
-  description = "Instance metadata to attach to the build VM (startup-script key overridden by var.startup_script and var.startup_script_file if either is set)"
+  description = "Instance metadata for the builder VM (use var.startup_script or var.startup_script_file to set startup-script metadata)"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
[GoogleCloudPlatform/guest-agent](https://github.com/GoogleCloudPlatform/guest-agent) automates the creation of users from SSH keys stored in instance and project metadata. This PR ensures that the image produced by Packer does not contain these users by:

- blocking project SSH key metadata (no users are created)
- properly deleting the temporary packer user at shutdown

Intended to resolve #1387.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
