### PR TITLE
Identify G2 family as having accelerators

### DIFF
--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -22,7 +22,7 @@ locals {
 locals {
   sa_email = var.service_account.email != null ? var.service_account.email : data.google_compute_default_service_account.default_sa.email
 
-  has_gpu = var.guest_accelerator != null || contains(["g2", "a2"], local.machine_family)
+  has_gpu = var.guest_accelerator != null || contains(["a2", "g2"], local.machine_family)
   gpu_taint = local.has_gpu ? [{
     key    = "nvidia.com/gpu"
     value  = "present"

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -39,7 +39,7 @@ locals {
   # compact_placement : true when placement policy is provided and collocation set; false if unset
   compact_placement = try(var.placement_policy.collocation, null) != null
 
-  gpu_attached = contains(["a2"], local.machine_family) || length(local.guest_accelerator) > 0
+  gpu_attached = contains(["a2", "g2"], local.machine_family) || length(local.guest_accelerator) > 0
 
   # both of these must be false if either compact placement or preemptible/spot instances are used
   # automatic restart is tolerant of GPUs while on host maintenance is not

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -48,7 +48,7 @@ locals {
   # determine best value for on_host_maintenance if not supplied by user
   machine_vals                = split("-", var.machine_type)
   machine_family              = local.machine_vals[0]
-  gpu_attached                = contains(["a2"], local.machine_family) || var.accelerator_type != null
+  gpu_attached                = contains(["a2", "g2"], local.machine_family) || var.accelerator_type != null
   on_host_maintenance_default = local.gpu_attached ? "TERMINATE" : "MIGRATE"
   on_host_maintenance = (
     var.on_host_maintenance != null

--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -59,7 +59,7 @@ locals {
   # for attaching GPUs to N1 VMs. For now, identify only A2 types.
   machine_vals                = split("-", var.machine_type)
   machine_family              = local.machine_vals[0]
-  gpu_attached                = contains(["a2"], local.machine_family)
+  gpu_attached                = contains(["a2", "g2"], local.machine_family)
   on_host_maintenance_default = local.gpu_attached ? "TERMINATE" : "MIGRATE"
 
   on_host_maintenance = (

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -48,7 +48,7 @@ locals {
   # determine best value for on_host_maintenance if not supplied by user
   machine_vals                = split("-", var.machine_type)
   machine_family              = local.machine_vals[0]
-  gpu_attached                = contains(["a2"], local.machine_family) || var.accelerator_type != null
+  gpu_attached                = contains(["a2", "g2"], local.machine_family) || var.accelerator_type != null
   on_host_maintenance_default = local.gpu_attached ? "TERMINATE" : "MIGRATE"
   on_host_maintenance = (
     var.on_host_maintenance != null

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -48,7 +48,7 @@ locals {
   # determine best value for on_host_maintenance if not supplied by user
   machine_vals                = split("-", var.machine_type)
   machine_family              = local.machine_vals[0]
-  gpu_attached                = contains(["a2"], local.machine_family) || var.accelerator_type != null
+  gpu_attached                = contains(["a2", "g2"], local.machine_family) || var.accelerator_type != null
   on_host_maintenance_default = local.gpu_attached ? "TERMINATE" : "MIGRATE"
   on_host_maintenance = (
     var.on_host_maintenance != null


### PR DESCRIPTION
Instances with accelerators attached do not support live migration. This commit updates section of code to automatically disable live migration on behalf of the user when G2 VMs are selected.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
