### PR TITLE
Update to hpc-enterprise-slurm blueprint with SuspendTime example

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -129,6 +129,8 @@ deployment_groups:
       exclusive: false # allows nodes to stay up after jobs are done
       enable_placement: false # the default is: true
       is_default: true
+      partition_conf:
+        SuspendTime: 1200 # time (in secs) the nodes in this partition stay active after their tasks have completed
 
   - id: c2_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group


### PR DESCRIPTION
Tested with hpc-slurm.yaml on the debug and compute partitions with separate SuspendTime lengths (1200 and 600sec respectively).  