### PR TITLE
Fix "Apply" prompt so user input is separated

### DIFF
--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -99,11 +99,11 @@ func ApplyChangesChoice(c ProposedChanges) bool {
 	var userResponse string
 
 	for {
-		fmt.Print(`Please select an option below [d,a,s,c]:
-(D)isplay full proposed changes,
+		fmt.Print(`(D)isplay full proposed changes,
 (A)pply proposed changes,
 (S)top and exit,
-(C)ontinue without applying`)
+(C)ontinue without applying
+Please select an option [d,a,s,c]: `)
 
 		_, err := fmt.Scanln(&userResponse)
 		if err != nil {


### PR DESCRIPTION
Currently, the "Apply changes" prompt looks like this:

```
Please select an option below [d,a,s,c]:
(D)isplay full proposed changes,
(A)pply proposed changes,
(S)top and exit,
(C)ontinue without applying
```

Because there is no trailing newline, the user's input appears immediately after `(C)ontinue without applying`, without any spaces.  For example (notice the "**d**" after "applying"):
<pre>
(C)ontinue without applying<b>d</b>
</pre>

This PR updates the prompt to clearly separate the user's input from the prompt.