### PR TITLE
Use strict `Path` builder to reduce human error.

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -130,7 +130,7 @@ func expandOrDie(path string) config.DeploymentConfig {
 func renderError(err error, ctx config.YamlCtx) string {
 	var be config.BpError
 	if errors.As(err, &be) {
-		if pos, ok := ctx.PathToPos[be.Path]; ok {
+		if pos, ok := ctx.Pos(be.Path); ok {
 			return renderRichError(be.Err, pos, ctx)
 		}
 	}

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -137,23 +137,23 @@ func (s *MySuite) TestRenderError(c *C) {
 		c.Check(got, Equals, "arbuz")
 	}
 	{ // has pos, but context is missing
-		pth := config.Path{}.Dot("rainbow").Dot("over")
+		ctx := config.NewYamlCtx([]byte(``))
+		pth := config.Root.Vars.Dot("kale")
 		err := config.BpError{Path: pth, Err: errors.New("arbuz")}
-		got := renderError(err, config.YamlCtx{})
-		c.Check(got, Equals, "rainbow.over: arbuz")
+		got := renderError(err, ctx)
+		c.Check(got, Equals, "vars.kale: arbuz")
 	}
 	{ // has pos, has context
-		pth := config.Path{}.Dot("rainbow").Dot("over")
-		ctx := config.YamlCtx{
-			PathToPos: map[config.Path]config.Pos{
-				pth: {Line: 2, Column: 3}},
-			Lines: []string{"uno", "dos", "tres"}}
+		ctx := config.NewYamlCtx([]byte(`
+vars:
+  kale: dos`))
+		pth := config.Root.Vars.Dot("kale")
 		err := config.BpError{Path: pth, Err: errors.New("arbuz")}
 		got := renderError(err, ctx)
 		c.Check(got, Equals, `
 Error: arbuz
-on line 2, column 3:
-2: dos
+on line 3, column 9:
+3:   kale: dos
 `)
 	}
 }

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -1,0 +1,163 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Path is unique identifier of a piece of configuration.
+type Paath interface {
+	String() string
+	Parent() Paath
+}
+
+type basePath struct {
+	Prev  Paath
+	Piece string
+}
+
+func (p basePath) Parent() Paath { return p.Prev }
+
+func (p basePath) String() string {
+	pref := ""
+	if p.Parent() != nil {
+		pref = p.Parent().String()
+	}
+	return fmt.Sprintf("%s%s", pref, p.Piece)
+}
+
+type arrayPath[E any] struct{ basePath }
+
+func (p arrayPath[E]) At(i int) E {
+	var e E
+	initPath(&e, &p, fmt.Sprintf("[%d]", i))
+	return e
+}
+
+type mapPath[E any] struct{ basePath }
+
+func (p mapPath[E]) At(k string) E {
+	var e E
+	initPath(&e, &p, fmt.Sprintf("[%s]", k))
+	return e
+}
+
+func initPath(p any, prev any, piece string) {
+	// Couldn't figure out how constrain it using `initPath` signature
+	if _, ok := p.(Paath); !ok {
+		panic(fmt.Sprintf("p is not a Paath: %#v", p))
+	}
+	if _, ok := prev.(Paath); prev != nil && !ok {
+		panic(fmt.Sprintf("prev is not a Paath: %#v", p))
+	}
+
+	if base, ok := p.(*basePath); ok {
+		base.Piece = piece
+		base.Prev = prev.(Paath)
+		return
+	}
+
+	pref := reflect.Indirect(reflect.ValueOf(p))
+	ty := reflect.TypeOf(p).Elem()
+
+	// !!! Get base in a better way
+	//  E.g.
+	// bref, ok := pref.Field(0).Addr().Interface().(basePath)
+	// if !ok {
+	// 	panic(fmt.Sprintf("%s does not embed basePath", ty.Name()))
+	// } else {
+	// 	bref.Piece = piece
+	// 	bref.Prev = prev.(Paath)
+	// 	return
+	// }
+
+	base := pref.Field(0)
+	base.FieldByName("Piece").SetString(piece)
+	if prev != nil {
+		base.FieldByName("Prev").Set(reflect.ValueOf(prev))
+	}
+
+	for i := 0; i < ty.NumField(); i++ {
+		field := ty.Field(i)
+		tag, ok := field.Tag.Lookup("path")
+		if !ok {
+			continue
+		}
+		ref, ok := pref.FieldByName(field.Name).Addr().Interface().(Paath)
+		if !ok {
+			panic(fmt.Sprintf("field %s.%s is not a Path", ty.Name(), field.Name))
+		}
+		initPath(ref, p, tag)
+	}
+}
+
+type rootPath struct {
+	basePath
+	BlueprintName   basePath                    `path:"blueprint_name"`
+	GhpcVersion     basePath                    `path:"ghpc_version"`
+	Validators      arrayPath[validatorCfgPath] `path:"validators"`
+	ValidationLevel basePath                    `path:"validation_level"`
+	Vars            dictPath                    `path:"vars"`
+	Groups          arrayPath[groupPath]        `path:"deployment_groups"`
+	Backend         backendPath                 `path:"terraform_backend_defaults"`
+}
+
+type validatorCfgPath struct {
+	basePath
+	Validator basePath `path:".validator"`
+	Inputs    dictPath `path:".inputs"`
+	Skip      basePath `path:".skip"`
+}
+
+type dictPath struct{ mapPath[basePath] }
+
+type backendPath struct {
+	basePath
+	Type          basePath `path:".type"`
+	Configuration dictPath `path:".configuration"`
+}
+
+type groupPath struct {
+	basePath
+	Name    basePath              `path:".group"`
+	Backend backendPath           `path:".terraform_backend"`
+	Modules arrayPath[modulePath] `path:".modules"`
+	Kind    basePath              `path:".kind"`
+}
+
+type modulePath struct {
+	basePath
+	Source   basePath               `path:".source"`
+	Kind     basePath               `path:".kind"`
+	ID       basePath               `path:".id"`
+	Use      arrayPath[backendPath] `path:".use"`
+	Outputs  arrayPath[outputPath]  `path:".outputs"`
+	Settings dictPath               `path:".settings"`
+}
+
+type outputPath struct {
+	basePath
+	Name        basePath `path:".name"`
+	Description basePath `path:".description"`
+	Sensitive   basePath `path:".sensitive"`
+}
+
+var Root rootPath = rootPath{}
+
+func init() {
+	initPath(&Root, nil, "")
+}

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -19,9 +19,8 @@ import (
 )
 
 func TestPath(t *testing.T) {
-	//fmt.Printf("p.string = %q\n", Root.Groups.At(7).Name)
 	type test struct {
-		p    Paath
+		p    Path
 		want string
 	}
 	r := Root
@@ -40,9 +39,9 @@ func TestPath(t *testing.T) {
 		{r.Validators.At(2).Validator, "validators[2].validator"},
 		{r.Validators.At(2).Skip, "validators[2].skip"},
 		{r.Validators.At(2).Inputs, "validators[2].inputs"},
-		{r.Validators.At(2).Inputs.At("zebra"), "validators[2].inputs[zebra]"},
+		{r.Validators.At(2).Inputs.Dot("zebra"), "validators[2].inputs.zebra"},
 
-		{r.Vars.At("red"), "vars[red]"},
+		{r.Vars.Dot("red"), "vars.red"},
 
 		{r.Groups.At(3), "deployment_groups[3]"},
 		{r.Groups.At(3).Name, "deployment_groups[3].group"},
@@ -62,11 +61,11 @@ func TestPath(t *testing.T) {
 		{m.Outputs.At(2).Description, "deployment_groups[3].modules[1].outputs[2].description"},
 		{m.Outputs.At(2).Sensitive, "deployment_groups[3].modules[1].outputs[2].sensitive"},
 		{m.Settings, "deployment_groups[3].modules[1].settings"},
-		{m.Settings.At("lime"), "deployment_groups[3].modules[1].settings[lime]"},
+		{m.Settings.Dot("lime"), "deployment_groups[3].modules[1].settings.lime"},
 
 		{r.Backend.Type, "terraform_backend_defaults.type"},
 		{r.Backend.Configuration, "terraform_backend_defaults.configuration"},
-		{r.Backend.Configuration.At("goo"), "terraform_backend_defaults.configuration[goo]"},
+		{r.Backend.Configuration.Dot("goo"), "terraform_backend_defaults.configuration.goo"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.want, func(t *testing.T) {

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+)
+
+func TestPath(t *testing.T) {
+	//fmt.Printf("p.string = %q\n", Root.Groups.At(7).Name)
+	type test struct {
+		p    Paath
+		want string
+	}
+	r := Root
+	m := r.Groups.At(3).Modules.At(1)
+	tests := []test{
+		{r, ""},
+		{r.BlueprintName, "blueprint_name"},
+		{r.GhpcVersion, "ghpc_version"},
+		{r.Validators, "validators"},
+		{r.ValidationLevel, "validation_level"},
+		{r.Vars, "vars"},
+		{r.Groups, "deployment_groups"},
+		{r.Backend, "terraform_backend_defaults"},
+
+		{r.Validators.At(2), "validators[2]"},
+		{r.Validators.At(2).Validator, "validators[2].validator"},
+		{r.Validators.At(2).Skip, "validators[2].skip"},
+		{r.Validators.At(2).Inputs, "validators[2].inputs"},
+		{r.Validators.At(2).Inputs.At("zebra"), "validators[2].inputs[zebra]"},
+
+		{r.Vars.At("red"), "vars[red]"},
+
+		{r.Groups.At(3), "deployment_groups[3]"},
+		{r.Groups.At(3).Name, "deployment_groups[3].group"},
+		{r.Groups.At(3).Kind, "deployment_groups[3].kind"},
+		{r.Groups.At(3).Backend, "deployment_groups[3].terraform_backend"},
+		{r.Groups.At(3).Modules, "deployment_groups[3].modules"},
+		{r.Groups.At(3).Modules.At(1), "deployment_groups[3].modules[1]"},
+		// m := r.Groups.At(3).Modules.At(1)
+		{m.Source, "deployment_groups[3].modules[1].source"},
+		{m.ID, "deployment_groups[3].modules[1].id"},
+		{m.Kind, "deployment_groups[3].modules[1].kind"},
+		{m.Use, "deployment_groups[3].modules[1].use"},
+		{m.Use.At(6), "deployment_groups[3].modules[1].use[6]"},
+		{m.Outputs, "deployment_groups[3].modules[1].outputs"},
+		{m.Outputs.At(2), "deployment_groups[3].modules[1].outputs[2]"},
+		{m.Outputs.At(2).Name, "deployment_groups[3].modules[1].outputs[2].name"},
+		{m.Outputs.At(2).Description, "deployment_groups[3].modules[1].outputs[2].description"},
+		{m.Outputs.At(2).Sensitive, "deployment_groups[3].modules[1].outputs[2].sensitive"},
+		{m.Settings, "deployment_groups[3].modules[1].settings"},
+		{m.Settings.At("lime"), "deployment_groups[3].modules[1].settings[lime]"},
+
+		{r.Backend.Type, "terraform_backend_defaults.type"},
+		{r.Backend.Configuration, "terraform_backend_defaults.configuration"},
+		{r.Backend.Configuration.At("goo"), "terraform_backend_defaults.configuration[goo]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			got := tc.p.String()
+			if got != tc.want {
+				t.Errorf("\ngot : %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -79,72 +79,72 @@ terraform_backend_defaults:
 		}
 	}
 
-	exp := map[string]Pos{
-		"":               {3, 1},
-		"blueprint_name": {3, 17},
-		"ghpc_version":   {5, 15},
+	type test struct {
+		path Path
+		want Pos
+	}
+	tests := []test{
+		{Root, Pos{3, 1}},
+		{Root.BlueprintName, Pos{3, 17}},
+		{Root.GhpcVersion, Pos{5, 15}},
+		{Root.Validators, Pos{8, 1}},
+		{Root.Validators.At(0), Pos{8, 3}},
+		{Root.Validators.At(0).Inputs, Pos{10, 5}},
+		{Root.Validators.At(0).Inputs.Dot("spice"), Pos{10, 12}},
+		{Root.Validators.At(0).Validator, Pos{8, 14}},
+		{Root.Validators.At(1), Pos{11, 3}},
+		{Root.Validators.At(1).Skip, Pos{12, 9}},
+		{Root.Validators.At(1).Validator, Pos{11, 14}},
+		{Root.ValidationLevel, Pos{14, 19}},
+		{Root.Vars, Pos{17, 3}},
+		{Root.Vars.Dot("red"), Pos{17, 8}},
+		{Root.Groups, Pos{20, 1}},
+		{Root.Groups.At(0), Pos{20, 3}},
+		{Root.Groups.At(0).Name, Pos{20, 10}},
 
-		"validators":                 {8, 1},
-		"validators[0]":              {8, 3},
-		"validators[0].inputs":       {10, 5},
-		"validators[0].inputs.spice": {10, 12},
-		"validators[0].validator":    {8, 14},
-		"validators[1]":              {11, 3},
-		"validators[1].skip":         {12, 9},
-		"validators[1].validator":    {11, 14},
+		{Root.Groups.At(0).Backend, Pos{22, 5}},
+		{Root.Groups.At(0).Backend.Type, Pos{22, 11}},
+		{Root.Groups.At(0).Backend.Configuration, Pos{24, 7}},
+		{Root.Groups.At(0).Backend.Configuration.Dot("carrot"), Pos{24, 15}},
+		{Root.Groups.At(0).Kind, Pos{25, 9}},
 
-		"validation_level": {14, 19},
+		{Root.Groups.At(0).Modules, Pos{27, 3}},
+		{Root.Groups.At(0).Modules.At(0), Pos{27, 5}},
+		{Root.Groups.At(0).Modules.At(0).ID, Pos{27, 9}},
+		{Root.Groups.At(0).Modules.At(0).Source, Pos{28, 13}},
+		{Root.Groups.At(0).Modules.At(0).Kind, Pos{29, 11}},
+		{Root.Groups.At(0).Modules.At(0).Use, Pos{30, 10}},
+		{Root.Groups.At(0).Modules.At(0).Use.At(0), Pos{30, 11}},
+		{Root.Groups.At(0).Modules.At(0).Use.At(1), Pos{30, 18}},
+		{Root.Groups.At(0).Modules.At(0).Outputs, Pos{32, 5}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(0), Pos{32, 7}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(0).Name, Pos{32, 7}}, // synthetic
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(1), Pos{33, 7}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Name, Pos{33, 13}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Description, Pos{34, 20}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Sensitive, Pos{35, 18}},
+		{Root.Groups.At(0).Modules.At(0).Settings, Pos{37, 7}},
+		{Root.Groups.At(0).Modules.At(0).Settings.Dot("dijon"), Pos{37, 14}},
 
-		"vars":     {17, 3},
-		"vars.red": {17, 8},
+		{Root.Groups.At(1), Pos{39, 3}},
+		{Root.Groups.At(1).Name, Pos{39, 10}},
+		{Root.Groups.At(1).Modules, Pos{41, 3}},
+		{Root.Groups.At(1).Modules.At(0), Pos{41, 5}},
+		{Root.Groups.At(1).Modules.At(0).ID, Pos{41, 9}},
+		{Root.Groups.At(1).Modules.At(1), Pos{42, 5}},
+		{Root.Groups.At(1).Modules.At(1).ID, Pos{42, 9}},
 
-		"deployment_groups":          {20, 1},
-		"deployment_groups[0]":       {20, 3},
-		"deployment_groups[0].group": {20, 10},
-
-		"deployment_groups[0].terraform_backend":                      {22, 5},
-		"deployment_groups[0].terraform_backend.type":                 {22, 11},
-		"deployment_groups[0].terraform_backend.configuration":        {24, 7},
-		"deployment_groups[0].terraform_backend.configuration.carrot": {24, 15},
-		"deployment_groups[0].kind":                                   {25, 9},
-
-		"deployment_groups[0].modules":                           {27, 3},
-		"deployment_groups[0].modules[0]":                        {27, 5},
-		"deployment_groups[0].modules[0].id":                     {27, 9},
-		"deployment_groups[0].modules[0].source":                 {28, 13},
-		"deployment_groups[0].modules[0].kind":                   {29, 11},
-		"deployment_groups[0].modules[0].use":                    {30, 10},
-		"deployment_groups[0].modules[0].use[0]":                 {30, 11},
-		"deployment_groups[0].modules[0].use[1]":                 {30, 18},
-		"deployment_groups[0].modules[0].outputs":                {32, 5},
-		"deployment_groups[0].modules[0].outputs[0]":             {32, 7},
-		"deployment_groups[0].modules[0].outputs[0].name":        {32, 7}, // synthetic
-		"deployment_groups[0].modules[0].outputs[1]":             {33, 7},
-		"deployment_groups[0].modules[0].outputs[1].name":        {33, 13},
-		"deployment_groups[0].modules[0].outputs[1].description": {34, 20},
-		"deployment_groups[0].modules[0].outputs[1].sensitive":   {35, 18},
-		"deployment_groups[0].modules[0].settings":               {37, 7},
-		"deployment_groups[0].modules[0].settings.dijon":         {37, 14},
-
-		"deployment_groups[1]":               {39, 3},
-		"deployment_groups[1].group":         {39, 10},
-		"deployment_groups[1].modules":       {41, 3},
-		"deployment_groups[1].modules[0]":    {41, 5},
-		"deployment_groups[1].modules[0].id": {41, 9},
-		"deployment_groups[1].modules[1]":    {42, 5},
-		"deployment_groups[1].modules[1].id": {42, 9},
-
-		"terraform_backend_defaults":      {45, 3},
-		"terraform_backend_defaults.type": {45, 9},
+		{Root.Backend, Pos{45, 3}},
+		{Root.Backend.Type, Pos{45, 9}},
 	}
 
-	ctx := newYamlCtx([]byte(data))
-	for path, pos := range exp {
-		t.Run(path, func(t *testing.T) {
-			got, ok := ctx.PathToPos[Path{path}]
+	ctx := NewYamlCtx([]byte(data))
+	for _, tc := range tests {
+		t.Run(tc.path.String(), func(t *testing.T) {
+			got, ok := ctx.Pos(tc.path)
 			if !ok {
-				t.Errorf("%q not found", path)
-			} else if diff := cmp.Diff(pos, got); diff != "" {
+				t.Errorf("%q not found", tc.path.String())
+			} else if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("diff (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
* Turn `Path` into interface;
* Provide strict `Path` builders to be used in code outside of `YamlCtx`;
* Add tests.