### PR TITLE
Include GCESysPrep in Windows image shutdown script

### DIFF
--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -47,7 +47,10 @@ locals {
   windows_packer_user = "packer_user"
   windows_user_metadata = {
     sysprep-specialize-script-cmd = "winrm quickconfig -quiet & net user /add ${local.windows_packer_user} & net localgroup administrators ${local.windows_packer_user} /add & winrm set winrm/config/service/auth @{Basic=\\\"true\\\"}"
-    windows-shutdown-script-cmd   = "net user /delete ${local.windows_packer_user}"
+    windows-shutdown-script-cmd   = <<-EOT
+      net user /delete ${local.windows_packer_user}
+      GCESysprep -no_shutdown
+      EOT
   }
   user_metadata = local.communicator == "winrm" ? local.windows_user_metadata : local.linux_user_metadata
 

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -47,7 +47,10 @@ locals {
   windows_packer_user = "packer_user"
   windows_user_metadata = {
     sysprep-specialize-script-cmd = "winrm quickconfig -quiet & net user /add ${local.windows_packer_user} & net localgroup administrators ${local.windows_packer_user} /add & winrm set winrm/config/service/auth @{Basic=\\\"true\\\"}"
-    windows-shutdown-script-cmd   = "net user /delete ${local.windows_packer_user}"
+    windows-shutdown-script-cmd   = <<-EOT
+      net user /delete ${local.windows_packer_user}
+      GCESysprep -no_shutdown
+      EOT
   }
   user_metadata = local.communicator == "winrm" ? local.windows_user_metadata : local.linux_user_metadata
 

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -47,7 +47,10 @@ locals {
   windows_packer_user = "packer_user"
   windows_user_metadata = {
     sysprep-specialize-script-cmd = "winrm quickconfig -quiet & net user /add ${local.windows_packer_user} & net localgroup administrators ${local.windows_packer_user} /add & winrm set winrm/config/service/auth @{Basic=\\\"true\\\"}"
-    windows-shutdown-script-cmd   = "net user /delete ${local.windows_packer_user}"
+    windows-shutdown-script-cmd   = <<-EOT
+      net user /delete ${local.windows_packer_user}
+      GCESysprep -no_shutdown
+      EOT
   }
   user_metadata = local.communicator == "winrm" ? local.windows_user_metadata : local.linux_user_metadata
 


### PR DESCRIPTION
This PR ensures that GCESysPrep is called at the final stages of Windows VM image customization. Effectively, it wipes the slate clean and ensures that the new image will set its custom hostname upon boot, activate Windows properly. Additionally it ensures that it will run sysprep startup scripts. Windows distinguishes between sysprep startup scripts that only run on the very first boot and startup scripts that run on every boot.

It is being run within the shutdown script called by Packer so it is invoked with the `NoShutdown` flag as it would simply confuse the situation.

- https://cloud.google.com/compute/docs/instances/windows/creating-windows-os-image
- https://github.com/GoogleCloudPlatform/compute-image-windows#instance-setup

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
