### PR TITLE
Enable custom service accounts with startup-script

### DIFF
--- a/community/modules/project/service-account/README.md
+++ b/community/modules/project/service-account/README.md
@@ -8,17 +8,42 @@ Allows creation of service accounts for a Google Cloud Platform project.
 - id: service_acct
   source: community/modules/project/service-account
   settings:
-  - project_id: $(vars.project_id)
-  - names: [ "instance_acct" ]
-  - project_roles: [
-    "roles/viewer",
-    "roles/storage.objectViewer",
-  ]
+    project_id: $(vars.project_id)
+    name: instance_acct
+    project_roles:
+    - logging.logWriter
+    - monitoring.metricWriter
+    - storage.objectViewer
 ```
 
 This creates a service account in GCP project "project_id" with the name
-"instance_acct". It will have the two roles "viewer" and
-"storage.objectViewer".
+"instance_acct". It will have the 3 roles listed for all resources within the
+project.
+
+### Usage with startup-script module
+
+When this module is used in conjunction with the [startup-script] module, the
+service account must be granted (at least) read access to the bucket. This can
+be achieved by granting project-wide access as shown above or by specifying the
+service account as a bucket viewer in the startup-script module:
+
+```yaml
+- id: service_acct
+  source: community/modules/project/service-account
+  settings:
+    project_id: $(vars.project_id)
+    name: instance_acct
+    project_roles:
+    - logging.logWriter
+    - monitoring.metricWriter
+- id: script
+  source: modules/scripts/startup-script
+  settings:
+    bucket_viewers:
+    - $(service_acct.service_account_iam_email)
+```
+
+[startup-script]: ../../../../modules/scripts/startup-script/README.md
 
 ## License
 

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -231,7 +231,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ansible_virtualenv_path"></a> [ansible\_virtualenv\_path](#input\_ansible\_virtualenv\_path) | Virtual environment path in which to install Ansible | `string` | `"/usr/local/ghpc-venv"` | no |
-| <a name="input_bucket_viewers"></a> [bucket\_viewers](#input\_bucket\_viewers) | Service accounts or other IAM members (groups, users, domains) to which to grant read-only access to startup-script bucket | `list(string)` | `[]` | no |
+| <a name="input_bucket_viewers"></a> [bucket\_viewers](#input\_bucket\_viewers) | Additional service accounts or groups, users, and domains to which to grant read-only access to startup-script bucket (leave unset if using default Compute Engine service account) | `list(string)` | `[]` | no |
 | <a name="input_configure_ssh_host_patterns"></a> [configure\_ssh\_host\_patterns](#input\_configure\_ssh\_host\_patterns) | If specified, it will automate ssh configuration by:<br>  - Defining a Host block for every element of this variable and setting StrictHostKeyChecking to 'No'.<br>  Ex: "hpc*", "hpc01*", "ml*"<br>  - The first time users log-in, it will create ssh keys that are added to the authorized keys list<br>  This requires a shared /home filesystem and relies on specifying the right prefix. | `list(string)` | `[]` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -221,6 +221,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_storage_bucket.configs_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_binding.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [google_storage_bucket_object.scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [local_file.debug_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
@@ -230,6 +231,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ansible_virtualenv_path"></a> [ansible\_virtualenv\_path](#input\_ansible\_virtualenv\_path) | Virtual environment path in which to install Ansible | `string` | `"/usr/local/ghpc-venv"` | no |
+| <a name="input_bucket_viewers"></a> [bucket\_viewers](#input\_bucket\_viewers) | Service accounts or other IAM members (groups, users, domains) to which to grant read-only access to startup-script bucket | `list(string)` | `[]` | no |
 | <a name="input_configure_ssh_host_patterns"></a> [configure\_ssh\_host\_patterns](#input\_configure\_ssh\_host\_patterns) | If specified, it will automate ssh configuration by:<br>  - Defining a Host block for every element of this variable and setting StrictHostKeyChecking to 'No'.<br>  Ex: "hpc*", "hpc01*", "ml*"<br>  - The first time users log-in, it will create ssh keys that are added to the authorized keys list<br>  This requires a shared /home filesystem and relies on specifying the right prefix. | `list(string)` | `[]` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -129,6 +129,12 @@ resource "google_storage_bucket" "configs_bucket" {
   labels                      = local.labels
 }
 
+resource "google_storage_bucket_iam_binding" "viewers" {
+  bucket  = local.storage_bucket_name
+  role    = "roles/storage.objectViewer"
+  members = var.bucket_viewers
+}
+
 resource "google_storage_bucket_object" "scripts" {
   # this writes all scripts exactly once into GCS
   for_each = local.runners_map

--- a/modules/scripts/startup-script/outputs.tf
+++ b/modules/scripts/startup-script/outputs.tf
@@ -17,14 +17,23 @@
 output "startup_script" {
   description = "script to load and run all runners, as a string value."
   value       = local.stdlib
+  depends_on = [
+    google_storage_bucket_iam_binding.viewers
+  ]
 }
 
 output "compute_startup_script" {
   description = "script to load and run all runners, as a string value. Targets the inputs for the slurm controller."
   value       = local.stdlib
+  depends_on = [
+    google_storage_bucket_iam_binding.viewers
+  ]
 }
 
 output "controller_startup_script" {
   description = "script to load and run all runners, as a string value. Targets the inputs for the slurm controller."
   value       = local.stdlib
+  depends_on = [
+    google_storage_bucket_iam_binding.viewers
+  ]
 }

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -36,7 +36,7 @@ variable "gcs_bucket_path" {
 }
 
 variable "bucket_viewers" {
-  description = "Service accounts or other IAM members (groups, users, domains) to which to grant read-only access to startup-script bucket"
+  description = "Additional service accounts or groups, users, and domains to which to grant read-only access to startup-script bucket (leave unset if using default Compute Engine service account)"
   type        = list(string)
   default     = []
 

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -29,11 +29,23 @@ variable "region" {
   type        = string
 }
 
-
 variable "gcs_bucket_path" {
   description = "The GCS path for storage bucket and the object."
   type        = string
   default     = null
+}
+
+variable "bucket_viewers" {
+  description = "Service accounts or other IAM members (groups, users, domains) to which to grant read-only access to startup-script bucket"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for u in var.bucket_viewers : length(regexall("^(allUsers$|allAuthenticatedUsers$|user:|group:|serviceAccount:|domain:)", u)) > 0
+    ])
+    error_message = "Bucket viewer members must begin with user/group/serviceAccount/domain following https://cloud.google.com/iam/docs/reference/rest/v1/Policy#Binding"
+  }
 }
 
 variable "debug_file" {


### PR DESCRIPTION
Improve our support for custom service accounts by modifying the startup-script module to accept a list of IAM members to which to grant the storage.objectViewer role.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
