### PR TITLE
Enable `flatten` and `merge` functions in `Eval`.

### DIFF
--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -113,10 +113,10 @@ deployment_groups:
           - script
         settings:
           deployment_name: ((var.deployment_name ))
-          labels:
-            ghpc_blueprint: igc
-            ghpc_deployment: golden_copy_deployment
-            ghpc_role: packer
+          labels: |-
+            ((merge(var.labels, {
+              ghpc_role = "packer"
+            })))
           project_id: ((var.project_id ))
           startup_script: ((module.script.startup_script))
           subnetwork_name: ((module.network0.subnetwork_name))

--- a/tools/validate_configs/golden_copies/expectations/text_escape/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/.ghpc/artifacts/expanded_blueprint.yaml
@@ -45,12 +45,12 @@ deployment_groups:
           deployment_name: ((var.deployment_name))
           image_family: \$(zebra/to(ad
           image_name: \((cat /dog))
-          labels:
-            brown: \$(fox)
-            ghpc_blueprint: text_escape
-            ghpc_deployment: golden_copy_deployment
-            ghpc_role: packer
-            ñred: ñblue
+          labels: |-
+            ((merge(var.labels, {
+              ghpc_role = "packer"
+              }, {
+              brown = "$(fox)"
+            })))
           project_id: ((var.project_id))
           subnetwork_name: \$(purple
           zone: ((var.zone))


### PR DESCRIPTION
To enable `use` on lists for packer modules
* Enable `flatten` and `merge` functions in `Eval`;
* Remove special handling of packer module `labels`.

Tested on blueprint from #1510

```yaml
# expanded.yaml
      - source: modules/packer/custom-image
        ...
        settings:
          ...
          labels: |-
            ((merge(var.labels, {
              ghpc_role = "packer"
            })))
          ...
          windows_startup_ps1: ((flatten([module.windows_startup.windows_startup_ps1])))
```

```hcl
# test-winimage/packer/image/defaults.auto.pkrvars.hcl
...
labels = {
  ghpc_blueprint  = "test-winimage"
  ghpc_deployment = "test-winimage"
  ghpc_role       = "packer"
}
...
```

```hcl
# test-winimage/packer/image/image_inputs.auto.pkrvars.hcl
...
windows_startup_ps1 = ["#Requires -RunAsAdministrato...tall-Driver\n"]
```

Though `./ghpc deploy test-winimage` failed with unrelated error:
```
--> test-winimage.googlecompute.toolkit_image: retry count exhausted. Last err: Tunnel start: ERROR: (gcloud.compute.start-iap-tunnel) While checking if a connection can be made: Error while connecting [4003: 'failed to connect to backend']. (Failed to connect to port 5986)
```