### PR TITLE
Simplify htcondor-install 

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -39,10 +39,8 @@ deployment_groups:
 
   - id: htcondor_install_script
     source: modules/scripts/startup-script
-    settings:
-      runners:
-      - $(htcondor_install.install_htcondor_runner)
-      - $(htcondor_install.install_autoscaler_deps_runner)
+    use:
+    - htcondor_install
 
 - group: packer
   modules:
@@ -150,7 +148,6 @@ deployment_groups:
     source: modules/scripts/startup-script
     settings:
       runners:
-      - $(htcondor_install.install_autoscaler_runner)
       - $(htcondor_secrets.access_point_runner)
       - $(htcondor_base.access_point_runner)
       - $(htcondor_execute_point.configure_autoscaler_runner)

--- a/community/modules/compute/htcondor-execute-point/versions.tf
+++ b/community/modules/compute/htcondor-execute-point/versions.tf
@@ -25,6 +25,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.19.1"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.20.0"
   }
 }

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.19.1"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.20.0"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -134,8 +134,6 @@ No resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_gcp_service_list"></a> [gcp\_service\_list](#output\_gcp\_service\_list) | Google Cloud APIs required by HTCondor |
-| <a name="output_install_autoscaler_deps_runner"></a> [install\_autoscaler\_deps\_runner](#output\_install\_autoscaler\_deps\_runner) | Toolkit Runner to install HTCondor autoscaler dependencies |
-| <a name="output_install_autoscaler_runner"></a> [install\_autoscaler\_runner](#output\_install\_autoscaler\_runner) | Toolkit Runner to install HTCondor autoscaler |
-| <a name="output_install_htcondor_runner"></a> [install\_htcondor\_runner](#output\_install\_htcondor\_runner) | Runner to install HTCondor using startup-scripts |
+| <a name="output_runners"></a> [runners](#output\_runners) | Runner to install HTCondor using startup-scripts |
 | <a name="output_windows_startup_ps1"></a> [windows\_startup\_ps1](#output\_windows\_startup\_ps1) | Windows PowerShell script to install HTCondor |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -15,32 +15,32 @@
  */
 
 locals {
-  runner_install_htcondor = {
-    "type"        = "ansible-local"
-    "source"      = "${path.module}/files/install-htcondor.yaml"
-    "destination" = "install-htcondor.yaml"
-    "args" = join(" ", [
-      "-e enable_docker=${var.enable_docker}",
-      "-e condor_version=${var.condor_version}",
-    ])
-  }
+  runners = [
+    {
+      "type"        = "ansible-local"
+      "source"      = "${path.module}/files/install-htcondor.yaml"
+      "destination" = "install-htcondor.yaml"
+      "args" = join(" ", [
+        "-e enable_docker=${var.enable_docker}",
+        "-e condor_version=${var.condor_version}",
+      ])
+    },
+    {
+      "type"        = "ansible-local"
+      "content"     = file("${path.module}/files/install-htcondor-autoscaler-deps.yml")
+      "destination" = "install-htcondor-autoscaler-deps.yml"
+    },
+    {
+      "type"        = "data"
+      "content"     = file("${path.module}/files/autoscaler.py")
+      "destination" = "/usr/local/htcondor/bin/autoscaler.py"
+    },
+  ]
 
   install_htcondor_ps1 = templatefile(
     "${path.module}/templates/install-htcondor.ps1.tftpl", {
       condor_version = var.condor_version
   })
-
-  runner_install_autoscaler_deps = {
-    "type"        = "ansible-local"
-    "content"     = file("${path.module}/files/install-htcondor-autoscaler-deps.yml")
-    "destination" = "install-htcondor-autoscaler-deps.yml"
-  }
-
-  runner_install_autoscaler = {
-    "type"        = "data"
-    "content"     = file("${path.module}/files/autoscaler.py")
-    "destination" = "/usr/local/htcondor/bin/autoscaler.py"
-  }
 
   required_apis = [
     "compute.googleapis.com",

--- a/community/modules/scripts/htcondor-install/outputs.tf
+++ b/community/modules/scripts/htcondor-install/outputs.tf
@@ -14,24 +14,14 @@
  * limitations under the License.
  */
 
-output "install_htcondor_runner" {
+output "runners" {
   description = "Runner to install HTCondor using startup-scripts"
-  value       = local.runner_install_htcondor
+  value       = local.runners
 }
 
 output "windows_startup_ps1" {
   description = "Windows PowerShell script to install HTCondor"
   value       = local.install_htcondor_ps1
-}
-
-output "install_autoscaler_deps_runner" {
-  description = "Toolkit Runner to install HTCondor autoscaler dependencies"
-  value       = local.runner_install_autoscaler_deps
-}
-
-output "install_autoscaler_runner" {
-  description = "Toolkit Runner to install HTCondor autoscaler"
-  value       = local.runner_install_autoscaler
 }
 
 output "gcp_service_list" {


### PR DESCRIPTION
Previous solution was bending over backwards to avoid installing a single file in all images: the autoscaler.py file itself. This simplifies usage by adopting the `use` pattern more explicitly, with the marginal cost of the autoscaler.py file being "dormant" in all HTCondor images.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
