### PR TITLE
Drop coverage requirement for pkg/shell

### DIFF
--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -19,7 +19,7 @@ use warnings;
 # TODO: raise ./cmd min coverage to 80% after tests are written
 my $min = 80;
 my $cmdmin = 40;
-my $shellmin = 15;
+my $shellmin = 0;
 my $failed_coverage = 0;
 
 while (<>){


### PR DESCRIPTION
Nearly all effective unit testing of pkg/shell requires a mock infrastructure we don't yet have so coverage requirement at 15% is doing little to help us. Current unit tests concentrate on failing effectively when Terraform or Packer are not present.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
