### PR TITLE
Module documentation update and improved DAOS examples

### DIFF
--- a/community/examples/intel/README.md
+++ b/community/examples/intel/README.md
@@ -228,18 +228,15 @@ ghpc create community/examples/intel/pfs-daos.yaml  \
   [--backend-config bucket=<GCS tf backend bucket>]
 ```
 
-This will create a set of directories containing Terraform modules and Packer
-templates.
+This will create the deployment directory containing Terraform modules and
+Packer templates. The `--backend-config` option is not required but recommended.
+It will save the terraform state in a pre-existing [Google Cloud Storage
+bucket][bucket]. For more information see [Setting up a remote terraform
+state][backend]. Use `ghpc deploy` to provision your DAOS storage cluster:
 
-The `--backend-config` option is not required but recommended. It will save the terraform state in a pre-existing [Google Cloud Storage bucket][bucket]. For more information see [Setting up a remote terraform state][backend].
-
-Follow `ghpc` instructions to deploy the environment
-
-  ```shell
-  terraform -chdir=pfs-daos/primary init
-  terraform -chdir=pfs-daos/primary validate
-  terraform -chdir=pfs-daos/primary apply
-  ```
+```text
+ghpc deploy pfs-daos --auto-approve
+```
 
 [backend]: ../../../examples/README.md#optional-setting-up-a-remote-terraform-state
 [bucket]: https://cloud.google.com/storage/docs/creating-buckets
@@ -396,7 +393,7 @@ See the [DFuse (DAOS FUSE)](https://docs.daos.io/v2.2/user/filesystem/?h=dfuse#d
 Delete the remaining infrastructure
 
 ```shell
-terraform -chdir=pfs-daos/primary destroy
+ghpc destroy pfs-daos --auto-approve
 ```
 
 ## DAOS Server with Slurm cluster
@@ -465,11 +462,9 @@ The `--backend-config` option is not required but recommended. It will save the 
 
 Follow `ghpc` instructions to deploy the environment
 
-  ```shell
-  terraform -chdir=daos-slurm/primary init
-  terraform -chdir=daos-slurm/primary validate
-  terraform -chdir=daos-slurm/primary apply
-  ```
+```text
+ghpc deploy daos-slurm --auto-approve
+```
 
 [backend]: ../../../examples/README.md#optional-setting-up-a-remote-terraform-state
 [bucket]: https://cloud.google.com/storage/docs/creating-buckets
@@ -609,5 +604,5 @@ have been shutdown and deleted by the Slurm autoscaler. Delete the remaining
 infrastructure with `terraform`:
 
 ```shell
-terraform -chdir=daos-slurm/primary destroy
+ghpc destroy daos-slurm --auto-approve
 ```

--- a/community/examples/intel/hpc-slurm-daos.yaml
+++ b/community/examples/intel/hpc-slurm-daos.yaml
@@ -21,9 +21,13 @@ vars:
   deployment_name: daos-slurm
   region: us-central1
   zone: us-central1-c
+  server_image_family: daos-server-hpc-rocky-8
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
+
+# Note: this blueprint assumes the existence of a default global network and
+# subnetwork in the region chosen above
 
 deployment_groups:
 - group: primary
@@ -37,18 +41,42 @@ deployment_groups:
     settings:
       local_mount: "/home"
 
-  # This module creates a DAOS server. Server images MUST be created before running this.
-  # https://github.com/daos-stack/google-cloud-daos/tree/main/images
+- group: daos-server-image
+  modules:
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/images
+  - id: daos-server-image
+    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.0&depth=1
+    kind: packer
+    settings:
+      daos_version: 2.2.0
+      daos_repo_base_url: https://packages.daos.io
+      daos_packages_repo_file: EL8/packages/x86_64/daos_packages.repo
+      use_iap: true
+      enable_oslogin: false
+      machine_type: n2-standard-32
+      source_image_family: hpc-rocky-linux-8
+      source_image_project_id: cloud-hpc-image-public
+      image_guest_os_features: ["GVNIC"]
+      disk_size: "20"
+      state_timeout: "10m"
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+      use_internal_ip: true
+      omit_external_ip: false
+      daos_install_type: server
+      image_family: $(vars.server_image_family)
+
+- group: cluster
+  modules:
   # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server
   - id: daos
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.4.0
+    source: github.com/daos-stack/google-cloud-daos//terraform/modules/daos_server?ref=v0.4.0&depth=1
     use: [network1]
     settings:
       labels: {ghpc_role: file-system}
       # The default DAOS settings are optimized for TCO
       # The following will tune this system for best perf
       machine_type: "n2-standard-16"
-      os_disk_size_gb: 20
+      os_family: $(vars.server_image_family)
       daos_disk_count: 4
       daos_scm_size: 45
       pools:

--- a/community/examples/intel/pfs-daos.yaml
+++ b/community/examples/intel/pfs-daos.yaml
@@ -21,9 +21,14 @@ vars:
   deployment_name: pfs-daos
   region: us-central1
   zone: us-central1-c
+  server_image_family: daos-server-hpc-rocky-8
+  client_image_family: daos-client-hpc-rocky-8
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
+
+# Note: this blueprint assumes the existence of a default global network and
+# subnetwork in the region chosen above
 
 deployment_groups:
 - group: primary
@@ -31,22 +36,70 @@ deployment_groups:
   - id: network1
     source: modules/network/pre-existing-vpc
 
-  # This module creates a DAOS server. Server images MUST be created before running this.
-  # https://github.com/daos-stack/google-cloud-daos/tree/main/images
-  # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server
+- group: daos-server-image
+  modules:
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/images
+  - id: daos-server-image
+    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.0&depth=1
+    kind: packer
+    settings:
+      daos_version: 2.2.0
+      daos_repo_base_url: https://packages.daos.io
+      daos_packages_repo_file: EL8/packages/x86_64/daos_packages.repo
+      use_iap: true
+      enable_oslogin: false
+      machine_type: n2-standard-32
+      source_image_family: hpc-rocky-linux-8
+      source_image_project_id: cloud-hpc-image-public
+      image_guest_os_features: ["GVNIC"]
+      disk_size: "20"
+      state_timeout: "10m"
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+      use_internal_ip: true
+      omit_external_ip: false
+      daos_install_type: server
+      image_family: $(vars.server_image_family)
+
+- group: daos-client-image
+  modules:
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/images
+  - id: daos-client-image
+    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.0&depth=1
+    kind: packer
+    settings:
+      daos_version: 2.2.0
+      daos_repo_base_url: https://packages.daos.io
+      daos_packages_repo_file: EL8/packages/x86_64/daos_packages.repo
+      use_iap: true
+      enable_oslogin: false
+      machine_type: n2-standard-32
+      source_image_family: hpc-rocky-linux-8
+      source_image_project_id: cloud-hpc-image-public
+      image_guest_os_features: ["GVNIC"]
+      disk_size: "20"
+      state_timeout: "10m"
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+      use_internal_ip: true
+      omit_external_ip: false
+      daos_install_type: client
+      image_family: $(vars.client_image_family)
+
+- group: daos-cluster
+  modules:
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/terraform/modules/daos_server
   - id: daos-server
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.4.0
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.4.0&depth=1
     use: [network1]
     settings:
       number_of_instances: 2
       labels: {ghpc_role: file-system}
+      os_family: $(vars.server_image_family)
 
-  # This module creates DAOS clients. Client images MUST be created before running this.
-  # https://github.com/daos-stack/google-cloud-daos/tree/main/images
-  # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_client
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/terraform/modules/daos_client
   - id: daos-client
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_client?ref=v0.4.0
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_client?ref=v0.4.0&depth=1
     use: [network1, daos-server]
     settings:
       number_of_instances: 2
       labels: {ghpc_role: compute}
+      os_family: $(vars.client_image_family)


### PR DESCRIPTION
This PR updates:

- the general documentation on the structure of the `module` object in blueprints
- DAOS examples to use #1467
- DAOS README to simplify instructions to use ghpc deploy/destroy commands

Both blueprints have been tested manually. The `pfs-daos.yaml` blueprint has been manually tested up to confirmation that the container is mounted (`df -h -t fuse.daos`). The `hpc-slurm-daos.yaml` blueprint has been manually tested but ran into problems mounting the container. I do not believe this to be related to the introduction of Packer package support -- the DAOS client is successfully installed -- but we should update the documentation to ensure that users do the right thing. It may be an ACL problem?

```text
[ext_tpdownes_google_com@slurm-daos-slurm-login0 ~]$ daos cont create --type=POSIX --properties=rf:0 --label=cont1 pool1
  Container UUID : 6c8d1725-6877-4f56-bece-497fc13b390a
  Container Label: cont1                               
  Container Type : POSIX                               

Successfully created container 6c8d1725-6877-4f56-bece-497fc13b390a
[ext_tpdownes_google_com@slurm-daos-slurm-login0 ~]$ mkdir -p ${HOME}/daos/cont1
[ext_tpdownes_google_com@slurm-daos-slurm-login0 ~]$ 
[ext_tpdownes_google_com@slurm-daos-slurm-login0 ~]$ dfuse --singlethread \
> --pool=pool1 \
> --container=cont1 \
> --mountpoint=${HOME}/daos/cont1
fusermount3: mount failed: Invalid argument
dfuse ERR  src/client/dfuse/dfuse_main.c:192 dfuse_launch_fuse(0x430b19) 
dfuse ERR  src/client/dfuse/dfuse_core.c:1129 dfuse_fs_start(0xee68a0) Failed to start dfuse, rc: DER_INVAL(-1003): 'Invalid parameters'
Exiting -1003 DER_INVAL
[ext_tpdownes_google_com@slurm-daos-slurm-login0 ~]$ sudo dfuse --singlethread --pool=pool1 --container=cont1 --mountpoint=${HOME}/daos/cont1
dfuse ERR  src/client/dfuse/dfuse_core.c:754 dfuse_cont_open_by_label(0x1ce9a80) daos_cont_open() failed: DER_NO_PERM(-1001): 'Operation not permitted'
Failed to connect to container (1) Operation not permitted
Exiting -1001 DER_NO_PERM
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
