### PR TITLE
Add `pipefail` to Makefile to prevent swallowing failed tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ MIN_GOLANG_VERSION=1.18 # for building ghpc
         terraform-format packer-format \
         check-tflint check-pre-commit
 
+SHELL=/bin/bash -o pipefail
 ENG = ./cmd/... ./pkg/...
 TERRAFORM_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.tf" -not -path '*/\.*' -exec dirname "{}" \; | sort -u)
 PACKER_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.pkr.hcl" -not -path '*/\.*' -exec dirname "{}" \; | sort -u)


### PR DESCRIPTION
```sh
go test -cover $(ENG) 2>&1 |  perl tools/enforce_coverage.pl
```

Ignored failed tests if `enforce_coverage.pl` was happy.