### PR TITLE
Add MIG ID as output/input in HTCondor modules

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -119,6 +119,7 @@ deployment_groups:
     - htcondor_execute_point
     - htcondor_execute_point_spot
     settings:
+      default_mig_id: $(htcondor_execute_point.mig_id)
       enable_public_ips: true
       instance_image:
         project: $(vars.project_id)

--- a/community/modules/compute/htcondor-execute-point/outputs.tf
+++ b/community/modules/compute/htcondor-execute-point/outputs.tf
@@ -18,3 +18,8 @@ output "autoscaler_runner" {
   value       = local.autoscaler_runner
   description = "Toolkit runner to configure the HTCondor autoscaler"
 }
+
+output "mig_id" {
+  value       = module.mig.instance_group_manager.name
+  description = "ID of the managed instance group containing the execute points"
+}

--- a/community/modules/scheduler/htcondor-access-point/README.md
+++ b/community/modules/scheduler/htcondor-access-point/README.md
@@ -46,7 +46,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.9 |
 
@@ -84,6 +84,7 @@ limitations under the License.
 | <a name="input_access_point_service_account_email"></a> [access\_point\_service\_account\_email](#input\_access\_point\_service\_account\_email) | Service account for access point (e-mail format) | `string` | n/a | yes |
 | <a name="input_autoscaler_runner"></a> [autoscaler\_runner](#input\_autoscaler\_runner) | A list of Toolkit runners for configuring autoscaling daemons | `list(map(string))` | `[]` | no |
 | <a name="input_central_manager_ips"></a> [central\_manager\_ips](#input\_central\_manager\_ips) | List of IP addresses of HTCondor Central Managers | `list(string)` | n/a | yes |
+| <a name="input_default_mig_id"></a> [default\_mig\_id](#input\_default\_mig\_id) | Default MIG ID for HTCondor jobs; if unset, jobs must specify MIG id | `string` | `""` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `null` | no |
 | <a name="input_enable_high_availability"></a> [enable\_high\_availability](#input\_enable\_high\_availability) | Provision HTCondor access point in high availability mode | `bool` | `false` | no |
@@ -94,6 +95,7 @@ limitations under the License.
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to resources. List key, value pairs. | `map(string)` | n/a | yes |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to use for HTCondor central managers | `string` | `"c2-standard-4"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata to add to HTCondor central managers | `map(string)` | `{}` | no |
+| <a name="input_mig_id"></a> [mig\_id](#input\_mig\_id) | List of Managed Instance Group IDs containing execute points in this pool (supplied by htcondor-execute-point module) | `list(string)` | `[]` | no |
 | <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | The self link of the network in which the HTCondor central manager will be created. | `string` | `null` | no |
 | <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured | <pre>list(object({<br>    server_ip             = string,<br>    remote_mount          = string,<br>    local_mount           = string,<br>    fs_type               = string,<br>    mount_options         = string,<br>    client_install_runner = map(string)<br>    mount_runner          = map(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |

--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -60,6 +60,8 @@ locals {
     htcondor_role       = "get_htcondor_submit",
     central_manager_ips = var.central_manager_ips
     spool_dir           = "${var.spool_parent_dir}/spool",
+    mig_ids             = var.mig_id,
+    default_mig_id      = var.default_mig_id
   })
 
   ap_object = "gs://${var.htcondor_bucket_name}/${google_storage_bucket_object.ap_config.output_name}"
@@ -116,6 +118,13 @@ resource "google_storage_bucket_object" "ap_config" {
   name    = "${local.name_prefix}-config-${substr(md5(local.ap_config), 0, 4)}"
   content = local.ap_config
   bucket  = var.htcondor_bucket_name
+
+  lifecycle {
+    precondition {
+      condition     = var.default_mig_id == "" || contains(var.mig_id, var.default_mig_id)
+      error_message = "If set, var.default_mig_id must be an element in var.mig_id"
+    }
+  }
 }
 
 module "startup_script" {

--- a/community/modules/scheduler/htcondor-access-point/templates/condor_config.tftpl
+++ b/community/modules/scheduler/htcondor-access-point/templates/condor_config.tftpl
@@ -36,20 +36,35 @@ SYSTEM_JOB_MACHINE_ATTRS_HISTORY_LENGTH = 10
 use feature:ScheddCronOneShot(cloud, $(LIBEXEC)/common-cloud-attributes-google.py)
 SCHEDD_CRON_cloud_PREFIX = Cloud
 
-# the sequence of job transforms and submit requirements below set
-# a default job attribute RequireSpot to False but allow the user to
-# specify *only* a boolean value with +RequireSpot = True in their job
-# submit file; the requirements of the job are transformed to filter
-# on +RequireSpot unless job has explicit CloudInterruptible requirements
-JOB_TRANSFORM_NAMES = SPOT_DEFAULT, SPOT_REQS
-JOB_TRANSFORM_SPOT_DEFAULT @=end
-   DEFAULT RequireSpot False
-@end
-# Unless explicit, set CloudInterruptible requirements to job RequireSpot attribute
+# aid the user by automatically using RequireSpot in their Requirements, unless
+# the user has explicitly used CloudInterruptible
+JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SPOT_REQS
 JOB_TRANSFORM_SPOT_REQS @=end
-   REQUIREMENTS ! unresolved(Requirements, "^CloudInterruptible$")
-   SET Requirements $(MY.Requirements) && (CloudInterruptible is My.RequireSpot)
+  REQUIREMENTS ! isUndefined(RequireSpot) && ! unresolved(Requirements, "^CloudInterruptible$")
+  SET Requirements ($(MY.Requirements)) && (CloudInterruptible is My.RequireSpot)
 @end
-SUBMIT_REQUIREMENT_NAMES = REQSPOT
-SUBMIT_REQUIREMENT_REQSPOT = isBoolean(RequireSpot)
-SUBMIT_REQUIREMENT_REQSPOT_REASON = "Jobs must set +RequireSpot to either True or False"
+
+# help the user by enforcing that RequireSpot is undefined or a boolean
+SUBMIT_REQUIREMENT_NAMES = $(SUBMIT_REQUIREMENT_NAMES) SPOT
+SUBMIT_REQUIREMENT_SPOT = isUndefined(RequireSpot) || isBoolean(RequireSpot)
+SUBMIT_REQUIREMENT_SPOT_REASON = "If +RequireSpot is defined, it must be either True or False"
+
+%{ if length(mig_ids) > 0 ~}
+MIG_IDS = "${join(" ", mig_ids)}"
+MIG_ID_LIST = split($(MIG_IDS))
+%{ if default_mig_id != "" ~}
+JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) ID_DEFAULT
+JOB_TRANSFORM_ID_DEFAULT @=end
+  DEFAULT RequireId "${default_mig_id}"
+@end
+%{ endif ~}
+SUBMIT_REQUIREMENT_NAMES = $(SUBMIT_REQUIREMENT_NAMES) MIGID
+SUBMIT_REQUIREMENT_MIGID = !isUndefined(RequireId) && member(RequireId, $(MIG_ID_LIST))
+SUBMIT_REQUIREMENT_MIGID_REASON = strcat("Jobs must set +RequireId to one of following values surrounded by quotation marks:\n", $(MIG_IDS))
+
+JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SPOT_REQS
+JOB_TRANSFORM_SPOT_REQS @=end
+  REQUIREMENTS ! isUndefined(RequireId) && ! unresolved(Requirements, "^CloudCreatedBy$")
+  SET Requirements ($(MY.Requirements)) && regexp(strcat("/", My.RequireId, "$"), CloudCreatedBy)
+@end
+%{ endif ~}

--- a/community/modules/scheduler/htcondor-access-point/variables.tf
+++ b/community/modules/scheduler/htcondor-access-point/variables.tf
@@ -156,3 +156,22 @@ variable "enable_public_ips" {
   type        = bool
   default     = false
 }
+
+variable "mig_id" {
+  description = "List of Managed Instance Group IDs containing execute points in this pool (supplied by htcondor-execute-point module)"
+  type        = list(string)
+  default     = []
+  nullable    = false
+
+  validation {
+    condition     = length(var.mig_id) > 0
+    error_message = "At least 1 MIG containing execute points must be provided to this module"
+  }
+}
+
+variable "default_mig_id" {
+  description = "Default MIG ID for HTCondor jobs; if unset, jobs must specify MIG id"
+  type        = string
+  default     = ""
+  nullable    = false
+}

--- a/community/modules/scheduler/htcondor-access-point/versions.tf
+++ b/community/modules/scheduler/htcondor-access-point/versions.tf
@@ -29,5 +29,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.20.0"
   }
 
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1"
 }


### PR DESCRIPTION
As part of transition to support N>2 instance configurations in HTCondor pools, jobs will need to identify their target by the ID of the managed instance group. This PR:

- adds the necessary output value and input variable
- removes the requirement that jobs specify `+RequireSpot = False` (or True); the "unset" value will now be allowed
  - logic: the MIG selection identifies pricing model and user can accidentally set these in conflict. Let's only require that one be set (MIG ID)
- renders the configuration logic necessary to guide the user toward setting `+RequireId = "MIG-ID"`

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
