### PR TITLE
Remove duplicated and outdated outputs from spack-setup

### DIFF
--- a/community/examples/AMD/hpc-amd-slurm.yaml
+++ b/community/examples/AMD/hpc-amd-slurm.yaml
@@ -132,7 +132,7 @@ deployment_groups:
     source: modules/scripts/startup-script
     settings:
       runners:
-      - $(spack-setup.setup_spack_runner)
+      - $(spack-setup.spack_runner)
       # the following installation of AOCC may be automated in the future
       # with a clear direction to the user to read the EULA at
       # https://developer.amd.com/aocc-compiler-eula/

--- a/community/modules/scripts/spack-setup/README.md
+++ b/community/modules/scripts/spack-setup/README.md
@@ -284,10 +284,7 @@ limitations under the License.
 |------|-------------|
 | <a name="output_controller_startup_script"></a> [controller\_startup\_script](#output\_controller\_startup\_script) | Path to the Spack installation script, duplicate for SLURM controller. |
 | <a name="output_gcs_bucket_path"></a> [gcs\_bucket\_path](#output\_gcs\_bucket\_path) | Bucket containing the startup scripts for spack, to be reused by spack-execute module. |
-| <a name="output_install_spack_deps_runner"></a> [install\_spack\_deps\_runner](#output\_install\_spack\_deps\_runner) | Runner to install dependencies for spack using an ansible playbook. The<br>startup-script module will automatically handle installation of ansible.<br>- id: example-startup-script<br>  source: modules/scripts/startup-script<br>  settings:<br>    runners:<br>    - $(your-spack-id.install\_spack\_deps\_runner)<br>... |
-| <a name="output_install_spack_runner"></a> [install\_spack\_runner](#output\_install\_spack\_runner) | Runner to install Spack using the startup-script module |
-| <a name="output_setup_spack_runner"></a> [setup\_spack\_runner](#output\_setup\_spack\_runner) | Adds Spack setup-env.sh script to /etc/profile.d so that it is called at shell startup. Among other things this adds Spack binary to user PATH. |
 | <a name="output_spack_path"></a> [spack\_path](#output\_spack\_path) | Path to the root of the spack installation |
-| <a name="output_spack_runner"></a> [spack\_runner](#output\_spack\_runner) | Runner to install Spack using the startup-script module |
+| <a name="output_spack_runner"></a> [spack\_runner](#output\_spack\_runner) | Runner to be used with startup-script module or passed to spack-execute module.<br>- installs Spack dependencies<br>- installs Spack <br>- generates profile.d script to enable access to Spack<br>This is safe to run in parallel by multiple machines. Use in place of deprecated `setup_spack_runner`. |
 | <a name="output_startup_script"></a> [startup\_script](#output\_startup\_script) | Path to the Spack installation script. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/spack-setup/README.md
+++ b/community/modules/scripts/spack-setup/README.md
@@ -96,33 +96,12 @@ To see a full example of this module in use, see the [hpc-slurm-gromacs.yaml] ex
 [Spack installation] produces a setup script that adds `spack` to your `PATH` as
 well as some other command-line integration tools. This script can be found at
 `<install path>/share/spack/setup-env.sh`. This script will be automatically
-added to bash startup by the `spack_runner`. In the case that you are using
-Spack on a different machine than the one where Spack was installed, you can use
-the `setup_spack_runner` to make sure Spack is also available on that machine.
+added to bash startup by any machine that runs the `spack_runner`.
+
+If you have multiple machines that all want to use the same shared Spack
+installation you can just have both machines run the `spack_runner`.
 
 [Spack installation]: https://spack-tutorial.readthedocs.io/en/latest/tutorial_basics.html#installing-spack
-
-### Example using `setup_spack_runner`
-
-The following examples assumes that a different machine is running
-`$(spack.install_spack_runner)` and the Slurm login node has access to the Spack
-instal through a shared file system.
-
-```yaml
-  - id: spack
-    source: community/modules/scripts/spack-setup
-    ...
-
-  - id: spack-setup
-    source: modules/scripts/startup-script
-    settings:
-      runners:
-      - $(spack.setup_spack_runner)
-
-  - id: slurm_login
-    source: community/modules/scheduler/SchedMD-slurm-on-gcp-login-node
-    use: [spack-setup, ...]
-```
 
 ### Managing Spack Python dependencies
 

--- a/community/modules/scripts/spack-setup/outputs.tf
+++ b/community/modules/scripts/spack-setup/outputs.tf
@@ -24,46 +24,19 @@ output "controller_startup_script" {
   value       = module.startup_script.startup_script
 }
 
-output "install_spack_deps_runner" {
-  description = <<-EOT
-  Runner to install dependencies for spack using an ansible playbook. The
-  startup-script module will automatically handle installation of ansible.
-  - id: example-startup-script
-    source: modules/scripts/startup-script
-    settings:
-      runners:
-      - $(your-spack-id.install_spack_deps_runner)
-  ...
-  EOT
-  value       = local.install_spack_deps_runner
-}
-
-output "install_spack_runner" {
-  description = "Runner to install Spack using the startup-script module"
-  value       = local.combined_runner
-}
-
-output "setup_spack_runner" {
-  description = "Adds Spack setup-env.sh script to /etc/profile.d so that it is called at shell startup. Among other things this adds Spack binary to user PATH."
-  value = {
-    "type"        = "data"
-    "destination" = "/etc/profile.d/spack.sh"
-    "content"     = <<-EOT
-      #!/bin/sh
-      if [ -f ${var.install_dir}/share/spack/setup-env.sh ]; then
-              . ${var.install_dir}/share/spack/setup-env.sh
-      fi
-      EOT
-  }
-}
-
 output "spack_path" {
   description = "Path to the root of the spack installation"
   value       = var.install_dir
 }
 
 output "spack_runner" {
-  description = "Runner to install Spack using the startup-script module"
+  description = <<-EOT
+  Runner to be used with startup-script module or passed to spack-execute module.
+  - installs Spack dependencies
+  - installs Spack 
+  - generates profile.d script to enable access to Spack
+  This is safe to run in parallel by multiple machines. Use in place of deprecated `setup_spack_runner`.
+  EOT
   value       = local.combined_runner
 }
 

--- a/examples/serverless-batch-mpi.yaml
+++ b/examples/serverless-batch-mpi.yaml
@@ -153,13 +153,7 @@ deployment_groups:
       task_count: 2
       mpi_mode: true
 
-  - id: login-spack-setup
-    source: modules/scripts/startup-script
-    settings:
-      runners:
-      - $(spack-setup.setup_spack_runner)
-
   - id: batch-login
     source: modules/scheduler/batch-login-node
-    use: [login-spack-setup, batch-job]
+    use: [spack-setup, batch-job]
     outputs: [instructions]


### PR DESCRIPTION
`install_spack_deps_runner`, `install_spack_runner`, and `setup_spack_runner` have all been combined and replaced by `spack-runner`. There is no harm to run each of these steps multiple times or in parallel on multiple machines so they no longer need to be delivered separately. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
