### PR TITLE
Reduce size of Spack builder as max default is to use 16 cores

### DIFF
--- a/examples/serverless-batch-mpi.yaml
+++ b/examples/serverless-batch-mpi.yaml
@@ -134,7 +134,7 @@ deployment_groups:
     settings:
       name_prefix: spack-builder
       add_deployment_name_before_prefix: true
-      machine_type: c2-standard-30
+      machine_type: c2-standard-16
 
   ### Batch Modules ###
   - id: batch-job


### PR DESCRIPTION
[Spack reference](https://spack.readthedocs.io/en/latest/config_yaml.html#build-jobs):

> The default parallelism is equal to the number of cores available to the process, up to 16.

Anything extra is additional cost with no benefit. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
