### PR TITLE
Do not swallow error during expanded.yaml write

### DIFF
--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -49,6 +49,6 @@ var (
 
 func runExpandCmd(cmd *cobra.Command, args []string) {
 	dc := expandOrDie(args[0])
-	dc.ExportBlueprint(outputFilename)
+	cobra.CheckErr(dc.ExportBlueprint(outputFilename))
 	fmt.Printf("Expanded Environment Definition created successfully, saved as %s.\n", outputFilename)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -476,7 +476,7 @@ func importBlueprint(blueprintFilename string) (Blueprint, error) {
 }
 
 // ExportBlueprint exports the internal representation of a blueprint config
-func (dc DeploymentConfig) ExportBlueprint(outputFilename string) ([]byte, error) {
+func (dc DeploymentConfig) ExportBlueprint(outputFilename string) error {
 	var buf bytes.Buffer
 	buf.WriteString(YamlLicense)
 	buf.WriteString("\n")
@@ -485,20 +485,18 @@ func (dc DeploymentConfig) ExportBlueprint(outputFilename string) ([]byte, error
 	err := encoder.Encode(&dc.Config)
 	encoder.Close()
 	d := buf.Bytes()
+
 	if err != nil {
-		return d, fmt.Errorf("%s: %w", errorMessages["yamlMarshalError"], err)
+		return fmt.Errorf("%s: %w", errorMessages["yamlMarshalError"], err)
 	}
 
-	if outputFilename == "" {
-		return d, nil
-	}
 	err = ioutil.WriteFile(outputFilename, d, 0644)
 	if err != nil {
 		// hitting this error writing yaml
-		return d, fmt.Errorf("%s, Filename: %s: %w",
+		return fmt.Errorf("%s, Filename: %s: %w",
 			errorMessages["fileSaveError"], outputFilename, err)
 	}
-	return nil, nil
+	return nil
 }
 
 // addKindToModules sets the kind to 'terraform' when empty.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -600,8 +600,7 @@ func (s *MySuite) TestCheckBlueprintName(c *C) {
 func (s *MySuite) TestNewBlueprint(c *C) {
 	dc := getDeploymentConfigForTest()
 	outFile := filepath.Join(tmpTestDir, "out_TestNewBlueprint.yaml")
-	_, err := dc.ExportBlueprint(outFile)
-	c.Assert(err, IsNil)
+	c.Assert(dc.ExportBlueprint(outFile), IsNil)
 	newDC, err := NewDeploymentConfig(outFile)
 	c.Assert(err, IsNil)
 	c.Assert(dc.Config, DeepEquals, newDC.Config)
@@ -731,17 +730,10 @@ dragon: "Lews Therin Telamon"`)
 }
 
 func (s *MySuite) TestExportBlueprint(c *C) {
-	// Return bytes
-	dc := DeploymentConfig{}
-	dc.Config = expectedSimpleBlueprint
-	obtainedYaml, err := dc.ExportBlueprint("")
-	c.Assert(err, IsNil)
-	c.Assert(obtainedYaml, Not(IsNil))
-
-	// Write file
+	dc := DeploymentConfig{Config: expectedSimpleBlueprint}
 	outFilename := "out_TestExportBlueprint.yaml"
 	outFile := filepath.Join(tmpTestDir, outFilename)
-	dc.ExportBlueprint(outFile)
+	c.Assert(dc.ExportBlueprint(outFile), IsNil)
 	fileInfo, err := os.Stat(outFile)
 	c.Assert(err, IsNil)
 	c.Assert(fileInfo.Name(), Equals, outFilename)

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -400,13 +400,7 @@ func prepArtifactsDir(artifactsDir string) error {
 func writeExpandedBlueprint(depDir string, dc config.DeploymentConfig) error {
 	artifactsDir := filepath.Join(depDir, HiddenGhpcDirName, ArtifactsDirName)
 	blueprintFile := filepath.Join(artifactsDir, expandedBlueprintName)
-
-	_, err := dc.ExportBlueprint(blueprintFile)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return dc.ExportBlueprint(blueprintFile)
 }
 
 func writeDestroyInstructions(w io.Writer, dc config.DeploymentConfig, deploymentDir string) {


### PR DESCRIPTION
* Do not swallow error during expanded.yaml write;
* Clean up interface of `ExportBlueprint`.
