### PR TITLE
hpc-enterprise-slurm gpu fix

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -89,7 +89,7 @@ deployment_groups:
     use: [network1]
     settings:
       filestore_tier: BASIC_SSD
-      size_gb: 2560 # smallest size for BASIC_SSD
+      size_gb: 2560  # smallest size for BASIC_SSD
       local_mount: /home
 
   - id: projectsfs
@@ -97,7 +97,7 @@ deployment_groups:
     use: [network1]
     settings:
       filestore_tier: HIGH_SCALE_SSD
-      size_gb: 10240 # smallest size for HIGH_SCALE_SSD
+      size_gb: 10240  # smallest size for HIGH_SCALE_SSD
       local_mount: /projects
 
   # This file system has an associated license cost.
@@ -126,15 +126,15 @@ deployment_groups:
     use: [n2_node_group, network1, homefs, projectsfs, scratchfs]
     settings:
       partition_name: n2
-      exclusive: false # allows nodes to stay up after jobs are done
-      enable_placement: false # the default is: true
+      exclusive: false  # allows nodes to stay up after jobs are done
+      enable_placement: false  # the default is: true
       is_default: true
 
   - id: c2_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: 20
-      machine_type: c2-standard-60 # this is the default
+      machine_type: c2-standard-60  # this is the default
       instance_image:
         family: $(vars.family)
         project: $(vars.project)
@@ -154,7 +154,7 @@ deployment_groups:
     settings:
       partition_name: c2
       # the following two are true by default
-      exclusive: true # this must be true if enable_placement is true
+      exclusive: true  # this must be true if enable_placement is true
       enable_placement: true
 
   - id: c2d_node_group
@@ -212,6 +212,9 @@ deployment_groups:
         project: $(vars.project)
       disk_type: pd-ssd
       disk_size_gb: 100
+      node_conf:
+        Sockets: 2
+        CoresPerSocket: 24
       service_account:
         email: $(compute_sa.service_account_email)
         scopes:
@@ -227,6 +230,10 @@ deployment_groups:
       # This makes this partition look for machines in any of the following zones
       # https://github.com/GoogleCloudPlatform/hpc-toolkit/tree/develop/community/modules/compute/schedmd-slurm-gcp-v5-partition#compute-vm-zone-policies
       zones: $(vars.gpu_zones)
+      # The following allows users to use more host memory without specifying cpus on a job
+      partition_conf:
+        DefMemPerGPU: 160000
+        DefMemPerCPU: null
 
   - id: a2_16_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
@@ -239,6 +246,9 @@ deployment_groups:
         project: $(vars.project)
       disk_type: pd-ssd
       disk_size_gb: 100
+      node_conf:
+        Sockets: 2
+        CoresPerSocket: 24
       service_account:
         email: $(compute_sa.service_account_email)
         scopes:
@@ -254,13 +264,17 @@ deployment_groups:
       # This makes this partition look for machines in any of the following zones
       # https://github.com/GoogleCloudPlatform/hpc-toolkit/tree/develop/community/modules/compute/schedmd-slurm-gcp-v5-partition#compute-vm-zone-policies
       zones: $(vars.gpu_zones)
+      # The following allows users to use more host memory without specifying cpus on a job
+      partition_conf:
+        DefMemPerGPU: 160000
+        DefMemPerCPU: null
 
   - id: h3_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: 16
       machine_type: h3-standard-88
-      bandwidth_tier: gvnic_enabled # https://cloud.google.com/compute/docs/compute-optimized-machines#h3_network
+      bandwidth_tier: gvnic_enabled  # https://cloud.google.com/compute/docs/compute-optimized-machines#h3_network
       instance_image:
         family: $(vars.family)
         project: $(vars.project)


### PR DESCRIPTION
This fixes partition and node configurations for the GPU marchines in the hpc-enterprise-slurm.yaml blueprint. 
Specifically, this fixes: 
        Sockets: 2
        CoresPerSocket: 24

For the node groups, and then sets: 
        DefMemPerGPU: 160000
        DefMemPerCPU: null

For the partitions. The rationale is that a lot of the GPU users would prefer not specifying number of cpus per jobs. 