### PR TITLE
Make spack output runner destination deterministic to fix known at apply error

### DIFF
--- a/community/modules/scripts/spack-install/main.tf
+++ b/community/modules/scripts/spack-install/main.tf
@@ -85,7 +85,8 @@ locals {
 
   runners = concat([local.install_spack_runner], local.data_runners, [local.execute_runner])
 
-  combined_md5 = substr(md5(module.startup_script.startup_script), 0, 4)
+  combined_unique_string = join("\n", [for runner in local.runners : try(runner["content"], runner["source"])])
+  combined_md5           = substr(md5(local.combined_unique_string), 0, 4)
   combined_install_execute_runner = {
     "type"        = "shell"
     "content"     = module.startup_script.startup_script

--- a/community/modules/scripts/spack-install/variables.tf
+++ b/community/modules/scripts/spack-install/variables.tf
@@ -75,14 +75,14 @@ variable "data_files" {
       for r in var.data_files :
       can(r["content"]) != can(r["source"])
     ])
-    error_message = "A runner must specify either 'content' or 'source', but never both."
+    error_message = "A data_file must specify either 'content' or 'source', but never both."
   }
   validation {
     condition = alltrue([
       for r in var.data_files :
       lookup(r, "content", lookup(r, "source", null)) != null
     ])
-    error_message = "A runner must specify a non-null 'content' or 'source'."
+    error_message = "A data_file must specify a non-null 'content' or 'source'."
   }
 }
 


### PR DESCRIPTION
This change fixes not know at apply time error. `md5` was processing module output which is not known at apply time. This change should maintain the same uniqueness properties but will be known before apply.

This may need some refactoring in the future when we split spack-install into two different modules.

Tested manually.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
