### PR TITLE
Add support for Packer packages

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/modulewriter"
 	"hpc-toolkit/pkg/shell"
 	"log"
 	"path/filepath"
@@ -86,7 +87,9 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 		switch group.Kind {
 		case config.PackerKind:
 			// Packer groups are enforced to have length 1
-			moduleDir := filepath.Join(groupDir, string(group.Modules[0].ID))
+			subPath, e := modulewriter.DeploymentSource(group.Modules[0])
+			cobra.CheckErr(e)
+			moduleDir := filepath.Join(groupDir, subPath)
 			err = deployPackerGroup(moduleDir)
 		case config.TerraformKind:
 			err = deployTerraformGroup(groupDir)

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -70,6 +70,8 @@ locals {
     : local.on_host_maintenance_default
   )
 
+  accelerator_type = var.accelerator_type == null ? null : "projects/${var.project_id}/zones/${var.zone}/acceleratorTypes/${var.accelerator_type}"
+
   winrm_username = local.communicator == "winrm" ? "packer_user" : null
   winrm_insecure = local.communicator == "winrm" ? true : null
   winrm_use_ssl  = local.communicator == "winrm" ? true : null
@@ -82,7 +84,7 @@ source "googlecompute" "toolkit_image" {
   image_family            = local.image_family
   image_labels            = var.labels
   machine_type            = var.machine_type
-  accelerator_type        = var.accelerator_type
+  accelerator_type        = local.accelerator_type
   accelerator_count       = var.accelerator_count
   on_host_maintenance     = local.on_host_maintenance
   disk_size               = var.disk_size

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -32,6 +32,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/hashicorp/go-getter"
 )
 
 // strings that get re-used throughout this package and others
@@ -159,21 +161,26 @@ func createGroupDirs(deploymentPath string, deploymentGroups *[]config.Deploymen
 //   - other
 //     => ./modules/<basename(source)>-<hash(abs(source))>
 func DeploymentSource(mod config.Module) (string, error) {
-	if sourcereader.IsGitPath(mod.Source) && mod.Kind == config.TerraformKind {
-		return mod.Source, nil
+	if mod.Kind != config.PackerKind && mod.Kind != config.TerraformKind {
+		return "", fmt.Errorf("unexpected module kind %#v", mod.Kind)
+	}
+	if sourcereader.IsGitPath(mod.Source) {
+		switch mod.Kind {
+		case config.TerraformKind:
+			return mod.Source, nil
+		case config.PackerKind:
+			_, subDir := getter.SourceDirSubdir(mod.Source)
+			return filepath.Join(string(mod.ID), subDir), nil
+		}
 	}
 	if mod.Kind == config.PackerKind {
 		return string(mod.ID), nil
 	}
-	if mod.Kind != config.TerraformKind {
-		return "", fmt.Errorf("unexpected module kind %#v", mod.Kind)
-	}
-
 	if sourcereader.IsEmbeddedPath(mod.Source) {
 		return "./modules/" + filepath.Join("embedded", mod.Source), nil
 	}
 	if !sourcereader.IsLocalPath(mod.Source) {
-		return "", fmt.Errorf("unuexpected module source %s", mod.Source)
+		return "", fmt.Errorf("unexpected module source %s", mod.Source)
 	}
 
 	abs, err := filepath.Abs(mod.Source)
@@ -224,17 +231,31 @@ func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGrou
 			}
 
 			/* Copy source files */
-			ds, err := DeploymentSource(*mod)
-			if err != nil {
-				return err
+			var modPath string
+			var dst string
+			if sourcereader.IsGitPath(mod.Source) && mod.Kind == config.PackerKind {
+				modPath, _ = getter.SourceDirSubdir(mod.Source)
+				dst = filepath.Join(basePath, string(mod.ID))
+
+			} else {
+				modPath = mod.Source
+				ds, err := DeploymentSource(*mod)
+				if err != nil {
+					return err
+				}
+				dst = filepath.Join(basePath, ds)
 			}
-			dst := filepath.Join(basePath, ds)
 			if _, err := os.Stat(dst); err == nil {
 				continue
 			}
-			reader := sourcereader.Factory(mod.Source)
-			if err := reader.GetModule(mod.Source, dst); err != nil {
-				return fmt.Errorf("failed to get module from %s to %s: %v", mod.Source, dst, err)
+			reader := sourcereader.Factory(modPath)
+			if err := reader.GetModule(modPath, dst); err != nil {
+				return fmt.Errorf("failed to get module from %s to %s: %v", modPath, dst, err)
+			}
+			// remove .git directory if one exists; we do not want submodule
+			// git history in deployment directory
+			if err := os.RemoveAll(filepath.Join(dst, ".git")); err != nil {
+				return err
 			}
 		}
 		if copyEmbedded {

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -148,7 +148,7 @@ func createGroupDirs(deploymentPath string, deploymentGroups *[]config.Deploymen
 	return nil
 }
 
-// Get module source within deployment group
+// DeploymentSource returns module source within deployment group
 // Rules are following:
 //   - git source
 //     => keep the same source
@@ -158,7 +158,7 @@ func createGroupDirs(deploymentPath string, deploymentGroups *[]config.Deploymen
 //     => ./modules/embedded/<source>
 //   - other
 //     => ./modules/<basename(source)>-<hash(abs(source))>
-func deploymentSource(mod config.Module) (string, error) {
+func DeploymentSource(mod config.Module) (string, error) {
 	if sourcereader.IsGitPath(mod.Source) && mod.Kind == config.TerraformKind {
 		return mod.Source, nil
 	}
@@ -224,7 +224,7 @@ func copySource(deploymentPath string, deploymentGroups *[]config.DeploymentGrou
 			}
 
 			/* Copy source files */
-			ds, err := deploymentSource(*mod)
+			ds, err := DeploymentSource(*mod)
 			if err != nil {
 				return err
 			}

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -742,43 +742,43 @@ func TestMain(m *testing.M) {
 func (s *MySuite) TestDeploymentSource(c *C) {
 	{ // git
 		m := config.Module{Kind: config.TerraformKind, Source: "github.com/x/y.git"}
-		s, err := deploymentSource(m)
+		s, err := DeploymentSource(m)
 		c.Check(err, IsNil)
 		c.Check(s, Equals, "github.com/x/y.git")
 	}
 	{ // packer
 		m := config.Module{Kind: config.PackerKind, Source: "modules/packer/custom-image", ID: "custom-image"}
-		s, err := deploymentSource(m)
+		s, err := DeploymentSource(m)
 		c.Check(err, IsNil)
 		c.Check(s, Equals, "custom-image")
 	}
 	{ // embedded core
 		m := config.Module{Kind: config.TerraformKind, Source: "modules/x/y"}
-		s, err := deploymentSource(m)
+		s, err := DeploymentSource(m)
 		c.Check(err, IsNil)
 		c.Check(s, Equals, "./modules/embedded/modules/x/y")
 	}
 	{ // embedded community
 		m := config.Module{Kind: config.TerraformKind, Source: "community/modules/x/y"}
-		s, err := deploymentSource(m)
+		s, err := DeploymentSource(m)
 		c.Check(err, IsNil)
 		c.Check(s, Equals, "./modules/embedded/community/modules/x/y")
 	}
 	{ // local rel in repo
 		m := config.Module{Kind: config.TerraformKind, Source: "./modules/x/y"}
-		s, err := deploymentSource(m)
+		s, err := DeploymentSource(m)
 		c.Check(err, IsNil)
 		c.Check(s, Matches, `^\./modules/y-\w\w\w\w$`)
 	}
 	{ // local rel
 		m := config.Module{Kind: config.TerraformKind, Source: "./../../../../x/y"}
-		s, err := deploymentSource(m)
+		s, err := DeploymentSource(m)
 		c.Check(err, IsNil)
 		c.Check(s, Matches, `^\./modules/y-\w\w\w\w$`)
 	}
 	{ // local abs
 		m := config.Module{Kind: config.TerraformKind, Source: "/tmp/x/y"}
-		s, err := deploymentSource(m)
+		s, err := DeploymentSource(m)
 		c.Check(err, IsNil)
 		c.Check(s, Matches, `^\./modules/y-\w\w\w\w$`)
 	}

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -747,10 +747,22 @@ func (s *MySuite) TestDeploymentSource(c *C) {
 		c.Check(s, Equals, "github.com/x/y.git")
 	}
 	{ // packer
-		m := config.Module{Kind: config.PackerKind, Source: "modules/packer/custom-image", ID: "custom-image"}
+		m := config.Module{Kind: config.PackerKind, Source: "modules/packer/custom-image", ID: "image-id"}
 		s, err := DeploymentSource(m)
 		c.Check(err, IsNil)
-		c.Check(s, Equals, "custom-image")
+		c.Check(s, Equals, "image-id")
+	}
+	{ // remote packer non-package
+		m := config.Module{Kind: config.PackerKind, Source: "github.com/GoogleCloudPlatform/modules/packer/custom-image", ID: "image-id"}
+		s, err := DeploymentSource(m)
+		c.Check(err, IsNil)
+		c.Check(s, Equals, "image-id")
+	}
+	{ // remote packer package
+		m := config.Module{Kind: config.PackerKind, Source: "github.com/GoogleCloudPlatform//modules/packer/custom-image?ref=main", ID: "image-id"}
+		s, err := DeploymentSource(m)
+		c.Check(err, IsNil)
+		c.Check(s, Equals, "image-id/modules/packer/custom-image")
 	}
 	{ // embedded core
 		m := config.Module{Kind: config.TerraformKind, Source: "modules/x/y"}

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -41,16 +41,15 @@ func (w *PackerWriter) addNumModules(value int) {
 	w.numModules += value
 }
 
-func printPackerInstructions(w io.Writer, modPath string, modID config.ModuleID, printImportInputs bool) {
+func printPackerInstructions(w io.Writer, groupPath string, subPath string, printImportInputs bool) {
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Packer group '%s' was successfully created in directory %s\n", modID, modPath)
+	fmt.Fprintf(w, "Packer group was successfully created in directory %s\n", groupPath)
 	fmt.Fprintln(w, "To deploy, run the following commands:")
 	fmt.Fprintln(w)
-	grpPath := filepath.Clean(filepath.Join(modPath, ".."))
 	if printImportInputs {
-		fmt.Fprintf(w, "ghpc import-inputs %s\n", grpPath)
+		fmt.Fprintf(w, "ghpc import-inputs %s\n", groupPath)
 	}
-	fmt.Fprintf(w, "cd %s\n", modPath)
+	fmt.Fprintf(w, "cd %s\n", filepath.Join(groupPath, subPath))
 	fmt.Fprintln(w, "packer init .")
 	fmt.Fprintln(w, "packer validate .")
 	fmt.Fprintln(w, "packer build .")
@@ -102,7 +101,7 @@ func (w PackerWriter) writeDeploymentGroup(
 			return err
 		}
 		hasIgc := len(pure.Items()) < len(mod.Settings.Items())
-		printPackerInstructions(instructionsFile, modPath, mod.ID, hasIgc)
+		printPackerInstructions(instructionsFile, groupPath, ds, hasIgc)
 	}
 
 	return nil

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -93,7 +93,7 @@ func (w PackerWriter) writeDeploymentGroup(
 			return err
 		}
 
-		ds, err := deploymentSource(mod)
+		ds, err := DeploymentSource(mod)
 		if err != nil {
 			return err
 		}

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -221,7 +221,7 @@ func writeMain(
 		moduleBody := moduleBlock.Body()
 
 		// Add source attribute
-		ds, err := deploymentSource(mod)
+		ds, err := DeploymentSource(mod)
 		if err != nil {
 			return err
 		}

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -334,8 +334,12 @@ func ImportInputs(deploymentGroupDir string, artifactsDir string, expandedBluepr
 		packerGroup := dc.Config.DeploymentGroups[thisGroupIdx]
 		// Packer groups are enforced to have length 1
 		packerModule := packerGroup.Modules[0]
-		moduleID := string(packerModule.ID)
-		outfile = filepath.Join(deploymentGroupDir, moduleID, fmt.Sprintf("%s_inputs.auto.pkrvars.hcl", moduleID))
+		modPath, err := modulewriter.DeploymentSource(packerModule)
+		if err != nil {
+			return err
+		}
+		outfile = filepath.Join(deploymentGroupDir, modPath,
+			fmt.Sprintf("%s_inputs.auto.pkrvars.hcl", packerModule.ID))
 
 		// evaluate Packer settings that contain intergroup references in the
 		// context of deployment variables and intergroup output values

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/instructions.txt
@@ -9,7 +9,7 @@ terraform -chdir=golden_copy_deployment/zero validate
 terraform -chdir=golden_copy_deployment/zero apply
 ghpc export-outputs golden_copy_deployment/zero
 
-Packer group 'image' was successfully created in directory golden_copy_deployment/one/image
+Packer group was successfully created in directory golden_copy_deployment/one
 To deploy, run the following commands:
 
 ghpc import-inputs golden_copy_deployment/one

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -70,6 +70,8 @@ locals {
     : local.on_host_maintenance_default
   )
 
+  accelerator_type = var.accelerator_type == null ? null : "projects/${var.project_id}/zones/${var.zone}/acceleratorTypes/${var.accelerator_type}"
+
   winrm_username = local.communicator == "winrm" ? "packer_user" : null
   winrm_insecure = local.communicator == "winrm" ? true : null
   winrm_use_ssl  = local.communicator == "winrm" ? true : null
@@ -82,7 +84,7 @@ source "googlecompute" "toolkit_image" {
   image_family            = local.image_family
   image_labels            = var.labels
   machine_type            = var.machine_type
-  accelerator_type        = var.accelerator_type
+  accelerator_type        = local.accelerator_type
   accelerator_count       = var.accelerator_count
   on_host_maintenance     = local.on_host_maintenance
   disk_size               = var.disk_size

--- a/tools/validate_configs/golden_copies/expectations/text_escape/instructions.txt
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/instructions.txt
@@ -1,7 +1,7 @@
 Advanced Deployment Instructions
 ================================
 
-Packer group 'lime' was successfully created in directory golden_copy_deployment/zero/lime
+Packer group was successfully created in directory golden_copy_deployment/zero
 To deploy, run the following commands:
 
 cd golden_copy_deployment/zero/lime

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -70,6 +70,8 @@ locals {
     : local.on_host_maintenance_default
   )
 
+  accelerator_type = var.accelerator_type == null ? null : "projects/${var.project_id}/zones/${var.zone}/acceleratorTypes/${var.accelerator_type}"
+
   winrm_username = local.communicator == "winrm" ? "packer_user" : null
   winrm_insecure = local.communicator == "winrm" ? true : null
   winrm_use_ssl  = local.communicator == "winrm" ? true : null
@@ -82,7 +84,7 @@ source "googlecompute" "toolkit_image" {
   image_family            = local.image_family
   image_labels            = var.labels
   machine_type            = var.machine_type
-  accelerator_type        = var.accelerator_type
+  accelerator_type        = local.accelerator_type
   accelerator_count       = var.accelerator_count
   on_host_maintenance     = local.on_host_maintenance
   disk_size               = var.disk_size


### PR DESCRIPTION
This PR improves support for remote Packer templates by enabling a package notation with source lines such as

```yaml
- group: slurm
  modules:
  - id: slurm-image
    source: github.com/SchedMD/slurm-gcp//packer?ref=5.7.4&depth=1
    kind: packer
```

This will cause the entire `slurm-gcp` repo to be staged to `slurm/slurm-image` and the source of the Packer module will be treated as `slurm/slurm-image/packer`. The problem being solved is that the Packer module may itself contain local references within the rest of the repo (i.e. `"../scripts"`).

Documentation will be added in a future PR alongside a production-ready example. A "beta" example blueprint is shown below that invokes the DAOS and Slurm image building processes is shown below. It has the following limitations:

- the DAOS module does not allow the selection of network (it defaults to the "default" network which must have IAP tunneling setup properly)

```yaml
---
blueprint_name: remote-packer

vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: images
  region: us-central1
  zone: us-central1-c

# Documentation for each of the modules used below can be found at
# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

deployment_groups:
- group: network
  modules:
  - id: network0
    source: modules/network/vpc

- group: daos
  modules:
  - id: daos-image
    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.0&depth=1
    kind: packer
    settings:
      daos_version: 2.2.0
      daos_repo_base_url: https://packages.daos.io
      daos_packages_repo_file: EL8/packages/x86_64/daos_packages.repo
      use_iap: true
      enable_oslogin: false
      machine_type: n2-standard-32
      source_image_family: hpc-rocky-linux-8
      source_image_project_id: cloud-hpc-image-public
      image_guest_os_features: ["GVNIC"]
      disk_size: "20"
      state_timeout: "10m"
      scopes: ["https://www.googleapis.com/auth/cloud-platform"]
      use_internal_ip: true
      omit_external_ip: false
      daos_install_type: server
      image_family: daos-server-hpc-rocky-8

- group: slurm
  modules:
  - id: slurm-image
    source: github.com/SchedMD/slurm-gcp//packer?ref=5.7.4&depth=1
    kind: packer
    settings:
      source_image_project_id: cloud-hpc-image-public
      source_image_family: hpc-rocky-linux-8
      use_iap: true
      subnetwork: $(network0.subnetwork_self_link)
      image_family_alt: new-image-family
      slurm_version: 22.05.9
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
