### PR TITLE
Output multiple errors instead of first one

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -127,10 +127,29 @@ func expandOrDie(path string) config.DeploymentConfig {
 	return dc
 }
 
+func findPos(path config.Path, ctx config.YamlCtx) (config.Pos, bool) {
+	pos, ok := ctx.Pos(path)
+	for !ok && path.Parent() != nil {
+		path = path.Parent()
+		pos, ok = ctx.Pos(path)
+	}
+	return pos, ok
+}
+
 func renderError(err error, ctx config.YamlCtx) string {
+	var me config.MultiError
+	if errors.As(err, &me) {
+		var sb strings.Builder
+		for _, e := range me.Errors {
+			sb.WriteString(renderError(e, ctx))
+			sb.WriteString("\n")
+		}
+		return sb.String()
+	}
+
 	var be config.BpError
 	if errors.As(err, &be) {
-		if pos, ok := ctx.Pos(be.Path); ok {
+		if pos, ok := findPos(be.Path, ctx); ok {
 			return renderRichError(be.Err, pos, ctx)
 		}
 	}
@@ -138,11 +157,12 @@ func renderError(err error, ctx config.YamlCtx) string {
 }
 
 func renderRichError(err error, pos config.Pos, ctx config.YamlCtx) string {
+	pref := fmt.Sprintf("%d: ", pos.Line)
+	arrow := strings.Repeat(" ", len(pref)+pos.Column-1) + "^"
 	return fmt.Sprintf(`
 Error: %s
-on line %d, column %d:
-%d: %s
-`, err, pos.Line, pos.Column, pos.Line, ctx.Lines[pos.Line-1])
+%s%s
+%s`, err, pref, ctx.Lines[pos.Line-1], arrow)
 }
 
 func setCLIVariables(bp *config.Blueprint, s []string) error {
@@ -197,7 +217,7 @@ func setValidationLevel(bp *config.Blueprint, s string) error {
 	case "IGNORE":
 		bp.ValidationLevel = config.ValidationIgnore
 	default:
-		return fmt.Errorf("invalid validation level (\"ERROR\", \"WARNING\", \"IGNORE\")")
+		return errors.New("invalid validation level (\"ERROR\", \"WARNING\", \"IGNORE\")")
 	}
 	return nil
 }

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -152,8 +152,7 @@ vars:
 		got := renderError(err, ctx)
 		c.Check(got, Equals, `
 Error: arbuz
-on line 3, column 9:
 3:   kale: dos
-`)
+           ^`)
 	}
 }

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 )
 
 // BpError is an error wrapper to augment Path
@@ -30,4 +31,52 @@ func (e BpError) Error() string {
 
 func (e BpError) Unwrap() error {
 	return e.Err
+}
+
+// InvalidSettingError signifies a problem with the supplied setting name in a
+// module definition.
+type InvalidSettingError struct {
+	cause string
+}
+
+func (err *InvalidSettingError) Error() string {
+	return fmt.Sprintf("invalid setting provided to a module, cause: %v", err.cause)
+}
+
+// MultiError is an error wrapper to combine multiple errors
+type MultiError struct {
+	Errors []error
+}
+
+func (e MultiError) Error() string {
+	errs := make([]string, len(e.Errors))
+	for i, err := range e.Errors {
+		errs[i] = err.Error()
+	}
+	return fmt.Sprintf("%d errors encountered:\n:%s", len(e.Errors), strings.Join(errs, "\n"))
+}
+
+// OrNil returns nil if there are no errors, otherwise returns itself
+func (e MultiError) OrNil() error {
+	switch len(e.Errors) {
+	case 0:
+		return nil
+	case 1:
+		return e.Errors[0]
+	default:
+		return e
+	}
+}
+
+// Add adds an error to the MultiError and returns itself
+func (e *MultiError) Add(err error) *MultiError {
+	if err == nil {
+		return e
+	}
+	if multi, ok := err.(*MultiError); ok {
+		e.Errors = append(e.Errors, multi.Errors...)
+	} else {
+		e.Errors = append(e.Errors, err)
+	}
+	return e
 }

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -76,3 +76,32 @@ func TestPath(t *testing.T) {
 		})
 	}
 }
+
+func TestPathParent(t *testing.T) {
+	type test struct {
+		p    Path
+		want Path
+	}
+	r := Root
+	tests := []test{
+		{r, nil},
+		{r.Groups, r},
+		{r.Groups.At(3), r.Groups},
+		{r.Groups.At(3).Modules, r.Groups.At(3)},
+		{r.Vars.Dot("red"), r.Vars},
+	}
+	for _, tc := range tests {
+		t.Run(tc.p.String(), func(t *testing.T) {
+			got := tc.p.Parent()
+			if (got == nil) || (tc.want == nil) {
+				if got != tc.want {
+					t.Errorf("\ngot : %#v\nwant: %#v", got, tc.want)
+				}
+				return
+			}
+			if got.String() != tc.want.String() {
+				t.Errorf("\ngot : %q\nwant: %q", got.String(), tc.want.String())
+			}
+		})
+	}
+}

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -15,12 +15,8 @@
 package config
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"hpc-toolkit/pkg/modulereader"
 
-	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 	. "gopkg.in/check.v1"
 )
@@ -54,23 +50,8 @@ func (s *MySuite) TestValidateVars(c *C) {
 	c.Assert(err, ErrorMatches, "vars.labels must be a map of strings")
 }
 
-func (s *MySuite) TestValidateModuleSettings(c *C) {
-	testSource := filepath.Join(tmpTestDir, "module")
-	testSettings := NewDict(map[string]cty.Value{
-		"test_variable": cty.StringVal("test_value"),
-	})
-	testDeploymentGroup := DeploymentGroup{
-		Name:             "",
-		TerraformBackend: TerraformBackend{},
-		Modules:          []Module{{Kind: TerraformKind, Source: testSource, Settings: testSettings}},
-	}
-	dc := DeploymentConfig{
-		Config: Blueprint{DeploymentGroups: []DeploymentGroup{testDeploymentGroup}},
-	}
-	dc.validateModuleSettings()
-}
-
 func (s *MySuite) TestValidateSettings(c *C) {
+	path := Root.Groups.At(7).Modules.At(2)
 	testSettingName := "TestSetting"
 	testSettingValue := cty.StringVal("TestValue")
 	validSettingNames := []string{
@@ -79,18 +60,17 @@ func (s *MySuite) TestValidateSettings(c *C) {
 	invalidSettingNames := []string{
 		"", "1", "Test.Setting", "Test$Setting", "1_TestSetting",
 	}
-	var e *InvalidSettingError
 
 	// Succeeds: No settings, no variables
 	mod := Module{}
 	info := modulereader.ModuleInfo{}
-	err := validateSettings(mod, info)
-	c.Assert(err, IsNil)
+	err := validateSettings(path, mod, info)
+	c.Check(err, IsNil)
 
 	// Fails: One required variable, no settings
 	mod.Settings = NewDict(map[string]cty.Value{testSettingName: testSettingValue})
-	err = validateSettings(mod, info)
-	c.Check(errors.As(err, &e), Equals, true)
+	err = validateSettings(path, mod, info)
+	c.Check(err, NotNil)
 
 	// Fails: Invalid setting names
 	for _, name := range invalidSettingNames {
@@ -98,8 +78,8 @@ func (s *MySuite) TestValidateSettings(c *C) {
 			{Name: name, Required: true},
 		}
 		mod.Settings = NewDict(map[string]cty.Value{name: testSettingValue})
-		err = validateSettings(mod, info)
-		c.Check(errors.As(err, &e), Equals, true)
+		err = validateSettings(path, mod, info)
+		c.Check(err, NotNil)
 	}
 
 	// Succeeds: Valid setting names
@@ -108,69 +88,81 @@ func (s *MySuite) TestValidateSettings(c *C) {
 			{Name: name, Required: true},
 		}
 		mod.Settings = NewDict(map[string]cty.Value{name: testSettingValue})
-		err = validateSettings(mod, info)
+		err = validateSettings(path, mod, info)
 		c.Assert(err, IsNil)
 	}
 
 }
 
 func (s *MySuite) TestValidateModule(c *C) {
-	// Catch no ID
-	testModule := Module{
-		ID:     "",
-		Source: "testSource",
+	p := Root.Groups.At(2).Modules.At(1)
+
+	{ // Catch no ID
+		err := validateModule(p, Module{Source: "green"})
+		c.Check(err, NotNil)
 	}
-	err := validateModule(testModule)
-	expectedErrorStr := fmt.Sprintf(
-		"%s\n%s", errorMessages["emptyID"], module2String(testModule))
-	c.Assert(err, ErrorMatches, cleanErrorRegexp(expectedErrorStr))
 
-	// Catch no Source
-	testModule.ID = "testModule"
-	testModule.Source = ""
-	err = validateModule(testModule)
-	expectedErrorStr = fmt.Sprintf(
-		"%s\n%s", errorMessages["emptySource"], module2String(testModule))
-	c.Assert(err, ErrorMatches, cleanErrorRegexp(expectedErrorStr))
+	{ // Catch no Source
+		err := validateModule(p, Module{ID: "bond"})
+		c.Check(err, NotNil)
+	}
 
-	// Catch invalid kind
-	testModule.Source = "testSource"
-	testModule.Kind = ModuleKind{kind: "invalidKind"}
-	err = validateModule(testModule)
-	expectedErrorStr = fmt.Sprintf(
-		"%s\n%s", errorMessages["wrongKind"], module2String(testModule))
-	c.Assert(err, ErrorMatches, cleanErrorRegexp(expectedErrorStr))
+	{ // Catch invalid kind
+		err := validateModule(p, Module{
+			ID:     "bond",
+			Source: "green",
+			Kind:   ModuleKind{kind: "mean"},
+		})
+		c.Check(err, NotNil)
+	}
 
-	// Successful validation
-	testModule.Kind = TerraformKind
-	err = validateModule(testModule)
-	c.Assert(err, IsNil)
+	{ // Successful validation
+		mod := Module{
+			ID:     "bond",
+			Source: "green",
+			Kind:   TerraformKind,
+		}
+		modulereader.SetModuleInfo(mod.Source, mod.Kind.String(), modulereader.ModuleInfo{})
+		err := validateModule(p, mod)
+		c.Check(err, IsNil)
+	}
 }
 
 func (s *MySuite) TestValidateOutputs(c *C) {
-	// Simple case, no outputs in either
-	mod := Module{ID: "green", Source: "test::green", Kind: TerraformKind}
-	modulereader.SetModuleInfo(mod.Source, mod.Kind.String(), modulereader.ModuleInfo{
-		Outputs: []modulereader.OutputInfo{}})
-	c.Assert(validateOutputs(mod), IsNil)
+	p := Root.Groups.At(2).Modules.At(1)
 
-	// Output in varInfo, nothing in module
-	modulereader.SetModuleInfo(mod.Source, mod.Kind.String(), modulereader.ModuleInfo{
-		Outputs: []modulereader.OutputInfo{
-			{Name: "velvet"}}})
-	c.Assert(validateOutputs(mod), IsNil)
+	{ // Simple case, no outputs in either
+		mod := Module{}
+		info := modulereader.ModuleInfo{}
+		c.Check(validateOutputs(p, mod, info), IsNil)
+	}
 
-	// Output matches between varInfo and module
-	mod.Outputs = []modulereader.OutputInfo{
-		{Name: "velvet"}}
-	c.Assert(validateOutputs(mod), IsNil)
+	{ // Output in varInfo, nothing in module
+		mod := Module{}
+		info := modulereader.ModuleInfo{
+			Outputs: []modulereader.OutputInfo{
+				{Name: "velvet"}}}
+		c.Check(validateOutputs(p, mod, info), IsNil)
+	}
 
-	// Addition output found in modules, not in varinfo
-	mod.Outputs = []modulereader.OutputInfo{
-		{Name: "velvet"},
-		{Name: "waldo"}}
-	expErr := fmt.Sprintf("%s.*", errorMessages["invalidOutput"])
-	c.Assert(validateOutputs(mod), ErrorMatches, expErr)
+	{ // Output matches between varInfo and module
+		out := modulereader.OutputInfo{Name: "velvet"}
+		mod := Module{
+			Outputs: []modulereader.OutputInfo{out}}
+		info := modulereader.ModuleInfo{
+			Outputs: []modulereader.OutputInfo{out}}
+		c.Check(validateOutputs(p, mod, info), IsNil)
+	}
+
+	{ // Addition output found in modules, not in varinfo
+		out := modulereader.OutputInfo{Name: "velvet"}
+		tuo := modulereader.OutputInfo{Name: "waldo"}
+		mod := Module{
+			Outputs: []modulereader.OutputInfo{out, tuo}}
+		info := modulereader.ModuleInfo{
+			Outputs: []modulereader.OutputInfo{out}}
+		c.Check(validateOutputs(p, mod, info), NotNil)
+	}
 }
 
 func (s *MySuite) TestAddDefaultValidators(c *C) {


### PR DESCRIPTION
```yaml
// tst.yaml
...
  modules:
  - source: modules/network/vpc
    outputs: [gold, silver]

  - id: nw2
    source: modules/network/vpc
    settings:
      kill.switch: true
      kill@switch: true
      kill_switch: true
```

```shell
$ ./ghpc expand tst.yaml
Error: a module id cannot be empty
34:   - source: modules/network/vpc
        ^

Error: requested output was not found in the module, module:  output: gold
35:     outputs: [gold, silver]
                  ^

Error: requested output was not found in the module, module:  output: silver
35:     outputs: [gold, silver]
                        ^

Error: a setting was added that is not found in the module
42:       kill_switch: true
                       ^

Error: a setting name contains a period, which is not supported; variable subfields cannot be set independently in a blueprint.
40:       kill.switch: true
                       ^

Error: a setting name must begin with a non-numeric character and all characters must be either letters, numbers, dashes ('-') or underscores ('_').
41:       kill@switch: true
                       ^
```
