### PR TITLE
Enable remote git Packer

### DIFF
--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -171,7 +171,7 @@ func createGroupDirs(deploymentPath string, deploymentGroups *[]config.Deploymen
 //   - other
 //     => ./modules/<basename(source)>-<hash(abs(source))>
 func deploymentSource(mod config.Module) (string, error) {
-	if sourcereader.IsGitPath(mod.Source) {
+	if sourcereader.IsGitPath(mod.Source) && mod.Kind == config.TerraformKind {
 		return mod.Source, nil
 	}
 	if mod.Kind == config.PackerKind {
@@ -231,7 +231,7 @@ func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGrou
 			}
 			mod.DeploymentSource = ds
 
-			if sourcereader.IsGitPath(mod.Source) {
+			if sourcereader.IsGitPath(mod.Source) && mod.Kind == config.TerraformKind {
 				continue // do not download
 			}
 			factory(mod.Kind.String()).addNumModules(1)


### PR DESCRIPTION
This PR implements basic/experimental support for Git-based Packer templates. The attached example will operate similarly to the existing `examples/image-builder.yaml` example.

```yaml
---
blueprint_name: remote-packer

vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: remote-packer
  region: us-central1
  zone: us-central1-c

# Documentation for each of the modules used below can be found at
# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

deployment_groups:
- group: primary
  modules:
  - id: network1
    source: modules/network/vpc

  - id: scripts_for_image
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: shell
        destination: generate_hello.sh
        content: |
          #!/bin/sh
          echo "Hello World" > /home/hello.txt

- group: packer
  modules:
  - id: custom-image
    source: github.com/GoogleCloudPlatform/hpc-toolkit.git/modules/packer/custom-image
    kind: packer
    use:
    - network1
    - scripts_for_image
    settings:
      source_image_project_id: [schedmd-slurm-public]
      source_image_family: schedmd-v5-slurm-22-05-9-hpc-centos-7
      disk_size: 32
      image_family: new-image-family
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
