### PR TITLE
Add a prefix to release labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
   labels:
   - dependencies
   - python
-  - chore
+  - release-chore
   schedule:
     interval: monthly
     time: "03:00"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,27 +18,27 @@
 changelog:
   exclude:
     labels:
-    - chore
+    - release-chore
     authors: []
   categories:
   - title: Key New Features 🎉
     labels:
-    - key-new-features
+    - release-key-new-features
   - title: New Modules 🧱
     labels:
-    - new-modules
+    - release-new-modules
   - title: Module Improvements 🛠
     labels:
-    - module-improvements
+    - release-module-improvements
   - title: Improvements
     labels:
-    - improvements
+    - release-improvements
   - title: Deprecations
     labels:
-    - deprecations
+    - release-deprecations
   - title: Version Updates
     labels:
-    - version-updates
+    - release-version-updates
   - title: Other changes
     labels:
     - "*"

--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -31,7 +31,7 @@ on:
     - develop
 
 jobs:
-  label:
+  pr-label-validation:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -41,8 +41,8 @@ jobs:
       with:
         mode: minimum
         count: 1
-        labels: "chore, key-new-features, new-modules, module-improvements, improvements, deprecations, version-updates"
-        message: "This PR is being prevented from merging because it is not labeled.  Please add a label to this PR.  Accepted labels: chore, key-new-features, new-modules, module-improvements, improvements, deprecations, version-updates"
+        labels: "release-chore, release-key-new-features, release-new-modules, release-module-improvements, release-improvements, release-deprecations, release-version-updates"
+        message: "This PR is being prevented from merging because it is not labeled.  Please add a label to this PR.  Accepted labels: release-chore, release-key-new-features, release-new-modules, release-module-improvements, release-improvements, release-deprecations, release-version-updates"
     - id: print-labels
       run: |
         echo "Current PR labels:"


### PR DESCRIPTION
This PR adds a prefix (`release-`) to the names of release PR labels.  This will make it easier to identify which labels are required for the `pr-label-validation` PR check.