### PR TITLE
Allow to specify `vm-instance.placement_policy.max_distance`

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -185,8 +185,8 @@ limitations under the License.
 | Name | Type |
 |------|------|
 | [google-beta_google_compute_instance.compute_vm](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance) | resource |
+| [google-beta_google_compute_resource_policy.placement_policy](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_resource_policy) | resource |
 | [google_compute_disk.boot_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
-| [google_compute_resource_policy.placement_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy) | resource |
 | [null_resource.image](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_image.compute_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 
@@ -216,7 +216,7 @@ limitations under the License.
 | <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | The self link of the network to attach the VM. Can use "default" for the default network. | `string` | `null` | no |
 | <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured. | <pre>list(object({<br>    server_ip             = string,<br>    remote_mount          = string,<br>    local_mount           = string,<br>    fs_type               = string,<br>    mount_options         = string,<br>    client_install_runner = map(string)<br>    mount_runner          = map(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Describes maintenance behavior for the instance. If left blank this will default to `MIGRATE` except for when `placement_policy`, spot provisioning, or GPUs require it to be `TERMINATE` | `string` | `null` | no |
-| <a name="input_placement_policy"></a> [placement\_policy](#input\_placement\_policy) | Control where your VM instances are physically located relative to each other within a zone. | <pre>object({<br>    vm_count                  = number,<br>    availability_domain_count = number,<br>    collocation               = string,<br>  })</pre> | `null` | no |
+| <a name="input_placement_policy"></a> [placement\_policy](#input\_placement\_policy) | Control where your VM instances are physically located relative to each other within a zone.<br>See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#nested_group_placement_policy | `any` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to deploy to | `string` | n/a | yes |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/cloud-platform"<br>  ]<br>}</pre> | no |

--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -162,16 +162,16 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.73.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.73.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.42 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.12 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.73.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.73.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 1.0 |
 
 ## Modules

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -120,14 +120,16 @@ resource "google_compute_disk" "boot_disk" {
 }
 
 resource "google_compute_resource_policy" "placement_policy" {
-  project = var.project_id
+  project  = var.project_id
+  provider = google-beta
 
   count = var.placement_policy != null ? 1 : 0
   name  = "${local.resource_prefix}-vm-instance-placement"
   group_placement_policy {
-    vm_count                  = var.placement_policy.vm_count
-    availability_domain_count = var.placement_policy.availability_domain_count
-    collocation               = var.placement_policy.collocation
+    vm_count                  = try(var.placement_policy.vm_count, null)
+    availability_domain_count = try(var.placement_policy.availability_domain_count, null)
+    collocation               = try(var.placement_policy.collocation, null)
+    max_distance              = try(var.placement_policy.max_distance, null)
   }
 }
 

--- a/modules/compute/vm-instance/variables.tf
+++ b/modules/compute/vm-instance/variables.tf
@@ -278,13 +278,31 @@ variable "bandwidth_tier" {
 }
 
 variable "placement_policy" {
-  description = "Control where your VM instances are physically located relative to each other within a zone."
-  type = object({
-    vm_count                  = number,
-    availability_domain_count = number,
-    collocation               = string,
-  })
+  description = <<-EOT
+  Control where your VM instances are physically located relative to each other within a zone.
+  See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#nested_group_placement_policy
+  EOT
+
+  type    = any # It's a workaround of lack of `optional` in Terraform 1.2
   default = null
+  validation {
+    condition     = var.placement_policy == null ? true : try(keys(var.placement_policy), null) != null
+    error_message = <<-EOT
+    The var.placement_policy should be either unset/null or be a map/object with 
+    fields: vm_count, availability_domain_count, collocation, max_distance.
+    EOT
+  }
+
+  validation {
+    condition = alltrue([
+      for k in try(keys(var.placement_policy), []) : contains([
+      "vm_count", "availability_domain_count", "collocation", "max_distance"], k)
+    ])
+    error_message = <<-EOT
+    The supported fields for var.placement_policy are:
+    vm_count, availability_domain_count, collocation, max_distance.
+    EOT
+  }
 }
 
 variable "spot" {

--- a/modules/compute/vm-instance/variables.tf
+++ b/modules/compute/vm-instance/variables.tf
@@ -289,7 +289,7 @@ variable "placement_policy" {
     condition     = var.placement_policy == null ? true : try(keys(var.placement_policy), null) != null
     error_message = <<-EOT
     The var.placement_policy should be either unset/null or be a map/object with 
-    fields: vm_count, availability_domain_count, collocation, max_distance.
+    fields: vm_count (number), availability_domain_count (number), collocation (string), max_distance (number).
     EOT
   }
 
@@ -300,7 +300,7 @@ variable "placement_policy" {
     ])
     error_message = <<-EOT
     The supported fields for var.placement_policy are:
-    vm_count, availability_domain_count, collocation, max_distance.
+    vm_count (number), availability_domain_count (number), collocation (string), max_distance (number).
     EOT
   }
 }

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -18,12 +18,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.42"
+      version = ">= 4.73.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.12"
+      version = ">= 4.73.0"
     }
     null = {
       version = ">= 1.0"


### PR DESCRIPTION
* Switch to `google-beta` provider;
* Workaround lack of `optional` in TF 1.2 and desire to make `max_distance` optional,
   change type to `any`;
* Add validation of for "being a map/object", "only valid keys are usde".
