### PR TITLE
Update google-cloud-daos version from v0.4.0 to v0.4.1

### DIFF
--- a/community/examples/intel/README.md
+++ b/community/examples/intel/README.md
@@ -185,42 +185,28 @@ terraform -chdir=hpc-intel-select/primary destroy
 ## DAOS Cluster
 
 The [pfs-daos.yaml](pfs-daos.yaml) blueprint describes an environment with
-- A [managed instance group][mig] with four DAOS server instances
-- A [managed instance group][mig] with two DAOS client instances
+- Two DAOS server instances
+- Two DAOS client instances
 
-For more information, please refer to the [Google Cloud DAOS repo on GitHub][google-cloud-daos].
-
-> **_NOTE:_** The [pre-deployment steps in the google-cloud-daos/README.md][pre-deployment] must be completed prior to running this HPC Toolkit example.
-
-[mig]: https://cloud.google.com/compute/docs/instance-groups
-[google-cloud-daos]: https://github.com/daos-stack/google-cloud-daos
-[pre-deployment]: https://github.com/daos-stack/google-cloud-daos#pre-deployment-steps
+The [pfs-daos.yaml](pfs-daos.yaml) blueprint uses a Packer template and Terraform modules from the [Google Cloud DAOS][google-cloud-daos] repository.
 
 Identify a project to work in and substitute its unique id wherever you see
 `<<PROJECT_ID>>` in the instructions below.
 
 ### Initial Setup for DAOS Cluster
 
-Before provisioning any infrastructure in this project you should follow the
-Toolkit guidance to enable [APIs][apis] and establish minimum resource
-[quotas][quotas]. In particular, the following APIs should be enabled
+Before provisioning the DAOS cluster you must follow the steps listed in the [Google Cloud DAOS Pre-deployment Guide][pre-deployment_guide].
 
-- [compute.googleapis.com](https://cloud.google.com/compute/docs/reference/rest/v1#service:-compute.googleapis.com) (Google Compute Engine)
-- [secretmanager.googleapis.com](https://cloud.google.com/secret-manager/docs/reference/rest#service:-secretmanager.googleapis.com) (Secret manager, for secure mode)
+Skip the "Build DAOS Images" step at the end of the [Pre-deployment Guide][pre-deployment_guide]. The [pfs-daos.yaml](pfs-daos.yaml) blueprint will build the images as part of the deployment.
 
-[apis]: ../../../README.md#enable-gcp-apis
-[quotas]: ../../../README.md#gcp-quotas
+The Pre-deployment Guide provides instructions for enabling service accounts, APIs, establishing minimum resource quotas and other necessary steps to prepare your project.
 
-The following available quota is required in the region used by the cluster:
-
-- C2 CPUs: 32 (16 per client node)
-- N2 CPUs: 144 (36 per server node)
-- PD-SSD: 120GB (20GB per client and server)
-- Local SSD: 4 \* 16 \* 375 = 24,000GB (6TB per server)
+[google-cloud-daos]: https://github.com/daos-stack/google-cloud-daos
+[pre-deployment_guide]: https://github.com/daos-stack/google-cloud-daos/blob/main/docs/pre-deployment_guide.md
 
 ### Deploy the DAOS Cluster
 
-Use `ghpc` to provision the blueprint
+After completing the steps in the [Pre-deployment Guide][pre-deployment_guide] use `ghpc` to provision the blueprint
 
 ```text
 ghpc create community/examples/intel/pfs-daos.yaml  \
@@ -363,9 +349,8 @@ The `cont1` container is now mounted on `${HOME}/daos/cont1`
 Create a 20GiB file which will be stored in the DAOS filesystem.
 
 ```bash
-pushd ${HOME}/daos/cont1
 time LD_PRELOAD=/usr/lib64/libioil.so \
-dd if=/dev/zero of=./test20GiB.img iflag=fullblock bs=1G count=20
+dd if=/dev/zero of="${HOME}/daos/cont1/test20GiB.img" iflag=fullblock bs=1G count=20
 ```
 
 See the [File System](https://docs.daos.io/v2.2/user/filesystem/) section of the DAOS User Guide for more information about DFuse.
@@ -406,39 +391,35 @@ The blueprint uses modules from
 - [community/modules/scheduler/SchedMD-slurm-on-gcp-login-node][SchedMD-slurm-on-gcp-login-node]
 - [community/modules/compute/SchedMD-slurm-on-gcp-partition][SchedMD-slurm-on-gcp-partition]
 
-> **_NOTE:_** The [pre-deployment steps in the google-cloud-daos/README.md][pre-deployment] must be completed prior to running this HPC Toolkit example.
-
-[mig]: https://cloud.google.com/compute/docs/instance-groups
-[google-cloud-daos]: https://github.com/daos-stack/google-cloud-daos
-[pre-deployment]: https://github.com/daos-stack/google-cloud-daos#pre-deployment-steps
-[apis]: ../../../README.md#enable-gcp-apis
-[SchedMD-slurm-on-gcp-controller]: ../../modules/scheduler/SchedMD-slurm-on-gcp-controller
-[SchedMD-slurm-on-gcp-login-node]: ../../modules/scheduler/SchedMD-slurm-on-gcp-login-node
-[SchedMD-slurm-on-gcp-partition]: ../../modules/compute/SchedMD-slurm-on-gcp-partition
+The blueprint also uses a Packer template from the [Google Cloud DAOS][google-cloud-daos] repository.
 
 Identify a project to work in and substitute its unique id wherever you see
 `<<PROJECT_ID>>` in the instructions below.
 
 ### Initial Setup for the DAOS/Slurm cluster
 
-Before provisioning any infrastructure in this project you should follow the
-Toolkit guidance to enable [APIs][apis] and establish minimum resource
-[quotas][quotas]. In particular, the following APIs should be enabled
+Before provisioning the DAOS cluster you must follow the steps listed in the [Google Cloud DAOS Pre-deployment Guide][pre-deployment_guide].
 
-- [compute.googleapis.com](https://cloud.google.com/compute/docs/reference/rest/v1#service:-compute.googleapis.com) (Google Compute Engine)
-- [secretmanager.googleapis.com](https://cloud.google.com/secret-manager/docs/reference/rest#service:-secretmanager.googleapis.com) (Secret manager, for secure mode)
+Skip the "Build DAOS Images" step at the end of the [Pre-deployment Guide][pre-deployment_guide]. The [hpc-slurm-daos.yaml](hpc-slurm-daos.yaml) blueprint will build the DAOS server image as part of the deployment.
+
+The Pre-deployment Guide provides instructions for enabling service accounts, APIs, establishing minimum resource quotas and other necessary steps to prepare your project for DAOS server deployment.
+
+[google-cloud-daos]: https://github.com/daos-stack/google-cloud-daos
+[pre-deployment_guide]: https://github.com/daos-stack/google-cloud-daos/blob/main/docs/pre-deployment_guide.md
+
+[packer-template]: https://github.com/daos-stack/google-cloud-daos/blob/main/images/daos.pkr.hcl
+[apis]: ../../../README.md#enable-gcp-apis
+[SchedMD-slurm-on-gcp-controller]: ../../modules/scheduler/SchedMD-slurm-on-gcp-controller
+[SchedMD-slurm-on-gcp-login-node]: ../../modules/scheduler/SchedMD-slurm-on-gcp-login-node
+[SchedMD-slurm-on-gcp-partition]: ../../modules/compute/SchedMD-slurm-on-gcp-partition
+
+Follow the Toolkit guidance to enable [APIs][apis] and establish minimum resource [quotas][quotas] for Slurm.
 
 [apis]: ../../../README.md#enable-gcp-apis
 [quotas]: ../../../README.md#gcp-quotas
 
-And the following available quota is required in the region used by the cluster:
+The following available quota is required in the region used by Slurm:
 
-For DAOS:
-- N2 CPUs: 64 (16 per server node)
-- PD-SSD: 80GB (20GB per server)
-- Local SSD: 4 \* 4 \* 375 = 6,000GB (1.5TB per server)
-
-For Slurm:
 - Filestore: 2560GB
 - C2 CPUs: 6000 (fully-scaled "compute" partition)
   - This quota is not necessary at initial deployment, but will be required to

--- a/community/examples/intel/hpc-slurm-daos.yaml
+++ b/community/examples/intel/hpc-slurm-daos.yaml
@@ -43,9 +43,9 @@ deployment_groups:
 
 - group: daos-server-image
   modules:
-  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/images
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.1/images
   - id: daos-server-image
-    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.0&depth=1
+    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.1&depth=1
     kind: packer
     settings:
       daos_version: 2.2.0
@@ -69,7 +69,7 @@ deployment_groups:
   modules:
   # more info: https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server
   - id: daos
-    source: github.com/daos-stack/google-cloud-daos//terraform/modules/daos_server?ref=v0.4.0&depth=1
+    source: github.com/daos-stack/google-cloud-daos//terraform/modules/daos_server?ref=v0.4.1&depth=1
     use: [network1]
     settings:
       labels: {ghpc_role: file-system}

--- a/community/examples/intel/pfs-daos.yaml
+++ b/community/examples/intel/pfs-daos.yaml
@@ -38,9 +38,9 @@ deployment_groups:
 
 - group: daos-server-image
   modules:
-  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/images
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.1/images
   - id: daos-server-image
-    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.0&depth=1
+    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.1&depth=1
     kind: packer
     settings:
       daos_version: 2.2.0
@@ -62,9 +62,9 @@ deployment_groups:
 
 - group: daos-client-image
   modules:
-  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/images
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.1/images
   - id: daos-client-image
-    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.0&depth=1
+    source: github.com/daos-stack/google-cloud-daos//images?ref=v0.4.1&depth=1
     kind: packer
     settings:
       daos_version: 2.2.0
@@ -86,18 +86,18 @@ deployment_groups:
 
 - group: daos-cluster
   modules:
-  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/terraform/modules/daos_server
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.1/terraform/modules/daos_server
   - id: daos-server
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.4.0&depth=1
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.4.1&depth=1
     use: [network1]
     settings:
       number_of_instances: 2
       labels: {ghpc_role: file-system}
       os_family: $(vars.server_image_family)
 
-  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.0/terraform/modules/daos_client
+  # more info: https://github.com/daos-stack/google-cloud-daos/tree/v0.4.1/terraform/modules/daos_client
   - id: daos-client
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_client?ref=v0.4.0&depth=1
+    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_client?ref=v0.4.1&depth=1
     use: [network1, daos-server]
     settings:
       number_of_instances: 2

--- a/community/modules/file-system/Intel-DAOS/README.md
+++ b/community/modules/file-system/Intel-DAOS/README.md
@@ -2,99 +2,64 @@
 
 This module allows creating an instance of Distributed Asynchronous Object Storage ([DAOS](https://docs.daos.io/)) on Google Cloud Platform ([GCP](https://cloud.google.com/)).
 
-For more information, please refer to the [Google Cloud DAOS repo on GitHub](https://github.com/daos-stack/google-cloud-daos).
+> **_NOTE:_**
+> DAOS on GCP does not require an HPC Toolkit wrapper.
+> Terraform modules are sourced directly from GitHub.
+> It will not work as a [local or embedded module](../../../../modules/README.md#embedded-modules).
 
-For more information on this and other network storage options in the Cloud HPC
-Toolkit, see the extended [Network Storage documentation](../../../../docs/network_storage.md).
+Terraform modules for DAOS servers and clients are located in the [Google Cloud DAOS repo on GitHub](https://github.com/daos-stack/google-cloud-daos).
 
-> **_NOTE:_** DAOS on GCP does not require an HPC Toolkit wrapper and, therefore, sources directly from GitHub. It will not work as a [local or embedded module](../../../../modules/README.md#embedded-modules).
+DAOS Terraform module parameters can be found in the README.md files in each module directory.
 
+- [DAOS Server module](https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server#readme)
+- [DAOS Client module](https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_client#readme)
+
+For more information on this and other network storage options in the Cloud HPC Toolkit, see the extended [Network Storage documentation](../../../../docs/network_storage.md).
 ## Examples
 
-Working examples of a DAOS deployment and how it can be used in conjunction with Slurm [can be found in the community examples folder](../../../examples/intel/).
+The [community examples folder](../../../examples/intel/) contains two example blueprints for deploying DAOS.
 
-A full list of server module parameters can be found at [the DAOS Server module README](https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/modules/daos_server).
+- [community/examples/intel/pfs-daos.yml](../../../examples/intel/pfs-daos.yml)
+  Blueprint for deploying a DAOS cluster consisting of servers and clients.
+  After deploying this example the DAOS storage system will be formatted but no pools or containers will exist.
+  The instructions in the [community/examples/intel/README.md](../../../examples/intel/README.md#create-a-daos-pool-and-container) describe how to
 
-### DAOS Server Images
+  - Deploy a DAOS cluster
+  - Manage storage (create a [pool](https://docs.daos.io/v2.2/overview/storage/?h=container#daos-pool) and a [container](https://docs.daos.io/v2.2/overview/storage/?h=container#daos-container))
+  - Mount a container on a client
+  - Store a large file in a DAOS container
 
-In order to use the DAOS server terraform module a DAOS server image must be created as instructed in the *images* directory [here](https://github.com/daos-stack/google-cloud-daos/tree/main/images).
-
-DAOS server images must be built from the same tagged version of the [google-cloud-daos](https://github.com/daos-stack/google-cloud-daos) repository that is specified in the `source:` attribute for modules used in the [community examples](../../../examples/intel/).
-
-For example, in the following snippet taken from the [community/example/intel/pfs-daos.yml](../../../examples/intel/pfs-daos.yaml) the `source:` attribute specifies v0.3.0 of the  daos_server terraform module
-
-```yaml
-  - id: daos-server
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.3.0
-    use: [network1]
-    settings:
-      number_of_instances: 2
-      labels: {ghpc_role: file-system}
-```
-
-In order to use the daos_server module v0.3.0 , you need to
-
-1. Clone the [google-cloud-daos](https://github.com/daos-stack/google-cloud-daos) repo and check out v0.3.0
-2. Follow the instructions in the images/README.md directory to build a DAOS server image
-
-## Recommended settings
-
-By default, the DAOS system is created with 4 servers will be configured for best cost per GB (TCO, see below), the system will be formated at the server side using [`dmg format`](https://github.com/daos-stack/google-cloud-daos/tree/develop/terraform/examples/daos_cluster#format-storage) but no pool or containers will be created.
-
-The following settings will configure this [system for TCO](https://github.com/daos-stack/google-cloud-daos/tree/main/terraform/examples/daos_cluster#the-terraformtfvarstcoexample-file) (default):
-
-```yaml
-  - id: daos-server
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.3.0
-    use: [network1]
-    settings:
-      labels: {ghpc_role: file-system}
-      number_of_instances : 4 # number of DAOS server instances
-      machine_type        : "n2-custom-36-215040"
-      os_disk_size_gb     : 20
-      daos_disk_count     : 16
-      daos_scm_size       : 180
-```
-
-The following settings will configure this system for [best performance](https://github.com/daos-stack/google-cloud-daos/tree/develop/terraform/examples/daos_cluster#the-terraformtfvarsperfexample-file):
-
-```yaml
-  - id: daos-server
-    source: github.com/daos-stack/google-cloud-daos.git//terraform/modules/daos_server?ref=v0.3.0
-    use: [network1]
-    settings:
-      labels: {ghpc_role: file-system}
-      # The default DAOS settings are optimized for TCO
-      # The following will tune this system for best perf
-      machine_type        : "n2-standard-16"
-      os_disk_size_gb     : 20
-      daos_disk_count     : 4
-      daos_scm_size       : 45
-```
+- [community/examples/intel/hpc-slurm-daos.yaml](../../../examples/intel/hpc-slurm-daos.yaml)
+  Blueprint for deploying a Slurm cluster and DAOS storage with 4 servers.
+  The Slurm compute nodes are configured as DAOS clients and have the ability to use the DAOS filesystem.
+  The instructions in the [community/examples/intel/README.md](../../../examples/intel/README.md#deploy-the-daosslurm-cluster) describe how to deploy the Slurm cluster and run a job which uses the DAOS file system.
 
 ## Support
 
 Content in the [google-cloud-daos](https://github.com/daos-stack/google-cloud-daos) repository is licensed under the [Apache License Version 2.0](https://github.com/daos-stack/google-cloud-daos/blob/main/LICENSE) open-source license.
 
-[DAOS](https://github.com/daos-stack/daos) is being distributed under the BSD-2-Clause-Patent open-source license.
+[DAOS](https://github.com/daos-stack/daos) is distributed under the BSD-2-Clause-Patent open-source license.
 
-Intel Corporation provides several ways for the users to get technical support:
+Intel Corporation provides two options for technical support:
 
-1. Community support is available to everybody through Jira and via the DAOS channel for the Google Cloud users on Slack.
+1. Community Support
 
-   To access Jira, please follow these steps:
+   Community support is available to anyone through Jira and via the DAOS channel for Google Cloud users on Slack.
 
-   - Navigate to https://daosio.atlassian.net/jira/software/c/projects/DAOS/issues/
+   JIRA: https://daosio.atlassian.net/jira/software/c/projects/DAOS/issues/
 
-   - You will need to request access to DAOS Jira to be able to create and update tickets. An Atlassian account is required for this type of access. Read-only access is available without an account.
-   - If you do not have an Atlassian account, follow the steps at https://support.atlassian.com/atlassian-account/docs/create-an-atlassian-account/ to create one.
+   - An Atlassian account is not needed for read only access to Jira.
+   - An Atlassian account is required to create and update tickets.
+     To create an account follow the steps at https://support.atlassian.com/atlassian-account/docs/create-an-atlassian-account.
 
-   To access the Slack channel for DAOS on Google Cloud, please follow this link https://daos-stack.slack.com/archives/C03GLTLHA59
+   Slack: https://daos-stack.slack.com/archives/C03GLTLHA59
 
-   > This type of support is provided on a best-effort basis, and it does not have any SLA attached.
+   Community support is provided on a best-effort basis.
 
-2. Commercial L3 support is available on an on-demand basis. Please get in touch with Intel Corporation to obtain more information.
+2. Commercial L3 Support
 
-   - You may inquire about the L3 support via the Slack channel (https://daos-stack.slack.com/archives/C03GLTLHA59)
+   Commercial L3 support is available on an on-demand basis.
 
-[here](https://github.com/daos-stack/google-cloud-daos/tree/main/images)
+   Contact Intel Corporation to obtain more information about Commercial L3 support.
+
+   You may inquire about L3 support via the [Slack channel](https://daos-stack.slack.com/archives/C03GLTLHA59).


### PR DESCRIPTION
google-cloud-daos v0.4.1 was released to fix 2 bugs.

See https://github.com/daos-stack/google-cloud-daos/releases/tag/v0.4.1

This change updates the version number referenced in the community/examples/intel/*-daos.yaml blueprints.

Made a few minor updates in the community/examples/intel/README.md

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
