### PR TITLE
Hotfix: eliminate panic on null value in terraform outputs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ HPC deployments on the Google Cloud Platform.`,
 				log.Fatalf("cmd.Help function failed: %s", err)
 			}
 		},
-		Version:     "v1.19.0",
+		Version:     "v1.19.1",
 		Annotations: annotation,
 	}
 )

--- a/community/modules/compute/gke-node-pool/versions.tf
+++ b/community/modules/compute/gke-node-pool/versions.tf
@@ -26,6 +26,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.19.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.19.1"
   }
   required_version = ">= 0.13.0"
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.19.1"
   }
   required_version = ">= 0.13.0"
 }

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -30,10 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.19.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.19.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/community/modules/file-system/cloud-storage-bucket/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.19.1"
   }
   required_version = ">= 0.14.0"
 }

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/gke-cluster/versions.tf
+++ b/community/modules/scheduler/gke-cluster/versions.tf
@@ -26,6 +26,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.19.1"
   }
 }

--- a/community/modules/scheduler/htcondor-configure/versions.tf
+++ b/community/modules/scheduler/htcondor-configure/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-configure/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-configure/v1.19.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-controller/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-controller/v1.19.1"
   }
   required_version = ">= 0.14.0"
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-login/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-login/v1.19.1"
   }
   required_version = ">= 0.14.0"
 }

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -27,10 +27,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.19.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.19.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scheduler/batch-login-node/versions.tf
+++ b/modules/scheduler/batch-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.19.0"
+    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.19.1"
   }
 
   required_version = ">= 0.14.0"

--- a/pkg/modulewriter/hcl_utils.go
+++ b/pkg/modulewriter/hcl_utils.go
@@ -63,6 +63,10 @@ func WriteHclAttributes(vars map[string]cty.Value, dst string) error {
 // TokensForValue is a modification of hclwrite.TokensForValue.
 // The only difference in behavior is handling "HCL literal" strings.
 func TokensForValue(val cty.Value) hclwrite.Tokens {
+	if val.IsNull() { // terminate early as Null value can has any type (e.g. String)
+		return hclwrite.TokensForValue(val)
+	}
+
 	// We need to handle both cases, until all "expression" users are moved to Expression
 	if e, is := config.IsExpressionValue(val); is {
 		return e.Tokenize()

--- a/pkg/modulewriter/hcl_utils_test.go
+++ b/pkg/modulewriter/hcl_utils_test.go
@@ -30,6 +30,7 @@ func TestTokensForValueNoLiteral(t *testing.T) {
 	val := cty.ObjectVal(map[string]cty.Value{
 		"tan": cty.TupleVal([]cty.Value{
 			cty.StringVal("biege"),
+			cty.NullVal(cty.String),
 			cty.MapVal(map[string]cty.Value{
 				"cu": cty.NumberIntVal(29),
 				"ba": cty.NumberIntVal(56),


### PR DESCRIPTION
Address panic when running `ghpc export-outputs panic/network` after creating and applying this blueprint.

```
---
blueprint_name: panic

vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: panic
  region: us-central1

# Documentation for each of the modules used below can be found at
# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

deployment_groups:
- group: network
  modules:
  - id: network0
    source: modules/network/vpc
    outputs:
    - subnetwork
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)