### PR TITLE
Fix object naming conflict in HTCondor modules

### DIFF
--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -97,7 +97,7 @@ data "google_compute_zones" "available" {
 }
 
 resource "google_storage_bucket_object" "execute_config" {
-  name    = "${var.deployment_name}-execute-config-${substr(md5(local.execute_config), 0, 4)}"
+  name    = "${local.hostnames}-config-${substr(md5(local.execute_config), 0, 4)}"
   content = local.execute_config
   bucket  = var.htcondor_bucket_name
 }

--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -111,7 +111,7 @@ data "google_compute_instance" "ap" {
 }
 
 resource "google_storage_bucket_object" "ap_config" {
-  name    = "${var.deployment_name}-ap-config-${substr(md5(local.ap_config), 0, 4)}"
+  name    = "${local.name_prefix}-config-${substr(md5(local.ap_config), 0, 4)}"
   content = local.ap_config
   bucket  = var.htcondor_bucket_name
 }

--- a/community/modules/scheduler/htcondor-central-manager/main.tf
+++ b/community/modules/scheduler/htcondor-central-manager/main.tf
@@ -83,7 +83,7 @@ data "google_compute_instance" "cm" {
 }
 
 resource "google_storage_bucket_object" "cm_config" {
-  name    = "${var.deployment_name}-cm-config-${substr(md5(local.cm_config), 0, 4)}"
+  name    = "${local.name_prefix}-config-${substr(md5(local.cm_config), 0, 4)}"
   content = local.cm_config
   bucket  = var.htcondor_bucket_name
 }


### PR DESCRIPTION
The existing name is not unique enough to support multiple flavors of execute points. Has gone undetected because (typically) the object looks exactly the same for each execute point, but #1596 adds a setting only when the node is known to have a GPU accelerator. This PR disambiguates the GCS objects for execute points in particular and adopts the same naming pattern for access points and the central manager.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
