### PR TITLE
Use `regexall` instead of `strcontains` to stay compatible with terraform 1.2

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/source_image_logic.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/source_image_logic.tf
@@ -22,7 +22,7 @@ locals {
   source_image_family     = local.source_image_input_used ? var.source_image_family : lookup(var.instance_image, "family", "")
   source_image_project    = local.source_image_input_used ? var.source_image_project : lookup(var.instance_image, "project", "")
   source_image_project_normalized = (
-    local.source_image != "" || strcontains(local.source_image_project, "/")
+    local.source_image != "" || length(regexall("/", local.source_image_project)) > 0
     ? local.source_image_project
     : "projects/${local.source_image_project}/global/images/family"
   )

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/source_image_logic.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/source_image_logic.tf
@@ -22,7 +22,7 @@ locals {
   source_image_family     = local.source_image_input_used ? var.source_image_family : lookup(var.instance_image, "family", "")
   source_image_project    = local.source_image_input_used ? var.source_image_project : lookup(var.instance_image, "project", "")
   source_image_project_normalized = (
-    local.source_image != "" || strcontains(local.source_image_project, "/")
+    local.source_image != "" || length(regexall("/", local.source_image_project)) > 0
     ? local.source_image_project
     : "projects/${local.source_image_project}/global/images/family"
   )

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/source_image_logic.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/source_image_logic.tf
@@ -22,7 +22,7 @@ locals {
   source_image_family     = local.source_image_input_used ? var.source_image_family : lookup(var.instance_image, "family", "")
   source_image_project    = local.source_image_input_used ? var.source_image_project : lookup(var.instance_image, "project", "")
   source_image_project_normalized = (
-    local.source_image != "" || strcontains(local.source_image_project, "/")
+    local.source_image != "" || length(regexall("/", local.source_image_project)) > 0
     ? local.source_image_project
     : "projects/${local.source_image_project}/global/images/family"
   )


### PR DESCRIPTION
The [`strcontains()`](https://developer.hashicorp.com/terraform/language/functions/strcontains) function was not introduced until Terraform 1.5.x.  Using [`regexall`](https://developer.hashicorp.com/terraform/language/v1.2.x/functions/regexall) instead allows HPC Toolkit to maintain compatibility with Terraform 1.2.x.