### PR TITLE
Add rich error messages with position and snippet

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/modulewriter"

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"hpc-toolkit/pkg/config"
 
 	"github.com/zclconf/go-cty/cty"
@@ -127,4 +128,32 @@ func (s *MySuite) TestValidationLevels(c *C) {
 	c.Check(bp.ValidationLevel, Equals, config.ValidationIgnore)
 
 	c.Check(setValidationLevel(&bp, "INVALID"), NotNil)
+}
+
+func (s *MySuite) TestRenderError(c *C) {
+	{ // simple
+		err := errors.New("arbuz")
+		got := renderError(err, config.YamlCtx{})
+		c.Check(got, Equals, "arbuz")
+	}
+	{ // has pos, but context is missing
+		pth := config.Path{}.Dot("rainbow").Dot("over")
+		err := config.BpError{Path: pth, Err: errors.New("arbuz")}
+		got := renderError(err, config.YamlCtx{})
+		c.Check(got, Equals, "rainbow.over: arbuz")
+	}
+	{ // has pos, has context
+		pth := config.Path{}.Dot("rainbow").Dot("over")
+		ctx := config.YamlCtx{
+			PathToPos: map[config.Path]config.Pos{
+				pth: {Line: 2, Column: 3}},
+			Lines: []string{"uno", "dos", "tres"}}
+		err := config.BpError{Path: pth, Err: errors.New("arbuz")}
+		got := renderError(err, ctx)
+		c.Check(got, Equals, `
+Error: arbuz
+on line 2, column 3:
+2: dos
+`)
+	}
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -75,7 +75,7 @@ func getApplyBehavior(autoApprove bool) shell.ApplyBehavior {
 
 func runDeployCmd(cmd *cobra.Command, args []string) {
 	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
-	dc, err := config.NewDeploymentConfig(expandedBlueprintFile)
+	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	cobra.CheckErr(err)
 	cobra.CheckErr(shell.ValidateDeploymentDirectory(dc.Config.DeploymentGroups, deploymentRoot))
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -64,7 +64,7 @@ func parseDestroyArgs(cmd *cobra.Command, args []string) error {
 
 func runDestroyCmd(cmd *cobra.Command, args []string) error {
 	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
-	dc, err := config.NewDeploymentConfig(expandedBlueprintFile)
+	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -87,7 +87,7 @@ func runExportCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
-	dc, err := config.NewDeploymentConfig(expandedBlueprintFile)
+	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -51,7 +51,7 @@ func runImportCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
-	dc, err := config.NewDeploymentConfig(expandedBlueprintFile)
+	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -1,0 +1,33 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+)
+
+// BpError is an error wrapper to augment Path
+type BpError struct {
+	Path Path
+	Err  error
+}
+
+func (e BpError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Path, e.Err)
+}
+
+func (e BpError) Unwrap() error {
+	return e.Err
+}

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -1,0 +1,110 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Path points to concrete location in the blueprint file.
+type Path struct {
+	v string
+}
+
+func (p Path) String() string {
+	return p.v
+}
+
+// At is a builder method for a path of a child in a sequence.
+func (p Path) At(i int) Path {
+	return Path{fmt.Sprintf("%s[%d]", p.v, i)}
+}
+
+// Dot is a builder method for a path of a child in a mapping.
+func (p Path) Dot(k string) Path {
+	if p.v == "" {
+		return Path{k}
+	}
+	return Path{fmt.Sprintf("%s.%s", p.v, k)}
+}
+
+// Pos is a position in the blueprint file.
+type Pos struct {
+	Line   int
+	Column int
+}
+
+func importBlueprint(f string) (Blueprint, YamlCtx, error) {
+	data, err := os.ReadFile(f)
+	if err != nil {
+		return Blueprint{}, YamlCtx{}, fmt.Errorf("%s, filename=%s: %v", errorMessages["fileLoadError"], f, err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+
+	var bp Blueprint
+	if err = decoder.Decode(&bp); err != nil {
+		return Blueprint{}, YamlCtx{}, fmt.Errorf(errorMessages["yamlUnmarshalError"], f, err)
+	}
+	return bp, newYamlCtx(data), nil
+}
+
+// YamlCtx is a contextual information to render errors.
+type YamlCtx struct {
+	PathToPos map[Path]Pos
+	Lines     []string
+}
+
+func newYamlCtx(data []byte) YamlCtx {
+	var c nodeCapturer
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		panic(err) // shouldn't happen
+	}
+
+	m := map[Path]Pos{}
+	var walk func(n *yaml.Node, p Path)
+	walk = func(n *yaml.Node, p Path) {
+		m[p] = Pos{n.Line, n.Column}
+		if n.Kind == yaml.MappingNode {
+			for i := 0; i < len(n.Content); i += 2 {
+				walk(n.Content[i+1], p.Dot(n.Content[i].Value))
+			}
+		} else if n.Kind == yaml.SequenceNode {
+			for i, c := range n.Content {
+				walk(c, p.At(i))
+			}
+		}
+	}
+	walk(c.n, Path{""})
+
+	var lines []string
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return YamlCtx{m, lines}
+}
+
+type nodeCapturer struct{ n *yaml.Node }
+
+func (c *nodeCapturer) UnmarshalYAML(n *yaml.Node) error {
+	c.n = n
+	return nil
+}

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestYamlCtx(t *testing.T) {
-	data := `
+	data := `            # line 1
 # comment
 blueprint_name: green
 
@@ -32,7 +32,7 @@ ghpc_version: apricot
 validators:
 - validator: clay
   inputs:
-    spice: curry
+    spice: curry         # line 10
 - validator: sand
   skip: true
 
@@ -42,7 +42,7 @@ vars:
   red: ruby
 
 deployment_groups:
-- group: tiger
+- group: tiger           # line 20
   terraform_backend:
     type: yam
     configuration:
@@ -52,7 +52,7 @@ deployment_groups:
   - id: tan
     source: oatmeal
     kind: terraform
-    use: [mocha, coffee]
+    use: [mocha, coffee] # line 30
     outputs:
     - latte
     - name: hazelnut
@@ -62,7 +62,7 @@ deployment_groups:
       dijon: pine
 
 - group: crocodile
-  modules:
+  modules:               # line 40
   - id: green
   - id: olive
 

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -1,0 +1,182 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/exp/maps"
+)
+
+func TestYamlCtx(t *testing.T) {
+	data := `
+# comment
+blueprint_name: green
+
+ghpc_version: apricot
+
+validators:
+- validator: clay
+  inputs:
+  spice: curry
+  herb: [basil, sage]
+- validator: sand
+  skip: true
+
+validation_level: 9000
+
+vars:
+  red: ruby
+  blue: [blush, candy]
+  berry: 
+    scarlet:
+    - blood: [jam, wine]
+    - sangria:
+        merlot: [cabernet, pinot]
+
+deployment_groups:
+- group: tiger
+  terraform_backend:
+    type: yam
+    configuration:
+      carrot: rust
+      squash: [amber]
+  kind: ginger
+  modules:
+  - id: tan
+    source: oatmeal
+    kind: fawn
+    use: [mocha, coffee]
+    outputs:
+    - latte
+    - capppuccino:
+      name: hazelnut
+      description: almond
+      sensitive: false
+    settings:
+      dijon: pine
+      seaweed: [kelp, nori]
+
+- group: crocodile
+  modules:
+  - id: green
+  - id: olive
+
+terraform_backend_defaults:
+  type: moss
+`
+	ctx := newYamlCtx([]byte(data))
+
+	gg := map[string]string{}
+	for path, pos := range ctx.PathToPos {
+		gg[fmt.Sprintf("%q", path)] = fmt.Sprintf("{%d, %d}", pos.Line, pos.Column)
+	}
+	keys := maps.Keys(gg)
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Printf("%s: %s,\n", k, gg[k])
+	}
+
+	exp := map[string]Pos{
+		"":                                                               {3, 1},
+		"blueprint_name":                                                 {3, 17},
+		"deployment_groups":                                              {27, 1},
+		"deployment_groups[0]":                                           {27, 3},
+		"deployment_groups[0].group":                                     {27, 10},
+		"deployment_groups[0].kind":                                      {33, 9},
+		"deployment_groups[0].modules":                                   {35, 3},
+		"deployment_groups[0].modules[0]":                                {35, 5},
+		"deployment_groups[0].modules[0].id":                             {35, 9},
+		"deployment_groups[0].modules[0].kind":                           {37, 11},
+		"deployment_groups[0].modules[0].outputs":                        {40, 5},
+		"deployment_groups[0].modules[0].outputs[0]":                     {40, 7},
+		"deployment_groups[0].modules[0].outputs[0].name":                {40, 7},
+		"deployment_groups[0].modules[0].outputs[1]":                     {41, 7},
+		"deployment_groups[0].modules[0].outputs[1].capppuccino":         {41, 19},
+		"deployment_groups[0].modules[0].outputs[1].description":         {43, 20},
+		"deployment_groups[0].modules[0].outputs[1].name":                {42, 13},
+		"deployment_groups[0].modules[0].outputs[1].sensitive":           {44, 18},
+		"deployment_groups[0].modules[0].settings":                       {46, 7},
+		"deployment_groups[0].modules[0].settings.dijon":                 {46, 14},
+		"deployment_groups[0].modules[0].settings.seaweed":               {47, 16},
+		"deployment_groups[0].modules[0].settings.seaweed[0]":            {47, 17},
+		"deployment_groups[0].modules[0].settings.seaweed[1]":            {47, 23},
+		"deployment_groups[0].modules[0].source":                         {36, 13},
+		"deployment_groups[0].modules[0].use":                            {38, 10},
+		"deployment_groups[0].modules[0].use[0]":                         {38, 11},
+		"deployment_groups[0].modules[0].use[1]":                         {38, 18},
+		"deployment_groups[0].terraform_backend":                         {29, 5},
+		"deployment_groups[0].terraform_backend.configuration":           {31, 7},
+		"deployment_groups[0].terraform_backend.configuration.carrot":    {31, 15},
+		"deployment_groups[0].terraform_backend.configuration.squash":    {32, 15},
+		"deployment_groups[0].terraform_backend.configuration.squash[0]": {32, 16},
+		"deployment_groups[0].terraform_backend.type":                    {29, 11},
+		"deployment_groups[1]":                                           {49, 3},
+		"deployment_groups[1].group":                                     {49, 10},
+		"deployment_groups[1].modules":                                   {51, 3},
+		"deployment_groups[1].modules[0]":                                {51, 5},
+		"deployment_groups[1].modules[0].id":                             {51, 9},
+		"deployment_groups[1].modules[1]":                                {52, 5},
+		"deployment_groups[1].modules[1].id":                             {52, 9},
+		"ghpc_version":                                                   {5, 15},
+		"terraform_backend_defaults":                                     {55, 3},
+		"terraform_backend_defaults.type":                                {55, 9},
+		"validation_level":                                               {15, 19},
+		"validators":                                                     {8, 1},
+		"validators[0]":                                                  {8, 3},
+		"validators[0].herb":                                             {11, 9},
+		"validators[0].herb[0]":                                          {11, 10},
+		"validators[0].herb[1]":                                          {11, 17},
+		"validators[0].inputs":                                           {9, 10},
+		"validators[0].spice":                                            {10, 10},
+		"validators[0].validator":                                        {8, 14},
+		"validators[1]":                                                  {12, 3},
+		"validators[1].skip":                                             {13, 9},
+		"validators[1].validator":                                        {12, 14},
+		"vars":                                                           {18, 3},
+		"vars.berry":                                                     {21, 5},
+		"vars.berry.scarlet":                                             {22, 5},
+		"vars.berry.scarlet[0]":                                          {22, 7},
+		"vars.berry.scarlet[0].blood":                                    {22, 14},
+		"vars.berry.scarlet[0].blood[0]":                                 {22, 15},
+		"vars.berry.scarlet[0].blood[1]":                                 {22, 20},
+		"vars.berry.scarlet[1]":                                          {23, 7},
+		"vars.berry.scarlet[1].sangria":                                  {24, 9},
+		"vars.berry.scarlet[1].sangria.merlot":                           {24, 17},
+		"vars.berry.scarlet[1].sangria.merlot[0]":                        {24, 18},
+		"vars.berry.scarlet[1].sangria.merlot[1]":                        {24, 28},
+		"vars.blue":    {19, 9},
+		"vars.blue[0]": {19, 10},
+		"vars.blue[1]": {19, 17},
+		"vars.red":     {18, 8},
+	}
+
+	for path, pos := range exp {
+		t.Run(path, func(t *testing.T) {
+			got := ctx.PathToPos[Path{path}]
+			if diff := cmp.Diff(pos, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+	/*if exp == nil {
+		panic("exp is nil")
+	}*/
+	t.Fail()
+
+}

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -15,12 +15,11 @@
 package config
 
 import (
-	"fmt"
-	"sort"
+	"bytes"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v3"
 )
 
 func TestYamlCtx(t *testing.T) {
@@ -33,8 +32,7 @@ ghpc_version: apricot
 validators:
 - validator: clay
   inputs:
-  spice: curry
-  herb: [basil, sage]
+    spice: curry
 - validator: sand
   skip: true
 
@@ -42,12 +40,6 @@ validation_level: 9000
 
 vars:
   red: ruby
-  blue: [blush, candy]
-  berry: 
-    scarlet:
-    - blood: [jam, wine]
-    - sangria:
-        merlot: [cabernet, pinot]
 
 deployment_groups:
 - group: tiger
@@ -55,22 +47,19 @@ deployment_groups:
     type: yam
     configuration:
       carrot: rust
-      squash: [amber]
-  kind: ginger
+  kind: terraform
   modules:
   - id: tan
     source: oatmeal
-    kind: fawn
+    kind: terraform
     use: [mocha, coffee]
     outputs:
     - latte
-    - capppuccino:
-      name: hazelnut
+    - name: hazelnut
       description: almond
       sensitive: false
     settings:
       dijon: pine
-      seaweed: [kelp, nori]
 
 - group: crocodile
   modules:
@@ -80,103 +69,84 @@ deployment_groups:
 terraform_backend_defaults:
   type: moss
 `
-	ctx := newYamlCtx([]byte(data))
 
-	gg := map[string]string{}
-	for path, pos := range ctx.PathToPos {
-		gg[fmt.Sprintf("%q", path)] = fmt.Sprintf("{%d, %d}", pos.Line, pos.Column)
-	}
-	keys := maps.Keys(gg)
-	sort.Strings(keys)
-	for _, k := range keys {
-		fmt.Printf("%s: %s,\n", k, gg[k])
+	{ // Tests sanity check - data describes valid blueprint.
+		decoder := yaml.NewDecoder(bytes.NewReader([]byte(data)))
+		decoder.KnownFields(true)
+		var bp Blueprint
+		if err := decoder.Decode(&bp); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	exp := map[string]Pos{
-		"":                                                               {3, 1},
-		"blueprint_name":                                                 {3, 17},
-		"deployment_groups":                                              {27, 1},
-		"deployment_groups[0]":                                           {27, 3},
-		"deployment_groups[0].group":                                     {27, 10},
-		"deployment_groups[0].kind":                                      {33, 9},
-		"deployment_groups[0].modules":                                   {35, 3},
-		"deployment_groups[0].modules[0]":                                {35, 5},
-		"deployment_groups[0].modules[0].id":                             {35, 9},
-		"deployment_groups[0].modules[0].kind":                           {37, 11},
-		"deployment_groups[0].modules[0].outputs":                        {40, 5},
-		"deployment_groups[0].modules[0].outputs[0]":                     {40, 7},
-		"deployment_groups[0].modules[0].outputs[0].name":                {40, 7},
-		"deployment_groups[0].modules[0].outputs[1]":                     {41, 7},
-		"deployment_groups[0].modules[0].outputs[1].capppuccino":         {41, 19},
-		"deployment_groups[0].modules[0].outputs[1].description":         {43, 20},
-		"deployment_groups[0].modules[0].outputs[1].name":                {42, 13},
-		"deployment_groups[0].modules[0].outputs[1].sensitive":           {44, 18},
-		"deployment_groups[0].modules[0].settings":                       {46, 7},
-		"deployment_groups[0].modules[0].settings.dijon":                 {46, 14},
-		"deployment_groups[0].modules[0].settings.seaweed":               {47, 16},
-		"deployment_groups[0].modules[0].settings.seaweed[0]":            {47, 17},
-		"deployment_groups[0].modules[0].settings.seaweed[1]":            {47, 23},
-		"deployment_groups[0].modules[0].source":                         {36, 13},
-		"deployment_groups[0].modules[0].use":                            {38, 10},
-		"deployment_groups[0].modules[0].use[0]":                         {38, 11},
-		"deployment_groups[0].modules[0].use[1]":                         {38, 18},
-		"deployment_groups[0].terraform_backend":                         {29, 5},
-		"deployment_groups[0].terraform_backend.configuration":           {31, 7},
-		"deployment_groups[0].terraform_backend.configuration.carrot":    {31, 15},
-		"deployment_groups[0].terraform_backend.configuration.squash":    {32, 15},
-		"deployment_groups[0].terraform_backend.configuration.squash[0]": {32, 16},
-		"deployment_groups[0].terraform_backend.type":                    {29, 11},
-		"deployment_groups[1]":                                           {49, 3},
-		"deployment_groups[1].group":                                     {49, 10},
-		"deployment_groups[1].modules":                                   {51, 3},
-		"deployment_groups[1].modules[0]":                                {51, 5},
-		"deployment_groups[1].modules[0].id":                             {51, 9},
-		"deployment_groups[1].modules[1]":                                {52, 5},
-		"deployment_groups[1].modules[1].id":                             {52, 9},
-		"ghpc_version":                                                   {5, 15},
-		"terraform_backend_defaults":                                     {55, 3},
-		"terraform_backend_defaults.type":                                {55, 9},
-		"validation_level":                                               {15, 19},
-		"validators":                                                     {8, 1},
-		"validators[0]":                                                  {8, 3},
-		"validators[0].herb":                                             {11, 9},
-		"validators[0].herb[0]":                                          {11, 10},
-		"validators[0].herb[1]":                                          {11, 17},
-		"validators[0].inputs":                                           {9, 10},
-		"validators[0].spice":                                            {10, 10},
-		"validators[0].validator":                                        {8, 14},
-		"validators[1]":                                                  {12, 3},
-		"validators[1].skip":                                             {13, 9},
-		"validators[1].validator":                                        {12, 14},
-		"vars":                                                           {18, 3},
-		"vars.berry":                                                     {21, 5},
-		"vars.berry.scarlet":                                             {22, 5},
-		"vars.berry.scarlet[0]":                                          {22, 7},
-		"vars.berry.scarlet[0].blood":                                    {22, 14},
-		"vars.berry.scarlet[0].blood[0]":                                 {22, 15},
-		"vars.berry.scarlet[0].blood[1]":                                 {22, 20},
-		"vars.berry.scarlet[1]":                                          {23, 7},
-		"vars.berry.scarlet[1].sangria":                                  {24, 9},
-		"vars.berry.scarlet[1].sangria.merlot":                           {24, 17},
-		"vars.berry.scarlet[1].sangria.merlot[0]":                        {24, 18},
-		"vars.berry.scarlet[1].sangria.merlot[1]":                        {24, 28},
-		"vars.blue":    {19, 9},
-		"vars.blue[0]": {19, 10},
-		"vars.blue[1]": {19, 17},
-		"vars.red":     {18, 8},
+		"":               {3, 1},
+		"blueprint_name": {3, 17},
+		"ghpc_version":   {5, 15},
+
+		"validators":                 {8, 1},
+		"validators[0]":              {8, 3},
+		"validators[0].inputs":       {10, 5},
+		"validators[0].inputs.spice": {10, 12},
+		"validators[0].validator":    {8, 14},
+		"validators[1]":              {11, 3},
+		"validators[1].skip":         {12, 9},
+		"validators[1].validator":    {11, 14},
+
+		"validation_level": {14, 19},
+
+		"vars":     {17, 3},
+		"vars.red": {17, 8},
+
+		"deployment_groups":          {20, 1},
+		"deployment_groups[0]":       {20, 3},
+		"deployment_groups[0].group": {20, 10},
+
+		"deployment_groups[0].terraform_backend":                      {22, 5},
+		"deployment_groups[0].terraform_backend.type":                 {22, 11},
+		"deployment_groups[0].terraform_backend.configuration":        {24, 7},
+		"deployment_groups[0].terraform_backend.configuration.carrot": {24, 15},
+		"deployment_groups[0].kind":                                   {25, 9},
+
+		"deployment_groups[0].modules":                           {27, 3},
+		"deployment_groups[0].modules[0]":                        {27, 5},
+		"deployment_groups[0].modules[0].id":                     {27, 9},
+		"deployment_groups[0].modules[0].source":                 {28, 13},
+		"deployment_groups[0].modules[0].kind":                   {29, 11},
+		"deployment_groups[0].modules[0].use":                    {30, 10},
+		"deployment_groups[0].modules[0].use[0]":                 {30, 11},
+		"deployment_groups[0].modules[0].use[1]":                 {30, 18},
+		"deployment_groups[0].modules[0].outputs":                {32, 5},
+		"deployment_groups[0].modules[0].outputs[0]":             {32, 7},
+		"deployment_groups[0].modules[0].outputs[0].name":        {32, 7}, // synthetic
+		"deployment_groups[0].modules[0].outputs[1]":             {33, 7},
+		"deployment_groups[0].modules[0].outputs[1].name":        {33, 13},
+		"deployment_groups[0].modules[0].outputs[1].description": {34, 20},
+		"deployment_groups[0].modules[0].outputs[1].sensitive":   {35, 18},
+		"deployment_groups[0].modules[0].settings":               {37, 7},
+		"deployment_groups[0].modules[0].settings.dijon":         {37, 14},
+
+		"deployment_groups[1]":               {39, 3},
+		"deployment_groups[1].group":         {39, 10},
+		"deployment_groups[1].modules":       {41, 3},
+		"deployment_groups[1].modules[0]":    {41, 5},
+		"deployment_groups[1].modules[0].id": {41, 9},
+		"deployment_groups[1].modules[1]":    {42, 5},
+		"deployment_groups[1].modules[1].id": {42, 9},
+
+		"terraform_backend_defaults":      {45, 3},
+		"terraform_backend_defaults.type": {45, 9},
 	}
 
+	ctx := newYamlCtx([]byte(data))
 	for path, pos := range exp {
 		t.Run(path, func(t *testing.T) {
-			got := ctx.PathToPos[Path{path}]
-			if diff := cmp.Diff(pos, got); diff != "" {
+			got, ok := ctx.PathToPos[Path{path}]
+			if !ok {
+				t.Errorf("%q not found", path)
+			} else if diff := cmp.Diff(pos, got); diff != "" {
 				t.Errorf("diff (-want +got):\n%s", diff)
 			}
 		})
 	}
-	/*if exp == nil {
-		panic("exp is nil")
-	}*/
-	t.Fail()
-
 }

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -288,7 +288,7 @@ func ExportOutputs(tf *tfexec.Terraform, artifactsDir string, applyBehavior Appl
 func ImportInputs(deploymentGroupDir string, artifactsDir string, expandedBlueprintFile string) error {
 	deploymentRoot := filepath.Clean(filepath.Join(deploymentGroupDir, ".."))
 
-	dc, err := config.NewDeploymentConfig(expandedBlueprintFile)
+	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Add `Path` & `BpError` to attribute errors to the BP parts;
* Add `ErrorRenderer` to control rendiring of error messages;
* Add `YamlErrorRenderer` that attributes `Path` to the `Pos`;
* Update a few errors to use `BpError`.

NOTE: The crude implementation of `Path` is improved in experimental #1347 and can be addressed after/before this PR is landed/considered worthy.

```sh
$ make && ./ghpc create tst.yaml
**************** building ghpc ************************
Error: deployment_name input error, cause: value was not of type string
on line 6, column 22:
6:   "deployment_name": []
```