### PR TITLE
Add custom unmarshaler for `Module.Use` for better error messaging

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -316,7 +316,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 			matchingIntragroupName1: cty.StringVal("explicit-intra-value"),
 			matchingIntragroupName2: ModuleRef(mod0.ID, matchingIntragroupName2).AsExpression().AsValue(),
 		}),
-		Use: []ModuleID{mod0.ID},
+		Use: ModuleIDs{mod0.ID},
 	}
 	setTestModuleInfo(mod1, testModuleInfo1)
 
@@ -329,7 +329,7 @@ func getMultiGroupDeploymentConfig() DeploymentConfig {
 		ID:     "TestModule2",
 		Kind:   TerraformKind,
 		Source: testModuleSource2,
-		Use:    []ModuleID{mod0.ID},
+		Use:    ModuleIDs{mod0.ID},
 	}
 	setTestModuleInfo(mod2, testModuleInfo2)
 
@@ -419,25 +419,25 @@ func (s *MySuite) TestCheckModulesAndGroups(c *C) {
 func (s *MySuite) TestListUnusedModules(c *C) {
 	{ // No modules in "use"
 		m := Module{ID: "m"}
-		c.Check(m.listUnusedModules(), DeepEquals, []ModuleID{})
+		c.Check(m.listUnusedModules(), DeepEquals, ModuleIDs{})
 	}
 
 	{ // Useful
 		m := Module{
 			ID:  "m",
-			Use: []ModuleID{"w"},
+			Use: ModuleIDs{"w"},
 			Settings: NewDict(map[string]cty.Value{
 				"x": AsProductOfModuleUse(cty.True, "w")})}
-		c.Check(m.listUnusedModules(), DeepEquals, []ModuleID{})
+		c.Check(m.listUnusedModules(), DeepEquals, ModuleIDs{})
 	}
 
 	{ // Unused
 		m := Module{
 			ID:  "m",
-			Use: []ModuleID{"w", "u"},
+			Use: ModuleIDs{"w", "u"},
 			Settings: NewDict(map[string]cty.Value{
 				"x": AsProductOfModuleUse(cty.True, "w")})}
-		c.Check(m.listUnusedModules(), DeepEquals, []ModuleID{"u"})
+		c.Check(m.listUnusedModules(), DeepEquals, ModuleIDs{"u"})
 	}
 }
 

--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -15,13 +15,9 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/gocty"
-	ctyJson "github.com/zclconf/go-cty/cty/json"
-	"gopkg.in/yaml.v3"
 )
 
 // Dict maps string key to cty.Value.
@@ -89,121 +85,6 @@ func (d *Dict) AsObject() cty.Value {
 // with the `omitempty“ flag.
 func (d Dict) IsZero() bool {
 	return len(d.m) == 0
-}
-
-// YamlValue is wrapper around cty.Value to handle YAML unmarshal.
-type YamlValue struct {
-	v cty.Value
-}
-
-// Unwrap returns wrapped cty.Value.
-func (y YamlValue) Unwrap() cty.Value {
-	return y.v
-}
-
-// UnmarshalYAML implements custom YAML unmarshaling.
-func (y *YamlValue) UnmarshalYAML(n *yaml.Node) error {
-	var err error
-	switch n.Kind {
-	case yaml.ScalarNode:
-		err = y.unmarshalScalar(n)
-	case yaml.MappingNode:
-		err = y.unmarshalObject(n)
-	case yaml.SequenceNode:
-		err = y.unmarshalTuple(n)
-	default:
-		err = fmt.Errorf("line %d: cannot decode node with unknown kind %d", n.Line, n.Kind)
-	}
-	return err
-}
-
-func (y *YamlValue) unmarshalScalar(n *yaml.Node) error {
-	var s interface{}
-	if err := n.Decode(&s); err != nil {
-		return err
-	}
-	ty, err := gocty.ImpliedType(s)
-	if err != nil {
-		return err
-	}
-	if y.v, err = gocty.ToCtyValue(s, ty); err != nil {
-		return err
-	}
-
-	if l, is := IsYamlExpressionLiteral(y.v); is { // HCL literal
-		var e Expression
-		if e, err = ParseExpression(l); err != nil {
-			return err
-		}
-		y.v = e.AsValue()
-	} else if y.v.Type() == cty.String && hasVariable(y.v.AsString()) { // "simple" variable
-		e, err := SimpleVarToExpression(y.v.AsString())
-		if err != nil {
-			return err
-		}
-		y.v = e.AsValue()
-	}
-	return nil
-}
-
-func (y *YamlValue) unmarshalObject(n *yaml.Node) error {
-	var my map[string]YamlValue
-	if err := n.Decode(&my); err != nil {
-		return err
-	}
-	mv := map[string]cty.Value{}
-	for k, y := range my {
-		mv[k] = y.v
-	}
-	y.v = cty.ObjectVal(mv)
-	return nil
-}
-
-func (y *YamlValue) unmarshalTuple(n *yaml.Node) error {
-	var ly []YamlValue
-	if err := n.Decode(&ly); err != nil {
-		return err
-	}
-	lv := []cty.Value{}
-	for _, y := range ly {
-		lv = append(lv, y.v)
-	}
-	y.v = cty.TupleVal(lv)
-	return nil
-}
-
-// UnmarshalYAML implements custom YAML unmarshaling.
-func (d *Dict) UnmarshalYAML(n *yaml.Node) error {
-	var m map[string]YamlValue
-	if err := n.Decode(&m); err != nil {
-		return err
-	}
-	for k, y := range m {
-		d.Set(k, y.v)
-	}
-	return nil
-}
-
-// MarshalYAML implements custom YAML marshaling.
-func (d Dict) MarshalYAML() (interface{}, error) {
-	o, _ := cty.Transform(d.AsObject(), func(p cty.Path, v cty.Value) (cty.Value, error) {
-		if e, is := IsExpressionValue(v); is {
-			return e.makeYamlExpressionValue(), nil
-		}
-		return v, nil
-	})
-
-	j := ctyJson.SimpleJSONValue{Value: o}
-	b, err := j.MarshalJSON()
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal JSON: %v", err)
-	}
-	var g interface{}
-	err = json.Unmarshal(b, &g)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON: %v", err)
-	}
-	return g, nil
 }
 
 // Eval returns a copy of this Dict, where all Expressions

--- a/pkg/config/dict_test.go
+++ b/pkg/config/dict_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
-	"gopkg.in/yaml.v3"
 )
 
 func TestZeroValueValid(t *testing.T) {
@@ -78,109 +77,6 @@ func TestItemsAreCopy(t *testing.T) {
 	want := cty.StringVal("fuji")
 	got := d.Get("apple")
 	if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
-		t.Errorf("diff (-want +got):\n%s", diff)
-	}
-}
-
-func TestYAMLDecode(t *testing.T) {
-	yml := `
-s1: "red"
-s2: pink
-m1: {}	
-m2:
-  m2f1: green
-  m2f2: [1, 0.2, -3, false]
-  gv: $(vars.gold)
-  mv: $(lime.bloom)
-  hl: ((3 + 9))
-`
-	want := Dict{}
-	want.
-		Set("s1", cty.StringVal("red")).
-		Set("s2", cty.StringVal("pink")).
-		Set("m1", cty.EmptyObjectVal).
-		Set("m2", cty.ObjectVal(map[string]cty.Value{
-			"m2f1": cty.StringVal("green"),
-			"m2f2": cty.TupleVal([]cty.Value{
-				cty.NumberIntVal(1),
-				cty.NumberFloatVal(0.2),
-				cty.NumberIntVal(-3),
-				cty.False,
-			}),
-			"gv": MustParseExpression("var.gold").AsValue(),
-			"mv": MustParseExpression("module.lime.bloom").AsValue(),
-			"hl": MustParseExpression("3 + 9").AsValue(),
-		}))
-	var got Dict
-	if err := yaml.Unmarshal([]byte(yml), &got); err != nil {
-		t.Fatalf("failed to decode: %v", err)
-	}
-	if diff := cmp.Diff(want.Items(), got.Items(), ctydebug.CmpOptions); diff != "" {
-		t.Errorf("diff (-want +got):\n%s", diff)
-	}
-}
-
-func TestMarshalYAML(t *testing.T) {
-	d := Dict{}
-	d.
-		Set("s1", cty.StringVal("red")).
-		Set("m1", cty.EmptyObjectVal).
-		Set("m2", cty.ObjectVal(map[string]cty.Value{
-			"m2f1": cty.StringVal("green"),
-			"m2f2": cty.TupleVal([]cty.Value{
-				cty.NumberIntVal(1),
-				cty.NumberFloatVal(0.2),
-				cty.NumberIntVal(-3),
-				cty.False,
-				MustParseExpression("7 + 4").AsValue(),
-			}),
-		}))
-	want := map[string]interface{}{
-		"s1": "red",
-		"m1": map[string]interface{}{},
-		"m2": map[string]interface{}{
-			"m2f1": "green",
-			"m2f2": []interface{}{1.0, 0.2, -3.0, false, "((7 + 4))"},
-		},
-	}
-	got, err := d.MarshalYAML()
-	if err != nil {
-		t.Fatalf("failed to marshal: %v", err)
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("diff (-want +got):\n%s", diff)
-	}
-}
-
-func TestYAMLMarshalIntAsInt(t *testing.T) {
-	d := Dict{}
-	d.Set("zebra", cty.NumberIntVal(5))
-	want := "zebra: 5\n"
-	got, err := yaml.Marshal(d)
-	if err != nil {
-		t.Fatalf("failed to marshal: %v", err)
-	}
-	if diff := cmp.Diff(want, string(got)); diff != "" {
-		t.Errorf("diff (-want +got):\n%s", diff)
-	}
-}
-
-func TestYAMLDecodeWithAlias(t *testing.T) {
-	yml := `
-pony: &passtime
-- eat
-- sleep
-zebra: *passtime
-`
-	want := Dict{}
-	want.
-		Set("pony", cty.TupleVal([]cty.Value{cty.StringVal("eat"), cty.StringVal("sleep")})).
-		Set("zebra", cty.TupleVal([]cty.Value{cty.StringVal("eat"), cty.StringVal("sleep")}))
-	var got Dict
-	if err := yaml.Unmarshal([]byte(yml), &got); err != nil {
-		t.Fatalf("failed to decode: %v", err)
-	}
-	if diff := cmp.Diff(want.Items(), got.Items(), ctydebug.CmpOptions); diff != "" {
 		t.Errorf("diff (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -211,7 +211,7 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 		using := Module{
 			ID:     "usingModule",
 			Source: "path/using",
-			Use:    []ModuleID{"usedModule"},
+			Use:    ModuleIDs{"usedModule"},
 		}
 		used := Module{ID: "usedModule", Source: "path/used"}
 

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -17,10 +17,14 @@ package config
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
 
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+	ctyJson "github.com/zclconf/go-cty/cty/json"
 	"gopkg.in/yaml.v3"
 )
 
@@ -156,4 +160,145 @@ type nodeCapturer struct{ n *yaml.Node }
 func (c *nodeCapturer) UnmarshalYAML(n *yaml.Node) error {
 	c.n = n
 	return nil
+}
+
+// UnmarshalYAML implements a custom unmarshaler from YAML string to ModuleKind
+func (mk *ModuleKind) UnmarshalYAML(n *yaml.Node) error {
+	var kind string
+	err := n.Decode(&kind)
+	if err == nil && IsValidModuleKind(kind) {
+		mk.kind = kind
+		return nil
+	}
+	return fmt.Errorf("line %d: kind must be \"packer\" or \"terraform\" or removed from YAML", n.Line)
+}
+
+// MarshalYAML implements a custom marshaler from ModuleKind to YAML string
+func (mk ModuleKind) MarshalYAML() (interface{}, error) {
+	return mk.String(), nil
+}
+
+// UnmarshalYAML is a custom unmarshaler for Module.Use, that will print nice error message.
+func (ms *ModuleIDs) UnmarshalYAML(n *yaml.Node) error {
+	var ids []ModuleID
+	if err := n.Decode(&ids); err != nil {
+		return fmt.Errorf("line %d: `use` must be a list of module ids", n.Line)
+	}
+	*ms = ids
+	return nil
+}
+
+// YamlValue is wrapper around cty.Value to handle YAML unmarshal.
+type YamlValue struct {
+	v cty.Value
+}
+
+// Unwrap returns wrapped cty.Value.
+func (y YamlValue) Unwrap() cty.Value {
+	return y.v
+}
+
+// UnmarshalYAML implements custom YAML unmarshaling.
+func (y *YamlValue) UnmarshalYAML(n *yaml.Node) error {
+	var err error
+	switch n.Kind {
+	case yaml.ScalarNode:
+		err = y.unmarshalScalar(n)
+	case yaml.MappingNode:
+		err = y.unmarshalObject(n)
+	case yaml.SequenceNode:
+		err = y.unmarshalTuple(n)
+	default:
+		err = fmt.Errorf("line %d: cannot decode node with unknown kind %d", n.Line, n.Kind)
+	}
+	return err
+}
+
+func (y *YamlValue) unmarshalScalar(n *yaml.Node) error {
+	var s interface{}
+	if err := n.Decode(&s); err != nil {
+		return err
+	}
+	ty, err := gocty.ImpliedType(s)
+	if err != nil {
+		return err
+	}
+	if y.v, err = gocty.ToCtyValue(s, ty); err != nil {
+		return err
+	}
+
+	if l, is := IsYamlExpressionLiteral(y.v); is { // HCL literal
+		var e Expression
+		if e, err = ParseExpression(l); err != nil {
+			return err
+		}
+		y.v = e.AsValue()
+	} else if y.v.Type() == cty.String && hasVariable(y.v.AsString()) { // "simple" variable
+		e, err := SimpleVarToExpression(y.v.AsString())
+		if err != nil {
+			return err
+		}
+		y.v = e.AsValue()
+	}
+	return nil
+}
+
+func (y *YamlValue) unmarshalObject(n *yaml.Node) error {
+	var my map[string]YamlValue
+	if err := n.Decode(&my); err != nil {
+		return err
+	}
+	mv := map[string]cty.Value{}
+	for k, y := range my {
+		mv[k] = y.v
+	}
+	y.v = cty.ObjectVal(mv)
+	return nil
+}
+
+func (y *YamlValue) unmarshalTuple(n *yaml.Node) error {
+	var ly []YamlValue
+	if err := n.Decode(&ly); err != nil {
+		return err
+	}
+	lv := []cty.Value{}
+	for _, y := range ly {
+		lv = append(lv, y.v)
+	}
+	y.v = cty.TupleVal(lv)
+	return nil
+}
+
+// UnmarshalYAML implements custom YAML unmarshaling.
+func (d *Dict) UnmarshalYAML(n *yaml.Node) error {
+	var m map[string]YamlValue
+	if err := n.Decode(&m); err != nil {
+		return err
+	}
+	for k, y := range m {
+		d.Set(k, y.v)
+	}
+	return nil
+}
+
+// MarshalYAML implements custom YAML marshaling.
+func (d Dict) MarshalYAML() (interface{}, error) {
+	o, _ := cty.Transform(d.AsObject(), func(p cty.Path, v cty.Value) (cty.Value, error) {
+		if e, is := IsExpressionValue(v); is {
+			return e.makeYamlExpressionValue(), nil
+		}
+		return v, nil
+	})
+
+	j := ctyJson.SimpleJSONValue{Value: o}
+	b, err := j.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal JSON: %v", err)
+	}
+	var g interface{}
+	err = json.Unmarshal(b, &g)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %v", err)
+	}
+	return g, nil
 }

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
 	"gopkg.in/yaml.v3"
 )
 
@@ -148,5 +150,168 @@ terraform_backend_defaults:
 				t.Errorf("diff (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestModuleKindUnmarshalYAML(t *testing.T) {
+	type test struct {
+		input string
+		want  ModuleKind
+		err   bool
+	}
+	tests := []test{
+		{"", UnknownKind, false},
+		{"terraform", TerraformKind, false},
+		{"packer", PackerKind, false},
+
+		{"unknown", ModuleKind{}, true},
+		{"[]", ModuleKind{}, true},
+		{"{]", ModuleKind{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			var got ModuleKind
+			err := yaml.Unmarshal([]byte(tc.input), &got)
+			if tc.err != (err != nil) {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if tc.want != got {
+				t.Errorf("want:%#v:\ngot%#v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestModuleIDsUnmarshalYAML(t *testing.T) {
+	type test struct {
+		input string
+		want  ModuleIDs
+		err   bool
+	}
+	tests := []test{
+		{"[green, red]", ModuleIDs{"green", "red"}, false},
+		{"[]", ModuleIDs{}, false},
+
+		{"green", nil, true},
+		{"44", nil, true},
+		{"{}", nil, true},
+		{"[[]]", nil, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			var got ModuleIDs
+			err := yaml.Unmarshal([]byte(tc.input), &got)
+			if tc.err != (err != nil) {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDictUnmarshalYAML(t *testing.T) {
+	yml := `
+s1: "red"
+s2: pink
+m1: {}	
+m2:
+  m2f1: green
+  m2f2: [1, 0.2, -3, false]
+  gv: $(vars.gold)
+  mv: $(lime.bloom)
+  hl: ((3 + 9))
+`
+	want := Dict{}
+	want.
+		Set("s1", cty.StringVal("red")).
+		Set("s2", cty.StringVal("pink")).
+		Set("m1", cty.EmptyObjectVal).
+		Set("m2", cty.ObjectVal(map[string]cty.Value{
+			"m2f1": cty.StringVal("green"),
+			"m2f2": cty.TupleVal([]cty.Value{
+				cty.NumberIntVal(1),
+				cty.NumberFloatVal(0.2),
+				cty.NumberIntVal(-3),
+				cty.False,
+			}),
+			"gv": MustParseExpression("var.gold").AsValue(),
+			"mv": MustParseExpression("module.lime.bloom").AsValue(),
+			"hl": MustParseExpression("3 + 9").AsValue(),
+		}))
+	var got Dict
+	if err := yaml.Unmarshal([]byte(yml), &got); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if diff := cmp.Diff(want.Items(), got.Items(), ctydebug.CmpOptions); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestDictMarshalYAML(t *testing.T) {
+	d := Dict{}
+	d.
+		Set("s1", cty.StringVal("red")).
+		Set("m1", cty.EmptyObjectVal).
+		Set("m2", cty.ObjectVal(map[string]cty.Value{
+			"m2f1": cty.StringVal("green"),
+			"m2f2": cty.TupleVal([]cty.Value{
+				cty.NumberIntVal(1),
+				cty.NumberFloatVal(0.2),
+				cty.NumberIntVal(-3),
+				cty.False,
+				MustParseExpression("7 + 4").AsValue(),
+			}),
+		}))
+	want := map[string]interface{}{
+		"s1": "red",
+		"m1": map[string]interface{}{},
+		"m2": map[string]interface{}{
+			"m2f1": "green",
+			"m2f2": []interface{}{1.0, 0.2, -3.0, false, "((7 + 4))"},
+		},
+	}
+	got, err := d.MarshalYAML()
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestYAMLValueMarshalIntAsInt(t *testing.T) {
+	d := Dict{}
+	d.Set("zebra", cty.NumberIntVal(5))
+	want := "zebra: 5\n"
+	got, err := yaml.Marshal(d)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestYAMLValueUnmarshalWithAlias(t *testing.T) {
+	yml := `
+pony: &passtime
+- eat
+- sleep
+zebra: *passtime
+`
+	want := Dict{}
+	want.
+		Set("pony", cty.TupleVal([]cty.Value{cty.StringVal("eat"), cty.StringVal("sleep")})).
+		Set("zebra", cty.TupleVal([]cty.Value{cty.StringVal("eat"), cty.StringVal("sleep")}))
+	var got Dict
+	if err := yaml.Unmarshal([]byte(yml), &got); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if diff := cmp.Diff(want.Items(), got.Items(), ctydebug.CmpOptions); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
* New error message:
```
failed to parse the blueprint in tst.yaml, check YAML syntax for errors, err=line 32: `use` must be a list of module ids
```
* Move YAML-related code `pkg/config` into `yaml*.go`.

NOTE to reviewer:
Most of the changed lines a just moved.
The new code is in following functions:

* `(ms *ModuleIDs) UnmarshalYAML`;
* `TestModuleKindUnmarshalYAML`;
* `TestModuleIDsUnmarshalYAML`.