### PR TITLE
Address integration test non-failures

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -131,6 +131,9 @@
       args:
         chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
         executable: /bin/bash
+    - name: Trigger Cloud Build failure (rescue blocks otherwise revert failures)
+      ansible.builtin.fail:
+        msg: "Failed while setting up test infrastructure"
 
 - name: Run Integration Tests
   hosts: remote_host

--- a/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
@@ -51,3 +51,7 @@
       args:
         chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
         executable: /bin/bash
+    - name: Trigger Cloud Build failure
+      when: ghpc_destroy.failed or image_deletion.failed
+      ansible.builtin.fail:
+        msg: "Failed while setting up test infrastructure"


### PR DESCRIPTION
Address 2 instances where tasks in our integration tests fail but Ansible does not ultimately exit with non-0 return code.

- end of rescue blocks must fail, otherwise they "rescue" the failure
- the always block has a sequence of "ignore_errors" to ensure that all tasks are attempted; this commit adds a test to fail if any of the tasks fail

See https://ansible-docs.readthedocs.io/zh/stable-2.0/rst/playbooks_filters.html#filters-often-used-with-conditionals for the implementation syntax of the 2nd bullet.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
