### PR TITLE
Insert a basic Ubuntu node pool into the GKE integration test

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -59,6 +59,11 @@ steps:
     echo '      machine_type: e2-standard-2'       >> $${SG_EXAMPLE}
     echo '      zone: us-central1-a'               >> $${SG_EXAMPLE}
 
+    echo '  - id: ubuntu_pool'                                         >> $${SG_EXAMPLE}
+    echo '    source: community/modules/compute/gke-node-pool'         >> $${SG_EXAMPLE}
+    echo '    use: [gke_cluster]'                                      >> $${SG_EXAMPLE}
+    echo '    settings: {name: ubuntu, image_type: UBUNTU_CONTAINERD}' >> $${SG_EXAMPLE}
+
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke.yml"


### PR DESCRIPTION
Prior to #1542 Ubuntu node pools did not work. This will prevent basic regressions for Ubuntu.

I expect there may be some controversy about using `echo` to edit the example in the test definition. It is a trade off between 1) making the public example more complex, 2) creating an alternative blueprint and not testing the public example, and 3) the proposed solution, modifying the blueprint on the fly.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
