### PR TITLE
Use PR labels to auto-generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For more info, see:
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
+
+changelog:
+  exclude:
+    labels:
+    - chore
+    authors: []
+  categories:
+  - title: Key New Features 🎉
+    labels:
+    - key-new-features
+  - title: New Modules 🧱
+    labels:
+    - new-modules
+  - title: Module Improvements 🛠
+    labels:
+    - module-improvements
+  - title: Improvements
+    labels:
+    - improvements
+  - title: Deprecations
+    labels:
+    - deprecations
+  - title: Version Updates
+    labels:
+    - version-updates
+  - title: Other changes
+    labels:
+    - "*"

--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -1,0 +1,48 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dependency Review Action
+#
+# This Action will ensure that a label exists on a PR.
+name: 'Ensure PR label exists'
+
+on:
+  pull_request:
+    types:
+    - opened
+    - labeled
+    - unlabeled
+    branches:
+    - develop
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+    - id: check-labels
+      uses: mheap/github-action-required-labels@v5
+      with:
+        mode: minimum
+        count: 1
+        labels: "chore, key-new-features, new-modules, module-improvements, improvements, deprecations, version-updates"
+        message: "This PR is being prevented from merging because it is not labeled.  Please add a label to this PR.  Accepted labels: chore, key-new-features, new-modules, module-improvements, improvements, deprecations, version-updates"
+    - id: print-labels
+      run: |
+        echo "Current PR labels:"
+        for f in $(echo "{{steps.check-labels.outputs.labels}}" | sed "s/,/ /g")
+        do
+          echo "$f"
+        done


### PR DESCRIPTION
This PR configures the auto-generation of release notes.  Config file: `.github/release.yml`.

It also adds a GitHub Action workflow to ensure PRs cannot be merged unless they have one of the accepted labels.  Workflow config file: `.github/workflows/pr-label-validation.yml`.  This is the list of accepted labels:

- chore
- key-new-features
- new-modules
- module-improvements
- improvements
- deprecations
- version-updates

I have tested the validation on this PR.