### PR TITLE
Improve zone selection for HTCondor Access Points

### DIFF
--- a/community/modules/scheduler/htcondor-access-point/README.md
+++ b/community/modules/scheduler/htcondor-access-point/README.md
@@ -101,6 +101,7 @@ limitations under the License.
 | <a name="input_service_account_scopes"></a> [service\_account\_scopes](#input\_service\_account\_scopes) | Scopes by which to limit service account attached to central manager. | `set(string)` | <pre>[<br>  "https://www.googleapis.com/auth/cloud-platform"<br>]</pre> | no |
 | <a name="input_spool_parent_dir"></a> [spool\_parent\_dir](#input\_spool\_parent\_dir) | HTCondor access point configuration SPOOL will be set to subdirectory named "spool" | `string` | `"/var/lib/condor"` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork in which the HTCondor central manager will be created. | `string` | `null` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | Zone(s) in which access point may be created. If not supplied, will default to all zones in var.region. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/community/modules/scheduler/htcondor-access-point/variables.tf
+++ b/community/modules/scheduler/htcondor-access-point/variables.tf
@@ -34,6 +34,13 @@ variable "region" {
   type        = string
 }
 
+variable "zones" {
+  description = "Zone(s) in which access point may be created. If not supplied, will default to all zones in var.region."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "network_self_link" {
   description = "The self link of the network in which the HTCondor central manager will be created."
   type        = string


### PR DESCRIPTION
Adopt Toolkit-standard `var.zones` variable to control the zones in which the regional MIG may choose to provision HTCondor access points.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
