### PR TITLE
GKE node-pool provider version requirement

### DIFF
--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -142,15 +142,15 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.60.0, < 5.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.60.0, < 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.61.0, < 5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.61.0, < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.60.0, < 5.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.60.0, < 5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.61.0, < 5.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.61.0, < 5.0 |
 
 ## Modules
 

--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -102,7 +102,7 @@ resource "google_container_node_pool" "node_pool" {
     }
 
     gvnic {
-      enabled = var.image_type == "COS_CONTAINERD" ? true : false
+      enabled = var.image_type == "COS_CONTAINERD"
     }
 
     dynamic "advanced_machine_features" {

--- a/community/modules/compute/gke-node-pool/versions.tf
+++ b/community/modules/compute/gke-node-pool/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.60.0, < 5.0"
+      version = ">= 4.61.0, < 5.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.60.0, < 5.0"
+      version = ">= 4.61.0, < 5.0"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
`ephemeral_storage_local_ssd_config` support was added which requires a later version of the google-beta terraform provider. This bumps min provider version to valid version.

In addition it simplifies the gvnic logical statement (no-op).

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
