### PR TITLE
Remove `Module.DeploymentSource`, compute it on demand

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -294,9 +294,7 @@ type ModuleID string
 
 // Module stores YAML definition of an HPC cluster component defined in a blueprint
 type Module struct {
-	Source string
-	// DeploymentSource - is source to be used for this module in written deployment.
-	DeploymentSource string `yaml:"-"` // "-" prevents user from specifying it
+	Source           string
 	Kind             ModuleKind
 	ID               ModuleID
 	Use              []ModuleID

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -225,11 +225,6 @@ func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGrou
 		var copyEmbedded = false
 		for iMod := range grp.Modules {
 			mod := &grp.Modules[iMod]
-			ds, err := deploymentSource(*mod)
-			if err != nil {
-				return err
-			}
-			mod.DeploymentSource = ds
 
 			if sourcereader.IsGitPath(mod.Source) && mod.Kind == config.TerraformKind {
 				continue // do not download
@@ -239,8 +234,13 @@ func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGrou
 				copyEmbedded = true
 				continue // all embedded terraform modules fill be copied at once
 			}
+
 			/* Copy source files */
-			dst := filepath.Join(basePath, mod.DeploymentSource)
+			ds, err := deploymentSource(*mod)
+			if err != nil {
+				return err
+			}
+			dst := filepath.Join(basePath, ds)
 			if _, err := os.Stat(dst); err == nil {
 				continue
 			}

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -491,7 +491,9 @@ func (s *MySuite) TestWriteMain(c *C) {
 
 	// Test with modules
 	testModule := config.Module{
-		ID: "test_module",
+		ID:     "test_module",
+		Kind:   config.TerraformKind,
+		Source: "modules/network/vpc",
 		Settings: config.NewDict(map[string]cty.Value{
 			"testSetting": cty.StringVal("testValue"),
 			"passthrough": config.MustParseExpression(`"${var.deployment_name}-allow"`).AsValue(),
@@ -528,6 +530,8 @@ func (s *MySuite) TestWriteMain(c *C) {
 		WrapSettingsWith: map[string][]string{
 			"wrappedSetting": {"list(flatten(", "))"},
 		},
+		Kind:   config.TerraformKind,
+		Source: "modules/network/vpc",
 		Settings: config.NewDict(map[string]cty.Value{
 			"wrappedSetting": cty.TupleVal([]cty.Value{
 				cty.StringVal("val1"),
@@ -687,9 +691,8 @@ func (s *MySuite) TestWriteDeploymentGroup_PackerWriter(c *C) {
 	}
 
 	testPackerModule := config.Module{
-		Kind:             config.PackerKind,
-		ID:               "testPackerModule",
-		DeploymentSource: "testPackerModule",
+		Kind: config.PackerKind,
+		ID:   "testPackerModule",
 	}
 	testDeploymentGroup := config.DeploymentGroup{
 		Name:    "packerGroup",

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -93,7 +93,11 @@ func (w PackerWriter) writeDeploymentGroup(
 			return err
 		}
 
-		modPath := filepath.Join(groupPath, mod.DeploymentSource)
+		ds, err := deploymentSource(mod)
+		if err != nil {
+			return err
+		}
+		modPath := filepath.Join(groupPath, ds)
 		if err = writePackerAutovars(av.Items(), modPath); err != nil {
 			return err
 		}

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -222,7 +222,11 @@ func writeMain(
 		moduleBody := moduleBlock.Body()
 
 		// Add source attribute
-		moduleBody.SetAttributeValue("source", cty.StringVal(mod.DeploymentSource))
+		ds, err := deploymentSource(mod)
+		if err != nil {
+			return err
+		}
+		moduleBody.SetAttributeValue("source", cty.StringVal(ds))
 
 		// For each Setting
 		for _, setting := range orderKeys(mod.Settings.Items()) {


### PR DESCRIPTION
Motivation:
* Reduce state and state mutations;
* Currently it only works because of the bug: shallow copy points to the same underlying `Module`s;

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
