### PR TITLE
Allow custom service accounts to be used with startup-script module

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -43,6 +43,8 @@ deployment_groups:
   - id: htcondor_startup_central_manager
     source: modules/scripts/startup-script
     settings:
+      bucket_viewers:
+      - $(htcondor_configure.central_manager_service_account_iam_email)
       runners:
       - $(htcondor_install.install_htcondor_runner)
       - $(htcondor_configure.central_manager_runner)
@@ -58,9 +60,9 @@ deployment_groups:
       machine_type: c2-standard-4
       disable_public_ips: true
       service_account:
-        email: $(htcondor_configure.central_manager_service_account)
+        email: $(htcondor_configure.central_manager_service_account_email)
         scopes:
-        - cloud-platform
+        - https://www.googleapis.com/auth/cloud-platform
       network_interfaces:
       - network: null
         subnetwork: $(network1.subnetwork_self_link)
@@ -78,6 +80,8 @@ deployment_groups:
   - id: htcondor_startup_execute_point
     source: modules/scripts/startup-script
     settings:
+      bucket_viewers:
+      - $(htcondor_configure.execute_point_service_account_iam_email)
       runners:
       - $(htcondor_install.install_htcondor_runner)
       - $(htcondor_configure.execute_point_runner)
@@ -92,9 +96,9 @@ deployment_groups:
     - htcondor_startup_execute_point
     settings:
       service_account:
-        email: $(htcondor_configure.execute_point_service_account)
+        email: $(htcondor_configure.execute_point_service_account_email)
         scopes:
-        - cloud-platform
+        - https://www.googleapis.com/auth/cloud-platform
 
   - id: htcondor_execute_point_spot
     source: community/modules/compute/htcondor-execute-point
@@ -104,13 +108,15 @@ deployment_groups:
     settings:
       spot: true
       service_account:
-        email: $(htcondor_configure.execute_point_service_account)
+        email: $(htcondor_configure.execute_point_service_account_email)
         scopes:
-        - cloud-platform
+        - https://www.googleapis.com/auth/cloud-platform
 
   - id: htcondor_startup_access_point
     source: modules/scripts/startup-script
     settings:
+      bucket_viewers:
+      - $(htcondor_configure.access_point_service_account_iam_email)
       runners:
       - $(htcondor_install.install_htcondor_runner)
       - $(htcondor_install.install_autoscaler_deps_runner)
@@ -142,9 +148,9 @@ deployment_groups:
       add_deployment_name_before_prefix: true
       machine_type: c2-standard-4
       service_account:
-        email: $(htcondor_configure.access_point_service_account)
+        email: $(htcondor_configure.access_point_service_account_email)
         scopes:
-        - cloud-platform
+        - https://www.googleapis.com/auth/cloud-platform
     outputs:
     - internal_ip
     - external_ip

--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -236,11 +236,11 @@ limitations under the License.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_point_roles"></a> [access\_point\_roles](#input\_access\_point\_roles) | Project-wide roles for HTCondor Access Point service account | `list(string)` | <pre>[<br>  "roles/compute.instanceAdmin",<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_access_point_roles"></a> [access\_point\_roles](#input\_access\_point\_roles) | Project-wide roles for HTCondor Access Point service account | `list(string)` | <pre>[<br>  "roles/compute.instanceAdmin",<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter"<br>]</pre> | no |
 | <a name="input_central_manager_high_availability"></a> [central\_manager\_high\_availability](#input\_central\_manager\_high\_availability) | Provision HTCondor central manager in high availability mode | `bool` | `false` | no |
-| <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter"<br>]</pre> | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
-| <a name="input_execute_point_roles"></a> [execute\_point\_roles](#input\_execute\_point\_roles) | Project-wide roles for HTCondor Execute Point service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| <a name="input_execute_point_roles"></a> [execute\_point\_roles](#input\_execute\_point\_roles) | Project-wide roles for HTCondor Execute Point service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter"<br>]</pre> | no |
 | <a name="input_job_queue_high_availability"></a> [job\_queue\_high\_availability](#input\_job\_queue\_high\_availability) | Provision HTCondor access points in high availability mode (experimental: see README) | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to resources. List key, value pairs. | `map(string)` | n/a | yes |
 | <a name="input_pool_password"></a> [pool\_password](#input\_pool\_password) | HTCondor Pool Password | `string` | `null` | no |
@@ -254,12 +254,15 @@ limitations under the License.
 | Name | Description |
 |------|-------------|
 | <a name="output_access_point_runner"></a> [access\_point\_runner](#output\_access\_point\_runner) | Toolkit Runner to configure an HTCondor Access Point |
-| <a name="output_access_point_service_account"></a> [access\_point\_service\_account](#output\_access\_point\_service\_account) | HTCondor Access Point Service Account (e-mail format) |
+| <a name="output_access_point_service_account_email"></a> [access\_point\_service\_account\_email](#output\_access\_point\_service\_account\_email) | HTCondor Access Point Service Account (e-mail format) |
+| <a name="output_access_point_service_account_iam_email"></a> [access\_point\_service\_account\_iam\_email](#output\_access\_point\_service\_account\_iam\_email) | HTCondor Access Point Service Account (IAM binding format) |
 | <a name="output_central_manager_internal_ip"></a> [central\_manager\_internal\_ip](#output\_central\_manager\_internal\_ip) | Reserved internal IP address for use by Central Manager |
 | <a name="output_central_manager_runner"></a> [central\_manager\_runner](#output\_central\_manager\_runner) | Toolkit Runner to configure an HTCondor Central Manager |
 | <a name="output_central_manager_secondary_internal_ip"></a> [central\_manager\_secondary\_internal\_ip](#output\_central\_manager\_secondary\_internal\_ip) | Reserved internal IP address for use by failover Central Manager |
-| <a name="output_central_manager_service_account"></a> [central\_manager\_service\_account](#output\_central\_manager\_service\_account) | HTCondor Central Manager Service Account (e-mail format) |
+| <a name="output_central_manager_service_account_email"></a> [central\_manager\_service\_account\_email](#output\_central\_manager\_service\_account\_email) | HTCondor Central Manager Service Account (e-mail format) |
+| <a name="output_central_manager_service_account_iam_email"></a> [central\_manager\_service\_account\_iam\_email](#output\_central\_manager\_service\_account\_iam\_email) | HTCondor Central Manager Service Account (IAM binding format) |
 | <a name="output_execute_point_runner"></a> [execute\_point\_runner](#output\_execute\_point\_runner) | Toolkit Runner to configure an HTCondor Execute Point |
-| <a name="output_execute_point_service_account"></a> [execute\_point\_service\_account](#output\_execute\_point\_service\_account) | HTCondor Execute Point Service Account (e-mail format) |
+| <a name="output_execute_point_service_account_email"></a> [execute\_point\_service\_account\_email](#output\_execute\_point\_service\_account\_email) | HTCondor Execute Point Service Account (e-mail format) |
+| <a name="output_execute_point_service_account_iam_email"></a> [execute\_point\_service\_account\_iam\_email](#output\_execute\_point\_service\_account\_iam\_email) | HTCondor Execute Point Service Account (IAM binding format) |
 | <a name="output_pool_password_secret_id"></a> [pool\_password\_secret\_id](#output\_pool\_password\_secret\_id) | Google Cloud Secret Manager ID containing HTCondor Pool Password |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/htcondor-configure/outputs.tf
+++ b/community/modules/scheduler/htcondor-configure/outputs.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-output "access_point_service_account" {
+output "access_point_service_account_email" {
   description = "HTCondor Access Point Service Account (e-mail format)"
   value       = module.access_point_service_account.email
   depends_on = [
@@ -23,7 +23,16 @@ output "access_point_service_account" {
   ]
 }
 
-output "central_manager_service_account" {
+output "access_point_service_account_iam_email" {
+  description = "HTCondor Access Point Service Account (IAM binding format)"
+  value       = module.access_point_service_account.iam_email
+  depends_on = [
+    google_secret_manager_secret_iam_member.access_point,
+    module.access_point_service_account
+  ]
+}
+
+output "central_manager_service_account_email" {
   description = "HTCondor Central Manager Service Account (e-mail format)"
   value       = module.central_manager_service_account.email
   depends_on = [
@@ -32,9 +41,27 @@ output "central_manager_service_account" {
   ]
 }
 
-output "execute_point_service_account" {
+output "central_manager_service_account_iam_email" {
+  description = "HTCondor Central Manager Service Account (IAM binding format)"
+  value       = module.central_manager_service_account.iam_email
+  depends_on = [
+    google_secret_manager_secret_iam_member.central_manager,
+    module.central_manager_service_account
+  ]
+}
+
+output "execute_point_service_account_email" {
   description = "HTCondor Execute Point Service Account (e-mail format)"
   value       = module.execute_point_service_account.email
+  depends_on = [
+    google_secret_manager_secret_iam_member.execute_point,
+    module.execute_point_service_account
+  ]
+}
+
+output "execute_point_service_account_iam_email" {
+  description = "HTCondor Execute Point Service Account (IAM binding format)"
+  value       = module.execute_point_service_account.iam_email
   depends_on = [
     google_secret_manager_secret_iam_member.execute_point,
     module.execute_point_service_account

--- a/community/modules/scheduler/htcondor-configure/variables.tf
+++ b/community/modules/scheduler/htcondor-configure/variables.tf
@@ -46,7 +46,6 @@ variable "access_point_roles" {
     "roles/compute.instanceAdmin",
     "roles/monitoring.metricWriter",
     "roles/logging.logWriter",
-    "roles/storage.objectViewer",
   ]
 }
 
@@ -56,7 +55,6 @@ variable "central_manager_roles" {
   default = [
     "roles/monitoring.metricWriter",
     "roles/logging.logWriter",
-    "roles/storage.objectViewer",
   ]
 }
 
@@ -66,7 +64,6 @@ variable "execute_point_roles" {
   default = [
     "roles/monitoring.metricWriter",
     "roles/logging.logWriter",
-    "roles/storage.objectViewer",
   ]
 }
 

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -221,6 +221,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_storage_bucket.configs_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_binding.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [google_storage_bucket_object.scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [local_file.debug_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
@@ -230,6 +231,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ansible_virtualenv_path"></a> [ansible\_virtualenv\_path](#input\_ansible\_virtualenv\_path) | Virtual environment path in which to install Ansible | `string` | `"/usr/local/ghpc-venv"` | no |
+| <a name="input_bucket_viewers"></a> [bucket\_viewers](#input\_bucket\_viewers) | Service accounts or other IAM members (groups, users, domains) to which to grant read-only access to startup-script bucket | `list(string)` | `[]` | no |
 | <a name="input_configure_ssh_host_patterns"></a> [configure\_ssh\_host\_patterns](#input\_configure\_ssh\_host\_patterns) | If specified, it will automate ssh configuration by:<br>  - Defining a Host block for every element of this variable and setting StrictHostKeyChecking to 'No'.<br>  Ex: "hpc*", "hpc01*", "ml*"<br>  - The first time users log-in, it will create ssh keys that are added to the authorized keys list<br>  This requires a shared /home filesystem and relies on specifying the right prefix. | `list(string)` | `[]` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -129,6 +129,12 @@ resource "google_storage_bucket" "configs_bucket" {
   labels                      = local.labels
 }
 
+resource "google_storage_bucket_iam_binding" "viewers" {
+  bucket  = local.storage_bucket_name
+  role    = "roles/storage.objectViewer"
+  members = var.bucket_viewers
+}
+
 resource "google_storage_bucket_object" "scripts" {
   # this writes all scripts exactly once into GCS
   for_each = local.runners_map

--- a/modules/scripts/startup-script/outputs.tf
+++ b/modules/scripts/startup-script/outputs.tf
@@ -17,14 +17,23 @@
 output "startup_script" {
   description = "script to load and run all runners, as a string value."
   value       = local.stdlib
+  depends_on = [
+    google_storage_bucket_iam_binding.viewers
+  ]
 }
 
 output "compute_startup_script" {
   description = "script to load and run all runners, as a string value. Targets the inputs for the slurm controller."
   value       = local.stdlib
+  depends_on = [
+    google_storage_bucket_iam_binding.viewers
+  ]
 }
 
 output "controller_startup_script" {
   description = "script to load and run all runners, as a string value. Targets the inputs for the slurm controller."
   value       = local.stdlib
+  depends_on = [
+    google_storage_bucket_iam_binding.viewers
+  ]
 }

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -29,11 +29,23 @@ variable "region" {
   type        = string
 }
 
-
 variable "gcs_bucket_path" {
   description = "The GCS path for storage bucket and the object."
   type        = string
   default     = null
+}
+
+variable "bucket_viewers" {
+  description = "Service accounts or other IAM members (groups, users, domains) to which to grant read-only access to startup-script bucket"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for u in var.bucket_viewers : length(regexall("^(allUsers$|allAuthenticatedUsers$|user:|group:|serviceAccount:|domain:)", u)) > 0
+    ])
+    error_message = "Bucket viewer members must begin with user/group/serviceAccount/domain following https://cloud.google.com/iam/docs/reference/rest/v1/Policy#Binding"
+  }
 }
 
 variable "debug_file" {


### PR DESCRIPTION
- Improve our support for custom service accounts by modifying the startup-script module to accept a list of IAM members to which to grant the storage.objectViewer role to the bucket, rather than the project as is current practice.
- Modify HTCondor modules and example to adopt this functionality by removing project-wide bucket reading permissions

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
