### PR TITLE
Support specification of MIG target shape in HTCondor modules

### DIFF
--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -176,7 +176,7 @@ limitations under the License.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_execute_point_instance_template"></a> [execute\_point\_instance\_template](#module\_execute\_point\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 8.0 |
-| <a name="module_mig"></a> [mig](#module\_mig) | terraform-google-modules/vm/google//modules/mig | ~> 8.0 |
+| <a name="module_mig"></a> [mig](#module\_mig) | github.com/terraform-google-modules/terraform-google-vm//modules/mig | aea74d1 |
 | <a name="module_startup_script"></a> [startup\_script](#module\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.20.0&depth=1 |
 
 ## Resources
@@ -194,6 +194,7 @@ limitations under the License.
 | <a name="input_central_manager_ips"></a> [central\_manager\_ips](#input\_central\_manager\_ips) | List of IP addresses of HTCondor Central Managers | `list(string)` | n/a | yes |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `100` | no |
+| <a name="input_distribution_policy_target_shape"></a> [distribution\_policy\_target\_shape](#input\_distribution\_policy\_target\_shape) | Target shape across zones for instance group managing execute points | `string` | `"ANY"` | no |
 | <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with "ENABLE" or "DISABLE". Set to "INHERIT" to inherit project OS Login setting. | `string` | `"ENABLE"` | no |
 | <a name="input_execute_point_runner"></a> [execute\_point\_runner](#input\_execute\_point\_runner) | A list of Toolkit runners for configuring an HTCondor execute point | `list(map(string))` | `[]` | no |
 | <a name="input_execute_point_service_account_email"></a> [execute\_point\_service\_account\_email](#input\_execute\_point\_service\_account\_email) | Service account for HTCondor execute point (e-mail format) | `string` | n/a | yes |

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -137,15 +137,15 @@ module "execute_point_instance_template" {
 }
 
 module "mig" {
-  source                    = "terraform-google-modules/vm/google//modules/mig"
-  version                   = "~> 8.0"
-  project_id                = var.project_id
-  region                    = var.region
-  distribution_policy_zones = local.zones
-  target_size               = var.target_size
-  hostname                  = local.name_prefix
-  mig_name                  = local.name_prefix
-  instance_template         = module.execute_point_instance_template.self_link
+  source                           = "github.com/terraform-google-modules/terraform-google-vm//modules/mig?ref=aea74d1"
+  project_id                       = var.project_id
+  region                           = var.region
+  distribution_policy_target_shape = var.distribution_policy_target_shape
+  distribution_policy_zones        = local.zones
+  target_size                      = var.target_size
+  hostname                         = local.name_prefix
+  mig_name                         = local.name_prefix
+  instance_template                = module.execute_point_instance_template.self_link
 
   health_check_name = "health-htcondor-${local.name_prefix}"
   health_check = {

--- a/community/modules/compute/htcondor-execute-point/variables.tf
+++ b/community/modules/compute/htcondor-execute-point/variables.tf
@@ -31,6 +31,12 @@ variable "zones" {
   nullable    = false
 }
 
+variable "distribution_policy_target_shape" {
+  description = "Target shape across zones for instance group managing execute points"
+  type        = string
+  default     = "ANY"
+}
+
 variable "deployment_name" {
   description = "HPC Toolkit deployment name. HTCondor cloud resource names will include this value."
   type        = string

--- a/community/modules/scheduler/htcondor-access-point/README.md
+++ b/community/modules/scheduler/htcondor-access-point/README.md
@@ -62,7 +62,7 @@ limitations under the License.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_point_instance_template"></a> [access\_point\_instance\_template](#module\_access\_point\_instance\_template) | github.com/terraform-google-modules/terraform-google-vm//modules/instance_template | 84d7959 |
-| <a name="module_htcondor_ap"></a> [htcondor\_ap](#module\_htcondor\_ap) | github.com/terraform-google-modules/terraform-google-vm//modules/mig | 84d7959 |
+| <a name="module_htcondor_ap"></a> [htcondor\_ap](#module\_htcondor\_ap) | github.com/terraform-google-modules/terraform-google-vm//modules/mig | aea74d1 |
 | <a name="module_startup_script"></a> [startup\_script](#module\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.20.0&depth=1 |
 
 ## Resources
@@ -87,6 +87,7 @@ limitations under the License.
 | <a name="input_default_mig_id"></a> [default\_mig\_id](#input\_default\_mig\_id) | Default MIG ID for HTCondor jobs; if unset, jobs must specify MIG id | `string` | `""` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `null` | no |
+| <a name="input_distribution_policy_target_shape"></a> [distribution\_policy\_target\_shape](#input\_distribution\_policy\_target\_shape) | Target shape acoss zones for instance group managing high availability of access point | `string` | `"BALANCED"` | no |
 | <a name="input_enable_high_availability"></a> [enable\_high\_availability](#input\_enable\_high\_availability) | Provision HTCondor access point in high availability mode | `bool` | `false` | no |
 | <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with "ENABLE" or "DISABLE". Set to "INHERIT" to inherit project OS Login setting. | `string` | `"ENABLE"` | no |
 | <a name="input_enable_public_ips"></a> [enable\_public\_ips](#input\_enable\_public\_ips) | Enable Public IPs on the access points | `bool` | `false` | no |

--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -160,14 +160,15 @@ module "access_point_instance_template" {
 
 module "htcondor_ap" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/terraform-google-modules/terraform-google-vm//modules/mig?ref=84d7959"
+  source = "github.com/terraform-google-modules/terraform-google-vm//modules/mig?ref=aea74d1"
 
-  project_id                = var.project_id
-  region                    = var.region
-  distribution_policy_zones = local.zones
-  target_size               = local.host_count
-  hostname                  = local.name_prefix
-  instance_template         = module.access_point_instance_template.self_link
+  project_id                       = var.project_id
+  region                           = var.region
+  distribution_policy_target_shape = var.distribution_policy_target_shape
+  distribution_policy_zones        = local.zones
+  target_size                      = local.host_count
+  hostname                         = local.name_prefix
+  instance_template                = module.access_point_instance_template.self_link
 
   health_check_name = "health-${local.name_prefix}"
   health_check = {

--- a/community/modules/scheduler/htcondor-access-point/variables.tf
+++ b/community/modules/scheduler/htcondor-access-point/variables.tf
@@ -41,6 +41,12 @@ variable "zones" {
   nullable    = false
 }
 
+variable "distribution_policy_target_shape" {
+  description = "Target shape acoss zones for instance group managing high availability of access point"
+  type        = string
+  default     = "BALANCED"
+}
+
 variable "network_self_link" {
   description = "The self link of the network in which the HTCondor central manager will be created."
   type        = string

--- a/community/modules/scheduler/htcondor-central-manager/README.md
+++ b/community/modules/scheduler/htcondor-central-manager/README.md
@@ -98,7 +98,7 @@ limitations under the License.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_central_manager_instance_template"></a> [central\_manager\_instance\_template](#module\_central\_manager\_instance\_template) | github.com/terraform-google-modules/terraform-google-vm//modules/instance_template | 84d7959 |
-| <a name="module_htcondor_cm"></a> [htcondor\_cm](#module\_htcondor\_cm) | github.com/terraform-google-modules/terraform-google-vm//modules/mig | 84d7959 |
+| <a name="module_htcondor_cm"></a> [htcondor\_cm](#module\_htcondor\_cm) | github.com/terraform-google-modules/terraform-google-vm//modules/mig | aea74d1 |
 | <a name="module_startup_script"></a> [startup\_script](#module\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.20.0&depth=1 |
 
 ## Resources
@@ -120,6 +120,7 @@ limitations under the License.
 | <a name="input_central_manager_service_account_email"></a> [central\_manager\_service\_account\_email](#input\_central\_manager\_service\_account\_email) | Service account e-mail for central manager (can be supplied by htcondor-setup module) | `string` | n/a | yes |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `20` | no |
+| <a name="input_distribution_policy_target_shape"></a> [distribution\_policy\_target\_shape](#input\_distribution\_policy\_target\_shape) | Target shape for instance group managing high availability of central manager | `string` | `"BALANCED"` | no |
 | <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with "ENABLE" or "DISABLE". Set to "INHERIT" to inherit project OS Login setting. | `string` | `"ENABLE"` | no |
 | <a name="input_htcondor_bucket_name"></a> [htcondor\_bucket\_name](#input\_htcondor\_bucket\_name) | Name of HTCondor configuration bucket | `string` | n/a | yes |
 | <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Custom VM image with HTCondor installed using the htcondor-install module. | <pre>object({<br>    family  = string,<br>    project = string<br>  })</pre> | n/a | yes |

--- a/community/modules/scheduler/htcondor-central-manager/main.tf
+++ b/community/modules/scheduler/htcondor-central-manager/main.tf
@@ -123,14 +123,15 @@ module "central_manager_instance_template" {
 
 module "htcondor_cm" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/terraform-google-modules/terraform-google-vm//modules/mig?ref=84d7959"
+  source = "github.com/terraform-google-modules/terraform-google-vm//modules/mig?ref=aea74d1"
 
-  project_id                = var.project_id
-  region                    = var.region
-  distribution_policy_zones = local.zones
-  target_size               = 1
-  hostname                  = local.name_prefix
-  instance_template         = module.central_manager_instance_template.self_link
+  project_id                       = var.project_id
+  region                           = var.region
+  distribution_policy_target_shape = var.distribution_policy_target_shape
+  distribution_policy_zones        = local.zones
+  target_size                      = 1
+  hostname                         = local.name_prefix
+  instance_template                = module.central_manager_instance_template.self_link
 
   health_check_name = "health-${local.name_prefix}"
   health_check = {

--- a/community/modules/scheduler/htcondor-central-manager/variables.tf
+++ b/community/modules/scheduler/htcondor-central-manager/variables.tf
@@ -41,6 +41,12 @@ variable "zones" {
   nullable    = false
 }
 
+variable "distribution_policy_target_shape" {
+  description = "Target shape for instance group managing high availability of central manager"
+  type        = string
+  default     = "BALANCED"
+}
+
 variable "network_self_link" {
   description = "The self link of the network in which the HTCondor central manager will be created."
   type        = string


### PR DESCRIPTION
See description in title. Making a conscious decision to use "balanced" as default for Access Point and Central Manager as it will honor "zone with most available resources" and increase likelihood they are provisioned in the same zone. For execute point, choose `ANY` as "Recommended for batch workloads that do not require high availability." See below for context:

https://cloud.google.com/compute/docs/instance-groups/regional-mig-distribution-shape

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
