### PR TITLE
Remove "failed tests" check from `enforce_coverage` since it doesn't …

### DIFF
--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -21,7 +21,6 @@ my $min = 80;
 my $cmdmin = 40;
 my $shellmin = 15;
 my $failed_coverage = 0;
-my $failed_tests = 0;
 
 while (<>){
   print $_;
@@ -32,14 +31,8 @@ while (<>){
   } elsif ( $_ =~ /coverage: (\d+\.\d)%/ ) {
     $failed_coverage++ if ($1 < $min);
   }
-  if ($_ =~ /\d+ passed, (\d+) FAILED/){
-    $failed_tests += $1;
-  }
 }
-if ($failed_tests > 0) {
-   print STDERR "$failed_tests test(s) failed.\n";
-   exit 1
-}
+
 if ($failed_coverage > 0) {
    print STDERR "Coverage must be above $cmdmin% for ./cmd and $min% for other packages, $failed_coverage packages were below that.\n";
    exit 1


### PR DESCRIPTION
…work

Rely on `pipefail` instead #1498
