### PR TITLE
Support N>2 groups of HTCondor execute points

### DIFF
--- a/community/examples/htc-htcondor.yaml
+++ b/community/examples/htc-htcondor.yaml
@@ -91,6 +91,7 @@ deployment_groups:
     - htcondor_setup
     - htcondor_cm
     settings:
+      name_prefix: grp1
       instance_image:
         project: $(vars.project_id)
         family: $(vars.new_image_family)
@@ -104,6 +105,7 @@ deployment_groups:
     - htcondor_setup
     - htcondor_cm
     settings:
+      name_prefix: spot
       instance_image:
         project: $(vars.project_id)
         family: $(vars.new_image_family)

--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -14,20 +14,22 @@ modules.
 
 ### Known limitations
 
-This module may be used exactly 1 or 2 times in a blueprint to create sets of
-execute points in an HTCondor pool. If using 1 set, it may use either Spot or
-On-demand pricing. If using 2 sets, one must use Spot and the other must
-use On-demand pricing. If you do not follow this constraint, you will likely
-receive an error while running `terraform apply` similar to that shown below.
-Future development is planned to support more than 2 sets of VM configurations,
-including all pricing options.
+This module may be used multiple times in a blueprint to create sets of
+execute points in an HTCondor pool. If used more than 1 time, the setting
+[name_prefix](#input_name_prefix) must be set to a value that is unique across
+all uses of the htcondor-execute-point module. If you do not follow this
+constraint, you will likely receive an error while running `terraform apply`
+similar to that shown below.
 
 ```text
-│     │ var.runners is list of map of string with 7 elements
-│
-│ All startup-script runners must have a unique destination.
-│
-│ This was checked by the validation rule at modules/startup-script/variables.tf:72,3-13.
+Error: Invalid value for variable
+
+  on modules/embedded/community/modules/scheduler/htcondor-access-point/main.tf line 136, in module "startup_script":
+ 136:   runners = local.all_runners
+    ├────────────────
+    │ var.runners is list of map of string with 5 elements
+
+All startup-script runners must have a unique destination.
 ```
 
 ### How to configure jobs to select execute points
@@ -203,6 +205,7 @@ limitations under the License.
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum size of the HTCondor execute point pool. | `number` | `100` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata to add to HTCondor execute points | `map(string)` | `{}` | no |
 | <a name="input_min_idle"></a> [min\_idle](#input\_min\_idle) | Minimum number of idle VMs in the HTCondor pool (if pool reaches var.max\_size, this minimum is not guaranteed); set to ensure jobs beginning run more quickly. | `number` | `0` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix given to hostnames in this group of execute points; must be unique across all instances of this module | `string` | n/a | yes |
 | <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | The self link of the network HTCondor execute points will join | `string` | `"default"` | no |
 | <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured | <pre>list(object({<br>    server_ip             = string,<br>    remote_mount          = string,<br>    local_mount           = string,<br>    fs_type               = string,<br>    mount_options         = string,<br>    client_install_runner = map(string)<br>    mount_runner          = map(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HTCondor execute points will be created | `string` | n/a | yes |

--- a/community/modules/compute/htcondor-execute-point/variables.tf
+++ b/community/modules/compute/htcondor-execute-point/variables.tf
@@ -185,3 +185,13 @@ variable "guest_accelerator" {
     error_message = "The HTCondor module supports 0 or 1 models of accelerator card on each execute point"
   }
 }
+
+variable "name_prefix" {
+  description = "Name prefix given to hostnames in this group of execute points; must be unique across all instances of this module"
+  type        = string
+  nullable    = false
+  validation {
+    condition     = length(var.name_prefix) > 0
+    error_message = "var.name_prefix must be a set to a non-empty string and must also be unique across all instances of htcondor-execute-point"
+  }
+}

--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -43,8 +43,6 @@ locals {
       log            = log.$(ClusterId).$(ProcId)
       request_cpus   = 1
       request_memory = 100MB
-      # if unset, defaults to false
-      +RequireSpot   = true
       queue
     EOT
   }

--- a/community/modules/scheduler/htcondor-access-point/templates/condor_config.tftpl
+++ b/community/modules/scheduler/htcondor-access-point/templates/condor_config.tftpl
@@ -38,8 +38,8 @@ SCHEDD_CRON_cloud_PREFIX = Cloud
 
 # aid the user by automatically using RequireSpot in their Requirements, unless
 # the user has explicitly used CloudInterruptible
-JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SPOT_REQS
-JOB_TRANSFORM_SPOT_REQS @=end
+JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SPOT
+JOB_TRANSFORM_SPOT @=end
   REQUIREMENTS ! isUndefined(RequireSpot) && ! unresolved(Requirements, "^CloudInterruptible$")
   SET Requirements ($(MY.Requirements)) && (CloudInterruptible is My.RequireSpot)
 @end
@@ -62,8 +62,8 @@ SUBMIT_REQUIREMENT_NAMES = $(SUBMIT_REQUIREMENT_NAMES) MIGID
 SUBMIT_REQUIREMENT_MIGID = !isUndefined(RequireId) && member(RequireId, $(MIG_ID_LIST))
 SUBMIT_REQUIREMENT_MIGID_REASON = strcat("Jobs must set +RequireId to one of following values surrounded by quotation marks:\n", $(MIG_IDS))
 
-JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) SPOT_REQS
-JOB_TRANSFORM_SPOT_REQS @=end
+JOB_TRANSFORM_NAMES = $(JOB_TRANSFORM_NAMES) MIGID
+JOB_TRANSFORM_MIGID @=end
   REQUIREMENTS ! isUndefined(RequireId) && ! unresolved(Requirements, "^CloudCreatedBy$")
   SET Requirements ($(MY.Requirements)) && regexp(strcat("/", My.RequireId, "$"), CloudCreatedBy)
 @end

--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -208,7 +208,7 @@ class AutoScaler:
         # this query will constrain the search for jobs to those that either
         # require spot VMs or do not require Spot VMs based on whether the
         # VM instance template is configured for Spot pricing
-        spot_query = classad.ExprTree(f"RequireSpot == {self.is_spot}")
+        spot_query = classad.ExprTree(f"RequireId == \"{self.instance_group_manager}\"")
 
         # For purpose of scaling a Managed Instance Group, count only jobs that
         # are idle and likely participated in a negotiation cycle (there does


### PR DESCRIPTION
The solution currently only supports 2 groups of execute points because the naming convention supports a fixed name with "spot" optionally added. This commit modifies the approach to require user specification of a group name that is unique to each group of execute points; future work may avoid need for user to explicitly supply this value.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
