### PR TITLE
Add explicit zone to batch-login-node module

### DIFF
--- a/modules/scheduler/batch-login-node/README.md
+++ b/modules/scheduler/batch-login-node/README.md
@@ -116,6 +116,7 @@ limitations under the License.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region in which to create the login node | `string` | n/a | yes |
 | <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script run before Google Cloud Batch job starts. Typically supplied by a batch-job-template module. | `string` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The zone in which to create the login node | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/scheduler/batch-login-node/main.tf
+++ b/modules/scheduler/batch-login-node/main.tf
@@ -118,6 +118,7 @@ resource "google_compute_instance_from_template" "batch_login" {
   name                     = "${var.deployment_name}-batch-login"
   source_instance_template = var.instance_template
   project                  = var.project_id
+  zone                     = var.zone
   metadata                 = local.login_metadata
 
   service_account {

--- a/modules/scheduler/batch-login-node/variables.tf
+++ b/modules/scheduler/batch-login-node/variables.tf
@@ -29,6 +29,11 @@ variable "region" {
   type        = string
 }
 
+variable "zone" {
+  description = "The zone in which to create the login node"
+  type        = string
+}
+
 variable "labels" {
   description = "Labels to add to the login node. Key-value pairs"
   type        = map(string)


### PR DESCRIPTION
The batch-login-node module does not presently specify a zone for the `google_compute_instance_from_template` resource that creates a "login node" to test Batch jobs. When this variable is not set, [it is set to the provider zone](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_from_template.html#zone).

Any blueprint that sets `vars.zone` will set `zone` in the provider block:

```
provider "google" {
  project = var.project_id
  zone    = var.zone
  region  = var.region
}
```

This allows the batch-login-node to deploy without problem. However, any blueprint that does not set `vars.zone` will not set any value in the provider block. Any module that needs a zone setting, but doesn't have one explicitly set, will experience failures like:

```
Error: Cannot determine zone: set in this resource, or set provider-level zone.

  with module.batch-login.google_compute_instance_from_template.batch_login,
  on modules/embedded/modules/scheduler/batch-login-node/main.tf line 117, in resource "google_compute_instance_from_template" "batch_login":
 117: resource "google_compute_instance_from_template" "batch_login" {

Error: exit status 1
```

This PR addresses the situation by explicitly setting the zone on the resource. This is better than relying on provider-level configuration because one might want the zone of the login node to differ from the default zone.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
