### PR TITLE
Improve makefile to avoid build fail if git describe fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifneq (,$(wildcard .git))
 ## GIT DIRECTORY EXISTS
 GIT_TAG_VERSION=$(shell git tag --points-at HEAD)
 GIT_BRANCH=$(shell git branch --show-current)
-GIT_COMMIT_INFO=$(shell git describe --tags --dirty --long)
+GIT_COMMIT_INFO=$(shell git describe --tags --dirty --long --always)
 GIT_COMMIT_HASH=$(shell git rev-parse HEAD)
 GIT_INITIAL_HASH=$(shell git rev-list --max-parents=0 HEAD)
 endif


### PR DESCRIPTION
If git fails to describe (i.e. no tags found), entire build would fail. This appends --always flag in ```git describe```.  
In this way,  ```GIT_COMMIT_INFO```  would be 
```
harshthakkar@harshthakkar:~/hpc-toolkit$ git describe --tags --dirty --long --always
0ebe8a7c-dirty
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
