### PR TITLE
Fix Ansible installation upon re-run

### DIFF
--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -206,7 +206,9 @@ main() {
 		${venv_python_path} -m pip install ansible=="${REQ_ANSIBLE_PIP_VERSION}"
 	fi
 	while read -r cmd; do
-		ln -s "${venv_path}/bin/${cmd}" "/usr/bin/${cmd}"
+		if ! [ -L "/usr/bin/${cmd}" ]; then
+			ln -s "${venv_path}/bin/${cmd}" "/usr/bin/${cmd}"
+		fi
 	done <<-EOF
 		ansible
 		ansible-config


### PR DESCRIPTION
PR #1379 introduced symbolic links for all Ansible commands in the system path rather than relying on virtual environment activation. Unfortunately, it was implemented in a manner that will fail upon 2nd execution (i.e. a reboot or after in the first boot of a custom image). This PR fixes Ansible installation so that it does not fail if the links already exist. If any links disappear, they will be re-created.

I believe this PR merits being included in the upcoming release.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
