### PR TITLE
OFE: fixing syntax mistake in the images template and updating machine type API client

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/cluster_manager/cloud_info.py
+++ b/community/front-end/ofe/website/ghpcfe/cluster_manager/cloud_info.py
@@ -56,8 +56,16 @@ gcp_machine_table = defaultdict(
 
 
 def _get_arch_for_node_type_gcp(instance):
-    (family, group, _) = instance.split("-")
-    return gcp_machine_table[family][group]
+    try:
+        logger.info(instance.split("-"))
+        family, group, _ = instance.split("-", maxsplit=2)
+        return gcp_machine_table[family][group]
+    except ValueError:
+        logger.error(f"Invalid instance format: {instance}")
+        return None
+    except KeyError:
+        logger.error(f"Keys not found in gcp_machine_table: {instance}")
+        return None
 
 
 def _get_gcp_client(credentials, service="compute", api_version="v1"):

--- a/community/front-end/ofe/website/ghpcfe/templates/image/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/image/list.html
@@ -106,7 +106,7 @@
         </td>
         <td>
           <a href="{% url 'image-view' image.id %}" class="action-link btn-primary btn">View</a>
-          {% if admin_view == 1 and image.status == "r" or image.status = "e" %}
+          {% if admin_view == 1 and image.status == "r" or image.status == "e" %}
             <button class="action-link image-delete-button btn-danger btn" data-url="{% url 'image-delete' image.id %}">Delete</button>
           {% endif %}
         </td>


### PR DESCRIPTION
Fixing syntax mistake in community/front-end/ofe/website/ghpcfe/templates/image/list.html template. Updating machine type API client that now gives more than 3 values:

```bash
NFO:cloud_info:cloud_info.py:59:['c3', 'highmem', '4']
INFO:cloud_info:cloud_info.py:59:['c3', 'highmem', '44']
INFO:cloud_info:cloud_info.py:59:['c3', 'highmem', '8']
INFO:cloud_info:cloud_info.py:59:['c3', 'highmem', '88']
INFO:cloud_info:cloud_info.py:59:['c3', 'standard', '176']
INFO:cloud_info:cloud_info.py:59:['c3', 'standard', '176', 'lssd']
```

This PR resolves the following error:
```bash
ERROR:clusters:clusters.py:838:Exception during cloud API query:
Traceback (most recent call last):
  File "/opt/gcluster/hpc-toolkit/community/front-end/website/ghpcfe/views/clusters.py", line 831, in list
    machine_info = cloud_info.get_machine_types(
  File "/opt/gcluster/hpc-toolkit/community/front-end/website/ghpcfe/cluster_manager/cloud_info.py", line 178, in get_machine_types
    return _get_gcp_machine_types(
  File "/opt/gcluster/hpc-toolkit/community/front-end/website/ghpcfe/cluster_manager/cloud_info.py", line 115, in _get_gcp_machine_types
    data = {
  File "/opt/gcluster/hpc-toolkit/community/front-end/website/ghpcfe/cluster_manager/cloud_info.py", line 121, in <dictcomp>
    "arch": _get_arch_for_node_type_gcp(mt["name"]),
  File "/opt/gcluster/hpc-toolkit/community/front-end/website/ghpcfe/cluster_manager/cloud_info.py", line 59, in _get_arch_for_node_type_gcp
    (family, group, _) = instance.split("-")
ValueError: too many values to unpack (expected 3)
```
