### PR TITLE
Remove OFE double-usage of deployment name in service account name

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/cluster_manager/clusterinfo.py
+++ b/community/front-end/ofe/website/ghpcfe/cluster_manager/clusterinfo.py
@@ -242,7 +242,7 @@ class ClusterInfo:
             ["hpc_network"] + filesystems_references
         )
 
-        controller_sa = f"{self.cluster.cloud_id}-sa"
+        controller_sa = "sa"
         # TODO: Determine if these all should be different, and if so, add to
         # resource to be created. NOTE though, that at the moment, GHPC won't
         # let us unpack output variables, so we can't index properly.


### PR DESCRIPTION
### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
