### PR TITLE
Initial commit of HTCondor windows install script

### DIFF
--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -137,4 +137,5 @@ No resources.
 | <a name="output_install_autoscaler_deps_runner"></a> [install\_autoscaler\_deps\_runner](#output\_install\_autoscaler\_deps\_runner) | Toolkit Runner to install HTCondor autoscaler dependencies |
 | <a name="output_install_autoscaler_runner"></a> [install\_autoscaler\_runner](#output\_install\_autoscaler\_runner) | Toolkit Runner to install HTCondor autoscaler |
 | <a name="output_install_htcondor_runner"></a> [install\_htcondor\_runner](#output\_install\_htcondor\_runner) | Runner to install HTCondor using startup-scripts |
+| <a name="output_windows_startup_ps1"></a> [windows\_startup\_ps1](#output\_windows\_startup\_ps1) | Windows PowerShell script to install HTCondor |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -25,6 +25,11 @@ locals {
     ])
   }
 
+  install_htcondor_ps1 = templatefile(
+    "${path.module}/templates/install-htcondor.ps1.tftpl", {
+      condor_version = var.condor_version
+  })
+
   runner_install_autoscaler_deps = {
     "type"        = "ansible-local"
     "content"     = file("${path.module}/files/install-htcondor-autoscaler-deps.yml")

--- a/community/modules/scripts/htcondor-install/outputs.tf
+++ b/community/modules/scripts/htcondor-install/outputs.tf
@@ -19,6 +19,11 @@ output "install_htcondor_runner" {
   value       = local.runner_install_htcondor
 }
 
+output "windows_startup_ps1" {
+  description = "Windows PowerShell script to install HTCondor"
+  value       = local.install_htcondor_ps1
+}
+
 output "install_autoscaler_deps_runner" {
   description = "Toolkit Runner to install HTCondor autoscaler dependencies"
   value       = local.runner_install_autoscaler_deps

--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -1,0 +1,34 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+# Windows 2016 defaults to old TLS protocols, override it
+[Net.ServicePointManager]::SecurityProtocol = 'Tls12'
+
+# do not show progress bar when running Invoke-WebRequest
+$ProgressPreference = 'SilentlyContinue'
+
+# download C Runtime DLL necessary for HTCondor installer
+Invoke-WebRequest https://aka.ms/vs/17/release/vc_redist.x64.exe -OutFile C:\vc_redist.x64.exe
+Start-Process C:\vc_redist.x64.exe -Wait -ArgumentList "/norestart /quiet /log c:\vc_redist_log.txt"
+Remove-Item C:\vc_redist.x64.exe
+
+# download HTCondor installer
+%{ if condor_version == "10.*" }
+Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/current/current/condor-Windows-x64.msi -OutFile C:\htcondor.msi
+%{ else ~}
+Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/current/${condor_version}/release/condor-${condor_version}-Windows-x64.msi -OutFile C:\htcondor.msi
+%{ endif ~}
+$args='/qn /l* condor-install-log.txt /i'
+$args=$args + ' C:\htcondor.msi'
+$args=$args + ' NEWPOOL="N"'
+$args=$args + ' RUNJOBS="N"'
+$args=$args + ' SUBMITJOBS="N"'
+$args=$args + ' INSTALLDIR="C:\Condor"'
+Start-Process msiexec.exe -Wait -ArgumentList $args
+Remove-Item C:\htcondor.msi
+
+# remove settings from condor_config that we want to override in configuration step
+Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^CONDOR_HOST' -NotMatch)
+Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^INSTALL_USER' -NotMatch)
+Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^DAEMON_LIST' -NotMatch)
+Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^use SECURITY' -NotMatch)


### PR DESCRIPTION
This PR adds a basic HTCondor windows installation script for use with the Packer module.

Can add `condor_version: 10.5.1` to deployment variables to select a specific release. No validation is performed that the release exists.

```yaml
blueprint_name: test-win-htc

vars:
  deployment_name: test-win-htc
  region: us-west4
  zone: us-west4-a

deployment_groups:
- group: primary
  modules:
  - id: network1
    source: modules/network/vpc
    settings:
      enable_iap_rdp_ingress: true
      enable_iap_winrm_ingress: true

  - id: htcondor_install
    source: community/modules/scripts/htcondor-install

- group: packer
  modules:
  - id: image
    source: modules/packer/custom-image
    kind: packer
    use:
    - network1
    - htcondor_install
    settings:
      source_image_family: windows-2016
      machine_type: n1-standard-8
      disk_size: 75
      disk_type: pd-ssd
      state_timeout: 15m
      omit_external_ip: false
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
