### PR TITLE
Add `disk_type` validation for H3

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/outputs.tf
@@ -19,7 +19,11 @@ output "node_groups" {
   value       = local.node_group
 
   precondition {
-    condition     = (substr(var.machine_type, 0, 3) != "c3-") || (var.disk_type != "pd-standard")
-    error_message = "A disk_type of pd-standard cannot be used with c3 machines."
+    condition = !contains([
+      "c3-:pd-standard",
+      "h3-:pd-standard",
+      "h3-:pd-ssd",
+    ], "${substr(var.machine_type, 0, 3)}:${var.disk_type}")
+    error_message = "A disk_type=${var.disk_type} cannot be used with machine_type=${var.machine_type}."
   }
 }

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -238,8 +238,12 @@ resource "google_compute_instance" "compute_vm" {
       error_message = "Exactly one of network_interfaces or network_self_link/subnetwork_self_link must be specified."
     }
     precondition {
-      condition     = (substr(var.machine_type, 0, 3) != "c3-") || (var.disk_type != "pd-standard")
-      error_message = "A disk_type of pd-standard cannot be used with c3 machines."
+      condition = !contains([
+        "c3-:pd-standard",
+        "h3-:pd-standard",
+        "h3-:pd-ssd",
+      ], "${substr(var.machine_type, 0, 3)}:${var.disk_type}")
+      error_message = "A disk_type=${var.disk_type} cannot be used with machine_type=${var.machine_type}."
     }
   }
 }


### PR DESCRIPTION
**Example:**
```hcl
│ Error: Resource precondition failed
│
│   on modules/vm-instance-20ee/main.tf line 241, in resource "google_compute_instance" "compute_vm":
│  241:       condition = !contains([
│  242:         "c3-:pd-standard",
│  243:         "h3-:pd-standard",
│  244:         "h3-:pd-ssd",
│  245:       ], "${substr(var.machine_type, 0, 3)}:${var.disk_type}")
│     ├────────────────
│     │ var.disk_type is "pd-standard"
│     │ var.machine_type is "c3-highcpu-176"
│
│ A disk_type=pd-standard cannot be used with machine_type=c3-highcpu-176.
```