### PR TITLE
Implement quota validation logic

### DIFF
--- a/pkg/validators/quota.go
+++ b/pkg/validators/quota.go
@@ -1,0 +1,217 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	sub "google.golang.org/api/serviceusage/v1beta1"
+)
+
+// Quota represents a desired quota.
+type Quota struct {
+	Consumer   string // e.g. "projects/myprojectid""
+	Service    string // e.g. "compute.googleapis.com"
+	Metric     string // e.g. "compute.googleapis.com/disks_total_storage"
+	Limit      int64
+	Dimensions map[string]string // e.g. {"region": "us-central1"}
+	// How this Quota should be aggregated with other Quotas in the same bucket.
+	Aggregation string
+}
+
+// InBucket returns true if the quota is in the QuotaBucket.
+func (q Quota) InBucket(b *sub.QuotaBucket) bool {
+	for d, v := range b.Dimensions {
+		if q.Dimensions[d] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// QuotaError represents an event of not having enough quota.
+type QuotaError struct {
+	Consumer       string
+	Service        string
+	Metric         string
+	Dimensions     map[string]string
+	EffectiveLimit int64
+	Requested      int64
+}
+
+func (e QuotaError) Error() string {
+	return fmt.Sprintf("QuotaError: %#v", e)
+}
+
+// ValidateQuotas validates the quotas
+func ValidateQuotas(quotas []Quota) ([]QuotaError, error) {
+	qe := []QuotaError{}
+	// Group by Consumer and Service
+	type gk struct {
+		Consumer string
+		Service  string
+	}
+
+	groups := map[gk][]Quota{}
+	for _, q := range quotas {
+		k := gk{q.Consumer, q.Service}
+		groups[k] = append(groups[k], q)
+	}
+
+	for k, qs := range groups {
+		metrics, err := quotaMetrics(k.Consumer, k.Service)
+		if err != nil {
+			return qe, err
+		}
+		qse, err := validateServiceMetrics(qs, metrics)
+		if err != nil {
+			return qe, err
+		}
+		qe = append(qe, qse...)
+	}
+
+	return qe, nil
+}
+
+func validateServiceMetrics(quotas []Quota, metrics []*sub.ConsumerQuotaMetric) ([]QuotaError, error) {
+	// Group by Metric and Aggregation
+	type gk struct {
+		Metric      string
+		Aggregation string
+	}
+	groups := map[gk][]Quota{}
+	for _, q := range quotas {
+		k := gk{q.Metric, q.Aggregation}
+		groups[k] = append(groups[k], q)
+	}
+
+	qe := []QuotaError{}
+	for k, qs := range groups {
+		agg, err := aggregation(k.Aggregation)
+		if err != nil {
+			return qe, err
+		}
+
+		limits := []*sub.ConsumerQuotaLimit{}
+		for _, m := range metrics {
+			if m.Metric == k.Metric {
+				limits = append(limits, m.ConsumerQuotaLimits...)
+			}
+		}
+		if len(limits) == 0 {
+			return qe, fmt.Errorf("limits for metric %q were not found", k.Metric)
+		}
+
+		for _, limit := range limits {
+			qle := validateLimitQuotas(qs, limit, agg)
+			qe = append(qe, qle...)
+		}
+	}
+	return qe, nil
+}
+
+func validateLimitQuotas(quotas []Quota, limit *sub.ConsumerQuotaLimit, agg aggFn) []QuotaError {
+	qe := []QuotaError{}
+	for _, bucket := range limit.QuotaBuckets {
+		ql := []int64{}
+		for _, q := range quotas {
+			if q.InBucket(bucket) {
+				ql = append(ql, q.Limit)
+			}
+		}
+		if len(ql) == 0 {
+			continue
+		}
+		requested := agg(ql)
+		for _, r := range requested {
+			if !satisfied(r, bucket.EffectiveLimit) {
+				q := quotas[0] // all should have the same consumer, service and metric
+				qe = append(qe, QuotaError{
+					Consumer:       q.Consumer,
+					Service:        q.Service,
+					Metric:         q.Metric,
+					Dimensions:     bucket.Dimensions,
+					EffectiveLimit: bucket.EffectiveLimit,
+					Requested:      r,
+				})
+			}
+		}
+	}
+	return qe
+}
+
+func satisfied(requested int64, limit int64) bool {
+	if limit == -1 {
+		return true
+	}
+	if requested == -1 {
+		return false
+	}
+	return requested <= limit
+}
+
+type aggFn func([]int64) []int64
+
+func aggregation(agg string) (aggFn, error) {
+	switch agg {
+	case "MAX":
+		return func(l []int64) []int64 {
+			max := int64(0)
+			for _, v := range l {
+				if v == -1 {
+					return []int64{-1}
+				}
+				if v > max {
+					max = v
+				}
+			}
+			return []int64{max}
+		}, nil
+	case "SUM":
+		return func(l []int64) []int64 {
+			sum := int64(0)
+			for _, v := range l {
+				if v == -1 {
+					return []int64{-1}
+				}
+				sum += v
+			}
+			return []int64{sum}
+		}, nil
+	case "DO_NOT_AGGREGATE":
+		return func(l []int64) []int64 { return l }, nil
+	default:
+		return nil, fmt.Errorf("aggregation %q is not supported", agg)
+	}
+}
+
+func quotaMetrics(consumer string, service string) ([]*sub.ConsumerQuotaMetric, error) {
+	ctx := context.Background()
+	s, err := sub.NewService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res := []*sub.ConsumerQuotaMetric{}
+	parent := fmt.Sprintf("%s/services/%s", consumer, service)
+	err = s.Services.ConsumerQuotaMetrics.
+		List(parent).
+		View("BASIC"). // BASIC reduces the response size & latency
+		Pages(ctx, func(page *sub.ListConsumerQuotaMetricsResponse) error {
+			res = append(res, page.Metrics...)
+			return nil
+		})
+	return res, err
+}

--- a/pkg/validators/quota_test.go
+++ b/pkg/validators/quota_test.go
@@ -1,0 +1,171 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	sub "google.golang.org/api/serviceusage/v1beta1"
+)
+
+func TestAggregation(t *testing.T) {
+	type test struct {
+		limits      []int64
+		aggregation string
+		want        []int64
+		err         bool
+	}
+	tests := []test{
+		{[]int64{1, 3, 2}, "SUM", []int64{6}, false},
+		{[]int64{1, 3, 2}, "MAX", []int64{3}, false},
+		{[]int64{}, "SUM", []int64{0}, false},
+		{[]int64{}, "MAX", []int64{0}, false},
+		{[]int64{1, -1, 2}, "SUM", []int64{-1}, false},
+		{[]int64{1, -1, 2}, "MAX", []int64{-1}, false},
+		{[]int64{1, -1, 2}, "DO_NOT_AGGREGATE", []int64{1, -1, 2}, false},
+		{[]int64{1, -1, 2}, "KARL_MAX", nil, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s%#v", tc.aggregation, tc.limits), func(t *testing.T) {
+			fn, err := aggregation(tc.aggregation)
+			if tc.err != (err != nil) {
+				t.Errorf("got unexpected error: %s", err)
+			}
+			if err != nil {
+				return
+			}
+			got := fn(tc.limits)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSatisfied(t *testing.T) {
+	type test struct {
+		requested int64
+		limit     int64
+		want      bool
+	}
+	tests := []test{
+		{1, 1, true},
+		{1, 2, true},
+		{2, 1, false},
+		{1, -1, true},
+		{-1, 1, false},
+		{-1, -1, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%d::%d", tc.requested, tc.limit), func(t *testing.T) {
+			got := satisfied(tc.requested, tc.limit)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestQuotaInBucket(t *testing.T) {
+	type test struct {
+		qDimensions map[string]string
+		bDimensions map[string]string
+		want        bool
+	}
+	tests := []test{
+		{map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1", "b": "2"}, true},
+		{map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1", "b": "3"}, false},
+		{map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1"}, true},
+		{map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1", "b": "2", "c": "3"}, false},
+		{map[string]string{}, map[string]string{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%#v::%#v", tc.qDimensions, tc.bDimensions), func(t *testing.T) {
+			q := Quota{Dimensions: tc.qDimensions}
+			b := sub.QuotaBucket{Dimensions: tc.bDimensions}
+
+			got := q.InBucket(&b)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateServiceMetrics(t *testing.T) {
+	// Configured quotas:
+	// global: 5
+	// green_eggs: 3
+	// green_sleeve: -1
+	//
+	// Requested:
+	// green_eggs: 4
+	// green_sleeve: 7
+	//
+	// Expected errors:
+	// green_eggs: 4 > 3
+	// global: 11 > 5
+	buckets := []*sub.QuotaBucket{
+		{
+			EffectiveLimit: int64(5),
+		}, {
+			EffectiveLimit: int64(3),
+			Dimensions:     map[string]string{"green": "eggs"},
+		}, {
+			EffectiveLimit: int64(-1),
+			Dimensions:     map[string]string{"green": "sleeve"},
+		},
+	}
+	quotas := []Quota{
+		{
+			Metric:      "pony",
+			Limit:       int64(4),
+			Dimensions:  map[string]string{"green": "eggs"},
+			Aggregation: "SUM",
+		}, {
+			Metric:      "pony",
+			Limit:       int64(7),
+			Dimensions:  map[string]string{"green": "sleeve"},
+			Aggregation: "SUM",
+		},
+	}
+
+	want := []QuotaError{
+		{Metric: "pony", Dimensions: nil, EffectiveLimit: 5, Requested: 11},
+		{Metric: "pony", Dimensions: map[string]string{"green": "eggs"}, EffectiveLimit: 3, Requested: 4},
+	}
+	got, err := validateServiceMetrics(quotas, []*sub.ConsumerQuotaMetric{
+		{
+			Metric: "pony",
+			ConsumerQuotaLimits: []*sub.ConsumerQuotaLimit{
+				{Metric: "pony", QuotaBuckets: buckets}},
+		},
+	})
+
+	if err != nil {
+		t.Errorf("got unexpected error: %s", err)
+		return
+	}
+	// Sort by error message to make test deterministic
+	sort.Slice(got, func(i, j int) bool { return got[i].Error() < got[j].Error() })
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("diff (-want +got):\n%s", diff)
+	}
+}

--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -20,6 +20,7 @@ use warnings;
 my $min = 80;
 my $cmdmin = 40;
 my $shellmin = 0;
+my $validatorsmin = 25;
 my $failed_coverage = 0;
 
 while (<>){
@@ -28,6 +29,8 @@ while (<>){
     $failed_coverage++ if ($1 < $cmdmin);
   } elsif ( $_ =~ /hpc-toolkit\/pkg\/shell.*coverage: (\d+\.\d)%/) {
     $failed_coverage++ if ($1 < $shellmin);
+  } elsif ( $_ =~ /hpc-toolkit\/pkg\/validators.*coverage: (\d+\.\d)%/) {
+    $failed_coverage++ if ($1 < $validatorsmin);  
   } elsif ( $_ =~ /coverage: (\d+\.\d)%/ ) {
     $failed_coverage++ if ($1 < $min);
   }


### PR DESCRIPTION
* Implement quota validation logic, no interactions with GHPC yet.
* Add code coverage exemption, bumped coverage (0% -> 30%).

**Tested:**
```go
ValidateQuotas([]ResourceRequirement{
	{
		Metric:   "compute.googleapis.com/disks_total_storage",
		Service:  "compute.googleapis.com",
		Consumer: "projects/X",
		Required:    900000,
		Dimensions: map[string]string{ "region": "us-east1" },
		Aggregation: "SUM"},
})

// Got:
QuotaError{Consumer:"projects/X", Service:"compute.googleapis.com", Metric:"compute.googleapis.com/disks_total_storage", Dimensions:map[string]string(nil), EffectiveLimit:A, Requested:900000}
QuotaError{Consumer:"projects/X", Service:"compute.googleapis.com", Metric:"compute.googleapis.com/disks_total_storage", Dimensions:map[string]string{"region":"us-east1"}, EffectiveLimit:B, Requested:900000}
```
