### PR TITLE
Simplify service-account module

### DIFF
--- a/community/modules/project/service-account/README.md
+++ b/community/modules/project/service-account/README.md
@@ -51,7 +51,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service_accounts"></a> [service\_accounts](#module\_service\_accounts) | terraform-google-modules/service-accounts/google | ~> 4.1 |
+| <a name="module_service_account"></a> [service\_account](#module\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.2 |
 
 ## Resources
 
@@ -62,31 +62,25 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_billing_account_id"></a> [billing\_account\_id](#input\_billing\_account\_id) | If assigning billing role, specify a billing account (default is to assign at the organizational level). | `string` | `""` | no |
-| <a name="input_description"></a> [description](#input\_description) | Default description of the created service accounts (defaults to no description). | `string` | `""` | no |
-| <a name="input_descriptions"></a> [descriptions](#input\_descriptions) | List of descriptions of the created service accounts (elements default to the value of description). | `list(string)` | `[]` | no |
-| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | display names of the created service accounts. | `string` | `""` | no |
-| <a name="input_generate_keys"></a> [generate\_keys](#input\_generate\_keys) | Generate keys for service accounts. | `bool` | `false` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment (will be prepended to service account name) | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | Description of the created service account. | `string` | `"Service Account"` | no |
+| <a name="input_descriptions"></a> [descriptions](#input\_descriptions) | Deprecated; create single service accounts using var.description. | `list(string)` | `null` | no |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | Display name of the created service account. | `string` | `"Service Account"` | no |
+| <a name="input_generate_keys"></a> [generate\_keys](#input\_generate\_keys) | Generate keys for service account. | `bool` | `false` | no |
 | <a name="input_grant_billing_role"></a> [grant\_billing\_role](#input\_grant\_billing\_role) | Grant billing user role. | `bool` | `false` | no |
 | <a name="input_grant_xpn_roles"></a> [grant\_xpn\_roles](#input\_grant\_xpn\_roles) | Grant roles for shared VPC management. | `bool` | `true` | no |
-| <a name="input_names"></a> [names](#input\_names) | Names of the services accounts to create. | `list(string)` | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the service account to create. | `string` | n/a | yes |
+| <a name="input_names"></a> [names](#input\_names) | Deprecated; create single service accounts using var.name. | `list(string)` | `null` | no |
 | <a name="input_org_id"></a> [org\_id](#input\_org\_id) | Id of the organization for org-level roles. | `string` | `""` | no |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | prefix applied to service account names | `string` | `""` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Deprecated; prefix now set using var.deployment\_name | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the project | `string` | n/a | yes |
-| <a name="input_project_roles"></a> [project\_roles](#input\_project\_roles) | list of roles to apply to created service accounts | `list(string)` | n/a | yes |
+| <a name="input_project_roles"></a> [project\_roles](#input\_project\_roles) | List of roles to grant to service account | `list(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_email"></a> [email](#output\_email) | Service account email (for single use). |
-| <a name="output_emails"></a> [emails](#output\_emails) | Service account emails by name. |
-| <a name="output_emails_list"></a> [emails\_list](#output\_emails\_list) | Service account emails s list. |
-| <a name="output_iam_email"></a> [iam\_email](#output\_iam\_email) | IAM-format service account email (for single use). |
-| <a name="output_iam_emails"></a> [iam\_emails](#output\_iam\_emails) | IAM-format service account emails by name. |
-| <a name="output_iam_emails_list"></a> [iam\_emails\_list](#output\_iam\_emails\_list) | IAM-format service account emails s list. |
-| <a name="output_key"></a> [key](#output\_key) | Service account key (for single use). |
-| <a name="output_keys"></a> [keys](#output\_keys) | Map of service account keys. |
-| <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Service account resource (for single use). |
-| <a name="output_service_accounts"></a> [service\_accounts](#output\_service\_accounts) | Service account resources as list. |
-| <a name="output_service_accounts_map"></a> [service\_accounts\_map](#output\_service\_accounts\_map) | Service account resources by name. |
+| <a name="output_key"></a> [key](#output\_key) | Service account key (if creation was requested) |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Service account e-mail address |
+| <a name="output_service_account_iam_email"></a> [service\_account\_iam\_email](#output\_service\_account\_iam\_email) | Service account IAM binding format (serviceAccount:name@example.com) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/project/service-account/main.tf
+++ b/community/modules/project/service-account/main.tf
@@ -14,20 +14,24 @@
  * limitations under the License.
 */
 
-module "service_accounts" {
+locals {
+  display_name = "${var.display_name} (${var.deployment_name})"
+  description  = "${var.description} (${var.deployment_name})"
+}
+
+module "service_account" {
   source  = "terraform-google-modules/service-accounts/google"
-  version = "~> 4.1"
+  version = "~> 4.2"
 
   billing_account_id = var.billing_account_id
-  description        = var.description
-  descriptions       = var.descriptions
-  display_name       = var.display_name
+  description        = local.description
+  display_name       = local.display_name
   generate_keys      = var.generate_keys
   grant_billing_role = var.grant_billing_role
   grant_xpn_roles    = var.grant_xpn_roles
-  names              = var.names
+  names              = [var.name]
   org_id             = var.org_id
-  prefix             = var.prefix
+  prefix             = var.deployment_name
   project_id         = var.project_id
   project_roles      = [for role in var.project_roles : "${var.project_id}=>roles/${role}"]
 }

--- a/community/modules/project/service-account/outputs.tf
+++ b/community/modules/project/service-account/outputs.tf
@@ -14,47 +14,23 @@
  * limitations under the License.
  */
 
-output "email" {
-  description = "Service account email (for single use)."
-  value       = module.service_accounts.email
-}
-output "emails" {
-  description = "Service account emails by name."
-  value       = module.service_accounts.emails
-}
-output "emails_list" {
-  description = "Service account emails s list."
-  value       = module.service_accounts.emails_list
-}
-output "iam_email" {
-  description = "IAM-format service account email (for single use)."
-  value       = module.service_accounts.iam_email
-}
-output "iam_emails" {
-  description = "IAM-format service account emails by name."
-  value       = module.service_accounts.iam_emails
-}
-output "iam_emails_list" {
-  description = "IAM-format service account emails s list."
-  value       = module.service_accounts.iam_emails_list
-}
 output "key" {
-  description = "Service account key (for single use)."
-  value       = module.service_accounts.key
+  description = "Service account key (if creation was requested)"
+  value       = module.service_account.key
 }
-output "keys" {
-  description = "Map of service account keys."
-  value       = module.service_accounts.keys
+
+output "service_account_email" {
+  description = "Service account e-mail address"
+  value       = module.service_account.email
+  depends_on = [
+    module.service_account,
+  ]
 }
-output "service_account" {
-  description = "Service account resource (for single use)."
-  value       = module.service_accounts.service_account
-}
-output "service_accounts" {
-  description = "Service account resources as list."
-  value       = module.service_accounts.service_accounts
-}
-output "service_accounts_map" {
-  description = "Service account resources by name."
-  value       = module.service_accounts.service_accounts_map
+
+output "service_account_iam_email" {
+  description = "Service account IAM binding format (serviceAccount:name@example.com)"
+  value       = module.service_account.iam_email
+  depends_on = [
+    module.service_account,
+  ]
 }

--- a/community/modules/project/service-account/variables.tf
+++ b/community/modules/project/service-account/variables.tf
@@ -20,26 +20,36 @@ variable "billing_account_id" {
   default     = ""
 }
 
-variable "description" {
-  description = "Default description of the created service accounts (defaults to no description)."
+variable "deployment_name" {
+  description = "Name of the deployment (will be prepended to service account name)"
   type        = string
-  default     = ""
+}
+
+variable "description" {
+  description = "Description of the created service account."
+  type        = string
+  default     = "Service Account"
 }
 
 variable "descriptions" {
-  description = "List of descriptions of the created service accounts (elements default to the value of description)."
+  description = "Deprecated; create single service accounts using var.description."
   type        = list(string)
-  default     = []
+  default     = null
+
+  validation {
+    condition     = var.descriptions == null
+    error_message = "var.descriptions has been deprecated in favor of creating single accounts with var.description"
+  }
 }
 
 variable "display_name" {
-  description = "display names of the created service accounts."
+  description = "Display name of the created service account."
   type        = string
-  default     = ""
+  default     = "Service Account"
 }
 
 variable "generate_keys" {
-  description = "Generate keys for service accounts."
+  description = "Generate keys for service account."
   type        = bool
   default     = false
 }
@@ -56,10 +66,20 @@ variable "grant_xpn_roles" {
   default     = true
 }
 
+variable "name" {
+  description = "Name of the service account to create."
+  type        = string
+}
+
 variable "names" {
-  description = "Names of the services accounts to create."
+  description = "Deprecated; create single service accounts using var.name."
   type        = list(string)
-  default     = []
+  default     = null
+
+  validation {
+    condition     = var.names == null
+    error_message = "var.names has been deprecated in favor of creating single accounts with var.name"
+  }
 }
 
 variable "org_id" {
@@ -69,9 +89,14 @@ variable "org_id" {
 }
 
 variable "prefix" {
-  description = "prefix applied to service account names"
+  description = "Deprecated; prefix now set using var.deployment_name"
   type        = string
-  default     = ""
+  default     = null
+
+  validation {
+    condition     = var.prefix == null
+    error_message = "var.prefix has been deprecated in favor of setting prefix with var.deployment_name"
+  }
 }
 
 variable "project_id" {
@@ -80,6 +105,6 @@ variable "project_id" {
 }
 
 variable "project_roles" {
-  description = "list of roles to apply to created service accounts"
+  description = "List of roles to grant to service account"
   type        = list(string)
 }

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -46,6 +46,36 @@ deployment_groups:
   - id: network1
     source: modules/network/pre-existing-vpc
 
+  - id: controller_sa
+    source: community/modules/project/service-account
+    settings:
+      name: controller
+      project_roles:
+      - compute.instanceAdmin.v1
+      - iam.serviceAccountUser
+      - logging.logWriter
+      - monitoring.metricWriter
+      - pubsub.admin
+      - storage.objectViewer
+
+  - id: login_sa
+    source: community/modules/project/service-account
+    settings:
+      name: login
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - storage.objectViewer
+
+  - id: compute_sa
+    source: community/modules/project/service-account
+    settings:
+      name: compute
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - storage.objectCreator
+
   - id: homefs
     source: modules/file-system/filestore
     use: [network1]
@@ -78,6 +108,10 @@ deployment_groups:
       instance_image:
         family: $(vars.family)
         project: $(vars.project)
+      service_account:
+        email: $(compute_sa.service_account_email)
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
 
   - id: n2_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -99,6 +133,10 @@ deployment_groups:
       bandwidth_tier: tier_1_enabled
       disk_type: pd-ssd
       disk_size_gb: 100
+      service_account:
+        email: $(compute_sa.service_account_email)
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
 
   # use `-p c2` to submit jobs to this partition:
   # ex: `srun -p c2 -N 1 hostname`
@@ -122,6 +160,10 @@ deployment_groups:
       bandwidth_tier: tier_1_enabled
       disk_type: pd-ssd
       disk_size_gb: 100
+      service_account:
+        email: $(compute_sa.service_account_email)
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
 
   - id: c2d_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -140,6 +182,10 @@ deployment_groups:
       bandwidth_tier: tier_1_enabled
       disk_type: pd-ssd
       disk_size_gb: 100
+      service_account:
+        email: $(compute_sa.service_account_email)
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
 
   - id: c3_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -158,6 +204,10 @@ deployment_groups:
         project: $(vars.project)
       disk_type: pd-ssd
       disk_size_gb: 100
+      service_account:
+        email: $(compute_sa.service_account_email)
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
 
   # use `-p a208` to submit jobs to this partition:
   # ex: `srun -p a208 --gpus-per-node=8 -N 1 nvidia-smi`
@@ -181,6 +231,10 @@ deployment_groups:
         project: $(vars.project)
       disk_type: pd-ssd
       disk_size_gb: 100
+      service_account:
+        email: $(compute_sa.service_account_email)
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
 
   # use `-p a208` to submit jobs to this partition:
   # ex: `srun -p a216 --gpus-per-node=16 -N 1 nvidia-smi`
@@ -213,6 +267,10 @@ deployment_groups:
       # but that requires your network to have a NAT or
       # private access configured
       disable_controller_public_ips: false
+      service_account:
+        email: $(controller_sa.service_account_email)
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
@@ -225,6 +283,10 @@ deployment_groups:
         project: $(vars.project)
       machine_type: n2-standard-4
       disable_login_public_ips: false
+      service_account:
+        email: $(login_sa.service_account_email)
+        scopes:
+        - https://www.googleapis.com/auth/cloud-platform
 
   - id: hpc_dashboard
     source: modules/monitoring/dashboard

--- a/tools/validate_configs/test_configs/hpc-cluster-service-acct.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-service-acct.yaml
@@ -40,11 +40,9 @@ deployment_groups:
     source: ./community/modules/project/service-account
     settings:
       project_id: $(vars.project_id)
-      names:
-      - "hpc-service-acct"
+      name: hpc-service-acct
       project_roles:
-      - "compute.instanceAdmin.v1"
-
+      - compute.instanceAdmin.v1
 
   - id: compute-partition
     source: ./community/modules/compute/SchedMD-slurm-on-gcp-partition
@@ -62,4 +60,4 @@ deployment_groups:
       - $(homefs.network_storage)
       partition:
       - $(compute-partition.partition)
-      controller_service_account: $(service_acct.email)
+      controller_service_account: $(service_acct.service_account_email)

--- a/tools/validate_configs/test_configs/test_outputs.yaml
+++ b/tools/validate_configs/test_configs/test_outputs.yaml
@@ -112,22 +112,13 @@ deployment_groups:
   - id: sa
     source: community/modules/project/service-account
     outputs:
-    - email
-    - emails
-    - emails_list
-    - iam_email
-    - iam_emails
-    - iam_emails_list
     - key
-    - keys
-    - service_account
-    - service_accounts
-    - service_accounts_map
+    - service_account_email
+    - service_account_iam_email
     settings:
-      names:
-      - "hpc-service-acct"
+      name: hpc-service-acct
       project_roles:
-      - "compute.instanceAdmin.v1"
+      - compute.instanceAdmin.v1
 
   - id: spack
     source: community/modules/scripts/spack-install


### PR DESCRIPTION
The service-account module is marked experimental; this PR intends to facilitate increasing its adoption by simplifying its interface.

- make Toolkit-native by using deployment name in resource naming and descriptions
- instead of creating N service accounts with identical project-wide roles, focus on common use case of a single service account
- update hpc-enterprise-slurm example to use minimally-scoped service accounts

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
