### PR TITLE
Fix nfs-server attached disk mounting.

### DIFF
--- a/community/modules/file-system/nfs-server/main.tf
+++ b/community/modules/file-system/nfs-server/main.tf
@@ -55,7 +55,6 @@ data "google_compute_default_service_account" "default" {}
 resource "google_compute_disk" "attached_disk" {
   project = var.project_id
   name    = "${local.name}-nfs-instance-disk"
-  image   = var.image
   size    = var.disk_size
   type    = var.type
   zone    = var.zone
@@ -76,7 +75,8 @@ resource "google_compute_instance" "compute_instance" {
   }
 
   attached_disk {
-    source = google_compute_disk.attached_disk.id
+    source      = google_compute_disk.attached_disk.id
+    device_name = "attached_disk"
   }
 
   network_interface {

--- a/community/modules/file-system/nfs-server/scripts/install-nfs-server.sh.tpl
+++ b/community/modules/file-system/nfs-server/scripts/install-nfs-server.sh.tpl
@@ -14,17 +14,20 @@
 # limitations under the License.
 set -ex
 
-systemctl start nfs-server rpcbind
-systemctl enable nfs-server 
+# format, add to fstab, and mount the disk. See https://cloud.google.com/compute/docs/disks/add-persistent-disk
+uuid=$(uuidgen)
+mkfs.ext4 -F -m 0 -U "$uuid" -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-attached_disk
 
-# format and mount the disk. See https://cloud.google.com/compute/docs/disks/add-persistent-disk
-mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-attached_disk
 mkdir /exports
-mount -o discard,defaults /dev/disk/by-id/google-attached_disk /exports
+echo "UUID=$uuid /exports ext4 discard,defaults 0 0" >> /etc/fstab
+mount --target /exports/
 
 %{ for mount in local_mounts ~}
-mkdir /exports${mount}
+mkdir -p /exports${mount}
 chmod 755 /exports${mount}
 echo '/exports${mount} *(rw,sync,no_root_squash)' >> "/etc/exports"    
 %{ endfor ~}
+
+systemctl start nfs-server rpcbind
+systemctl enable nfs-server 
 exportfs -r

--- a/community/modules/file-system/nfs-server/scripts/install-nfs-server.sh.tpl
+++ b/community/modules/file-system/nfs-server/scripts/install-nfs-server.sh.tpl
@@ -12,14 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -ex
 
-yum -y install nfs-utils
 systemctl start nfs-server rpcbind
 systemctl enable nfs-server 
+
+# format and mount the disk. See https://cloud.google.com/compute/docs/disks/add-persistent-disk
+mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-attached_disk
 mkdir /exports
+mount -o discard,defaults /dev/disk/by-id/google-attached_disk /exports
+
 %{ for mount in local_mounts ~}
-echo ${mount}
-mkdir -p /exports${mount}
+mkdir /exports${mount}
 chmod 755 /exports${mount}
 echo '/exports${mount} *(rw,sync,no_root_squash)' >> "/etc/exports"    
 %{ endfor ~}


### PR DESCRIPTION
* Don't set `google_compute_disk.image` to avoid confused mounting;
* Remove faulty and unnecessary `yum -y install nfs-utils`;
* `set -ex` on `install-nfs-server.sh`;
* format and mount attached disk explicitly.