### PR TITLE
HTCondor access point wrapper patches

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -145,4 +145,5 @@ deployment_groups:
         project: $(vars.project_id)
         family: $(vars.new_image_family)
     outputs:
-    - list_instances_command
+    - access_point_ips
+    - access_point_name

--- a/community/modules/scheduler/htcondor-access-point/README.md
+++ b/community/modules/scheduler/htcondor-access-point/README.md
@@ -48,12 +48,14 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.9 |
 
 ## Modules
 
@@ -68,7 +70,9 @@ limitations under the License.
 | Name | Type |
 |------|------|
 | [google_storage_bucket_object.ap_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [time_sleep.mig_warmup](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [google_compute_image.htcondor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+| [google_compute_instance.ap](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance) | data source |
 | [google_compute_region_instance_group.ap](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_region_instance_group) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 
@@ -102,5 +106,6 @@ limitations under the License.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_list_instances_command"></a> [list\_instances\_command](#output\_list\_instances\_command) | Command to list Access Points provisioned by this module |
+| <a name="output_access_point_ips"></a> [access\_point\_ips](#output\_access\_point\_ips) | IP addresses of the access points provisioned by this module |
+| <a name="output_access_point_name"></a> [access\_point\_name](#output\_access\_point\_name) | Name of the access point provisioned by this module |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/htcondor-access-point/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-access-point/files/htcondor_configure.yml
@@ -56,6 +56,8 @@
       fi
     args:
       executable: /bin/bash
+    notify:
+    - Reload HTCondor
   - name: Configure HTCondor SchedD
     when: htcondor_role == 'get_htcondor_submit'
     block:

--- a/community/modules/scheduler/htcondor-access-point/outputs.tf
+++ b/community/modules/scheduler/htcondor-access-point/outputs.tf
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-output "list_instances_command" {
-  description = "Command to list Access Points provisioned by this module"
-  value       = local.list_instances_command
+output "access_point_ips" {
+  description = "IP addresses of the access points provisioned by this module"
+  value       = local.access_point_ips
+}
+
+output "access_point_name" {
+  description = "Name of the access point provisioned by this module"
+  value       = local.access_point_name
 }

--- a/community/modules/scheduler/htcondor-access-point/versions.tf
+++ b/community/modules/scheduler/htcondor-access-point/versions.tf
@@ -20,6 +20,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.83"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
   }
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.20.0"


### PR DESCRIPTION
- Fix HTCondor access point playbook to ensure HTCondor is reloaded when configuration updates
- mimic `time_sleep` solution from #1585 to add IP/name outputs directly to module instead of a "here's a command to run"

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
