### PR TITLE
Refactor HTCondor configuration file management

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -152,14 +152,15 @@ deployment_groups:
         destination: /var/tmp/helloworld.sub
         content: |
           universe       = vanilla
-          executable     = /bin/echo
-          arguments      = "Hello, World!"
+          executable     = /bin/sleep
+          arguments      = 1000
           output         = out.\$(ClusterId).\$(ProcId)
           error          = err.\$(ClusterId).\$(ProcId)
           log            = log.\$(ClusterId).\$(ProcId)
           request_cpus   = 1
           request_memory = 100MB
-          +RequireSpot   = true # if unset, defaults to false
+          # if unset, defaults to false
+          +RequireSpot   = true
           queue
 
   - id: htcondor_access

--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -214,11 +214,12 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_access_point_service_account"></a> [access\_point\_service\_account](#module\_access\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
+| <a name="module_access_point_service_account"></a> [access\_point\_service\_account](#module\_access\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.2 |
 | <a name="module_address"></a> [address](#module\_address) | terraform-google-modules/address/google | ~> 3.0 |
-| <a name="module_central_manager_service_account"></a> [central\_manager\_service\_account](#module\_central\_manager\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
-| <a name="module_execute_point_service_account"></a> [execute\_point\_service\_account](#module\_execute\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.1 |
+| <a name="module_central_manager_service_account"></a> [central\_manager\_service\_account](#module\_central\_manager\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.2 |
+| <a name="module_execute_point_service_account"></a> [execute\_point\_service\_account](#module\_execute\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.2 |
 | <a name="module_health_check_firewall_rule"></a> [health\_check\_firewall\_rule](#module\_health\_check\_firewall\_rule) | terraform-google-modules/network/google//modules/firewall-rules | ~> 6.0 |
+| <a name="module_htcondor_bucket"></a> [htcondor\_bucket](#module\_htcondor\_bucket) | terraform-google-modules/cloud-storage/google | ~> 4.0 |
 
 ## Resources
 
@@ -229,6 +230,9 @@ limitations under the License.
 | [google_secret_manager_secret_iam_member.central_manager](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.execute_point](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.pool_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [google_storage_bucket_object.ap_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.cm_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.execute_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [random_password.pool](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [google_compute_subnetwork.htcondor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -20,24 +20,17 @@
     job_queue_ha: false
     spool_dir: /var/lib/condor/spool
     condor_config_root: /etc/condor
-    role_file: 00-role
-    pool_file: 01-pool
-    cm_config_file: 02-central-manager
-    cm_ha_config_file: 02-central-manager-high-availability
-    schedd_config_file: 02-schedd
-    schedd_ha_config_file: 02-schedd-high-availability
+    ghpc_config_file: 50-ghpc-managed
+    schedd_ha_config_file: 51-ghpc-schedd-high-availability
     execute_config_file: 02-execute
   tasks:
-  - name: User must supply HTCondor role
+  - name: Ensure necessary variables are set
     ansible.builtin.assert:
       that:
-      - htcondor_central_manager_ips is defined
       - htcondor_role is defined
       - password_id is defined
-      - project_id is defined
-  - name: Set Trust Domain
-    ansible.builtin.set_fact:
-      trust_domain: c.{{ project_id }}.internal
+      - trust_domain is defined
+      - config_object is defined
   - name: Set HTCondor Pool password (token signing key)
     ansible.builtin.shell: |
       set -e -o pipefail
@@ -45,30 +38,35 @@
       echo -n "$POOL_PASSWORD" | sh -c "condor_store_cred add -c -i -"
     args:
       creates: "{{ condor_config_root }}/passwords.d/POOL"
+      executable: /bin/bash
   - name: Remove default HTCondor configuration
     ansible.builtin.file:
       path: "{{ condor_config_root }}/config.d/00-htcondor-9.0.config"
       state: absent
     notify:
     - Reload HTCondor
-  - name: Set HTCondor role on all hosts
-    ansible.builtin.copy:
-      dest: "{{ condor_config_root }}/config.d/{{ role_file }}"
-      mode: 0644
-      content: |
-        use role:{{ htcondor_role }}
-    notify:
-    - Reload HTCondor
-  - name: Set HTCondor Central Manager and trust domain on all hosts
-    ansible.builtin.copy:
-      dest: "{{ condor_config_root }}/config.d/{{ pool_file }}"
-      mode: 0644
-      content: |
-        CONDOR_HOST={{ htcondor_central_manager_ips }}
-        UID_DOMAIN={{ trust_domain }}
-        TRUST_DOMAIN={{ trust_domain }}
-    notify:
-    - Reload HTCondor
+  - name: Create Toolkit configuration file
+    register: config_update
+    changed_when: config_update.rc == 137
+    failed_when: config_update.rc != 0 and config_update.rc != 137
+    ansible.builtin.shell: |
+      set -e -o pipefail
+      REMOTE_HASH=$(gcloud --format="value(md5_hash)" storage hash {{ config_object }})
+
+      CONFIG_FILE="{{ condor_config_root }}/config.d/{{ ghpc_config_file }}"
+      if [ -f "${CONFIG_FILE}" ]; then
+          LOCAL_HASH=$(gcloud --format="value(md5_hash)" storage hash "${CONFIG_FILE}")
+      else
+          LOCAL_HASH="INVALID-HASH"
+      fi
+
+      if [ "${REMOTE_HASH}" != "${LOCAL_HASH}" ]; then
+          gcloud storage cp {{ config_object }} "${CONFIG_FILE}"
+          chmod 0644 "${CONFIG_FILE}"
+          exit 137
+      fi
+    args:
+      executable: /bin/bash
   - name: Configure HTCondor Central Manager
     when: htcondor_role == 'get_htcondor_central_manager'
     block:
@@ -81,53 +79,6 @@
           -token condor@{{ trust_domain }}
       args:
         creates: "{{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}"
-    - name: Generate list of Central Managers
-      ansible.builtin.set_fact:
-        central_manager_list: "{{ htcondor_central_manager_ips | split(',') }}"
-    - name: Create Central Manager standard configuration file
-      ansible.builtin.copy:
-        dest: "{{ condor_config_root }}/config.d/{{ cm_config_file }}"
-        mode: 0644
-        content: |
-          COLLECTOR_UPDATE_INTERVAL=30
-          NEGOTIATOR_UPDATE_INTERVAL=30
-          NEGOTIATOR_DEPTH_FIRST=True
-          NEGOTIATOR_UPDATE_AFTER_CYCLE=True
-      notify:
-      - Reload HTCondor
-    - name: Create Central Manager HA configuration file
-      when: central_manager_list | length > 1
-      ansible.builtin.copy:
-        dest: "{{ condor_config_root }}/config.d/{{ cm_ha_config_file }}"
-        mode: 0644
-        content: |
-          # following https://htcondor.readthedocs.io/en/latest/admin-manual/high-availability.html#high-availability-of-the-central-manager
-          CM_LIST = \
-            {{ central_manager_list[0] }}:$(SHARED_PORT_PORT), \
-            {{ central_manager_list[1] }}:$(SHARED_PORT_PORT)
-
-          HAD_USE_SHARED_PORT=True
-          HAD_LIST=$(CM_LIST)
-
-          REPLICATION_USE_SHARED_PORT=True
-          REPLICATION_LIST=$(CM_LIST)
-
-          HAD_USE_PRIMARY=True
-          HAD_CONTROLLEE=NEGOTIATOR
-          MASTER_NEGOTIATOR_CONTROLLER=HAD
-
-          DAEMON_LIST=$(DAEMON_LIST), HAD, REPLICATION
-          HAD_USE_REPLICATION=True
-          MASTER_HAD_BACKOFF_CONSTANT=360
-      notify:
-      - Restart HTCondor
-    - name: Remove Central Manager HA configuration file
-      when: central_manager_list | length == 1
-      ansible.builtin.file:
-        path: "{{ condor_config_root }}/config.d/{{ cm_ha_config_file }}"
-        state: absent
-      notify:
-      - Restart HTCondor
   - name: Configure HTCondor SchedD
     when: htcondor_role == 'get_htcondor_submit'
     block:
@@ -138,41 +89,6 @@
         owner: condor
         group: condor
         mode: 0755
-    - name: Create SchedD configuration file
-      ansible.builtin.copy:
-        dest: "{{ condor_config_root }}/config.d/{{ schedd_config_file }}"
-        mode: 0644
-        content: |
-          SCHEDD_INTERVAL=30
-          TRUST_UID_DOMAIN=True
-          SUBMIT_ATTRS=RunAsOwner
-          RunAsOwner=True
-          use feature:JobsHaveInstanceIDs
-          SYSTEM_JOB_MACHINE_ATTRS=$(SYSTEM_JOB_MACHINE_ATTRS) \
-            CloudVMType CloudZone CloudInterruptible
-          SYSTEM_JOB_MACHINE_ATTRS_HISTORY_LENGTH=10
-          SPOOL={{ spool_dir }}
-          use feature:ScheddCronOneShot(cloud, $(LIBEXEC)/common-cloud-attributes-google.py)
-          SCHEDD_CRON_cloud_PREFIX=Cloud
-          # the sequence of job transforms and submit requirements below set
-          # a default job attribute RequireSpot to False but allow the user to
-          # specify *only* a boolean value with +RequireSpot = True in their job
-          # submit file; the requirements of the job are transformed to filter
-          # on +RequireSpot unless job has explicit CloudInterruptible requirements
-          JOB_TRANSFORM_NAMES = SPOT_DEFAULT, SPOT_REQS
-          JOB_TRANSFORM_SPOT_DEFAULT @=end
-             DEFAULT RequireSpot False
-          @end
-          # Unless explicit, set CloudInterruptible requirements to job RequireSpot attribute
-          JOB_TRANSFORM_SPOT_REQS @=end
-             REQUIREMENTS ! unresolved(Requirements, "^CloudInterruptible$")
-             SET Requirements $(MY.Requirements) && (CloudInterruptible is My.RequireSpot)
-          @end
-          SUBMIT_REQUIREMENT_NAMES = REQSPOT
-          SUBMIT_REQUIREMENT_REQSPOT = isBoolean(RequireSpot)
-          SUBMIT_REQUIREMENT_REQSPOT_REASON = "Jobs must set +RequireSpot to either True or False"
-      notify:
-      - Reload HTCondor
     - name: Create IDTOKEN to advertise access point
       ansible.builtin.shell: |
         umask 0077
@@ -237,19 +153,6 @@
   - name: Configure HTCondor StartD
     when: htcondor_role == 'get_htcondor_execute'
     block:
-    - name: Create StartD configuration file
-      ansible.builtin.copy:
-        dest: "{{ condor_config_root }}/config.d/{{ execute_config_file }}"
-        mode: 0644
-        content: |
-          use feature:PartitionableSlot
-          use feature:CommonCloudAttributesGoogle("-c created-by")
-          UPDATE_INTERVAL=30
-          TRUST_UID_DOMAIN=True
-          STARTER_ALLOW_RUNAS_OWNER=True
-          RUNBENCHMARKS=False
-      notify:
-      - Reload HTCondor
     - name: Create IDTOKEN to advertise execute point
       ansible.builtin.shell: |
         umask 0077

--- a/community/modules/scheduler/htcondor-configure/outputs.tf
+++ b/community/modules/scheduler/htcondor-configure/outputs.tf
@@ -49,7 +49,7 @@ output "pool_password_secret_id" {
 
 output "central_manager_runner" {
   description = "Toolkit Runner to configure an HTCondor Central Manager"
-  value       = local.runner_cm_role
+  value       = local.runner_cm
   depends_on = [
     google_secret_manager_secret_version.pool_password
   ]
@@ -57,7 +57,7 @@ output "central_manager_runner" {
 
 output "access_point_runner" {
   description = "Toolkit Runner to configure an HTCondor Access Point"
-  value       = local.runner_access_role
+  value       = local.runner_access
   depends_on = [
     google_secret_manager_secret_version.pool_password
   ]
@@ -65,7 +65,7 @@ output "access_point_runner" {
 
 output "execute_point_runner" {
   description = "Toolkit Runner to configure an HTCondor Execute Point"
-  value       = local.runner_execute_role
+  value       = local.runner_execute
   depends_on = [
     google_secret_manager_secret_version.pool_password
   ]

--- a/community/modules/scheduler/htcondor-configure/templates/htcondor.tftpl
+++ b/community/modules/scheduler/htcondor-configure/templates/htcondor.tftpl
@@ -1,0 +1,100 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this file is managed by the HPC Toolkit; do not edit it manually
+# override settings with a higher priority (last lexically) named file
+# https://htcondor.readthedocs.io/en/latest/admin-manual/introduction-to-configuration.html?#ordered-evaluation-to-set-the-configuration
+
+use role:${htcondor_role}
+CONDOR_HOST = ${join(",", central_manager_ips)}
+UID_DOMAIN = ${trust_domain}
+TRUST_DOMAIN = ${trust_domain}
+
+%{ if htcondor_role == "get_htcondor_central_manager" ~}
+# Central Manager configuraition settings
+COLLECTOR_UPDATE_INTERVAL = 30
+NEGOTIATOR_UPDATE_INTERVAL = 30
+NEGOTIATOR_DEPTH_FIRST = True
+NEGOTIATOR_UPDATE_AFTER_CYCLE = True
+%{ endif ~}
+
+%{ if htcondor_role == "get_htcondor_central_manager" && length(central_manager_ips) > 1 ~}
+# Central Manager high availability configuration settings
+# following https://htcondor.readthedocs.io/en/latest/admin-manual/high-availability.html#high-availability-of-the-central-manager
+CM_LIST = \
+  ${central_manager_ips[0]}:$(SHARED_PORT_PORT), \
+  ${central_manager_ips[1]}:$(SHARED_PORT_PORT)
+
+HAD_USE_SHARED_PORT = True
+HAD_LIST = $(CM_LIST)
+
+REPLICATION_USE_SHARED_PORT = True
+REPLICATION_LIST = $(CM_LIST)
+
+HAD_USE_PRIMARY = True
+HAD_CONTROLLEE = NEGOTIATOR
+MASTER_NEGOTIATOR_CONTROLLER = HAD
+
+DAEMON_LIST = $(DAEMON_LIST), HAD, REPLICATION
+HAD_USE_REPLICATION = True
+MASTER_HAD_BACKOFF_CONSTANT = 360
+%{ endif ~}
+
+%{ if htcondor_role == "get_htcondor_submit" ~}
+# SchedD configuration settings
+SPOOL = ${spool_dir}
+SCHEDD_INTERVAL = 30
+TRUST_UID_DOMAIN = True
+SUBMIT_ATTRS = RunAsOwner
+RunAsOwner = True
+
+# When a job matches to a machine, add machine attributes to the job for
+# condor_history (e.g. VM Instance ID)
+use feature:JobsHaveInstanceIDs
+SYSTEM_JOB_MACHINE_ATTRS = $(SYSTEM_JOB_MACHINE_ATTRS) \
+  CloudVMType CloudZone CloudInterruptible
+SYSTEM_JOB_MACHINE_ATTRS_HISTORY_LENGTH = 10
+
+# Add Cloud attributes to SchedD ClassAd
+use feature:ScheddCronOneShot(cloud, $(LIBEXEC)/common-cloud-attributes-google.py)
+SCHEDD_CRON_cloud_PREFIX = Cloud
+
+# the sequence of job transforms and submit requirements below set
+# a default job attribute RequireSpot to False but allow the user to
+# specify *only* a boolean value with +RequireSpot = True in their job
+# submit file; the requirements of the job are transformed to filter
+# on +RequireSpot unless job has explicit CloudInterruptible requirements
+JOB_TRANSFORM_NAMES = SPOT_DEFAULT, SPOT_REQS
+JOB_TRANSFORM_SPOT_DEFAULT @=end
+   DEFAULT RequireSpot False
+@end
+# Unless explicit, set CloudInterruptible requirements to job RequireSpot attribute
+JOB_TRANSFORM_SPOT_REQS @=end
+   REQUIREMENTS ! unresolved(Requirements, "^CloudInterruptible$")
+   SET Requirements $(MY.Requirements) && (CloudInterruptible is My.RequireSpot)
+@end
+SUBMIT_REQUIREMENT_NAMES = REQSPOT
+SUBMIT_REQUIREMENT_REQSPOT = isBoolean(RequireSpot)
+SUBMIT_REQUIREMENT_REQSPOT_REASON = "Jobs must set +RequireSpot to either True or False"
+%{ endif ~}
+
+%{ if htcondor_role == "get_htcondor_execute" ~}
+# StartD configuration settings
+use feature:PartitionableSlot
+use feature:CommonCloudAttributesGoogle("-c created-by")
+UPDATE_INTERVAL = 30
+TRUST_UID_DOMAIN = True
+STARTER_ALLOW_RUNAS_OWNER = True
+RUNBENCHMARKS = False
+%{ endif ~}


### PR DESCRIPTION
- Fix HTCondor example job (comments must be on a separate line) and make it more useful for diagnosis (sleep 1000 vs echo "Hello, World!"
- NOP refactoring of existing configuration
  - simplify condor_config.d directory structure such that only 1 (or 2 for SchedD HA) files are created; rest of directory can be manually altered by user
  - render configuration files directly in Terraform templating language and upload as an object
  - refactor Ansible to download object only when necessary

The configuration refactoring anticipates a subsequent PR which will add support for a simple Windows startup script that downloads the object and triggers a reload. This is in lieu of adding full-fledged Ansible support on Windows.

I anticipate the bucket moving to a different module as the revised HTCondor solution is developed. Putting it in htcondor-configure is a step in the process and enables it to be done without modification to blueprint.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
