### PR TITLE
Add boot-time IDTOKEN support to Windows-based HTCondor execute points

### DIFF
--- a/community/modules/scheduler/htcondor-configure/main.tf
+++ b/community/modules/scheduler/htcondor-configure/main.tf
@@ -100,7 +100,9 @@ locals {
   windows_startup_ps1 = templatefile(
     "${path.module}/templates/download-condor-config.ps1.tftpl",
     {
-      config_object = local.execute_object
+      config_object        = local.execute_object,
+      trust_domain         = local.trust_domain,
+      xp_idtoken_secret_id = google_secret_manager_secret.execute_point_idtoken.secret_id,
     }
   )
 }

--- a/community/modules/scheduler/htcondor-configure/templates/download-condor-config.ps1.tftpl
+++ b/community/modules/scheduler/htcondor-configure/templates/download-condor-config.ps1.tftpl
@@ -1,15 +1,18 @@
+gcloud secrets versions access latest --secret ${xp_idtoken_secret_id} `
+    --out-file C:\condor\tokens.d\condor@${trust_domain}
+
 $remote_hash = gcloud --format="value(md5_hash)" storage hash ${config_object}
 
 # custom install location are not supported in Windows
 $config_file = "C:\condor\condor_config.local"
 if (Test-Path -Path $config_file -PathType Leaf) {
-  $local_hash = gcloud --format="value(md5_hash)" storage hash $config_file
+    $local_hash = gcloud --format="value(md5_hash)" storage hash $config_file
 } else {
-  $local_hash = "INVALID-HASH"
+    $local_hash = "INVALID-HASH"
 }
 
 if ($local_hash -cne $remote_hash) {
-  Write-Output "Updating condor configuration"
-  gcloud storage cp ${config_object} $config_file
-  condor_reconfig.exe
+    Write-Output "Updating condor configuration"
+    gcloud storage cp ${config_object} $config_file
+    Restart-Service condor
 }

--- a/community/modules/scheduler/htcondor-configure/templates/download-condor-config.ps1.tftpl
+++ b/community/modules/scheduler/htcondor-configure/templates/download-condor-config.ps1.tftpl
@@ -1,16 +1,22 @@
+# obtain IDTOKEN for authentication by StartD to Central Manager
 gcloud secrets versions access latest --secret ${xp_idtoken_secret_id} `
     --out-file C:\condor\tokens.d\condor@${trust_domain}
 
-$remote_hash = gcloud --format="value(md5_hash)" storage hash ${config_object}
+# create directory for local condor_config customizations
+$config_dir = 'C:\Condor\config'
+if(!(test-path -PathType container -Path $config_dir)) {
+      New-Item -ItemType Directory -Path $config_dir
+}
 
-# custom install location are not supported in Windows
-$config_file = "C:\condor\condor_config.local"
+# update local condor_config if blueprint has changed
+$config_file = "$config_dir\50-ghpc-managed"
 if (Test-Path -Path $config_file -PathType Leaf) {
     $local_hash = gcloud --format="value(md5_hash)" storage hash $config_file
 } else {
     $local_hash = "INVALID-HASH"
 }
 
+$remote_hash = gcloud --format="value(md5_hash)" storage hash ${config_object}
 if ($local_hash -cne $remote_hash) {
     Write-Output "Updating condor configuration"
     gcloud storage cp ${config_object} $config_file

--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -21,6 +21,7 @@
 from absl import app
 from absl import flags
 from collections import OrderedDict
+from datetime import datetime
 from pprint import pprint
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
@@ -224,7 +225,7 @@ class AutoScaler:
             print(f"The negotiator has not yet started a match cycle. Exiting auto-scaling.")
             exit()
 
-        print(f"Last negotiation cycle occurred at: {last_negotiation_cycle_time}")
+        print(f"Last negotiation cycle occurred at: {datetime.fromtimestamp(last_negotiation_cycle_time)}")
         idle_job_query = classad.ExprTree(f"JobStatus == 1 && QDate < {last_negotiation_cycle_time}")
         idle_job_ads = schedd.query(constraint=idle_job_query.and_(spot_query),
                                     projection=job_attributes)

--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -276,11 +276,11 @@ class AutoScaler:
             constraint=filter_idle_vms.and_(filter_mig),
             projection=["Machine", "CloudZone"])
 
-        NODENAME_ATTRIBUTE = "UtsnameNodename"
+        NODENAME_ATTRIBUTE = "Machine"
         claimed_node_ads = coll.query(htcondor.AdTypes.Startd,
             constraint=filter_claimed_vms.and_(filter_mig),
             projection=[NODENAME_ATTRIBUTE])
-        claimed_nodes = [ ad[NODENAME_ATTRIBUTE] for ad in claimed_node_ads]
+        claimed_nodes = [ ad[NODENAME_ATTRIBUTE].split(".")[0] for ad in claimed_node_ads]
 
         # treat OrderedDict as a set by ignoring key values; this set will
         # contain VMs we would consider deleting, in inverse order of

--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -8,27 +8,36 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
 # download C Runtime DLL necessary for HTCondor installer
-Invoke-WebRequest https://aka.ms/vs/17/release/vc_redist.x64.exe -OutFile C:\vc_redist.x64.exe
-Start-Process C:\vc_redist.x64.exe -Wait -ArgumentList "/norestart /quiet /log c:\vc_redist_log.txt"
-Remove-Item C:\vc_redist.x64.exe
+$runtime_installer = 'C:\vc_redist.x64.exe'
+Invoke-WebRequest https://aka.ms/vs/17/release/vc_redist.x64.exe -OutFile "$runtime_installer"
+Start-Process -FilePath "$runtime_installer" -Wait -ArgumentList "/norestart /quiet /log c:\vc_redist_log.txt"
+Remove-Item "$runtime_installer"
 
 # download HTCondor installer
+$htcondor_installer = 'C:\htcondor.msi'
 %{ if condor_version == "10.*" }
-Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/current/current/condor-Windows-x64.msi -OutFile C:\htcondor.msi
+Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/current/current/condor-Windows-x64.msi -OutFile "$htcondor_installer"
 %{ else ~}
-Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/current/${condor_version}/release/condor-${condor_version}-Windows-x64.msi -OutFile C:\htcondor.msi
+Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/current/${condor_version}/release/condor-${condor_version}-Windows-x64.msi -OutFile "$htcondor_installer"
 %{ endif ~}
 $args='/qn /l* condor-install-log.txt /i'
-$args=$args + ' C:\htcondor.msi'
+$args=$args + " $htcondor_installer"
 $args=$args + ' NEWPOOL="N"'
 $args=$args + ' RUNJOBS="N"'
 $args=$args + ' SUBMITJOBS="N"'
 $args=$args + ' INSTALLDIR="C:\Condor"'
-Start-Process msiexec.exe -Wait -ArgumentList $args
-Remove-Item C:\htcondor.msi
+Start-Process "msiexec.exe" -Wait -ArgumentList "$args"
+Remove-Item "$htcondor_installer"
 
 # remove settings from condor_config that we want to override in configuration step
 Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^CONDOR_HOST' -NotMatch)
 Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^INSTALL_USER' -NotMatch)
 Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^DAEMON_LIST' -NotMatch)
 Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^use SECURITY' -NotMatch)
+
+$python_installer = 'C:\python-installer.exe'
+Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.11.4/python-3.11.4-amd64.exe" -OutFile "$python_installer"
+Start-Process -FilePath "$python_installer" -Wait -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_test=0'
+Start-Process "py.exe" -Wait -ArgumentList "-3.11 -m pip install --no-warn-script-location requests"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/htcondor/htcondor/main/src/condor_scripts/common-cloud-attributes-google.py" -OutFile "C:\Condor\bin\common-cloud-attributes-google.py"
+Remove-Item "$python_installer"


### PR DESCRIPTION
This PR adds the ability to provision HTCondor pools with Linux-based core infrastructure (Central Manager, Access Point) with a mix of Linux and Windows Execute Points ("compute nodes"). 

- downloads secure IDTOKEN (JWT) that execute points use to authenticate to Central Manager
  - this enables end-to-end automation of a blueprint that creates a Windows image and uses it in a pool. An integration test for this will be added as future work
- Adds Cloud hook script and configuration that enables Windows-based HTCondor execute points to advertise cloud properties useful for scheduling and required for autoscaling
  - the script is packaged with HTCondor for Linux and I will discuss with the HTCondor team how difficult it would be to add it for Windows (no modification needed except explicit install of Python)
- autoscaler changes
  - use cross-platform definition of hostname
  - improve timestamp in logs

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
