### PR TITLE
Enable expressions in `Blueprint.Vars`

### DIFF
--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -92,12 +92,7 @@ func (d Dict) IsZero() bool {
 func (d Dict) Eval(bp Blueprint) (Dict, error) {
 	var res Dict
 	for k, v := range d.Items() {
-		r, err := cty.Transform(v, func(p cty.Path, v cty.Value) (cty.Value, error) {
-			if e, is := IsExpressionValue(v); is {
-				return e.Eval(bp)
-			}
-			return v, nil
-		})
+		r, err := evalValue(v, bp)
 		if err != nil {
 			return Dict{}, fmt.Errorf("error while trying to evaluate %#v: %w", k, err)
 		}

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -45,6 +45,9 @@ var (
 // expand expands variables and strings in the yaml config. Used directly by
 // ExpandConfig for the create and expand commands.
 func (dc *DeploymentConfig) expand() error {
+	if err := dc.Config.evalVars(); err != nil {
+		return err
+	}
 	dc.expandBackends()
 	dc.addDefaultValidators()
 	dc.combineLabels()
@@ -450,20 +453,13 @@ func (dg DeploymentGroup) FindAllIntergroupReferences(bp Blueprint) []Reference 
 // FindIntergroupReferences finds all references to other groups used in the given value
 func FindIntergroupReferences(v cty.Value, mod Module, bp Blueprint) []Reference {
 	g := bp.ModuleGroupOrDie(mod.ID)
-	res := map[Reference]bool{}
-	cty.Walk(v, func(p cty.Path, v cty.Value) (bool, error) {
-		e, is := IsExpressionValue(v)
-		if !is {
-			return true, nil
+	res := []Reference{}
+	for _, r := range valueReferences(v) {
+		if !r.GlobalVar && bp.ModuleGroupOrDie(r.Module).Name != g.Name {
+			res = append(res, r)
 		}
-		for _, r := range e.References() {
-			if !r.GlobalVar && bp.ModuleGroupOrDie(r.Module).Name != g.Name {
-				res[r] = true
-			}
-		}
-		return true, nil
-	})
-	return maps.Keys(res)
+	}
+	return res
 }
 
 // find all intergroup references and add them to source Module.Outputs

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -173,17 +173,6 @@ func (dc DeploymentConfig) validateVars() error {
 			return fmt.Errorf(nilErr, key)
 		}
 	}
-
-	err := cty.Walk(vars.AsObject(), func(p cty.Path, v cty.Value) (bool, error) {
-		if e, is := IsExpressionValue(v); is {
-			return false, fmt.Errorf("can not use expressions in vars block, got %#v", e.makeYamlExpressionValue().AsString())
-		}
-		return true, nil
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Allow usage of expressions in `Blueprint.Vars` and references to other `vars`.

**NOTE**: Evaluation is happening during "expand", overwritten values (during apply) have no a effect on expressions that **used** them.

```yaml
vars:
  zone: (("${var.region}-c")) # order doesn't matter
  region: us-west4

# expanded
vars:
  region: us-west4
  zone: us-west4-c
```
### Errors:
```yaml
vars:
  region: $(vars.zone)
  zone: (("${var.region}-c"))
...
Error: cyclic dependency detected: "zone" -> "region"
on line 23, column 9:
23:   zone: (("${var.region}-c"))
```

```yaml
vars:
  region: $(foo.zone)
  zone: (("${var.region}-c"))
...
Error: non-global variable "zone" referenced in expression
on line 22, column 11:
22:   region: $(foo.zone)
```