### PR TITLE
Update all references to golang base image

### DIFF
--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -23,7 +23,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -19,7 +19,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/hpc-high-io-v4.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-high-io-v4.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/hpc-high-io-v5.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-high-io-v5.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/lustre-new-vpc.yaml
+++ b/tools/cloud-build/daily-tests/builds/lustre-new-vpc.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/omnia.yaml
+++ b/tools/cloud-build/daily-tests/builds/omnia.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/pbspro.yaml
+++ b/tools/cloud-build/daily-tests/builds/pbspro.yaml
@@ -22,7 +22,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/quantum-circuit.yaml
+++ b/tools/cloud-build/daily-tests/builds/quantum-circuit.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-hpc-centos7.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-hpc-centos7.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-startup-scripts.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-ubuntu2004.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-ubuntu2004.yaml
@@ -18,7 +18,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -23,7 +23,7 @@ steps:
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
-  name: golang
+  name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml
+++ b/tools/cloud-build/dependency-checks/hpc-toolkit-go-builder.yaml
@@ -20,7 +20,7 @@ steps:
 - id: git-fetch-unshallow
   name: gcr.io/cloud-builders/git
   args: ['fetch', '--unshallow']
-- name: golang:bullseye
+- name: "golang:bullseye"
   entrypoint: /bin/bash
   args:
   - -c


### PR DESCRIPTION
The integration tests currently use "golang:latest" as the base image, while the hpc-toolkit-builder uses "golang:bullseye" as the base image. This means that the tests will build using the system packages available in "golang:latest", and run the built binary in an environment based on "golang:bullseye". The "golang:latest" image tends to get updated before the "golang:bullseye" image, potentially causing integration test failures when they are mismatched.

This PR makes sure that all Docker image builds will use "golang:bullseye" as the base image, preventing these kinds of build failures in the future.