### PR TITLE
Spack module tweeks to make compatible across supported images

### DIFF
--- a/community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl
+++ b/community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl
@@ -34,6 +34,8 @@
         {{ commands }}
         echo " === Finished commands ==="
         } 2>&1 | tee -a {{ log_file }}
+      args:
+        executable: /bin/bash
       register: output
 
     always:

--- a/community/modules/scripts/spack-execute/templates/execute_commands.yml.tpl
+++ b/community/modules/scripts/spack-execute/templates/execute_commands.yml.tpl
@@ -34,6 +34,8 @@
         {{ commands }}
         echo " === Finished commands ==="
         } 2>&1 | tee -a {{ log_file }}
+      args:
+        executable: /bin/bash
       register: output
 
     always:

--- a/community/modules/scripts/spack-setup/main.tf
+++ b/community/modules/scripts/spack-setup/main.tf
@@ -29,7 +29,7 @@ locals {
 
   finalize_setup_script = <<-EOF
     set -e
-    source /etc/profile.d/spack.sh
+    . /etc/profile.d/spack.sh
     spack gpg init
     spack compiler find --scope site
   EOF

--- a/community/modules/scripts/spack-setup/scripts/install_spack_deps.yml
+++ b/community/modules/scripts/spack-setup/scripts/install_spack_deps.yml
@@ -23,7 +23,7 @@
   - name: Install pip3 and git
     ansible.builtin.package:
       name:
-      - python
+      - python3
       - python3-pip
       - git
     register: package


### PR DESCRIPTION
The Spack modules were tested across the following operating systems:

```
      instance_image:
        family: hpc-centos-7
        project: cloud-hpc-image-public

      instance_image:
        family: hpc-rocky-linux-8
        project: cloud-hpc-image-public

      instance_image:
        family: debian-11
        project: debian-cloud

      instance_image:
        family: ubuntu-2004-lts
        project: ubuntu-os-cloud
```

Fixes in this change:
- `source` is not available in default shell for Ubuntu and Debian
- Explicitly call `bash` for command execution to maintain bash pipefail option
- `python` package is not defined for rocky.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
