### PR TITLE
Add commands feature to spack-install to allow execution of arbitrary commands

### DIFF
--- a/community/modules/scripts/spack-install/README.md
+++ b/community/modules/scripts/spack-install/README.md
@@ -189,36 +189,48 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_startup_script"></a> [startup\_script](#module\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.19.1 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [local_file.debug_file_ansible_execute](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [local_file.debug_file_shell_install](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_caches_to_populate"></a> [caches\_to\_populate](#input\_caches\_to\_populate) | Defines caches which will be populated with the installed packages.<br>  Each cache must specify a type (either directory, or mirror).<br>  Each cache must also specify a path. For directory caches, this path<br>  must be on a local file system (i.e. file:///path/to/cache). For<br>  mirror paths, this can be any valid URL that spack accepts.<br><br>  NOTE: GPG Keys should be installed before trying to populate a cache<br>  with packages.<br><br>  NOTE: The gpg\_keys variable can be used to install existing GPG keys<br>  and create new GPG keys, both of which are acceptable for populating a<br>  cache. | `list(map(any))` | `[]` | no |
+| <a name="input_commands"></a> [commands](#input\_commands) | String of commands to run within this module | `string` | `null` | no |
 | <a name="input_compilers"></a> [compilers](#input\_compilers) | Defines compilers for spack to install before installing packages. | `list(string)` | `[]` | no |
 | <a name="input_concretize_flags"></a> [concretize\_flags](#input\_concretize\_flags) | Defines the flags to pass into `spack concretize` | `string` | `""` | no |
 | <a name="input_configs"></a> [configs](#input\_configs) | List of configuration options to set within spack.<br>    Configs can be of type 'single-config' or 'file'.<br>    All configs must specify content, and a<br>    a scope. | `list(map(any))` | `[]` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of deployment, used to name bucket containing startup script. | `string` | n/a | yes |
 | <a name="input_environments"></a> [environments](#input\_environments) | Defines spack environments to configure, given as a list.<br>  Each environment must define a name.<br>  Additional optional attributes are 'content' and 'packages'.<br>  'content' must be a string, defining the content of the Spack Environment YAML file.<br>  'packages' must be a list of strings, defining the spack specs to install.<br>  If both 'content' and 'packages' are defined, 'content' is processed first. | `any` | `[]` | no |
 | <a name="input_gpg_keys"></a> [gpg\_keys](#input\_gpg\_keys) | GPG Keys to trust within spack.<br>  Each key must define a type. Valid types are 'file' and 'new'.<br>  Keys of type 'file' must define a path to the key that<br>  should be trusted.<br>  Keys of type 'new' must define a 'name' and 'email' to create<br>  the key with. | `list(map(any))` | `[]` | no |
 | <a name="input_install_dir"></a> [install\_dir](#input\_install\_dir) | Directory to install spack into. | `string` | `"/sw/spack"` | no |
 | <a name="input_install_flags"></a> [install\_flags](#input\_install\_flags) | Defines the flags to pass into `spack install` | `string` | `""` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Key-value pairs of labels to be added to created resources. | `map(string)` | n/a | yes |
 | <a name="input_licenses"></a> [licenses](#input\_licenses) | List of software licenses to install within spack. | <pre>list(object({<br>    source = string<br>    dest   = string<br>  }))</pre> | `null` | no |
 | <a name="input_log_file"></a> [log\_file](#input\_log\_file) | Defines the logfile that script output will be written to | `string` | `"/var/log/spack.log"` | no |
 | <a name="input_packages"></a> [packages](#input\_packages) | Defines root packages for spack to install (in order). | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region to place bucket containing startup script. | `string` | n/a | yes |
 | <a name="input_spack_cache_url"></a> [spack\_cache\_url](#input\_spack\_cache\_url) | List of buildcaches for spack. | <pre>list(object({<br>    mirror_name = string<br>    mirror_url  = string<br>  }))</pre> | `null` | no |
 | <a name="input_spack_ref"></a> [spack\_ref](#input\_spack\_ref) | Git ref to checkout for spack. | `string` | `"v0.20.0"` | no |
 | <a name="input_spack_url"></a> [spack\_url](#input\_spack\_url) | URL to clone the spack repo from. | `string` | `"https://github.com/spack/spack"` | no |

--- a/community/modules/scripts/spack-install/outputs.tf
+++ b/community/modules/scripts/spack-install/outputs.tf
@@ -16,12 +16,12 @@
 
 output "startup_script" {
   description = "Path to the Spack installation script."
-  value       = local.script_content
+  value       = module.startup_script.startup_script
 }
 
 output "controller_startup_script" {
   description = "Path to the Spack installation script, duplicate for SLURM controller."
-  value       = local.script_content
+  value       = module.startup_script.startup_script
 }
 
 output "install_spack_deps_runner" {
@@ -40,7 +40,7 @@ output "install_spack_deps_runner" {
 
 output "install_spack_runner" {
   description = "Runner to install Spack using the startup-script module"
-  value       = local.install_spack_runner
+  value       = local.combined_install_execute_runner
 }
 
 output "setup_spack_runner" {

--- a/community/modules/scripts/spack-install/templates/execute_commands.yml.tpl
+++ b/community/modules/scripts/spack-install/templates/execute_commands.yml.tpl
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Execute Commands
+  hosts: localhost
+  vars:
+    pre_script: ${pre_script}
+    log_file: ${log_file}
+    commands: ${commands}
+  tasks:
+  - name: Execute command block
+    block:
+    - name: Print commands to be executed
+      ansible.builtin.debug:
+        msg: "{{ commands.split('\n') }}"
+
+    - name: Execute commands
+      ansible.builtin.shell: |
+        set -eo pipefail
+        {
+        {{ pre_script }}
+        echo " === Starting commands ==="
+        {{ commands }}
+        echo " === Finished commands ==="
+        } | tee -a {{ log_file }}
+      register: output
+
+    always:
+    - name: Print commands output to stderr
+      ansible.builtin.debug:
+        var: output.stderr_lines
+
+    - name: Print commands output to stdout
+      ansible.builtin.debug:
+        var: output.stdout_lines

--- a/community/modules/scripts/spack-install/variables.tf
+++ b/community/modules/scripts/spack-install/variables.tf
@@ -24,6 +24,8 @@ variable "project_id" {
   type        = string
 }
 
+# spack-setup variables
+
 variable "install_dir" {
   description = "Directory to install spack into."
   type        = string
@@ -41,6 +43,43 @@ variable "spack_ref" {
   type        = string
   default     = "v0.20.0"
 }
+
+variable "spack_virtualenv_path" {
+  description = "Virtual environment path in which to install Spack Python interpreter and other dependencies"
+  default     = "/usr/local/spack-python"
+  type        = string
+}
+
+# spack-build variables
+
+variable "log_file" {
+  description = "Defines the logfile that script output will be written to"
+  default     = "/var/log/spack.log"
+  type        = string
+}
+
+variable "commands" {
+  description = "String of commands to run within this module"
+  default     = null
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "Name of deployment, used to name bucket containing startup script."
+  type        = string
+}
+
+variable "region" {
+  description = "Region to place bucket containing startup script."
+  type        = string
+}
+
+variable "labels" {
+  description = "Key-value pairs of labels to be added to created resources."
+  type        = map(string)
+}
+
+# variables to be deprecated
 
 variable "spack_cache_url" {
   description = "List of buildcaches for spack."
@@ -220,16 +259,4 @@ EOT
     ])
     error_message = "The content attribute within environments is required to be a string."
   }
-}
-
-variable "log_file" {
-  description = "Defines the logfile that script output will be written to"
-  default     = "/var/log/spack.log"
-  type        = string
-}
-
-variable "spack_virtualenv_path" {
-  description = "Virtual environment path in which to install Spack Python interpreter and other dependencies"
-  default     = "/usr/local/spack-python"
-  type        = string
 }

--- a/community/modules/scripts/spack-install/versions.tf
+++ b/community/modules/scripts/spack-install/versions.tf
@@ -15,5 +15,11 @@
 */
 
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = ">= 1.0.0"
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
+    }
+  }
 }

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -45,6 +45,10 @@ duplicates = [
         "community/modules/compute/gke-node-pool/threads_per_core_calc.tf",
         "modules/compute/vm-instance/threads_per_core_calc.tf"
     ],
+    [
+        "community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl",
+        "community/modules/scripts/spack-install/templates/execute_commands.yml.tpl",
+    ],
 ]
 
 for group in duplicates:


### PR DESCRIPTION
This change is essentially a no-opt except for that it adds the commands input. Later when this module is split into separate setup and execute modules the commands functionality will be on the execute side of the split. For now this change is needed as next steps will be to move custom functionality out of the shell script and replace it with equivalent generic commands.

Tested manually:
- Basic install of spack
- Commands that succeed
- Commands that fail

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
