### PR TITLE
Deprecate `DeploymentGroup.Kind`

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -84,7 +84,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 		cobra.CheckErr(shell.ImportInputs(groupDir, artifactsDir, expandedBlueprintFile))
 
 		var err error
-		switch group.Kind {
+		switch group.Kind() {
 		case config.PackerKind:
 			// Packer groups are enforced to have length 1
 			subPath, e := modulewriter.DeploymentSource(group.Modules[0])
@@ -94,7 +94,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 		case config.TerraformKind:
 			err = deployTerraformGroup(groupDir)
 		default:
-			err = fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind.String())
+			err = fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind().String())
 		}
 		cobra.CheckErr(err)
 	}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -80,7 +80,7 @@ func runDestroyCmd(cmd *cobra.Command, args []string) error {
 		groupDir := filepath.Join(deploymentRoot, string(group.Name))
 
 		var err error
-		switch group.Kind {
+		switch group.Kind() {
 		case config.PackerKind:
 			// Packer groups are enforced to have length 1
 			// TODO: destroyPackerGroup(moduleDir)
@@ -89,7 +89,7 @@ func runDestroyCmd(cmd *cobra.Command, args []string) error {
 		case config.TerraformKind:
 			err = destroyTerraformGroup(groupDir)
 		default:
-			err = fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind.String())
+			err = fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind().String())
 		}
 		if err != nil {
 			return err

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -100,8 +100,11 @@ func runExportCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if group.Kind == config.PackerKind {
+	if group.Kind() == config.PackerKind {
 		return fmt.Errorf("export command is unsupported on Packer modules because they do not have outputs")
+	}
+	if group.Kind() != config.TerraformKind {
+		return fmt.Errorf("export command is supported for Terraform modules only")
 	}
 
 	tf, err := shell.ConfigureTerraform(groupDir)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -388,13 +388,18 @@ func (s *MySuite) TestExpandConfig(c *C) {
 
 func (s *MySuite) TestCheckModulesAndGroups(c *C) {
 	{ // Duplicate module name same group
-		g := DeploymentGroup{Name: "ice", Modules: []Module{{ID: "pony"}, {ID: "pony"}}}
+		g := DeploymentGroup{Name: "ice", Modules: []Module{
+			{ID: "pony", Kind: PackerKind},
+			{ID: "pony", Kind: PackerKind},
+		}}
 		err := checkModulesAndGroups([]DeploymentGroup{g})
 		c.Check(err, ErrorMatches, ".*pony used more than once")
 	}
 	{ // Duplicate module name different groups
-		ice := DeploymentGroup{Name: "ice", Modules: []Module{{ID: "pony"}}}
-		fire := DeploymentGroup{Name: "fire", Modules: []Module{{ID: "pony"}}}
+		ice := DeploymentGroup{Name: "ice", Modules: []Module{
+			{ID: "pony", Kind: PackerKind}}}
+		fire := DeploymentGroup{Name: "fire", Modules: []Module{
+			{ID: "pony", Kind: PackerKind}}}
 		err := checkModulesAndGroups([]DeploymentGroup{ice, fire})
 		c.Check(err, ErrorMatches, ".*pony used more than once")
 	}
@@ -404,7 +409,12 @@ func (s *MySuite) TestCheckModulesAndGroups(c *C) {
 			{ID: "zebra", Kind: TerraformKind},
 		}}
 		err := checkModulesAndGroups([]DeploymentGroup{g})
-		c.Check(err, ErrorMatches, ".*got packer and terraform")
+		c.Check(err, NotNil)
+	}
+	{ // Empty group
+		g := DeploymentGroup{Name: "ice"}
+		err := checkModulesAndGroups([]DeploymentGroup{g})
+		c.Check(err, NotNil)
 	}
 }
 

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -111,7 +111,6 @@ type groupPath struct {
 	Name    basePath              `path:".group"`
 	Backend backendPath           `path:".terraform_backend"`
 	Modules arrayPath[modulePath] `path:".modules"`
-	Kind    basePath              `path:".kind"`
 }
 
 type modulePath struct {

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -45,7 +45,6 @@ func TestPath(t *testing.T) {
 
 		{r.Groups.At(3), "deployment_groups[3]"},
 		{r.Groups.At(3).Name, "deployment_groups[3].group"},
-		{r.Groups.At(3).Kind, "deployment_groups[3].kind"},
 		{r.Groups.At(3).Backend, "deployment_groups[3].terraform_backend"},
 		{r.Groups.At(3).Modules, "deployment_groups[3].modules"},
 		{r.Groups.At(3).Modules.At(1), "deployment_groups[3].modules[1]"},

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -49,7 +49,6 @@ deployment_groups:
     type: yam
     configuration:
       carrot: rust
-  kind: terraform
   modules:
   - id: tan
     source: oatmeal
@@ -108,36 +107,35 @@ terraform_backend_defaults:
 		{Root.Groups.At(0).Backend.Type, Pos{22, 11}},
 		{Root.Groups.At(0).Backend.Configuration, Pos{24, 7}},
 		{Root.Groups.At(0).Backend.Configuration.Dot("carrot"), Pos{24, 15}},
-		{Root.Groups.At(0).Kind, Pos{25, 9}},
 
-		{Root.Groups.At(0).Modules, Pos{27, 3}},
-		{Root.Groups.At(0).Modules.At(0), Pos{27, 5}},
-		{Root.Groups.At(0).Modules.At(0).ID, Pos{27, 9}},
-		{Root.Groups.At(0).Modules.At(0).Source, Pos{28, 13}},
-		{Root.Groups.At(0).Modules.At(0).Kind, Pos{29, 11}},
-		{Root.Groups.At(0).Modules.At(0).Use, Pos{30, 10}},
-		{Root.Groups.At(0).Modules.At(0).Use.At(0), Pos{30, 11}},
-		{Root.Groups.At(0).Modules.At(0).Use.At(1), Pos{30, 18}},
-		{Root.Groups.At(0).Modules.At(0).Outputs, Pos{32, 5}},
-		{Root.Groups.At(0).Modules.At(0).Outputs.At(0), Pos{32, 7}},
-		{Root.Groups.At(0).Modules.At(0).Outputs.At(0).Name, Pos{32, 7}}, // synthetic
-		{Root.Groups.At(0).Modules.At(0).Outputs.At(1), Pos{33, 7}},
-		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Name, Pos{33, 13}},
-		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Description, Pos{34, 20}},
-		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Sensitive, Pos{35, 18}},
-		{Root.Groups.At(0).Modules.At(0).Settings, Pos{37, 7}},
-		{Root.Groups.At(0).Modules.At(0).Settings.Dot("dijon"), Pos{37, 14}},
+		{Root.Groups.At(0).Modules, Pos{26, 3}},
+		{Root.Groups.At(0).Modules.At(0), Pos{26, 5}},
+		{Root.Groups.At(0).Modules.At(0).ID, Pos{26, 9}},
+		{Root.Groups.At(0).Modules.At(0).Source, Pos{27, 13}},
+		{Root.Groups.At(0).Modules.At(0).Kind, Pos{28, 11}},
+		{Root.Groups.At(0).Modules.At(0).Use, Pos{29, 10}},
+		{Root.Groups.At(0).Modules.At(0).Use.At(0), Pos{29, 11}},
+		{Root.Groups.At(0).Modules.At(0).Use.At(1), Pos{29, 18}},
+		{Root.Groups.At(0).Modules.At(0).Outputs, Pos{31, 5}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(0), Pos{31, 7}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(0).Name, Pos{31, 7}}, // synthetic
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(1), Pos{32, 7}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Name, Pos{32, 13}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Description, Pos{33, 20}},
+		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Sensitive, Pos{34, 18}},
+		{Root.Groups.At(0).Modules.At(0).Settings, Pos{36, 7}},
+		{Root.Groups.At(0).Modules.At(0).Settings.Dot("dijon"), Pos{36, 14}},
 
-		{Root.Groups.At(1), Pos{39, 3}},
-		{Root.Groups.At(1).Name, Pos{39, 10}},
-		{Root.Groups.At(1).Modules, Pos{41, 3}},
-		{Root.Groups.At(1).Modules.At(0), Pos{41, 5}},
-		{Root.Groups.At(1).Modules.At(0).ID, Pos{41, 9}},
-		{Root.Groups.At(1).Modules.At(1), Pos{42, 5}},
-		{Root.Groups.At(1).Modules.At(1).ID, Pos{42, 9}},
+		{Root.Groups.At(1), Pos{38, 3}},
+		{Root.Groups.At(1).Name, Pos{38, 10}},
+		{Root.Groups.At(1).Modules, Pos{40, 3}},
+		{Root.Groups.At(1).Modules.At(0), Pos{40, 5}},
+		{Root.Groups.At(1).Modules.At(0).ID, Pos{40, 9}},
+		{Root.Groups.At(1).Modules.At(1), Pos{41, 5}},
+		{Root.Groups.At(1).Modules.At(1).ID, Pos{41, 9}},
 
-		{Root.Backend, Pos{45, 3}},
-		{Root.Backend.Type, Pos{45, 9}},
+		{Root.Backend, Pos{44, 3}},
+		{Root.Backend.Type, Pos{44, 9}},
 	}
 
 	ctx := NewYamlCtx([]byte(data))

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -90,10 +90,10 @@ func WriteDeployment(dc config.DeploymentConfig, deploymentDir string, overwrite
 	fmt.Fprintln(f, "================================")
 
 	for grpIdx, grp := range dc.Config.DeploymentGroups {
-		writer, ok := kinds[grp.Kind.String()]
+		writer, ok := kinds[grp.Kind().String()]
 		if !ok {
 			return fmt.Errorf(
-				"invalid kind in deployment group %s, got '%s'", grp.Name, grp.Kind)
+				"invalid kind in deployment group %s, got '%s'", grp.Name, grp.Kind())
 		}
 
 		err := writer.writeDeploymentGroup(dc, grpIdx, deploymentDir, f)
@@ -420,10 +420,10 @@ func writeDestroyInstructions(w io.Writer, dc config.DeploymentConfig, deploymen
 	for grpIdx := len(dc.Config.DeploymentGroups) - 1; grpIdx >= 0; grpIdx-- {
 		grp := dc.Config.DeploymentGroups[grpIdx]
 		grpPath := filepath.Join(deploymentDir, string(grp.Name))
-		if grp.Kind == config.TerraformKind {
+		if grp.Kind() == config.TerraformKind {
 			fmt.Fprintf(w, "terraform -chdir=%s destroy\n", grpPath)
 		}
-		if grp.Kind == config.PackerKind {
+		if grp.Kind() == config.PackerKind {
 			packerManifests = append(packerManifests, filepath.Join(grpPath, string(grp.Modules[0].ID), "packer-manifest.json"))
 
 		}

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -104,7 +104,6 @@ func getDeploymentConfigForTest() config.DeploymentConfig {
 	testDeploymentGroups := []config.DeploymentGroup{
 		{
 			Name:    "test_resource_group",
-			Kind:    config.TerraformKind,
 			Modules: []config.Module{testModule, testModuleWithLabels},
 		},
 	}

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -326,7 +326,7 @@ func ImportInputs(deploymentGroupDir string, artifactsDir string, expandedBluepr
 	}
 
 	var outfile string
-	switch g.Kind {
+	switch g.Kind() {
 	case config.TerraformKind:
 		outfile = filepath.Join(deploymentGroupDir, fmt.Sprintf("%s_inputs.auto.tfvars", g.Name))
 	case config.PackerKind:

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -113,7 +113,6 @@ deployment_groups:
             sensitive: true
         settings:
           install_nvidia_driver: true
-    kind: terraform
   - group: one
     modules:
       - source: modules/packer/custom-image
@@ -134,4 +133,3 @@ deployment_groups:
           subnetwork_name: ((module.network0.subnetwork_name))
           windows_startup_ps1: ((flatten([module.windows_startup.windows_startup_ps1])))
           zone: ((var.zone ))
-    kind: packer

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
@@ -51,7 +51,6 @@ deployment_groups:
           deployment_name: ((var.deployment_name ))
           project_id: ((var.project_id ))
           region: ((var.region ))
-    kind: terraform
   - group: one
     modules:
       - source: modules/file-system/filestore
@@ -71,4 +70,3 @@ deployment_groups:
           project_id: ((var.project_id ))
           region: ((var.region ))
           zone: ((var.zone ))
-    kind: terraform

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
@@ -110,4 +110,3 @@ deployment_groups:
           project_id: ((var.project_id ))
           region: ((var.region ))
           zone: ((var.zone ))
-    kind: terraform

--- a/tools/validate_configs/golden_copies/expectations/text_escape/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/.ghpc/artifacts/expanded_blueprint.yaml
@@ -54,4 +54,3 @@ deployment_groups:
           project_id: ((var.project_id))
           subnetwork_name: \$(purple
           zone: ((var.zone))
-    kind: packer


### PR DESCRIPTION
* Deprecate `DeploymentGroup.Kind`, parse but ignore the yaml field for backward compatibility;
* Add method to derive "kind";
* Add check "deployment group must have at least one module";

**Motivation:**
* The field doesn't improves usability, other than "extra check";
* Doesn't make sense if support is added for groups of mixed modules;
* Bloats the state;
* Set by `checkModulesAndGroups` that should not mutate the state;
* Is not mentioned in our docs/examples.