### PR TITLE
Disambiguate deployment_name for Packer/Slurm test

### DIFF
--- a/tools/cloud-build/daily-tests/tests/packer.yml
+++ b/tools/cloud-build/daily-tests/tests/packer.yml
@@ -15,7 +15,7 @@
 ---
 
 test_name: packer
-deployment_name: packer-image-{{ build }}
+deployment_name: pkr{{ build }}
 zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/image-builder.yaml"


### PR DESCRIPTION
Existing name is long enough that, when shorted by Slurm v5 modules, it results in project metadata keys that are no longer unique

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
