### PR TITLE
Update DDN-EXAscaler module reference

### DIFF
--- a/community/modules/file-system/DDN-EXAScaler/README.md
+++ b/community/modules/file-system/DDN-EXAScaler/README.md
@@ -102,7 +102,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ddn_exascaler"></a> [ddn\_exascaler](#module\_ddn\_exascaler) | github.com/DDNStorage/exascaler-cloud-terraform//gcp | e33f439a |
+| <a name="module_ddn_exascaler"></a> [ddn\_exascaler](#module\_ddn\_exascaler) | github.com/DDNStorage/exascaler-cloud-terraform//gcp | a3355d50deebe45c0556b45bd599059b7c06988d |
 
 ## Resources
 
@@ -113,7 +113,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_boot"></a> [boot](#input\_boot) | Boot disk properties | <pre>object({<br>    disk_type   = string<br>    auto_delete = bool<br>    script_url  = string<br>  })</pre> | <pre>{<br>  "auto_delete": true,<br>  "disk_type": "pd-standard",<br>  "script_url": null<br>}</pre> | no |
-| <a name="input_cls"></a> [cls](#input\_cls) | Compute client properties | <pre>object({<br>    node_type  = string<br>    node_cpu   = string<br>    nic_type   = string<br>    node_count = number<br>    public_ip  = bool<br>  })</pre> | <pre>{<br>  "nic_type": "GVNIC",<br>  "node_count": 1,<br>  "node_cpu": "Intel Cascade Lake",<br>  "node_type": "n2-standard-2",<br>  "public_ip": true<br>}</pre> | no |
+| <a name="input_cls"></a> [cls](#input\_cls) | Compute client properties | <pre>object({<br>    node_type  = string<br>    node_cpu   = string<br>    nic_type   = string<br>    node_count = number<br>    public_ip  = bool<br>  })</pre> | <pre>{<br>  "nic_type": "GVNIC",<br>  "node_count": 0,<br>  "node_cpu": "Intel Cascade Lake",<br>  "node_type": "n2-standard-2",<br>  "public_ip": true<br>}</pre> | no |
 | <a name="input_clt"></a> [clt](#input\_clt) | Compute client target properties | <pre>object({<br>    disk_bus   = string<br>    disk_type  = string<br>    disk_size  = number<br>    disk_count = number<br>  })</pre> | <pre>{<br>  "disk_bus": "SCSI",<br>  "disk_count": 0,<br>  "disk_size": 256,<br>  "disk_type": "pd-standard"<br>}</pre> | no |
 | <a name="input_fsname"></a> [fsname](#input\_fsname) | EXAScaler filesystem name, only alphanumeric characters are allowed, and the value must be 1-8 characters long | `string` | `"exacloud"` | no |
 | <a name="input_image"></a> [image](#input\_image) | Source image properties | `any` | <pre>{<br>  "family": "exascaler-cloud-6-1-centos",<br>  "project": "ddn-public"<br>}</pre> | no |

--- a/community/modules/file-system/DDN-EXAScaler/main.tf
+++ b/community/modules/file-system/DDN-EXAScaler/main.tf
@@ -42,7 +42,7 @@ locals {
 }
 
 module "ddn_exascaler" {
-  source          = "github.com/DDNStorage/exascaler-cloud-terraform//gcp?ref=e33f439a"
+  source          = "github.com/DDNStorage/exascaler-cloud-terraform//gcp?ref=a3355d50deebe45c0556b45bd599059b7c06988d"
   fsname          = var.fsname
   zone            = var.zone
   project         = var.project_id

--- a/community/modules/file-system/DDN-EXAScaler/variables.tf
+++ b/community/modules/file-system/DDN-EXAScaler/variables.tf
@@ -425,7 +425,7 @@ variable "cls" {
     node_cpu   = "Intel Cascade Lake"
     nic_type   = "GVNIC"
     public_ip  = true
-    node_count = 1
+    node_count = 0
   }
 }
 # Compute client target properties


### PR DESCRIPTION
I updated the DDN-EXAscaler module reference to v6.2 in PR #1606, however there was a bug which caused validation to fail if `var.cls.node_count` was set to zero.  To get around this, I set the default value to 1.  See the following issue in the `DDNStorage/exascaler-cloud-terraform` repo for more information: https://github.com/DDNStorage/exascaler-cloud-terraform/issues/17

This PR:

- Updates the module reference to point to the commit for tag `v2.1.8`, where the fix was implemented.
- Reverts the change to the default value for `var.cls.node_count`, so that it is set to zero.