### PR TITLE
Support network_storage runners in HTCondor modules

### DIFF
--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -69,6 +69,27 @@ locals {
     ])
   }
 
+  native_fstype = []
+  startup_script_network_storage = [
+    for ns in var.network_storage :
+    ns if !contains(local.native_fstype, ns.fs_type)
+  ]
+  storage_client_install_runners = [
+    for ns in local.startup_script_network_storage :
+    ns.client_install_runner if ns.client_install_runner != null
+  ]
+  mount_runners = [
+    for ns in local.startup_script_network_storage :
+    ns.mount_runner if ns.mount_runner != null
+  ]
+
+  all_runners = concat(
+    local.storage_client_install_runners,
+    local.mount_runners,
+    var.execute_point_runner,
+    [local.execute_runner],
+  )
+
   execute_config_windows_startup_ps1 = templatefile(
     "${path.module}/templates/download-condor-config.ps1.tftpl",
     {
@@ -110,7 +131,7 @@ module "startup_script" {
   labels          = local.labels
   deployment_name = var.deployment_name
 
-  runners = flatten([var.execute_point_runner, local.execute_runner])
+  runners = local.all_runners
 }
 
 module "execute_point_instance_template" {

--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -47,7 +47,23 @@ locals {
     EOT
   }
 
+  native_fstype = []
+  startup_script_network_storage = [
+    for ns in var.network_storage :
+    ns if !contains(local.native_fstype, ns.fs_type)
+  ]
+  storage_client_install_runners = [
+    for ns in local.startup_script_network_storage :
+    ns.client_install_runner if ns.client_install_runner != null
+  ]
+  mount_runners = [
+    for ns in local.startup_script_network_storage :
+    ns.mount_runner if ns.mount_runner != null
+  ]
+
   all_runners = concat(
+    local.storage_client_install_runners,
+    local.mount_runners,
     var.access_point_runner,
     [local.schedd_runner],
     var.autoscaler_runner,


### PR DESCRIPTION
The HTCondor modules were not properly handling network_storage inputs to mount filesystems. This PR addresses that.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
