### PR TITLE
Add hint to error message `invalid module reference: var`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95 // indirect
 	github.com/acomagu/bufpipe v1.0.4 // indirect
-	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/agext/levenshtein v1.2.2
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,7 +50,6 @@ var errorMessages = map[string]string{
 	"missingSetting":    "a required setting is missing from a module",
 	"settingsLabelType": "labels in module settings are not a map",
 	"invalidVar":        "invalid variable definition in",
-	"invalidMod":        "invalid module reference",
 	"varNotFound":       "Could not find source of variable",
 	"intergroupOrder":   "References to outputs from other groups must be to earlier groups",
 	"noOutput":          "Output not found for a variable",
@@ -130,7 +129,7 @@ func (bp *Blueprint) Module(id ModuleID) (*Module, error) {
 		return nil
 	})
 	if mod == nil {
-		err := InvalidModuleError{string(id)}
+		err := InvalidModuleError{id}
 		clMod := ""
 		minDist := -1.0
 		bp.WalkModules(func(m *Module) error {
@@ -158,7 +157,7 @@ func (bp Blueprint) ModuleGroup(mod ModuleID) (DeploymentGroup, error) {
 			}
 		}
 	}
-	return DeploymentGroup{}, InvalidModuleError{string(mod)}
+	return DeploymentGroup{}, InvalidModuleError{mod}
 }
 
 // ModuleGroupOrDie returns the group containing the module; panics if unfound

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,7 +137,7 @@ func (bp *Blueprint) Module(id ModuleID) (*Module, error) {
 
 // SuggestModuleIDHint return a correct spelling of given ModuleID id if one
 // is close enough (based on maxHintDist)
-func (bp *Blueprint) SuggestModuleIDHint(id ModuleID) (string, bool) {
+func (bp Blueprint) SuggestModuleIDHint(id ModuleID) (string, bool) {
 	clMod := ""
 	minDist := -1
 	bp.WalkModules(func(m *Module) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1039,17 +1039,17 @@ func (s *MySuite) TestValidateModuleSettingReference(c *C) {
 	// FAIL. get global hint
 	mod := ModuleID("var")
 	unkModErr := UnknownModuleError{mod}
-	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{"vars", unkModErr}), Equals, true)
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{"Did you mean \"vars\"?", unkModErr}), Equals, true)
 
 	// FAIL. get module ID hint
 	mod = ModuleID("pkp")
 	unkModErr = UnknownModuleError{mod}
-	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{string(pkr.ID), unkModErr}), Equals, true)
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{fmt.Sprintf("Did you mean \"%s\"?", string(pkr.ID)), unkModErr}), Equals, true)
 
 	// FAIL. get no hint
 	mod = ModuleID("test")
 	unkModErr = UnknownModuleError{mod}
-	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{string(pkr.ID), unkModErr}), Equals, false)
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{fmt.Sprintf("Did you mean \"%s\"?", string(pkr.ID)), unkModErr}), Equals, false)
 	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), unkModErr), Equals, true)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1033,8 +1033,24 @@ func (s *MySuite) TestValidateModuleSettingReference(c *C) {
 	// FAIL. missing output
 	c.Check(vld(bp, mod22, ModuleRef("mod21", "kale")), NotNil)
 
-	// Fail. packer module
+	// FAIL. packer module
 	c.Check(vld(bp, mod21, ModuleRef("pkr", "outPkr")), NotNil)
+
+	// FAIL. get global hint
+	mod := ModuleID("var")
+	unkModErr := UnknownModuleError{mod}
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{"vars", unkModErr}), Equals, true)
+
+	// FAIL. get module ID hint
+	mod = ModuleID("pkp")
+	unkModErr = UnknownModuleError{mod}
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{string(pkr.ID), unkModErr}), Equals, true)
+
+	// FAIL. get no hint
+	mod = ModuleID("test")
+	unkModErr = UnknownModuleError{mod}
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{string(pkr.ID), unkModErr}), Equals, false)
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), unkModErr), Equals, true)
 }
 
 func (s *MySuite) TestValidateModuleSettingReferences(c *C) {

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -33,6 +33,23 @@ func (e BpError) Unwrap() error {
 	return e.Err
 }
 
+// HintError is an error wrapper to suggest other variable names
+type HintError struct {
+	varName string
+	Err     error
+}
+
+func (e HintError) Error() string {
+	if len(e.varName) > 0 {
+		return fmt.Sprintf("%s. Did you mean \"%s\"?", e.Err, e.varName)
+	}
+	return e.Err.Error()
+}
+
+func (e HintError) Unwrap() error {
+	return e.Err
+}
+
 // InvalidSettingError signifies a problem with the supplied setting name in a
 // module definition.
 type InvalidSettingError struct {

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -33,15 +33,15 @@ func (e BpError) Unwrap() error {
 	return e.Err
 }
 
-// HintError is an error wrapper to suggest other variable names
+// HintError wraps another error to suggest other values
 type HintError struct {
-	varName string
-	Err     error
+	Hint string
+	Err  error
 }
 
 func (e HintError) Error() string {
-	if len(e.varName) > 0 {
-		return fmt.Sprintf("%s. Did you mean \"%s\"?", e.Err, e.varName)
+	if len(e.Hint) > 0 {
+		return fmt.Sprintf("%s - Did you mean '%s'?", e.Err, e.Hint)
 	}
 	return e.Err.Error()
 }
@@ -58,6 +58,15 @@ type InvalidSettingError struct {
 
 func (err *InvalidSettingError) Error() string {
 	return fmt.Sprintf("invalid setting provided to a module, cause: %v", err.cause)
+}
+
+// InvalidModuleError signifies a problem with the supplied module name.
+type InvalidModuleError struct {
+	modID string
+}
+
+func (e InvalidModuleError) Error() string {
+	return fmt.Sprintf("%s: %s", errorMessages["invalidMod"], e.modID)
 }
 
 // Errors is an error wrapper to combine multiple errors

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -62,11 +62,11 @@ func (err *InvalidSettingError) Error() string {
 
 // InvalidModuleError signifies a problem with the supplied module name.
 type InvalidModuleError struct {
-	modID string
+	modID ModuleID
 }
 
 func (e InvalidModuleError) Error() string {
-	return fmt.Sprintf("%s: %s", errorMessages["invalidMod"], e.modID)
+	return fmt.Sprintf("invalid module reference: \"%s\"", e.modID)
 }
 
 // Errors is an error wrapper to combine multiple errors

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -41,7 +41,7 @@ type HintError struct {
 
 func (e HintError) Error() string {
 	if len(e.Hint) > 0 {
-		return fmt.Sprintf("%s - Did you mean '%s'?", e.Err, e.Hint)
+		return fmt.Sprintf("%s - Did you mean \"%s\"?", e.Err, e.Hint)
 	}
 	return e.Err.Error()
 }
@@ -60,13 +60,13 @@ func (err *InvalidSettingError) Error() string {
 	return fmt.Sprintf("invalid setting provided to a module, cause: %v", err.cause)
 }
 
-// InvalidModuleError signifies a problem with the supplied module name.
-type InvalidModuleError struct {
-	modID ModuleID
+// UnknownModuleError signifies a problem with the supplied module name.
+type UnknownModuleError struct {
+	ID ModuleID
 }
 
-func (e InvalidModuleError) Error() string {
-	return fmt.Sprintf("invalid module reference: \"%s\"", e.modID)
+func (e UnknownModuleError) Error() string {
+	return fmt.Sprintf("invalid module id: \"%s\"", e.ID)
 }
 
 // Errors is an error wrapper to combine multiple errors

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -41,7 +41,7 @@ type HintError struct {
 
 func (e HintError) Error() string {
 	if len(e.Hint) > 0 {
-		return fmt.Sprintf("%s - Did you mean \"%s\"?", e.Err, e.Hint)
+		return fmt.Sprintf("%s - %s", e.Err, e.Hint)
 	}
 	return e.Err.Error()
 }

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -551,7 +551,7 @@ func intersection(s1 []string, s2 []string) []string {
 }
 
 // Find the closest module that the reference could be referring to (only ones that are defined before reference)
-// Returns a hint string to be part of an error message
+// Returns a string with the closest module name (default vars)
 // Currently limited to finding strings that are at least 40% similar based on module string length and levenshtein distance
 func closestReference(bp *Blueprint, mod *Module, ref *Reference) string {
 	minDist := 0.0

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -23,7 +23,6 @@ import (
 
 	"hpc-toolkit/pkg/modulereader"
 
-	"github.com/agext/levenshtein"
 	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -340,8 +339,8 @@ func validateModuleSettingReference(bp Blueprint, mod Module, r Reference) error
 	}
 
 	if err := validateModuleReference(bp, mod, r.Module); err != nil {
-		if strings.Contains(err.Error(), errorMessages["invalidMod"]) {
-			err = HintError{closestReference(&bp, &mod, &r), err}
+		if _, ok := err.(InvalidModuleError); ok && bp.Vars.Has(r.Name) {
+			err = HintError{fmt.Sprintf("vars.%s", r.Name), err}
 		}
 		return err
 	}
@@ -548,44 +547,4 @@ func intersection(s1 []string, s2 []string) []string {
 	is := maps.Keys(both)
 	slices.Sort(is)
 	return is
-}
-
-// Find the closest module that the reference could be referring to (only ones that are defined before reference)
-// Returns a string with the closest module name (default vars)
-// Currently limited to finding strings that are at least 40% similar based on module string length and levenshtein distance
-func closestReference(bp *Blueprint, mod *Module, ref *Reference) string {
-	minDist := 0.0
-	var clMod Module
-	newRef := "vars"
-
-	if bp.Vars.Has(string(ref.Name)) {
-		return newRef
-	}
-
-top:
-	for _, g := range bp.DeploymentGroups {
-		for _, m := range g.Modules {
-			switch m.ID {
-			case mod.ID:
-				break top
-			case ref.Module:
-				clMod = m
-				minDist = 0
-				break top
-			default:
-				dist := float64(levenshtein.Distance(string(m.ID), string(ref.Module), nil)) / float64(len(string(m.ID)))
-				if minDist == 0 || dist < minDist {
-					minDist = dist
-					clMod = m
-				}
-			}
-		}
-	}
-
-	// Check if the closest mod is close enough
-	if minDist > 0 && minDist <= 0.6 {
-		newRef = string(clMod.ID)
-	}
-
-	return newRef
 }

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -311,7 +311,7 @@ func validateModuleReference(bp Blueprint, from Module, toID ModuleID) error {
 	to, err := bp.Module(toID)
 	if err != nil {
 		if hint, ok := bp.SuggestModuleIDHint(toID); ok {
-			return HintError{hint, err}
+			return HintError{fmt.Sprintf("Did you mean \"%s\"?", hint), err}
 		}
 		return err
 	}
@@ -346,7 +346,7 @@ func validateModuleSettingReference(bp Blueprint, mod Module, r Reference) error
 	if err := validateModuleReference(bp, mod, r.Module); err != nil {
 		var unkModErr UnknownModuleError
 		if errors.As(err, &unkModErr) && levenshtein.Distance(string(unkModErr.ID), "vars", nil) <= 2 {
-			return HintError{"vars", unkModErr}
+			return HintError{"Did you mean \"vars\"?", unkModErr}
 		}
 		return err
 	}

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -23,6 +24,7 @@ import (
 
 	"hpc-toolkit/pkg/modulereader"
 
+	"github.com/agext/levenshtein"
 	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -308,6 +310,9 @@ func AutomaticOutputName(outputName string, moduleID ModuleID) string {
 func validateModuleReference(bp Blueprint, from Module, toID ModuleID) error {
 	to, err := bp.Module(toID)
 	if err != nil {
+		if hint, ok := bp.SuggestModuleIDHint(toID); ok {
+			return HintError{hint, err}
+		}
 		return err
 	}
 
@@ -339,8 +344,9 @@ func validateModuleSettingReference(bp Blueprint, mod Module, r Reference) error
 	}
 
 	if err := validateModuleReference(bp, mod, r.Module); err != nil {
-		if _, ok := err.(InvalidModuleError); ok && bp.Vars.Has(r.Name) {
-			err = HintError{fmt.Sprintf("vars.%s", r.Name), err}
+		var unkModErr UnknownModuleError
+		if errors.As(err, &unkModErr) && levenshtein.Distance(string(unkModErr.ID), "vars", nil) <= 2 {
+			return HintError{"vars", unkModErr}
 		}
 		return err
 	}

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -230,7 +230,7 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 
 		// Use ID doesn't exists (fail)
 		g.Modules[len(g.Modules)-1].ID = "wrongID"
-		c.Assert(dc.applyUseModules(), ErrorMatches, fmt.Sprintf("%s: %s", errorMessages["invalidMod"], used.ID))
+		c.Assert(dc.applyUseModules(), ErrorMatches, fmt.Sprintf("%s: %s - Did you mean '%s'\\?", errorMessages["invalidMod"], used.ID, using.ID))
 	}
 
 	{ // test multigroup deployment with config that has a known good match

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -232,9 +232,9 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 		// Use ID doesn't exists (fail)
 		g.Modules[len(g.Modules)-1].ID = "wrongID"
 		err := dc.applyUseModules()
-		invModErr := InvalidModuleError{used.ID}
-		c.Assert(errors.Is(err, invModErr), Equals, true)
-		c.Assert(errors.Is(err, HintError{string(using.ID), invModErr}), Equals, true)
+		unkModErr := UnknownModuleError{used.ID}
+		c.Check(errors.Is(err, unkModErr), Equals, true)
+		c.Check(errors.Is(err, HintError{string(using.ID), unkModErr}), Equals, false)
 	}
 
 	{ // test multigroup deployment with config that has a known good match

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -232,12 +232,9 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 		// Use ID doesn't exists (fail)
 		g.Modules[len(g.Modules)-1].ID = "wrongID"
 		err := dc.applyUseModules()
-		c.Assert(errors.As(err, &HintError{}), Equals, true)
-		c.Assert(err.(HintError).Hint, Equals, string(using.ID))
-		c.Assert(errors.As(err, &InvalidModuleError{}), Equals, true)
-		c.Assert(err.(HintError).Err.(InvalidModuleError).modID, Equals, used.ID)
-
-		// c.Assert(dc.applyUseModules(), ErrorMatches, fmt.Sprintf("invalid module reference: \"%s\" - Did you mean \"%s\"\\?", used.ID, using.ID))
+		invModErr := InvalidModuleError{used.ID}
+		c.Assert(errors.Is(err, invModErr), Equals, true)
+		c.Assert(errors.Is(err, HintError{string(using.ID), invModErr}), Equals, true)
 	}
 
 	{ // test multigroup deployment with config that has a known good match


### PR DESCRIPTION
Made changes to include hints for the 'invalidMod' errors specifically in validateModuleSettingReference function.  The code will check the levenshtein distance of the reference and all possible modules it could legally reference.  If the distance is within 40% of the length of the module (for normalization), it will suggest that module.  If not, it will suggest vars for global variables.  

This also introduces a new error type HintError.  