### PR TITLE
Fix provider to 4.74.0

### DIFF
--- a/community/modules/compute/gke-node-pool/README.md
+++ b/community/modules/compute/gke-node-pool/README.md
@@ -177,15 +177,15 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.61.0, < 5.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.61.0, < 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.61.0, <= 4.74.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.61.0, <= 4.74.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.61.0, < 5.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.61.0, < 5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.61.0, <= 4.74.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.61.0, <= 4.74.0 |
 
 ## Modules
 

--- a/community/modules/compute/gke-node-pool/versions.tf
+++ b/community/modules/compute/gke-node-pool/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.61.0, < 5.0"
+      version = ">= 4.61.0, <= 4.74.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.61.0, < 5.0"
+      version = ">= 4.61.0, <= 4.74.0"
     }
   }
   provider_meta "google" {

--- a/pkg/modulewriter/tfversions.go
+++ b/pkg/modulewriter/tfversions.go
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.0"
+      version = "~> 4.74.0"
     }
   }
 }


### PR DESCRIPTION
- Adopt TPG 4.74.0 generally
- Restrict gke-node-pool module to no greater than 4.74.0

Our `make tests` run on each module individually without the general constraint fixing the TPG to 4.XX.Y so they pick the latest release compatible with the module's defined constraints. This addresses recently observed PR-validation failures due to the new field in the guest_accelerator argument to google_container_node_pool resource.

https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.75.0

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
