### PR TITLE
Implement wrapper for HTCondor central manager

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -67,42 +67,18 @@ deployment_groups:
     use:
     - htcondor_base
 
-  - id: htcondor_startup_central_manager
-    source: modules/scripts/startup-script
-    settings:
-      runners:
-      - $(htcondor_secrets.central_manager_runner)
-      - $(htcondor_base.central_manager_runner)
-
   - id: htcondor_cm
-    source: modules/compute/vm-instance
+    source: community/modules/scheduler/htcondor-central-manager
     use:
-    - htcondor_startup_central_manager
+    - network1
+    - htcondor_secrets
+    - htcondor_base
     settings:
-      name_prefix: cm
       instance_image:
         project: $(vars.project_id)
         family: $(vars.new_image_family)
-      add_deployment_name_before_prefix: true
-      machine_type: c2-standard-4
-      disable_public_ips: true
-      service_account:
-        email: $(htcondor_base.central_manager_service_account_email)
-        scopes:
-        - cloud-platform
-      network_interfaces:
-      - network: null
-        subnetwork: $(network1.subnetwork_self_link)
-        subnetwork_project: $(vars.project_id)
-        network_ip: $(htcondor_base.central_manager_ips[0])
-        stack_type: null
-        access_config: []
-        ipv6_access_config: []
-        alias_ip_range: []
-        nic_type: VIRTIO_NET
-        queue_count: null
     outputs:
-    - internal_ip
+    - central_manager_name
 
   # the HTCondor modules support up to 2 execute points per blueprint
   # if using 1, it may use Spot or On-demand pricing
@@ -113,6 +89,7 @@ deployment_groups:
     - network1
     - htcondor_secrets
     - htcondor_base
+    - htcondor_cm
     settings:
       instance_image:
         project: $(vars.project_id)
@@ -125,6 +102,7 @@ deployment_groups:
     - network1
     - htcondor_secrets
     - htcondor_base
+    - htcondor_cm
     settings:
       instance_image:
         project: $(vars.project_id)
@@ -137,6 +115,7 @@ deployment_groups:
     - network1
     - htcondor_secrets
     - htcondor_base
+    - htcondor_cm
     - htcondor_execute_point
     - htcondor_execute_point_spot
     settings:

--- a/community/modules/scheduler/htcondor-base/README.md
+++ b/community/modules/scheduler/htcondor-base/README.md
@@ -1,12 +1,19 @@
 ## Description
 
-This module performs the following tasks:
+This module creates the basic security infrastructure of an HTCondor pool in
+Google Cloud.
+
+> **_NOTE:_** This module was previously named htcondor-configure. The interface
+> and responsibilities of this module have changed significantly. Please review
+> the [example](#example) and modify your blueprints accordingly.
+
+## Security setup
+
+This module will take the following actions:
 
 - store an HTCondor Pool password in Google Cloud Secret Manager
   - will generate a new password if one is not supplied
 - create service accounts for an HTCondor Access Point and Central Manager
-- create a Toolkit runner for an Access Point
-- create a Toolkit runner for a Central Manager
 
 It is expected to be used with the [htcondor-install] and
 [htcondor-execute-point] modules.

--- a/community/modules/scheduler/htcondor-base/README.md
+++ b/community/modules/scheduler/htcondor-base/README.md
@@ -213,7 +213,6 @@ limitations under the License.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_point_service_account"></a> [access\_point\_service\_account](#module\_access\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.2 |
-| <a name="module_address"></a> [address](#module\_address) | terraform-google-modules/address/google | ~> 3.0 |
 | <a name="module_central_manager_service_account"></a> [central\_manager\_service\_account](#module\_central\_manager\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.2 |
 | <a name="module_execute_point_service_account"></a> [execute\_point\_service\_account](#module\_execute\_point\_service\_account) | terraform-google-modules/service-accounts/google | ~> 4.2 |
 | <a name="module_health_check_firewall_rule"></a> [health\_check\_firewall\_rule](#module\_health\_check\_firewall\_rule) | terraform-google-modules/network/google//modules/firewall-rules | ~> 6.0 |
@@ -223,7 +222,6 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
-| [google_storage_bucket_object.cm_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_compute_subnetwork.htcondor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 
 ## Inputs
@@ -231,7 +229,6 @@ limitations under the License.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_point_roles"></a> [access\_point\_roles](#input\_access\_point\_roles) | Project-wide roles for HTCondor Access Point service account | `list(string)` | <pre>[<br>  "roles/compute.instanceAdmin",<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
-| <a name="input_central_manager_high_availability"></a> [central\_manager\_high\_availability](#input\_central\_manager\_high\_availability) | Provision HTCondor central manager in high availability mode | `bool` | `false` | no |
 | <a name="input_central_manager_roles"></a> [central\_manager\_roles](#input\_central\_manager\_roles) | Project-wide roles for HTCondor Central Manager service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_execute_point_roles"></a> [execute\_point\_roles](#input\_execute\_point\_roles) | Project-wide roles for HTCondor Execute Point service account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/storage.objectViewer"<br>]</pre> | no |
@@ -245,8 +242,6 @@ limitations under the License.
 | Name | Description |
 |------|-------------|
 | <a name="output_access_point_service_account_email"></a> [access\_point\_service\_account\_email](#output\_access\_point\_service\_account\_email) | HTCondor Access Point Service Account (e-mail format) |
-| <a name="output_central_manager_ips"></a> [central\_manager\_ips](#output\_central\_manager\_ips) | Reserved internal IP address for use by Central Manager |
-| <a name="output_central_manager_runner"></a> [central\_manager\_runner](#output\_central\_manager\_runner) | Toolkit Runner to configure an HTCondor Central Manager |
 | <a name="output_central_manager_service_account_email"></a> [central\_manager\_service\_account\_email](#output\_central\_manager\_service\_account\_email) | HTCondor Central Manager Service Account (e-mail format) |
 | <a name="output_execute_point_service_account_email"></a> [execute\_point\_service\_account\_email](#output\_execute\_point\_service\_account\_email) | HTCondor Execute Point Service Account (e-mail format) |
 | <a name="output_htcondor_bucket_name"></a> [htcondor\_bucket\_name](#output\_htcondor\_bucket\_name) | Name of the HTCondor configuration bucket |

--- a/community/modules/scheduler/htcondor-base/outputs.tf
+++ b/community/modules/scheduler/htcondor-base/outputs.tf
@@ -38,16 +38,6 @@ output "execute_point_service_account_email" {
   ]
 }
 
-output "central_manager_runner" {
-  description = "Toolkit Runner to configure an HTCondor Central Manager"
-  value       = local.runner_cm
-}
-
-output "central_manager_ips" {
-  description = "Reserved internal IP address for use by Central Manager"
-  value       = module.address.addresses
-}
-
 output "htcondor_bucket_name" {
   description = "Name of the HTCondor configuration bucket"
   value       = module.htcondor_bucket.name

--- a/community/modules/scheduler/htcondor-base/variables.tf
+++ b/community/modules/scheduler/htcondor-base/variables.tf
@@ -69,9 +69,3 @@ variable "execute_point_roles" {
     "roles/storage.objectViewer",
   ]
 }
-
-variable "central_manager_high_availability" {
-  description = "Provision HTCondor central manager in high availability mode"
-  type        = bool
-  default     = false
-}

--- a/community/modules/scheduler/htcondor-central-manager/README.md
+++ b/community/modules/scheduler/htcondor-central-manager/README.md
@@ -1,0 +1,103 @@
+## Description
+
+This module provisions a highly available HTCondor central manager using a [Managed
+Instance Group (MIG)][mig] with auto-healing.
+
+[mig]: https://cloud.google.com/compute/docs/instance-groups
+
+## Usage
+
+Although this provisions an HTCondor central manager with standard configuration,
+for a functioning node, you must supply Toolkit runners as described below:
+
+- [var.central_manager_runner](#input_central_manager_runner)
+  - Runner must download a POOL password / signing key and create an [IDTOKEN]
+  with no scopes (full authorization).
+
+A reference implementation is included in the Toolkit module
+[htcondor-pool-secrets]. You may substitute implementations so long as they
+duplicate the functionality in the references. Usage is demonstrated in the
+[HTCondor example][htc-example].
+
+[htc-example]: ../../../../examples/README.md#htc-htcondoryaml--
+[htcondor-pool-secrets]: ../htcondor-pool-secrets/README.md
+[IDTOKEN]: https://htcondor.readthedocs.io/en/latest/admin-manual/security.html#introducing-idtokens
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.9 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_central_manager_instance_template"></a> [central\_manager\_instance\_template](#module\_central\_manager\_instance\_template) | github.com/terraform-google-modules/terraform-google-vm//modules/instance_template | 84d7959 |
+| <a name="module_htcondor_cm"></a> [htcondor\_cm](#module\_htcondor\_cm) | github.com/terraform-google-modules/terraform-google-vm//modules/mig | 84d7959 |
+| <a name="module_startup_script"></a> [startup\_script](#module\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.20.0&depth=1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_storage_bucket_object.cm_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [time_sleep.mig_warmup](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [google_compute_image.htcondor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+| [google_compute_instance.cm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance) | data source |
+| [google_compute_region_instance_group.cm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_region_instance_group) | data source |
+| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_central_manager_runner"></a> [central\_manager\_runner](#input\_central\_manager\_runner) | A list of Toolkit runners for configuring an HTCondor central manager | `list(map(string))` | `[]` | no |
+| <a name="input_central_manager_service_account_email"></a> [central\_manager\_service\_account\_email](#input\_central\_manager\_service\_account\_email) | Service account for central manager (e-mail format) | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `null` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with "ENABLE" or "DISABLE". Set to "INHERIT" to inherit project OS Login setting. | `string` | `"ENABLE"` | no |
+| <a name="input_htcondor_bucket_name"></a> [htcondor\_bucket\_name](#input\_htcondor\_bucket\_name) | Name of HTCondor configuration bucket | `string` | n/a | yes |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Custom VM image with HTCondor and Toolkit support installed. | <pre>object({<br>    family  = string,<br>    project = string<br>  })</pre> | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to resources. List key, value pairs. | `map(string)` | n/a | yes |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to use for HTCondor central managers | `string` | `"c2-standard-4"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata to add to HTCondor central managers | `map(string)` | `{}` | no |
+| <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | The self link of the network in which the HTCondor central manager will be created. | `string` | `null` | no |
+| <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured | <pre>list(object({<br>    server_ip             = string,<br>    remote_mount          = string,<br>    local_mount           = string,<br>    fs_type               = string,<br>    mount_options         = string,<br>    client_install_runner = map(string)<br>    mount_runner          = map(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Default region for creating resources | `string` | n/a | yes |
+| <a name="input_service_account_scopes"></a> [service\_account\_scopes](#input\_service\_account\_scopes) | Scopes by which to limit service account attached to central manager. | `set(string)` | <pre>[<br>  "https://www.googleapis.com/auth/cloud-platform"<br>]</pre> | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork in which the HTCondor central manager will be created. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_central_manager_ips"></a> [central\_manager\_ips](#output\_central\_manager\_ips) | IP addresses of the central managers provisioned by this module |
+| <a name="output_central_manager_name"></a> [central\_manager\_name](#output\_central\_manager\_name) | Name of the central managers provisioned by this module |
+| <a name="output_list_instances_command"></a> [list\_instances\_command](#output\_list\_instances\_command) | Command to list central managers provisioned by this module |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/htcondor-central-manager/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-central-manager/files/htcondor_configure.yml
@@ -13,19 +13,16 @@
 # limitations under the License.
 
 ---
-- name: Configure HTCondor Role
+- name: Configure HTCondor central manager
   hosts: localhost
   become: true
   vars:
-    job_queue_ha: false
-    spool_dir: /var/lib/condor/spool
     condor_config_root: /etc/condor
     ghpc_config_file: 50-ghpc-managed
   tasks:
   - name: Ensure necessary variables are set
     ansible.builtin.assert:
       that:
-      - htcondor_role is defined
       - config_object is defined
   - name: Remove default HTCondor configuration
     ansible.builtin.file:

--- a/community/modules/scheduler/htcondor-central-manager/main.tf
+++ b/community/modules/scheduler/htcondor-central-manager/main.tf
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "htcondor-central-manager" })
+}
+
+locals {
+  network_storage_metadata = var.network_storage == null ? {} : { network_storage = jsonencode(var.network_storage) }
+  oslogin_api_values = {
+    "DISABLE" = "FALSE"
+    "ENABLE"  = "TRUE"
+  }
+  enable_oslogin_metadata = var.enable_oslogin == "INHERIT" ? {} : { enable-oslogin = lookup(local.oslogin_api_values, var.enable_oslogin, "") }
+  metadata                = merge(local.network_storage_metadata, local.enable_oslogin_metadata, var.metadata)
+
+  name_prefix = "${var.deployment_name}-cm"
+
+  all_runners = flatten([var.central_manager_runner, local.schedd_runner])
+
+  cm_config = templatefile("${path.module}/templates/condor_config.tftpl", {})
+
+  cm_object = "gs://${var.htcondor_bucket_name}/${google_storage_bucket_object.cm_config.output_name}"
+  schedd_runner = {
+    type        = "ansible-local"
+    content     = file("${path.module}/files/htcondor_configure.yml")
+    destination = "htcondor_configure.yml"
+    args = join(" ", [
+      "-e config_object=${local.cm_object}",
+    ])
+  }
+
+  central_manager_ips  = [data.google_compute_instance.cm.network_interface[0].network_ip]
+  central_manager_name = data.google_compute_instance.cm.name
+
+  list_instances_command = "gcloud compute instance-groups list-instances ${data.google_compute_region_instance_group.cm.name} --region ${var.region} --project ${var.project_id}"
+}
+
+data "google_compute_image" "htcondor" {
+  family  = var.instance_image.family
+  project = var.instance_image.project
+
+  lifecycle {
+    postcondition {
+      condition     = self.disk_size_gb <= var.disk_size_gb
+      error_message = "var.disk_size_gb must be set to at least the size of the image (${self.disk_size_gb})"
+    }
+  }
+}
+
+data "google_compute_zones" "available" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_compute_region_instance_group" "cm" {
+  self_link = time_sleep.mig_warmup.triggers.self_link
+}
+
+data "google_compute_instance" "cm" {
+  self_link = data.google_compute_region_instance_group.cm.instances[0].instance
+}
+
+resource "google_storage_bucket_object" "cm_config" {
+  name    = "${var.deployment_name}-cm-config-${substr(md5(local.cm_config), 0, 4)}"
+  content = local.cm_config
+  bucket  = var.htcondor_bucket_name
+}
+
+module "startup_script" {
+  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=v1.20.0&depth=1"
+
+  project_id      = var.project_id
+  region          = var.region
+  labels          = local.labels
+  deployment_name = var.deployment_name
+
+  runners = local.all_runners
+}
+
+module "central_manager_instance_template" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "github.com/terraform-google-modules/terraform-google-vm//modules/instance_template?ref=84d7959"
+
+  name_prefix = local.name_prefix
+  project_id  = var.project_id
+  network     = var.network_self_link
+  subnetwork  = var.subnetwork_self_link
+  service_account = {
+    email  = var.central_manager_service_account_email
+    scopes = var.service_account_scopes
+  }
+  labels = local.labels
+
+  machine_type   = var.machine_type
+  disk_size_gb   = var.disk_size_gb
+  preemptible    = false
+  startup_script = module.startup_script.startup_script
+  metadata       = local.metadata
+  source_image   = data.google_compute_image.htcondor.self_link
+}
+
+module "htcondor_cm" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "github.com/terraform-google-modules/terraform-google-vm//modules/mig?ref=84d7959"
+
+  project_id        = var.project_id
+  region            = var.region
+  target_size       = 1
+  hostname          = local.name_prefix
+  instance_template = module.central_manager_instance_template.self_link
+
+  health_check_name = "health-${local.name_prefix}"
+  health_check = {
+    type                = "tcp"
+    initial_delay_sec   = 600
+    check_interval_sec  = 20
+    healthy_threshold   = 2
+    timeout_sec         = 8
+    unhealthy_threshold = 3
+    response            = ""
+    proxy_header        = "NONE"
+    port                = 9618
+    request             = ""
+    request_path        = ""
+    host                = ""
+    enable_logging      = true
+  }
+
+  update_policy = [{
+    instance_redistribution_type = "NONE"
+    replacement_method           = "SUBSTITUTE"
+    max_surge_fixed              = length(data.google_compute_zones.available.names)
+    max_unavailable_fixed        = length(data.google_compute_zones.available.names)
+    max_surge_percent            = null
+    max_unavailable_percent      = null
+    min_ready_sec                = 300
+    minimal_action               = "REPLACE"
+    type                         = "OPPORTUNISTIC"
+  }]
+
+  stateful_ips = [{
+    interface_name = "nic0"
+    delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
+    is_external    = false
+  }]
+}
+
+resource "time_sleep" "mig_warmup" {
+  create_duration = "120s"
+
+  triggers = {
+    self_link = module.htcondor_cm.self_link
+  }
+}

--- a/community/modules/scheduler/htcondor-central-manager/outputs.tf
+++ b/community/modules/scheduler/htcondor-central-manager/outputs.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "list_instances_command" {
+  description = "Command to list central managers provisioned by this module"
+  value       = local.list_instances_command
+}
+
+output "central_manager_ips" {
+  description = "IP addresses of the central managers provisioned by this module"
+  value       = local.central_manager_ips
+}
+
+output "central_manager_name" {
+  description = "Name of the central managers provisioned by this module"
+  value       = local.central_manager_name
+}

--- a/community/modules/scheduler/htcondor-central-manager/templates/condor_config.tftpl
+++ b/community/modules/scheduler/htcondor-central-manager/templates/condor_config.tftpl
@@ -16,35 +16,11 @@
 # override settings with a higher priority (last lexically) named file
 # https://htcondor.readthedocs.io/en/latest/admin-manual/introduction-to-configuration.html?#ordered-evaluation-to-set-the-configuration
 
-use role:${htcondor_role}
-CONDOR_HOST = ${join(",", central_manager_ips)}
+use role:get_htcondor_central_manager
+CONDOR_HOST = $(IPV4_ADDRESS)
 
-%{ if htcondor_role == "get_htcondor_central_manager" ~}
-# Central Manager configuraition settings
+# Central Manager configuration settings
 COLLECTOR_UPDATE_INTERVAL = 30
 NEGOTIATOR_UPDATE_INTERVAL = 30
 NEGOTIATOR_DEPTH_FIRST = True
 NEGOTIATOR_UPDATE_AFTER_CYCLE = True
-%{ endif ~}
-
-%{ if htcondor_role == "get_htcondor_central_manager" && length(central_manager_ips) > 1 ~}
-# Central Manager high availability configuration settings
-# following https://htcondor.readthedocs.io/en/latest/admin-manual/high-availability.html#high-availability-of-the-central-manager
-CM_LIST = \
-  ${central_manager_ips[0]}:$(SHARED_PORT_PORT), \
-  ${central_manager_ips[1]}:$(SHARED_PORT_PORT)
-
-HAD_USE_SHARED_PORT = True
-HAD_LIST = $(CM_LIST)
-
-REPLICATION_USE_SHARED_PORT = True
-REPLICATION_LIST = $(CM_LIST)
-
-HAD_USE_PRIMARY = True
-HAD_CONTROLLEE = NEGOTIATOR
-MASTER_NEGOTIATOR_CONTROLLER = HAD
-
-DAEMON_LIST = $(DAEMON_LIST), HAD, REPLICATION
-HAD_USE_REPLICATION = True
-MASTER_HAD_BACKOFF_CONSTANT = 360
-%{ endif ~}

--- a/community/modules/scheduler/htcondor-central-manager/variables.tf
+++ b/community/modules/scheduler/htcondor-central-manager/variables.tf
@@ -15,7 +15,7 @@
  */
 
 variable "project_id" {
-  description = "Project in which HTCondor pool will be created"
+  description = "Project in which HTCondor central manager will be created"
   type        = string
 }
 
@@ -34,6 +34,13 @@ variable "region" {
   type        = string
 }
 
+variable "zones" {
+  description = "Zone(s) in which central manager may be created. If not supplied, will default to all zones in var.region."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "network_self_link" {
   description = "The self link of the network in which the HTCondor central manager will be created."
   type        = string
@@ -41,7 +48,7 @@ variable "network_self_link" {
 }
 
 variable "central_manager_service_account_email" {
-  description = "Service account for central manager (e-mail format)"
+  description = "Service account e-mail for central manager (can be supplied by htcondor-base module)"
   type        = string
 }
 
@@ -70,7 +77,8 @@ variable "network_storage" {
 variable "disk_size_gb" {
   description = "Boot disk size in GB"
   type        = number
-  default     = null
+  default     = 20
+  nullable    = false
 }
 
 variable "metadata" {
@@ -97,7 +105,7 @@ variable "subnetwork_self_link" {
 }
 
 variable "instance_image" {
-  description = "Custom VM image with HTCondor and Toolkit support installed."
+  description = "Custom VM image with HTCondor installed using the htcondor-install module."
   type = object({
     family  = string,
     project = string

--- a/community/modules/scheduler/htcondor-central-manager/variables.tf
+++ b/community/modules/scheduler/htcondor-central-manager/variables.tf
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project in which HTCondor pool will be created"
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "HPC Toolkit deployment name. HTCondor cloud resource names will include this value."
+  type        = string
+}
+
+variable "labels" {
+  description = "Labels to add to resources. List key, value pairs."
+  type        = map(string)
+}
+
+variable "region" {
+  description = "Default region for creating resources"
+  type        = string
+}
+
+variable "network_self_link" {
+  description = "The self link of the network in which the HTCondor central manager will be created."
+  type        = string
+  default     = null
+}
+
+variable "central_manager_service_account_email" {
+  description = "Service account for central manager (e-mail format)"
+  type        = string
+}
+
+variable "service_account_scopes" {
+  description = "Scopes by which to limit service account attached to central manager."
+  type        = set(string)
+  default = [
+    "https://www.googleapis.com/auth/cloud-platform",
+  ]
+}
+
+variable "network_storage" {
+  description = "An array of network attached storage mounts to be configured"
+  type = list(object({
+    server_ip             = string,
+    remote_mount          = string,
+    local_mount           = string,
+    fs_type               = string,
+    mount_options         = string,
+    client_install_runner = map(string)
+    mount_runner          = map(string)
+  }))
+  default = []
+}
+
+variable "disk_size_gb" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = null
+}
+
+variable "metadata" {
+  description = "Metadata to add to HTCondor central managers"
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_oslogin" {
+  description = "Enable or Disable OS Login with \"ENABLE\" or \"DISABLE\". Set to \"INHERIT\" to inherit project OS Login setting."
+  type        = string
+  default     = "ENABLE"
+  nullable    = false
+  validation {
+    condition     = contains(["ENABLE", "DISABLE", "INHERIT"], var.enable_oslogin)
+    error_message = "Allowed string values for var.enable_oslogin are \"ENABLE\", \"DISABLE\", or \"INHERIT\"."
+  }
+}
+
+variable "subnetwork_self_link" {
+  description = "The self link of the subnetwork in which the HTCondor central manager will be created."
+  type        = string
+  default     = null
+}
+
+variable "instance_image" {
+  description = "Custom VM image with HTCondor and Toolkit support installed."
+  type = object({
+    family  = string,
+    project = string
+  })
+}
+
+variable "machine_type" {
+  description = "Machine type to use for HTCondor central managers"
+  type        = string
+  default     = "c2-standard-4"
+}
+
+variable "central_manager_runner" {
+  description = "A list of Toolkit runners for configuring an HTCondor central manager"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "htcondor_bucket_name" {
+  description = "Name of HTCondor configuration bucket"
+  type        = string
+}

--- a/community/modules/scheduler/htcondor-central-manager/versions.tf
+++ b/community/modules/scheduler/htcondor-central-manager/versions.tf
@@ -29,5 +29,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.20.0"
   }
 
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1.0"
 }

--- a/community/modules/scheduler/htcondor-central-manager/versions.tf
+++ b/community/modules/scheduler/htcondor-central-manager/versions.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.20.0"
+  }
+
+  required_version = ">= 0.13.0"
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,7 @@ var errorMessages = map[string]string{
 var movedModules = map[string]string{
 	"community/modules/scheduler/cloud-batch-job":        "modules/scheduler/batch-job-template",
 	"community/modules/scheduler/cloud-batch-login-node": "modules/scheduler/batch-login-node",
+	"community/modules/scheduler/htcondor-configure":     "community/modules/scheduler/htcondor-base",
 }
 
 // GroupName is the name of a deployment group
@@ -417,9 +418,9 @@ func (bp Blueprint) checkMovedModules() error {
 
 	bp.WalkModules(func(p modulePath, m *Module) error {
 		if replacement, ok := movedModules[strings.Trim(m.Source, "./")]; ok {
-			err := fmt.Errorf(
-				"a module has moved. %s has been replaced with %s. Please update the source in your blueprint and try again",
-				m.Source, replacement)
+			err := fmt.Errorf("a module has moved. %s has been replaced with %s; "+
+				"update the source in your blueprint and read %s/README.md for migration instructions",
+				m.Source, replacement, replacement)
 			errs.At(p.Source, err)
 		}
 		return nil


### PR DESCRIPTION
Refactor existing blueprint using vm-instance and startup-script modules using a wrapper that adds the additional functionality of provisioning highly available HTCondor central manager using a managed instance group.

This PR makes the deliberate decision to rely upon MIGs for high availability rather than the "hot-hot" built-in high availability of HTCondor collector daemon and hot-cold HA of negotiator daemon. Reasoning:

1. The hot-hot solutions means you can query either collector for node informations, but their answers may sometimes differ slightly. They are "eventually consistent". This is fine for job scheduling, but a little less great for autoscaling decisions.
2. A MIG provides similar time recovery time for the negotiator daemon (the thing that matches jobs) as the hot-cold failover mechanism.
3. Using a MIG with stateful IP addresses means we do not know the IP addresses of the central managers until after the MIG is provisioned. This creates a cycle within the Terraform graph for the startup-script of the central managers themselves because you need to know the IP address of the other central manager to render it in the configuration file.
We can eliminate the cycle by configuring 1-and-only-1 central manager which is configured with CONDOR_HOST pointing to its own IP address (which is known by the machine and does not need to be rendered in the script).

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
