### PR TITLE
Add check for invalid module id

### DIFF
--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -175,6 +175,9 @@ func validateModule(p modulePath, m Module, bp Blueprint) error {
 	if m.ID == "" {
 		errs.At(p.ID, fmt.Errorf(errorMessages["emptyID"]))
 	}
+	if m.ID == "vars" { // invalid module ID
+		errs.At(p.ID, errors.New("module id cannot be 'vars'"))
+	}
 	return errs.
 		Add(validateSettings(p, m, info)).
 		Add(validateOutputs(p, m, info)).

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -100,6 +100,15 @@ func (s *MySuite) TestValidateModule(c *C) {
 		c.Check(err, NotNil)
 	}
 
+	{ // Catch invalid ID
+		err := validateModule(p, Module{
+			ID:     "vars",
+			Source: "green",
+			Kind:   TerraformKind,
+		}, dummyBp)
+		c.Check(err, NotNil)
+	}
+
 	{ // Catch no Source
 		err := validateModule(p, Module{ID: "bond"}, dummyBp)
 		c.Check(err, NotNil)


### PR DESCRIPTION
This adds a check in module validator to check and return error if the module id is set to invalid IDs such as `vars`.