### PR TITLE
Improve HTCondor example and integration tests

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -17,19 +17,17 @@ blueprint_name: htc-htcondor
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: htcondor-001
+  deployment_name: htcondor-pool
   region: us-central1
   zone: us-central1-c
-  # Only CentOS 7 and Rocky 8 are supported; for CentOS 7, remove next 2 lines
-  instance_image:
-    project: cloud-hpc-image-public
-    family: hpc-rocky-linux-8
+  disk_size_gb: 100
+  image_family: htcondor-10x
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
 
 deployment_groups:
-- group: htcondor
+- group: primary
   modules:
   - id: network1
     source: modules/network/vpc
@@ -39,6 +37,28 @@ deployment_groups:
   - id: htcondor_install
     source: community/modules/scripts/htcondor-install
 
+  - id: htcondor_install_script
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - $(htcondor_install.install_htcondor_runner)
+      - $(htcondor_install.install_autoscaler_deps_runner)
+
+- group: packer
+  modules:
+  - id: custom-image
+    source: modules/packer/custom-image
+    kind: packer
+    use:
+    - network1
+    - htcondor_install_script
+    settings:
+      disk_size: $(vars.disk_size_gb)
+      source_image_family: hpc-rocky-linux-8
+      image_family: $(vars.image_family)
+
+- group: pool
+  modules:
   - id: htcondor_configure
     source: community/modules/scheduler/htcondor-configure
     use:
@@ -48,7 +68,6 @@ deployment_groups:
     source: modules/scripts/startup-script
     settings:
       runners:
-      - $(htcondor_install.install_htcondor_runner)
       - $(htcondor_configure.central_manager_runner)
 
   - id: htcondor_cm
@@ -58,6 +77,9 @@ deployment_groups:
     - htcondor_startup_central_manager
     settings:
       name_prefix: cm
+      instance_image:
+        project: $(vars.project_id)
+        family: $(vars.image_family)
       add_deployment_name_before_prefix: true
       machine_type: c2-standard-4
       disable_public_ips: true
@@ -83,7 +105,6 @@ deployment_groups:
     source: modules/scripts/startup-script
     settings:
       runners:
-      - $(htcondor_install.install_htcondor_runner)
       - $(htcondor_configure.execute_point_runner)
 
   # the HTCondor modules support up to 2 execute points per blueprint
@@ -95,6 +116,10 @@ deployment_groups:
     - network1
     - htcondor_startup_execute_point
     settings:
+      instance_image:
+        project: $(vars.project_id)
+        family: $(vars.image_family)
+      min_idle: 2
       service_account:
         email: $(htcondor_configure.execute_point_service_account)
         scopes:
@@ -107,6 +132,9 @@ deployment_groups:
     - htcondor_startup_execute_point
     settings:
       spot: true
+      instance_image:
+        project: $(vars.project_id)
+        family: $(vars.image_family)
       service_account:
         email: $(htcondor_configure.execute_point_service_account)
         scopes:
@@ -116,8 +144,6 @@ deployment_groups:
     source: modules/scripts/startup-script
     settings:
       runners:
-      - $(htcondor_install.install_htcondor_runner)
-      - $(htcondor_install.install_autoscaler_deps_runner)
       - $(htcondor_install.install_autoscaler_runner)
       - $(htcondor_configure.access_point_runner)
       - $(htcondor_execute_point.configure_autoscaler_runner)
@@ -143,6 +169,9 @@ deployment_groups:
     - htcondor_startup_access_point
     settings:
       name_prefix: ap
+      instance_image:
+        project: $(vars.project_id)
+        family: $(vars.image_family)
       add_deployment_name_before_prefix: true
       machine_type: c2-standard-4
       service_account:

--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -21,7 +21,7 @@ vars:
   region: us-central1
   zone: us-central1-c
   disk_size_gb: 100
-  image_family: htcondor-10x
+  new_image_family: htcondor-10x
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -55,7 +55,7 @@ deployment_groups:
     settings:
       disk_size: $(vars.disk_size_gb)
       source_image_family: hpc-rocky-linux-8
-      image_family: $(vars.image_family)
+      image_family: $(vars.new_image_family)
 
 - group: pool
   modules:
@@ -79,7 +79,7 @@ deployment_groups:
       name_prefix: cm
       instance_image:
         project: $(vars.project_id)
-        family: $(vars.image_family)
+        family: $(vars.new_image_family)
       add_deployment_name_before_prefix: true
       machine_type: c2-standard-4
       disable_public_ips: true
@@ -118,7 +118,7 @@ deployment_groups:
     settings:
       instance_image:
         project: $(vars.project_id)
-        family: $(vars.image_family)
+        family: $(vars.new_image_family)
       min_idle: 2
       service_account:
         email: $(htcondor_configure.execute_point_service_account)
@@ -134,7 +134,7 @@ deployment_groups:
       spot: true
       instance_image:
         project: $(vars.project_id)
-        family: $(vars.image_family)
+        family: $(vars.new_image_family)
       service_account:
         email: $(htcondor_configure.execute_point_service_account)
         scopes:
@@ -171,7 +171,7 @@ deployment_groups:
       name_prefix: ap
       instance_image:
         project: $(vars.project_id)
-        family: $(vars.image_family)
+        family: $(vars.new_image_family)
       add_deployment_name_before_prefix: true
       machine_type: c2-standard-4
       service_account:

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -1,12 +1,14 @@
 ## Description
 
 This module creates a Toolkit runner that will install HTCondor on RedHat 7 or
-derivative operating systems such as the CentOS 7 release in the [HPC VM
-Image][hpcvmimage]. It should also function on RedHat or Rocky Linux releases 8
-and 9, however it is not yet supported. Please report any [issues] on these
-platforms.
+8 and its derivative operating systems. These include the CentOS 7 and Rocky
+Linux 8 releases of the [HPC VM Image][hpcvmimage]. It may also function on
+RedHat 9 and derivatives, however it is not yet supported. Please report any
+[issues] on these 3 distributions or open a [discussion] to request support on
+Debian or Ubuntu distributions.
 
 [issues]: https://github.com/GoogleCloudPlatform/hpc-toolkit/issues
+[discussion]: https://github.com/GoogleCloudPlatform/hpc-toolkit/discussions
 
 It also exports a list of Google Cloud APIs which must be enabled prior to
 provisioning an HTCondor Pool.

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -23,16 +23,14 @@
   vars:
     enable_docker: true
   become: true
+  module_defaults:
+    ansible.builtin.yum:
+      lock_timeout: 300
   tasks:
   - name: Enable EPEL repository
-    ansible.builtin.package:
+    ansible.builtin.yum:
       name:
       - epel-release
-  # adding key explicitly addresses https://github.com/ansible/ansible/pull/71640
-  - name: Add HTCondor RPM key
-    ansible.builtin.rpm_key:
-      state: present
-      key: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key
   - name: Enable HTCondor Feature Release repository
     ansible.builtin.yum_repository:
       name: htcondor-feature
@@ -54,7 +52,7 @@
       repo_gpgcheck: true
       priority: "90"
   - name: Install HTCondor
-    ansible.builtin.package:
+    ansible.builtin.yum:
       name: condor-{{ condor_version | default("10.*") | string }}
       state: present
   - name: Ensure token directory
@@ -66,11 +64,6 @@
   - name: Install Docker and configure HTCondor to use it
     when: enable_docker | bool  # allows string to be passed at CLI
     block:
-    # adding key explicitly addresses https://github.com/ansible/ansible/pull/71640
-    - name: Add Docker RPM key
-      ansible.builtin.rpm_key:
-        state: present
-        key: https://download.docker.com/linux/centos/gpg
     - name: Setup Docker repo
       ansible.builtin.yum_repository:
         name: docker-ce-stable
@@ -80,7 +73,7 @@
         gpgcheck: yes
         gpgkey: https://download.docker.com/linux/centos/gpg
     - name: Install Docker
-      ansible.builtin.package:
+      ansible.builtin.yum:
         name:
         - docker-ce
         - docker-ce-cli

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -80,11 +80,14 @@
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
-      changed_when: false
-      ansible.builtin.shell: >-
-        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com |
-         awk -F'"' '{print $2}'
       register: build_ip
+      changed_when: false
+      args:
+        executable: /bin/bash
+      ansible.builtin.shell: |
+        set -e -o pipefail
+        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
+            awk -F'"' '{print $2}'
     - name: Create firewall rule
       register: fw_result
       changed_when: fw_result.rc == 0
@@ -159,7 +162,6 @@
         minutes: 2
     - name: Run Integration tests for HPC toolkit
       ansible.builtin.include_tasks: "{{ test }}"
-      run_once: true
       vars:
         remote_node: "{{ remote_node }}"
         deployment_name: "{{ deployment_name }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -33,18 +33,14 @@
       file: tasks/create_deployment_directory.yml
   - name: Create Infrastructure and test
     block:
-    - name: Setup network and HTCondor install scripts
-      ansible.builtin.command:
-        cmd: "{{ item }}"
-        chdir: "{{ workspace }}/{{ deployment_name }}/htcondor"
+    - name: Execute ghpc deploy
+      register: deployment
+      changed_when: deployment.changed
+      ansible.builtin.command: ./ghpc deploy {{ deployment_name }} --auto-approve
       args:
-        creates: "{{ workspace }}/{{ deployment_name }}/.terraform"
+        chdir: "{{ workspace }}"
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      with_items:
-      - terraform init
-      - terraform validate
-      - terraform apply -auto-approve -no-color
     - name: Print instance IDs of VMs
       ansible.builtin.include_tasks:
         file: tasks/get_instance_ids.yml
@@ -52,10 +48,10 @@
       register: access_ip
       changed_when: false
       args:
-        chdir: "{{ workspace }}/{{ deployment_name }}/htcondor"
+        chdir: "{{ workspace }}/{{ deployment_name }}/pool"
         executable: /bin/bash
       ansible.builtin.shell: |
-        set -o pipefail
+        set -e -o pipefail
         terraform output -json external_ip_htcondor_access | jq -r '.[0]'
     - name: Add Login node as host
       ansible.builtin.add_host:
@@ -66,9 +62,12 @@
     - name: Get Builder IP
       register: build_ip
       changed_when: false
-      ansible.builtin.shell: >-
-        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com |
-         awk -F'"' '{print $2}'
+      args:
+        executable: /bin/bash
+      ansible.builtin.shell: |
+        set -e -o pipefail
+        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
+            awk -F'"' '{print $2}'
     - name: Create firewall rule
       register: fw_result
       changed_when: fw_result.rc == 0
@@ -111,19 +110,25 @@
         - firewall-rules
         - delete
         - "{{ deployment_name }}"
-    - name: Tear Down Pool
-      changed_when: true  # assume something destroyed
-      failed_when: false  # keep cleaning up
-      run_once: true
-      delegate_to: localhost
+    - name: Destroy deployment
+      register: ghpc_destroy
+      changed_when: ghpc_destroy.changed
+      ignore_errors: true
+      ansible.builtin.command: ./ghpc destroy {{ deployment_name }} --auto-approve
+      args:
+        chdir: "{{ workspace }}"
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      ansible.builtin.command:
-        cmd: "{{ item }}"
-        chdir: "{{ workspace }}/{{ deployment_name }}/htcondor"
-      with_items:
-      - terraform init
-      - terraform destroy -auto-approve
+    - name: Delete VM Image
+      register: image_deletion
+      changed_when: image_deletion.changed
+      ignore_errors: true
+      ansible.builtin.shell: |
+        set -e -o pipefail
+        gcloud compute images delete --project={{ project }} --quiet $(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d ":" -f2)
+      args:
+        chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
+        executable: /bin/bash
 
 - name: Run Integration Tests
   hosts: remote_host
@@ -148,7 +153,6 @@
         timeout: 480
     - name: Run Integration tests for HPC toolkit
       ansible.builtin.include_tasks: "{{ test }}"
-      run_once: true
       vars:
         access_point: "{{ access_point }}"
       loop: "{{ post_deploy_tests }}"
@@ -156,11 +160,10 @@
         loop_var: test
     always:
     - name: Delete Firewall Rule
+      delegate_to: localhost
       register: fw_deleted
       changed_when: fw_deleted.rc == 0
       failed_when: false  # keep cleaning up
-      run_once: true
-      delegate_to: localhost
       ansible.builtin.command:
         argv:
         - gcloud
@@ -168,15 +171,24 @@
         - firewall-rules
         - delete
         - "{{ deployment_name }}"
-    - name: Tear Down Pool
-      changed_when: true  # assume something destroyed
+    - name: Destroy deployment
       delegate_to: localhost
-      run_once: true
+      register: ghpc_destroy
+      changed_when: ghpc_destroy.changed
+      ignore_errors: true
+      ansible.builtin.command: ./ghpc destroy {{ deployment_name }} --auto-approve
+      args:
+        chdir: "{{ workspace }}"
       environment:
         TF_IN_AUTOMATION: "TRUE"
-      ansible.builtin.command:
-        cmd: "{{ item }}"
-        chdir: "{{ workspace }}/{{ deployment_name }}/htcondor"
-      with_items:
-      - terraform init
-      - terraform destroy -auto-approve
+    - name: Delete VM Image
+      delegate_to: localhost
+      register: image_deletion
+      changed_when: image_deletion.changed
+      ignore_errors: true
+      ansible.builtin.shell: |
+        set -e -o pipefail
+        gcloud compute images delete --project={{ project }} --quiet $(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d ":" -f2)
+      args:
+        chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
+        executable: /bin/bash

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -86,11 +86,14 @@
 
     ## Setup firewall for cloud build
     - name: Get Builder IP
-      changed_when: false
-      ansible.builtin.shell: >-
-        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com |
-         awk -F'"' '{print $2}'
       register: build_ip
+      changed_when: false
+      args:
+        executable: /bin/bash
+      ansible.builtin.shell: |
+        set -e -o pipefail
+        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
+            awk -F'"' '{print $2}'
     - name: Create firewall rule
       register: fw_created
       changed_when: fw_created.rc == 0
@@ -172,7 +175,6 @@
         timeout: 600
     - name: Run Integration tests for HPC toolkit
       ansible.builtin.include_tasks: "{{ test }}"
-      run_once: true
       vars:
         login_node: "{{ login_node }}"
         custom_vars: "{{ custom_vars }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-htcondor-access-point.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-htcondor-access-point.yml
@@ -24,6 +24,7 @@
   ansible.builtin.command: condor_status -collector -autoformat HostsTotal
   register: hosts_total
   changed_when: False
+  # must match total min_idle settings of execute-point modules in blueprint
   until: hosts_total.stdout == "2"
   retries: 20
   delay: 15

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-htcondor-access-point.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-htcondor-access-point.yml
@@ -13,10 +13,17 @@
 # limitations under the License.
 
 ---
-- name: Ensure schedd has joined pool
+- name: Ensure schedd has joined the pool
   ansible.builtin.command: condor_status -schedd -autof Name
   register: schedd_status
   changed_when: False
-  until: ansible_fqdn == schedd_status.stdout
+  until: schedd_status.stdout == ansible_fqdn
   retries: 8
+  delay: 15
+- name: Ensure execute points have joined the pool
+  ansible.builtin.command: condor_status -collector -autoformat HostsTotal
+  register: hosts_total
+  changed_when: False
+  until: hosts_total.stdout == "2"
+  retries: 20
   delay: 15


### PR DESCRIPTION
- Convert HTCondor example to multigroup deployment with custom image
- Modify integration test to use deploy/destroy commands
- Modify example to autoscale 2 idle nodes and add a test to check
- Increase yum/dnf timeout to 300 seconds to mitigate race condition with yum-cron/dnf-automatic installation of packages during boot

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
