### PR TITLE
Update HTCondor example to use Rocky Linux 8

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -20,6 +20,10 @@ vars:
   deployment_name: htcondor-001
   region: us-central1
   zone: us-central1-c
+  # Only CentOS 7 and Rocky 8 are supported; for CentOS 7, remove next 2 lines
+  instance_image:
+    project: cloud-hpc-image-public
+    family: hpc-rocky-linux-8
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -41,7 +41,6 @@
   - name: Set HTCondor Pool password (token signing key)
     ansible.builtin.shell: |
       set -e -o pipefail
-      export CLOUDSDK_PYTHON=/usr/bin/python
       POOL_PASSWORD=$(gcloud secrets versions access latest --secret={{ password_id }})
       echo -n "$POOL_PASSWORD" | sh -c "condor_store_cred add -c -i -"
     args:

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -124,6 +124,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_condor_version"></a> [condor\_version](#input\_condor\_version) | Yum/DNF-compatible version string; leave unset to default to 10.x series (examples: "10.5.1","10.*")) | `string` | `"10.*"` | no |
 | <a name="input_enable_docker"></a> [enable\_docker](#input\_enable\_docker) | Install and enable docker daemon alongside HTCondor | `bool` | `true` | no |
 
 ## Outputs

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -50,7 +50,7 @@
       priority: "90"
   - name: Install HTCondor
     ansible.builtin.package:
-      name: condor
+      name: condor-{{ condor_version | default("10.*") | string }}
       state: present
   - name: Ensure token directory
     ansible.builtin.file:

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -28,6 +28,11 @@
     ansible.builtin.package:
       name:
       - epel-release
+  # adding key explicitly addresses https://github.com/ansible/ansible/pull/71640
+  - name: Add HTCondor RPM key
+    ansible.builtin.rpm_key:
+      state: present
+      key: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key
   - name: Enable HTCondor Feature Release repository
     ansible.builtin.yum_repository:
       name: htcondor-feature
@@ -61,6 +66,11 @@
   - name: Install Docker and configure HTCondor to use it
     when: enable_docker | bool  # allows string to be passed at CLI
     block:
+    # adding key explicitly addresses https://github.com/ansible/ansible/pull/71640
+    - name: Add Docker RPM key
+      ansible.builtin.rpm_key:
+        state: present
+        key: https://download.docker.com/linux/centos/gpg
     - name: Setup Docker repo
       ansible.builtin.yum_repository:
         name: docker-ce-stable

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -19,7 +19,10 @@ locals {
     "type"        = "ansible-local"
     "source"      = "${path.module}/files/install-htcondor.yaml"
     "destination" = "install-htcondor.yaml"
-    "args"        = "-e enable_docker=${var.enable_docker}"
+    "args" = join(" ", [
+      "-e enable_docker=${var.enable_docker}",
+      "-e condor_version=${var.condor_version}",
+    ])
   }
 
   runner_install_autoscaler_deps = {

--- a/community/modules/scripts/htcondor-install/variables.tf
+++ b/community/modules/scripts/htcondor-install/variables.tf
@@ -19,3 +19,9 @@ variable "enable_docker" {
   type        = bool
   default     = true
 }
+
+variable "condor_version" {
+  description = "Yum/DNF-compatible version string; leave unset to default to 10.x series (examples: \"10.5.1\",\"10.*\"))"
+  type        = string
+  default     = "10.*"
+}


### PR DESCRIPTION
This PR updates the HTCondor example to use Rocky Linux 8 and allow the specification of any yum/dnf-compatible version string. Changes made:

1. Address https://github.com/ansible/ansible/pull/71640 by explicitly importing the repository GPG key prior to configuring repository and installing packages.
2. Remove a "hack" that explicitly configured `CLOUDSDK_PYTHON`; this hack breaks on systems like Rocky 8 without Python 2.x and I tested it manually to confirm it's no longer necessary on CentOS 7 (I believe it had origins in releases of gcloud with early support for Secret Manager)
3. Support enterprise environments that want predictable releases of HTCondor by adding an optional var.condor_version to be specified. It defaults to "10.*" which will select the latest 10.x release. This feature is not added to the default example.

To test CentOS 7 and a fixed version, I suggest:

```yaml
---
blueprint_name: htc-htcondor

vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: htcondor-7
  region: us-central1
  zone: us-central1-c

# Documentation for each of the modules used below can be found at
# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

deployment_groups:
- group: htcondor
  modules:
  - id: network1
    source: modules/network/vpc
    outputs:
    - network_name

  - id: htcondor_install
    source: community/modules/scripts/htcondor-install
    settings:
      condor_version: 10.4.3

  - id: htcondor_configure
    source: community/modules/scheduler/htcondor-configure
    use:
    - network1

  - id: htcondor_startup_central_manager
    source: modules/scripts/startup-script
    settings:
      runners:
      - $(htcondor_install.install_htcondor_runner)
      - $(htcondor_configure.central_manager_runner)

  - id: htcondor_cm
    source: modules/compute/vm-instance
    use:
    - network1
    - htcondor_startup_central_manager
    settings:
      name_prefix: cm
      add_deployment_name_before_prefix: true
      machine_type: c2-standard-4
      disable_public_ips: true
      service_account:
        email: $(htcondor_configure.central_manager_service_account)
        scopes:
        - cloud-platform
      network_interfaces:
      - network: null
        subnetwork: $(network1.subnetwork_self_link)
        subnetwork_project: $(vars.project_id)
        network_ip: $(htcondor_configure.central_manager_internal_ip)
        stack_type: null
        access_config: []
        ipv6_access_config: []
        alias_ip_range: []
        nic_type: VIRTIO_NET
        queue_count: null
    outputs:
    - internal_ip

  - id: htcondor_startup_execute_point
    source: modules/scripts/startup-script
    settings:
      runners:
      - $(htcondor_install.install_htcondor_runner)
      - $(htcondor_configure.execute_point_runner)

  # the HTCondor modules support up to 2 execute points per blueprint
  # if using 1, it may use Spot or On-demand pricing
  # if using 2, one must use Spot and the other must use On-demand (default)
  - id: htcondor_execute_point
    source: community/modules/compute/htcondor-execute-point
    use:
    - network1
    - htcondor_startup_execute_point
    settings:
      service_account:
        email: $(htcondor_configure.execute_point_service_account)
        scopes:
        - cloud-platform

  - id: htcondor_execute_point_spot
    source: community/modules/compute/htcondor-execute-point
    use:
    - network1
    - htcondor_startup_execute_point
    settings:
      spot: true
      service_account:
        email: $(htcondor_configure.execute_point_service_account)
        scopes:
        - cloud-platform

  - id: htcondor_startup_access_point
    source: modules/scripts/startup-script
    settings:
      runners:
      - $(htcondor_install.install_htcondor_runner)
      - $(htcondor_install.install_autoscaler_deps_runner)
      - $(htcondor_install.install_autoscaler_runner)
      - $(htcondor_configure.access_point_runner)
      - $(htcondor_execute_point.configure_autoscaler_runner)
      - $(htcondor_execute_point_spot.configure_autoscaler_runner)
      - type: data
        destination: /var/tmp/helloworld.sub
        content: |
          universe       = vanilla
          executable     = /bin/echo
          arguments      = "Hello, World!"
          output         = out.\$(ClusterId).\$(ProcId)
          error          = err.\$(ClusterId).\$(ProcId)
          log            = log.\$(ClusterId).\$(ProcId)
          request_cpus   = 1
          request_memory = 100MB
          +RequireSpot   = true # if unset, defaults to false
          queue

  - id: htcondor_access
    source: modules/compute/vm-instance
    use:
    - network1
    - htcondor_startup_access_point
    settings:
      name_prefix: ap
      add_deployment_name_before_prefix: true
      machine_type: c2-standard-4
      service_account:
        email: $(htcondor_configure.access_point_service_account)
        scopes:
        - cloud-platform
    outputs:
    - internal_ip
    - external_ip
```



### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
