### PR TITLE
Modify execute point IDTOKEN creation

### DIFF
--- a/community/modules/scheduler/htcondor-configure/README.md
+++ b/community/modules/scheduler/htcondor-configure/README.md
@@ -225,9 +225,11 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
+| [google_secret_manager_secret.execute_point_idtoken](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret.pool_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_iam_member.access_point](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
-| [google_secret_manager_secret_iam_member.central_manager](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.central_manager_idtoken](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.central_manager_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.execute_point](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.pool_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_storage_bucket_object.ap_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |

--- a/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-configure/files/htcondor_configure.yml
@@ -32,10 +32,13 @@
       - trust_domain is defined
       - config_object is defined
   - name: Set HTCondor Pool password (token signing key)
+    when: htcondor_role != 'get_htcondor_execute'
     ansible.builtin.shell: |
       set -e -o pipefail
-      POOL_PASSWORD=$(gcloud secrets versions access latest --secret={{ password_id }})
-      echo -n "$POOL_PASSWORD" | sh -c "condor_store_cred add -c -i -"
+      TMPFILE=$(mktemp)
+      gcloud secrets versions access latest --out-file "$TMPFILE" --secret={{ password_id }}
+      condor_store_cred add -c -i "$TMPFILE"
+      rm -f "$TMPFILE"
     args:
       creates: "{{ condor_config_root }}/passwords.d/POOL"
       executable: /bin/bash
@@ -79,6 +82,17 @@
           -token condor@{{ trust_domain }}
       args:
         creates: "{{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}"
+    - name: Create IDTOKEN secret for Execute Points
+      changed_when: true
+      ansible.builtin.shell: |
+        umask 0077
+        TRUST_DOMAIN=$(condor_config_val TRUST_DOMAIN)
+        TMPFILE=$(mktemp)
+        condor_token_create -authz READ -authz ADVERTISE_MASTER \
+            -authz ADVERTISE_STARTD -identity condor@{{ trust_domain }} > "$TMPFILE"
+        gcloud secrets versions add --data-file "$TMPFILE" {{ xp_idtoken_secret_id }}
+        rm -f "$TMPFILE"
+      when: xp_idtoken_secret_id | length > 0
   - name: Configure HTCondor SchedD
     when: htcondor_role == 'get_htcondor_submit'
     block:
@@ -134,7 +148,7 @@
             [Unit]
             RequiresMountsFor={{ spool_dir }}
         notify:
-        - Reload HTCondor SystemD unit
+        - Reload SystemD
     - name: Disable SchedD high availability
       when: not job_queue_ha | bool
       block:
@@ -149,20 +163,29 @@
           path: /etc/systemd/system/condor.service.d/mount-spool.conf
           state: absent
         notify:
-        - Reload HTCondor SystemD unit
+        - Reload SystemD
   - name: Configure HTCondor StartD
     when: htcondor_role == 'get_htcondor_execute'
     block:
-    - name: Create IDTOKEN to advertise execute point
-      ansible.builtin.shell: |
-        umask 0077
-        condor_token_create -authz READ -authz ADVERTISE_MASTER \
-          -authz ADVERTISE_STARTD -identity condor@{{ trust_domain }} \
-          -token condor@{{ trust_domain }}
-      args:
-        creates: "{{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}"
+    - name: Create SystemD override directory for HTCondor Execute Point
+      ansible.builtin.file:
+        path: /etc/systemd/system/condor.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Fetch IDTOKEN to advertise execute point
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/condor.service.d/htcondor-token-fetcher.conf"
+        mode: 0644
+        content: |
+          [Service]
+          ExecStartPre=gcloud secrets versions access latest --secret {{ xp_idtoken_secret_id }} \
+              --out-file {{ condor_config_root }}/tokens.d/condor@{{ trust_domain }}
+      notify:
+      - Reload SystemD
   handlers:
-  - name: Reload HTCondor SystemD unit
+  - name: Reload SystemD
     ansible.builtin.systemd:
       daemon_reload: true
   - name: Restart HTCondor

--- a/community/modules/scheduler/htcondor-configure/outputs.tf
+++ b/community/modules/scheduler/htcondor-configure/outputs.tf
@@ -27,7 +27,8 @@ output "central_manager_service_account" {
   description = "HTCondor Central Manager Service Account (e-mail format)"
   value       = module.central_manager_service_account.email
   depends_on = [
-    google_secret_manager_secret_iam_member.central_manager,
+    google_secret_manager_secret_iam_member.central_manager_idtoken,
+    google_secret_manager_secret_iam_member.central_manager_password,
     module.central_manager_service_account
   ]
 }


### PR DESCRIPTION
- Central Manager will now update a secret with an IDTOKEN scoped for advertising the StartD daemon on an execute point
- Linux Execute Points no longer download the pool password and generate a token from it. Instead they directly download the IDTOKEN secret. Windows execute points will have this functionality added in a future commit.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
