### PR TITLE
Update list of supported VM images

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ minutes. Please consider it only for blueprints that are quickly deployed.
 The HPC Toolkit officially supports the following VM images:
 
 * HPC CentOS 7
+* HPC Rocky Linux 8
+* Debian 11
 * Ubuntu 20.04 LTS
 
 For more information on these and other images, see

--- a/community/modules/scripts/omnia-install/README.md
+++ b/community/modules/scripts/omnia-install/README.md
@@ -9,7 +9,7 @@ omnia-install, see the [omnia-cluster example].
 sudo permissions. You may want to remove this user and/or it's permissions from
 each node.
 
-[omnia-cluster example]: ../../../community/examples/omnia-cluster.yaml
+[omnia-cluster example]: ../../../../community/examples/omnia-cluster.yaml
 
 ## License
 

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -1,70 +1,170 @@
 # Supported and Tested VM Images
 
-* [HPC CentOS 7 VM Image](#hpc-centos-7-vm-image)
-* [Ubuntu](#ubuntu)
+* [HPC CentOS 7](#hpc-centos-7)
+* [HPC Rocky Linux 8](#hpc-rocky-linux-8)
+* [Debian 11](#debian-11)
+* [Ubuntu 20.04 LTS](#ubuntu-2004-lts)
 * [Windows](#windows)
 * [Other Images](#other-images)
 
 For information on customizing VM images with extra software and configuration
 settings, see [Building Images](image-building.md).
 
-## HPC CentOS 7 VM Image
+Please see the [blueprint catalog](https://cloud.google.com/hpc-toolkit/docs/setup/hpc-blueprint-catalog) for examples.
+
+For Slurm images, please see [SchedMD's GitHub repository](https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#public-image).
+
+## HPC CentOS 7
+
 The HPC Toolkit has officially supported the [HPC CentOS 7 VM Image][hpcimage] as the
 primary VM image for HPC workloads on Google Cloud since it's release. Since the
 [HPC CentOS 7 VM Image][hpcimage] comes pre-tuned for optimal performance on
 typical HPC workloads, it is the default VM image in our modules, unless there
 is specific requirement for a different OS distribution.
 
-Exceptions:
-
-* [DDN-EXAScaler]: The underlying terraform module has a limitted set of
-  supported images [documented][exascalerimages] in the exascaler-cloud-terraform
-  github repo. **This requirement only applies to the servers, not the clients.**
-* [omnia-install]: Only provides support for Rocky 8.
-
 [hpcimage]: https://cloud.google.com/blog/topics/hpc/introducing-hpc-vm-images
 
-## Ubuntu
-The HPC Toolkit officially supports Ubuntu based VM images in the majority of
-our modules, with a couple exceptions:
+## HPC Rocky Linux 8
 
-* [htcondor-configure]: Only provides support for the HPC CentOS 7 image.
-* [nfs-server]: Only provides support for CentOS 7 images for the server itself.
-* [DDN-EXAScaler]: The underlying terraform module has a limitted set of
-  supported images [documented][exascalerimages] in the exascaler-cloud-terraform
-  github repo. **This requirement only applies to the servers, not the clients.**
-* [omnia-install]: Only provides support for Rocky 8.
+HPC Rocky Linux 8 is planned to become the primary supported VM image for HPC workloads on Google Cloud from 2024.
 
-HPC Toolkit modules and startup scripts
-have been evaulated against the `ubuntu-2004-lts` image family. For more
-information about the Ubuntu Google Cloud images, see the Canonical
-[documentation](https://ubuntu.com/server/docs/cloud-images/google-cloud-engine).
+## Debian 11
 
-To use the Ubuntu images with the `schedmd-slurm-gcp-v5` modules, follow
-the pattern used in the [hpc-slurm-ubuntu2004.yaml] example.
+The HPC Toolkit officially supports Debian 11 based VM images in the majority of our modules, with a couple of exceptions.
 
-In most other modules that provide the option to set a VM image, you can set it
-to use the Ubuntu image with the following:
+## Ubuntu 20.04 LTS
 
-```yaml
-...
-settings:
-  instance_image:
-    family: ubuntu-2004-lts
-    project: ubuntu-os-cloud
-```
-
-[htcondor-configure]: ../community/modules/scheduler/htcondor-configure/README.md
-[nfs-server]: ../community/modules/file-system/nfs-server/README.md
-[DDN-EXAScaler]: ../community/modules/file-system/DDN-EXAScaler/README.md
-[exascalerimages]: https://github.com/DDNStorage/exascaler-cloud-terraform/blob/master/gcp/README.md#boot-image-options
-[omnia-install]: ../community/modules/scripts/omnia-install/README.md
-[hpc-slurm-ubuntu2004.yaml]: ../community/examples/hpc-slurm-ubuntu2004.yaml
+The HPC Toolkit officially supports Ubuntu 20.04 LTS based VM images in the majority of
+our modules, with a couple of exceptions.
 
 ## Windows
 
 See [building Windows images](image-building.md#windows-support) for
 a description of our support for Windows images.
+
+## Supported features
+
+<table>
+<tr>
+  <th>Deployment Type/Scheduler</th>
+  <th>Feature</th>
+  <th></th>
+  <th>CentOS 7</th><th>Debian 11</th><th>Rocky Linux 8</th><th>Ubuntu 20.04</th>
+</tr>
+<tr>
+  <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+</tr>
+
+<tr>
+  <th rowspan="3">Cloud Batch</th>
+  <th>Lustre</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
+  <td></td>
+  <td></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
+</tr>
+<tr>
+  <th>Shared filestore</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
+</tr>
+<tr>
+  <th>Startup script</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-startup.yaml">✓</a></td>
+</tr>
+
+<tr>
+  <th rowspan="4">Slurm</th>
+  <th>Chrome Remote Desktop</th>
+  <th></th>
+  <td></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-crd.yaml">✓</a></td>
+  <td></td>
+  <td></td>
+</tr>
+<tr>
+  <th>Lustre</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-lustre.yaml">✓</a></td>
+  <td></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-lustre.yaml">✓</a></td>
+  <td></td>
+</tr>
+<tr>
+  <th>Shared filestore</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml">✓</a></td>
+</tr>
+<tr>
+  <th>Startup script</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/slurm-startup.yaml">✓</a></td>
+</tr>
+
+<tr>
+  <th rowspan="4">VM Instance</th>
+  <th>Chrome Remote Desktop</th>
+  <th></th>
+  <td></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-crd.yaml">✓</a></td>
+  <td></td>
+  <td><sup><b>*</b></sup></td>
+</tr>
+<tr>
+  <th>Lustre</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-lustre.yaml">✓</a></td>
+  <td></td>
+  <td></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-lustre.yaml">✓</a></td>
+</tr>
+<tr>
+  <th>Shared filestore</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml">✓</a></td>
+</tr>
+<tr>
+  <th>Startup script</th>
+  <th></th>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-startup.yaml">✓</a></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-startup.yaml">✓</a></td>
+</tr>
+
+<tr>
+  <th rowspan="1">HTCondor</th>
+  <th></th>
+  <th></th>
+  <td>✓</td><td></td><td></td><td></td>
+</tr>
+
+<tr>
+  <th rowspan="1">Omnia</th>
+  <th></th>
+  <th></th>
+  <td></td><td></td><td>✓</td><td></td>
+</tr>
+</table>
+
+<sup><b>*</b></sup> Chrome Remote desktop does not support Ubuntu 20.04, but it does support Ubuntu 22.04.
 
 ## Other Images
 
@@ -105,7 +205,27 @@ These instructions apply to the following modules:
 [slurm-gcp]: https://github.com/SchedMD/slurm-gcp
 [slurm-gcp-packer]: https://github.com/SchedMD/slurm-gcp/tree/master/packer
 [slurm-gcp-images]: https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md
+
+[vm-instance]: ../modules/compute/vm-instance
 [hpc-toolkit-packer]: ../modules/packer/custom-image
 [schedmd-slurm-gcp-v5-controller]: ../community/modules/scheduler/schedmd-slurm-gcp-v5-controller
 [schedmd-slurm-gcp-v5-login]: ../community/modules/scheduler/schedmd-slurm-gcp-v5-login
 [schedmd-slurm-gcp-v5-node-group]: ../community/modules/compute/schedmd-slurm-gcp-v5-node-group
+[batch-job]: ../modules/scheduler/batch-job-template
+[batch-login]: ../modules/scheduler/batch-login-node
+[htcondor-configure]: ../community/modules/scheduler/htcondor-configure
+[omnia-install]: ../community/modules/scripts/omnia-install
+[hpc-slurm-ubuntu2004.yaml]: ../community/examples/hpc-slurm-ubuntu2004.yaml
+
+[htc-htcondor.yaml]: ../community/examples/htc-htcondor.yaml
+[omnia-cluster.yaml]: ../community/examples/omnia-cluster.yaml
+[vm-startup.yaml]: ../tools/validate_configs/os_compatibility_tests/vm-startup.yaml
+[vm-crd.yaml]: ../tools/validate_configs/os_compatibility_tests/vm-crd.yaml
+[vm-filestore.yaml]: ../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
+[vm-lustre.yaml]: ../tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
+[slurm-startup.yaml]: ../tools/validate_configs/os_compatibility_tests/slurm-startup.yaml
+[slurm-crd.yaml]: ../tools/validate_configs/os_compatibility_tests/slurm-crd.yaml
+[slurm-filestore.yaml]: ../tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml
+[slurm-lustre.yaml]: ../tools/validate_configs/os_compatibility_tests/slurm-lustre.yaml
+[batch-startup.yaml]: ../tools/validate_configs/os_compatibility_tests/batch-startup.yaml
+[batch-filestore.yaml]: ../tools/validate_configs/os_compatibility_tests/batch-filestore.yaml

--- a/tools/validate_configs/os_compatibility_tests/batch-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-filestore.yaml
@@ -1,0 +1,76 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-batch-filestore
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  # image:
+  #   family: ubuntu-2004-lts
+  #   project: ubuntu-os-cloud
+  # image:
+  #   family: centos-7
+  #   project: centos-cloud
+  image:
+    family: rocky-linux-8
+    project: rocky-linux-cloud
+  # image:
+  #   family: debian-11
+  #   project: debian-cloud
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Storage #
+  ###########
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network1]
+    settings:
+      local_mount: /home
+
+  ###############
+  # Cloud Batch #
+  ###############
+
+  - id: batch-job
+    source: modules/scheduler/batch-job-template
+    use:
+    - network1
+    - homefs
+    settings:
+      runnable: "echo 'hello, world!' > /home/test-from-batch.txt"
+      machine_type: n2-standard-4
+
+  - id: batch-login
+    source: modules/scheduler/batch-login-node
+    use: [batch-job]
+    outputs: [instructions]

--- a/tools/validate_configs/os_compatibility_tests/batch-lustre.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-lustre.yaml
@@ -1,0 +1,93 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-batch-lustre
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  # image:
+  #   family: hpc-centos-7
+  #   project: centos-cloud
+  image:
+    family: hpc-rocky-linux-8
+    project: rocky-linux-cloud
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Storage #
+  ###########
+
+  # This file system has an associated license cost.
+  # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
+  - id: lustre
+    source: community/modules/file-system/DDN-EXAScaler
+    use:
+    - network1
+    settings:
+      local_mount: /lustre
+      mgs:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 1
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+      mds:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 1
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+      oss:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 3
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+
+  ###############
+  # Cloud Batch #
+  ###############
+
+  - id: batch-job
+    source: modules/scheduler/batch-job-template
+    use:
+    - network1
+    - lustre
+    settings:
+      runnable: "sudo echo 'hello, world!' > /lustre/test-from-batch.txt"
+      machine_type: n2-standard-4
+
+  - id: batch-login
+    source: modules/scheduler/batch-login-node
+    use:
+    - batch-job
+    outputs: [instructions]

--- a/tools/validate_configs/os_compatibility_tests/batch-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-startup.yaml
@@ -1,0 +1,87 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-batch-startup
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  # image:
+  #   family: ubuntu-2004-lts
+  #   project: ubuntu-os-cloud
+  # image:
+  #   family: centos-7
+  #   project: centos-cloud
+  image:
+    family: rocky-linux-8
+    project: rocky-linux-cloud
+  # image:
+  #   family: debian-11
+  #   project: debian-cloud
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Startup #
+  ###########
+
+  - id: startup
+    source: modules/scripts/startup-script
+    settings:
+      install_ansible: true
+
+  ###########
+  # Storage #
+  ###########
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network1]
+    settings:
+      local_mount: /home
+
+  ###############
+  # Cloud Batch #
+  ###############
+
+  - id: batch-job
+    source: modules/scheduler/batch-job-template
+    use:
+    - network1
+    - homefs
+    - startup
+    settings:
+      runnable: "ansible --version"
+      machine_type: n2-standard-4
+
+  - id: batch-login
+    source: modules/scheduler/batch-login-node
+    use:
+    - batch-job
+    outputs: [instructions]

--- a/tools/validate_configs/os_compatibility_tests/slurm-crd.yaml
+++ b/tools/validate_configs/os_compatibility_tests/slurm-crd.yaml
@@ -1,0 +1,108 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-slurm-crd
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  machine_type: n1-standard-2
+  instance_image:
+    # Please refer to the following link for the latest images:
+    # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
+    family: slurm-gcp-5-7-debian-11
+    project: schedmd-slurm-public
+  guest_accelerator:
+  - type: nvidia-tesla-t4-vws
+    count: 1
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Startup #
+  ###########
+
+  - id: remote-desktop
+    source: community/modules/remote-desktop/chrome-remote-desktop
+    use:
+    - network1
+    settings:
+      name_prefix: crd
+      install_nvidia_driver: true
+      # instance_count: 0 will create installation scripts only
+      # which can be used with slurm node provisioning
+      instance_count: 0
+
+  #############
+  # Slurm VMs #
+  #############
+  - id: debug_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      node_count_dynamic_max: 3
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - debug_node_group
+    - remote-desktop
+    settings:
+      partition_name: debug
+      exclusive: false # allows nodes to stay up after jobs are done
+      enable_placement: false # the default is: true
+      is_default: true
+      partition_startup_scripts_timeout: 900
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    use:
+    - network1
+    - debug_partition
+    settings:
+      disable_controller_public_ips: false
+      compute_startup_script: $(remote-desktop.startup_script)
+      controller_startup_script: $(remote-desktop.startup_script)
+      compute_startup_scripts_timeout: 900
+      controller_startup_scripts_timeout: 900
+      login_startup_scripts_timeout: 900
+  - id: wait
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.slurm_controller.controller_instance_id))
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    use:
+    - network1
+    - slurm_controller
+    - remote-desktop
+    settings:
+      disable_login_public_ips: false

--- a/tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml
@@ -1,0 +1,94 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-slurm-filestore
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  machine_type: n1-standard-2
+  instance_image:
+    # Please refer to the following link for the latest images:
+    # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
+    # family: slurm-gcp-5-7-ubuntu-2004-lts
+    # family: slurm-gcp-5-7-hpc-centos-7
+    family: slurm-gcp-5-7-hpc-rocky-linux-8
+    # family: slurm-gcp-5-7-debian-11
+    project: schedmd-slurm-public
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Storage #
+  ###########
+
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network1]
+    settings:
+      local_mount: /home
+
+  #############
+  # Slurm VMs #
+  #############
+  - id: debug_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      node_count_dynamic_max: 3
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - debug_node_group
+    - homefs
+    settings:
+      partition_name: debug
+      exclusive: false # allows nodes to stay up after jobs are done
+      enable_placement: false # the default is: true
+      is_default: true
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    use:
+    - network1
+    - debug_partition
+    - homefs
+    settings:
+      disable_controller_public_ips: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    use:
+    - network1
+    - slurm_controller
+    - homefs
+    settings:
+      disable_login_public_ips: false

--- a/tools/validate_configs/os_compatibility_tests/slurm-lustre.yaml
+++ b/tools/validate_configs/os_compatibility_tests/slurm-lustre.yaml
@@ -1,0 +1,113 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-slurm-lustre
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  machine_type: n1-standard-2
+  instance_image:
+    # Please refer to the following link for the latest images:
+    # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
+    # family: slurm-gcp-5-7-ubuntu-2004-lts
+    # family: slurm-gcp-5-7-hpc-centos-7
+    family: slurm-gcp-5-7-hpc-rocky-linux-8
+    project: schedmd-slurm-public
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Storage #
+  ###########
+
+  # This file system has an associated license cost.
+  # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
+  - id: lustre
+    source: community/modules/file-system/DDN-EXAScaler
+    use: [network1]
+    settings:
+      local_mount: /lustre
+      mgs:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 1
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+      mds:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 1
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+      oss:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 3
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+
+  #############
+  # Slurm VMs #
+  #############
+  - id: debug_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      node_count_dynamic_max: 3
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - debug_node_group
+    - lustre
+    settings:
+      partition_name: debug
+      exclusive: false # allows nodes to stay up after jobs are done
+      enable_placement: false # the default is: true
+      is_default: true
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    use:
+    - network1
+    - debug_partition
+    - lustre
+    settings:
+      disable_controller_public_ips: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    use:
+    - network1
+    - slurm_controller
+    - lustre
+    settings:
+      disable_login_public_ips: false

--- a/tools/validate_configs/os_compatibility_tests/slurm-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/slurm-startup.yaml
@@ -1,0 +1,99 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-slurm-startup
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  machine_type: n1-standard-2
+  instance_image:
+    # Please refer to the following link for the latest images:
+    # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
+    # family: slurm-gcp-5-7-ubuntu-2004-lts
+    # family: slurm-gcp-5-7-hpc-centos-7
+    family: slurm-gcp-5-7-hpc-rocky-linux-8
+    # family: slurm-gcp-5-7-debian-11
+    project: schedmd-slurm-public
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Startup #
+  ###########
+
+  - id: startup
+    source: modules/scripts/startup-script
+    settings:
+      install_ansible: true
+      runners:
+      - type: shell
+        destination: startup-test-partition.sh
+        content: |
+          #!/bin/bash
+          set -ex
+          echo "Hello partition! Hostname: \$(hostname)"
+
+  #############
+  # Slurm VMs #
+  #############
+  - id: debug_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      node_count_dynamic_max: 3
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - network1
+    - debug_node_group
+    settings:
+      partition_name: debug
+      exclusive: false # allows nodes to stay up after jobs are done
+      enable_placement: false # the default is: true
+      is_default: true
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    use:
+    - network1
+    - debug_partition
+    - startup
+    settings:
+      disable_controller_public_ips: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    use:
+    - network1
+    - slurm_controller
+    - startup
+    settings:
+      disable_login_public_ips: false

--- a/tools/validate_configs/os_compatibility_tests/vm-crd.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-crd.yaml
@@ -1,0 +1,59 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: vm-crd
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  instance_image:
+    family: ubuntu-2004-lts
+    project: ubuntu-os-cloud
+  # instance_image:
+  #   family: debian-11
+  #   project: debian-cloud
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  #############
+  # Simple VM #
+  #############
+  - id: remote-desktop
+    source: community/modules/remote-desktop/chrome-remote-desktop
+    use:
+    - network1
+    settings:
+      name_prefix: crd
+      install_nvidia_driver: true
+      instance_count: 1
+  - id: wait
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.remote-desktop.instance_name))

--- a/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
@@ -1,0 +1,116 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-workstation-filestore
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  machine_type: n1-standard-2
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Storage #
+  ###########
+
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network1]
+    settings:
+      local_mount: /home
+
+  #############
+  # Simple VM #
+  #############
+
+  - id: workstation_ubuntu
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - homefs
+    settings:
+      instance_image:
+        family: ubuntu-2004-lts
+        project: ubuntu-os-cloud
+      name_prefix: workstation-ubuntu
+      instance_count: 1
+  - id: wait_ubuntu
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.workstation_ubuntu.name[0]))
+
+  - id: workstation_centos
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - homefs
+    settings:
+      instance_image:
+        family: centos-7
+        project: centos-cloud
+      name_prefix: workstation-centos
+      instance_count: 1
+  - id: wait_centos
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.workstation_centos.name[0]))
+
+  - id: workstation_rocky
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - homefs
+    settings:
+      instance_image:
+        family: rocky-linux-8
+        project: rocky-linux-cloud
+      name_prefix: workstation-rocky
+      instance_count: 1
+  - id: wait_rocky
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.workstation_rocky.name[0]))
+
+  - id: workstation_debian
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - homefs
+    settings:
+      instance_image:
+        family: debian-11
+        project: debian-cloud
+      name_prefix: workstation-debian
+      instance_count: 1
+  - id: wait_debian
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.workstation_debian.name[0]))

--- a/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
@@ -1,0 +1,95 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-workstation-lustre
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  machine_type: n1-standard-2
+  # instance_image:
+  #   family: ubuntu-2004-lts
+  #   project: ubuntu-os-cloud
+  instance_image:
+    family: centos-7
+    project: centos-cloud
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Storage #
+  ###########
+
+  # This file system has an associated license cost.
+  # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
+  - id: lustre
+    source: community/modules/file-system/DDN-EXAScaler
+    use: [network1]
+    settings:
+      local_mount: /lustre
+      mgs:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 1
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+      mds:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 1
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+      oss:
+        nic_type: "GVNIC"
+        node_type: n2-standard-2
+        node_count: 3
+        node_cpu: "Intel Cascade Lake"
+        public_ip: true
+
+  #############
+  # Simple VM #
+  #############
+
+  - id: workstation
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - lustre
+    settings:
+      name_prefix: workstation-
+      instance_count: 2
+  - id: wait0
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.workstation.name[0]))
+  - id: wait1
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.workstation.name[1]))

--- a/tools/validate_configs/os_compatibility_tests/vm-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-startup.yaml
@@ -1,0 +1,82 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: test-workstation-startup
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: test
+  region: us-central1
+  zone: us-central1-a
+  machine_type: n1-standard-2
+  # instance_image:
+  #   family: ubuntu-2004-lts
+  #   project: ubuntu-os-cloud
+  # instance_image:
+  #   family: centos-7
+  #   project: centos-cloud
+  instance_image:
+    family: rocky-linux-8
+    project: rocky-linux-cloud
+  # instance_image:
+  #   family: debian-11
+  #   project: debian-cloud
+
+deployment_groups:
+- group: primary
+  modules:
+
+  ###########
+  # Network #
+  ###########
+
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network1
+    source: modules/network/vpc
+
+  ###########
+  # Startup #
+  ###########
+
+  - id: startup
+    source: modules/scripts/startup-script
+    settings:
+      install_ansible: true
+      runners:
+      - type: shell
+        destination: startup-test-partition.sh
+        content: |
+          #!/bin/bash
+          set -ex
+          echo "Hello partition! Hostname: \$(hostname)"
+
+  #############
+  # Simple VM #
+  #############
+  - id: workstation
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - startup
+    settings:
+      name_prefix: workstation-
+      instance_count: 2
+  - id: wait0
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: ((module.workstation.name[0]))


### PR DESCRIPTION
This PR updates the documentation to reflect which images the HPC Toolkit officially supports, and provides the blueprints used for testing all of the above configurations.

I have tested Rocky Linux 8, CentOS 7, Debian 11 and Ubuntu 20.04 LTS in workstation, slurm and GCP Cloud Batch configurations with a shared filestore, Lustre networked storage, a startup script and Chrome Remote Desktop.

I have removed the "Exceptions" sections under each supported VM image heading in the [Supported VM Images doc](../blob/a84ce30763ffd83e3715480a92c5dc7a1111e801/docs/vm-images.md) because:
1. Images used for servers (e.g. Lustre servers) are likely not of importance to users, since most will probably use the default image.
2. Support for clients can be put in the Compatibility Table.