### PR TITLE
Make output of execute_commands more user friendly

### DIFF
--- a/community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl
+++ b/community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl
@@ -23,7 +23,7 @@
     block:
     - name: Print commands to be executed
       ansible.builtin.debug:
-        msg: "{{ commands.split('\n') }}"
+        msg: "{{ commands.split('\n') | ansible.builtin.to_nice_yaml }}"
 
     - name: Execute commands
       ansible.builtin.shell: |
@@ -33,14 +33,10 @@
         echo " === Starting commands ==="
         {{ commands }}
         echo " === Finished commands ==="
-        } | tee -a {{ log_file }}
+        } 2>&1 | tee -a {{ log_file }}
       register: output
 
     always:
-    - name: Print commands output to stderr
-      ansible.builtin.debug:
-        var: output.stderr_lines
-
-    - name: Print commands output to stdout
+    - name: Print commands output
       ansible.builtin.debug:
         var: output.stdout_lines

--- a/community/modules/scripts/spack-execute/templates/execute_commands.yml.tpl
+++ b/community/modules/scripts/spack-execute/templates/execute_commands.yml.tpl
@@ -23,7 +23,7 @@
     block:
     - name: Print commands to be executed
       ansible.builtin.debug:
-        msg: "{{ commands.split('\n') }}"
+        msg: "{{ commands.split('\n') | ansible.builtin.to_nice_yaml }}"
 
     - name: Execute commands
       ansible.builtin.shell: |
@@ -33,14 +33,10 @@
         echo " === Starting commands ==="
         {{ commands }}
         echo " === Finished commands ==="
-        } | tee -a {{ log_file }}
+        } 2>&1 | tee -a {{ log_file }}
       register: output
 
     always:
-    - name: Print commands output to stderr
-      ansible.builtin.debug:
-        var: output.stderr_lines
-
-    - name: Print commands output to stdout
+    - name: Print commands output
       ansible.builtin.debug:
         var: output.stdout_lines


### PR DESCRIPTION
This change:
- prints commands to be called with one command per line
- includes stderr in output file 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
