### PR TITLE
Improve vpc module

### DIFF
--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -184,6 +184,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_subnetworks"></a> [additional\_subnetworks](#input\_additional\_subnetworks) | DEPRECATED: please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions | `list(map(string))` | `null` | no |
+| <a name="input_allowed_ssh_ip_ranges"></a> [allowed\_ssh\_ip\_ranges](#input\_allowed\_ssh\_ip\_ranges) | A list of CIDR IP ranges from which to allow ssh access | `list(string)` | `[]` | no |
 | <a name="input_default_primary_subnetwork_size"></a> [default\_primary\_subnetwork\_size](#input\_default\_primary\_subnetwork\_size) | The size, in CIDR bits, of the default primary subnetwork unless explicitly defined in var.subnetworks | `number` | `15` | no |
 | <a name="input_delete_default_internet_gateway_routes"></a> [delete\_default\_internet\_gateway\_routes](#input\_delete\_default\_internet\_gateway\_routes) | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |

--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -189,7 +189,9 @@ No resources.
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
 | <a name="input_enable_iap_rdp_ingress"></a> [enable\_iap\_rdp\_ingress](#input\_enable\_iap\_rdp\_ingress) | Enable a firewall rule to allow Windows Remote Desktop Protocol access using IAP tunnels | `bool` | `false` | no |
 | <a name="input_enable_iap_ssh_ingress"></a> [enable\_iap\_ssh\_ingress](#input\_enable\_iap\_ssh\_ingress) | Enable a firewall rule to allow SSH access using IAP tunnels | `bool` | `true` | no |
+| <a name="input_enable_iap_winrm_ingress"></a> [enable\_iap\_winrm\_ingress](#input\_enable\_iap\_winrm\_ingress) | Enable a firewall rule to allow Windows Remote Management (WinRM) access using IAP tunnels | `bool` | `false` | no |
 | <a name="input_enable_internal_traffic"></a> [enable\_internal\_traffic](#input\_enable\_internal\_traffic) | Enable a firewall rule to allow all internal TCP, UDP, and ICMP traffic within the network | `bool` | `true` | no |
+| <a name="input_extra_iap_ports"></a> [extra\_iap\_ports](#input\_extra\_iap\_ports) | A list of TCP ports for which to create firewall rules that enable IAP for TCP forwarding (use dedicated enable\_iap variables for standard ports) | `list(string)` | `[]` | no |
 | <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | List of firewall rules | `any` | `[]` | no |
 | <a name="input_ips_per_nat"></a> [ips\_per\_nat](#input\_ips\_per\_nat) | The number of IP addresses to allocate for each regional Cloud NAT (set to 0 to disable NAT) | `number` | `2` | no |
 | <a name="input_mtu"></a> [mtu](#input\_mtu) | The network MTU (default: 8896). Recommended values: 0 (use Compute Engine default), 1460 (default outside HPC environments), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively. | `number` | `8896` | no |

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -101,6 +101,26 @@ locals {
     }
   }
 
+  allow_ssh_ingress = {
+    name                    = "${local.network_name}-fw-allow-ssh-ingress"
+    description             = "allow SSH access"
+    direction               = "INGRESS"
+    priority                = null
+    ranges                  = var.allowed_ssh_ip_ranges
+    source_tags             = null
+    source_service_accounts = null
+    target_tags             = null
+    target_service_accounts = null
+    allow = [{
+      protocol = "tcp"
+      ports    = ["22"]
+    }]
+    deny = []
+    log_config = {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+
   allow_internal_traffic = {
     name                    = "${local.network_name}-fw-allow-internal-traffic"
     priority                = null
@@ -130,6 +150,7 @@ locals {
 
   firewall_rules = concat(
     var.firewall_rules,
+    length(var.allowed_ssh_ip_ranges) > 0 ? [local.allow_ssh_ingress] : [],
     var.enable_internal_traffic ? [local.allow_internal_traffic] : [],
     length(local.iap_ports) > 0 ? [local.allow_iap_ingress] : []
   )

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -75,9 +75,15 @@ locals {
   output_primary_subnetwork_self_link     = local.output_primary_subnetwork.self_link
   output_primary_subnetwork_ip_cidr_range = local.output_primary_subnetwork.ip_cidr_range
 
-  allow_iap_ssh_ingress = {
-    name                    = "${local.network_name}-fw-allow-iap-ssh-ingress"
-    description             = "allow SSH access via Identity-Aware Proxy"
+  iap_ports = distinct(concat(compact([
+    var.enable_iap_rdp_ingress ? "3389" : "",
+    var.enable_iap_ssh_ingress ? "22" : "",
+    var.enable_iap_winrm_ingress ? "5986" : "",
+  ]), var.extra_iap_ports))
+
+  allow_iap_ingress = {
+    name                    = "${local.network_name}-fw-allow-iap-ingress"
+    description             = "allow TCP access via Identity-Aware Proxy"
     direction               = "INGRESS"
     priority                = null
     ranges                  = ["35.235.240.0/20"]
@@ -87,34 +93,13 @@ locals {
     target_service_accounts = null
     allow = [{
       protocol = "tcp"
-      ports    = ["22"]
+      ports    = local.iap_ports
     }]
     deny = []
     log_config = {
       metadata = "INCLUDE_ALL_METADATA"
     }
   }
-
-  allow_iap_rdp_ingress = {
-    name                    = "${local.network_name}-fw-allow-iap-rdp-ingress"
-    description             = "allow Windows remote desktop access via Identity-Aware Proxy"
-    direction               = "INGRESS"
-    priority                = null
-    ranges                  = ["35.235.240.0/20"]
-    source_tags             = null
-    source_service_accounts = null
-    target_tags             = null
-    target_service_accounts = null
-    allow = [{
-      protocol = "tcp"
-      ports    = ["3389"]
-    }]
-    deny = []
-    log_config = {
-      metadata = "INCLUDE_ALL_METADATA"
-    }
-  }
-
 
   allow_internal_traffic = {
     name                    = "${local.network_name}-fw-allow-internal-traffic"
@@ -143,10 +128,10 @@ locals {
     }
   }
 
-  firewall_rules = concat(var.firewall_rules,
+  firewall_rules = concat(
+    var.firewall_rules,
     var.enable_internal_traffic ? [local.allow_internal_traffic] : [],
-    var.enable_iap_rdp_ingress ? [local.allow_iap_rdp_ingress] : [],
-    var.enable_iap_ssh_ingress ? [local.allow_iap_ssh_ingress] : [],
+    length(local.iap_ports) > 0 ? [local.allow_iap_ingress] : []
   )
 }
 

--- a/modules/network/vpc/variables.tf
+++ b/modules/network/vpc/variables.tf
@@ -190,10 +190,22 @@ variable "enable_iap_rdp_ingress" {
   default     = false
 }
 
+variable "enable_iap_winrm_ingress" {
+  type        = bool
+  description = "Enable a firewall rule to allow Windows Remote Management (WinRM) access using IAP tunnels"
+  default     = false
+}
+
 variable "enable_internal_traffic" {
   type        = bool
   description = "Enable a firewall rule to allow all internal TCP, UDP, and ICMP traffic within the network"
   default     = true
+}
+
+variable "extra_iap_ports" {
+  type        = list(string)
+  description = "A list of TCP ports for which to create firewall rules that enable IAP for TCP forwarding (use dedicated enable_iap variables for standard ports)"
+  default     = []
 }
 
 variable "firewall_rules" {

--- a/modules/network/vpc/variables.tf
+++ b/modules/network/vpc/variables.tf
@@ -208,6 +208,17 @@ variable "extra_iap_ports" {
   default     = []
 }
 
+variable "allowed_ssh_ip_ranges" {
+  type        = list(string)
+  description = "A list of CIDR IP ranges from which to allow ssh access"
+  default     = []
+
+  validation {
+    condition     = alltrue([for r in var.allowed_ssh_ip_ranges : can(cidrhost(r, 32))])
+    error_message = "Each element of var.allowed_ssh_ip_ranges must be a valid CIDR-formatted IPv4 range."
+  }
+}
+
 variable "firewall_rules" {
   type        = any
   description = "List of firewall rules"


### PR DESCRIPTION
- Improve IAP firewall rule support with
  - explicit setting for WinRM port
  - a setting for arbitrary TCP ports
- Improve SSH firewall rule support with a setting for arbitrary CIDR ranges

NB: when run on existing VPCs, this blueprint will potentially cause an SSH-over-IAP hiccup due to renaming of the IAP firewall resource that implements. We are condensing a list of IAP firewall rules with 1 port each into 1 firewall rule with a list of ports. This change is driven by the addition of arbitrary port list and reducing code duplication. IMO this can be handled in release notes. I am not sure if the terraform moved block can reliably handle this change because we are potentially merging 2 IAP firewall rules into 1 while adding a 3rd port. I believe a short (potential) "hiccup" is a better alternative than a failure.

Example blueprint:

```yaml
 ---
blueprint_name: test-fw

vars:
  deployment_name: test-fw
  region: us-central1

deployment_groups:
- group: primary
  modules:
  - id: network1
    source: modules/network/vpc
    settings:
      enable_iap_winrm_ingress: true
      allowed_ssh_ip_ranges:
      - 0.0.0.0/0
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
