### PR TITLE
Make execute command ansible script generic so it can be reused

### DIFF
--- a/community/modules/scripts/ramble-execute/main.tf
+++ b/community/modules/scripts/ramble-execute/main.tf
@@ -20,10 +20,9 @@ locals {
   execute_contents = templatefile(
     "${path.module}/templates/ramble_execute.yml.tpl",
     {
-      spack_path  = var.spack_path
-      ramble_path = var.ramble_path
-      log_file    = var.log_file
-      commands    = local.commands_content
+      pre_script = ". ${var.spack_path}/share/spack/setup-env.sh && . ${var.ramble_path}/share/ramble/setup-env.sh"
+      log_file   = var.log_file
+      commands   = local.commands_content
     }
   )
 

--- a/community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl
+++ b/community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl
@@ -12,38 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Execute Ramble Commands
+- name: Execute Commands
   hosts: localhost
   vars:
-    spack_path: ${spack_path}
-    ramble_path: ${ramble_path}
+    pre_script: ${pre_script}
     log_file: ${log_file}
     commands: ${commands}
   tasks:
   - name: Execute command block
     block:
-    - name: Print Ramble commands to be executed
+    - name: Print commands to be executed
       ansible.builtin.debug:
         msg: "{{ commands.split('\n') }}"
 
-    - name: Execute ramble commands
+    - name: Execute commands
       ansible.builtin.shell: |
         set -eo pipefail
         {
-        . {{ spack_path }}/share/spack/setup-env.sh
-        . {{ ramble_path }}/share/ramble/setup-env.sh
-
-        echo " === Starting ramble commands ==="
+        {{ pre_script }}
+        echo " === Starting commands ==="
         {{ commands }}
-        echo " === Finished ramble commands ==="
+        echo " === Finished commands ==="
         } | tee -a {{ log_file }}
-      register: ramble_output
+      register: output
 
     always:
     - name: Print commands output to stderr
       ansible.builtin.debug:
-        var: ramble_output.stderr_lines
+        var: output.stderr_lines
 
     - name: Print commands output to stdout
       ansible.builtin.debug:
-        var: ramble_output.stdout_lines
+        var: output.stdout_lines


### PR DESCRIPTION
This change is a no-op. This script will be reused by `spack-execute` module. 

Note the target branch. Since there are several breaking changes associated with Spack redesign I would like the user to only see a single change. Development will happen on a feature branch. 

As this change is a no-op it could be merged to develop but I think it will make the history easier to track to keep it all on the feature branch.

Tested manually. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
