### PR TITLE
Do not use `log.Fatal` in `pkg/config`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,9 @@ HPC deployments on the Google Cloud Platform.`,
 
 // Execute the root command
 func Execute() error {
+	// Don't prefix messages with data & time to improve readability.
+	// See https://pkg.go.dev/log#pkg-constants
+	log.SetFlags(0)
 
 	mismatch, branch, hash, dir := checkGitHashMismatch()
 	if mismatch {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -350,9 +350,15 @@ func (dc *DeploymentConfig) ExpandConfig() error {
 	}
 	dc.Config.setGlobalLabels()
 	dc.Config.addKindToModules()
-	dc.validateConfig()
-	dc.expand()
-	dc.validate()
+	if err := dc.validateConfig(); err != nil {
+		return err
+	}
+	if err := dc.expand(); err != nil {
+		return err
+	}
+	if err := dc.validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -602,45 +608,46 @@ func checkBackends(bp Blueprint) error {
 }
 
 // validateConfig runs a set of simple early checks on the imported input YAML
-func (dc *DeploymentConfig) validateConfig() {
-	_, err := dc.Config.DeploymentName()
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = dc.Config.checkBlueprintName()
-	if err != nil {
-		log.Fatal(err)
+func (dc *DeploymentConfig) validateConfig() error {
+
+	if _, err := dc.Config.DeploymentName(); err != nil {
+		return err
 	}
 
-	if err = dc.validateVars(); err != nil {
-		log.Fatal(err)
+	if err := dc.Config.checkBlueprintName(); err != nil {
+		return err
 	}
 
-	if err = dc.Config.checkModulesInfo(); err != nil {
-		log.Fatal(err)
+	if err := dc.validateVars(); err != nil {
+		return err
 	}
 
-	if err = checkModulesAndGroups(dc.Config.DeploymentGroups); err != nil {
-		log.Fatal(err)
+	if err := dc.Config.checkModulesInfo(); err != nil {
+		return err
+	}
+
+	if err := checkModulesAndGroups(dc.Config.DeploymentGroups); err != nil {
+		return err
 	}
 
 	// checkPackerGroups must come after checkModulesAndGroups, in which group
 	// Kind is set and aligned with module Kinds
-	if err = checkPackerGroups(dc.Config.DeploymentGroups); err != nil {
-		log.Fatal(err)
+	if err := checkPackerGroups(dc.Config.DeploymentGroups); err != nil {
+		return err
 	}
 
-	if err = checkUsedModuleNames(dc.Config); err != nil {
-		log.Fatal(err)
+	if err := checkUsedModuleNames(dc.Config); err != nil {
+		return err
 	}
 
-	if err = checkBackends(dc.Config); err != nil {
-		log.Fatal(err)
+	if err := checkBackends(dc.Config); err != nil {
+		return err
 	}
 
-	if err = checkModuleSettings(dc.Config); err != nil {
-		log.Fatal(err)
+	if err := checkModuleSettings(dc.Config); err != nil {
+		return err
 	}
+	return nil
 }
 
 // SkipValidator marks validator(s) as skipped,

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -45,37 +45,33 @@ var (
 
 // expand expands variables and strings in the yaml config. Used directly by
 // ExpandConfig for the create and expand commands.
-func (dc *DeploymentConfig) expand() {
+func (dc *DeploymentConfig) expand() error {
 	if err := dc.addMetadataToModules(); err != nil {
 		log.Printf("could not determine required APIs: %v", err)
 	}
 
 	if err := dc.expandBackends(); err != nil {
-		log.Fatalf("failed to apply default backend to deployment groups: %v", err)
+		return fmt.Errorf("failed to apply default backend to deployment groups: %v", err)
 	}
 
 	if err := dc.addDefaultValidators(); err != nil {
-		log.Fatalf(
-			"failed to update validators when expanding the config: %v", err)
+		return fmt.Errorf("failed to update validators when expanding the config: %v", err)
 	}
 
 	if err := dc.combineLabels(); err != nil {
-		log.Fatalf(
-			"failed to update module labels when expanding the config: %v", err)
+		return fmt.Errorf("failed to update module labels when expanding the config: %v", err)
 	}
 
 	if err := dc.applyUseModules(); err != nil {
-		log.Fatalf(
-			"failed to apply \"use\" modules when expanding the config: %v", err)
+		return fmt.Errorf("failed to apply \"use\" modules when expanding the config: %v", err)
 	}
 
 	if err := dc.applyGlobalVariables(); err != nil {
-		log.Fatalf(
-			"failed to apply deployment variables in modules when expanding the config: %v",
-			err)
+		return fmt.Errorf("failed to apply deployment variables in modules when expanding the config: %v", err)
 	}
 
 	dc.Config.populateOutputs()
+	return nil
 }
 
 func (dc *DeploymentConfig) addMetadataToModules() error {

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -24,8 +24,7 @@ import (
 
 func (s *MySuite) TestExpand(c *C) {
 	dc := getDeploymentConfigForTest()
-	fmt.Println("TEST_DEBUG: If tests die without report, check TestExpand")
-	dc.expand()
+	c.Check(dc.expand(), IsNil)
 }
 
 func (s *MySuite) TestExpandBackends(c *C) {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -50,24 +50,18 @@ func (err *InvalidSettingError) Error() string {
 }
 
 // validate is the top-level function for running the validation suite.
-func (dc DeploymentConfig) validate() {
-	// Drop the flags for log to improve readability only for running the validation suite
-	log.SetFlags(0)
-
+func (dc DeploymentConfig) validate() error {
 	// variables should be validated before running validators
 	if err := dc.executeValidators(); err != nil {
-		log.Fatal(err)
+		return err
 	}
-
 	if err := dc.validateModules(); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	if err := dc.validateModuleSettings(); err != nil {
-		log.Fatal(err)
+		return err
 	}
-
-	// Set it back to the initial value
-	log.SetFlags(log.LstdFlags)
+	return nil
 }
 
 // performs validation of global variables


### PR DESCRIPTION
Motivation:
* `pkg/config` is a library, it shouldn't control lifecycle of the application;
* Improve tests failure investigation.
