### PR TITLE
Fix: startup script could only be executed from filesystem root

### DIFF
--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -31,7 +31,7 @@ stdlib::runner() {
   stdlib::info "=== start executing runner: $object ==="
   case "$1" in
     ansible-local) stdlib::run_playbook "$destpath/$filename" "$args";;
-    shell) chmod u+x /$destpath/$filename && ./$destpath/$filename $args;;
+    shell) chmod u+x $destpath/$filename && $destpath/$filename $args;;
   esac
   
   exit_code=$?


### PR DESCRIPTION
`destpath` will always be a self contained path and does not need a preceding `/`. The `./` after the `&&` seems to have had no purpose and only worked since startup script is executed at the root directory. 

Manually tested:
- `destination: my_script.sh`
- `destination: home/my_script.sh`
- `destination: ./local/my_script.sh`

`vm-instance` runs startup script through a submodule. This was accounted for by swapping the source using an absolute path during testing for the [startup-script metamodule](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/61130586c901dd9467aefea0aad07629ff5e0531/modules/compute/vm-instance/startup_from_network_storage.tf#L58).

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
