### PR TITLE
Updates to workstation build scripts to add new code-oss extensions

### DIFF
--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -2,7 +2,8 @@ archspec==0.2.1
 argcomplete==3.1.1
 asgiref==3.7.2
 astroid==2.15.5
-backports.zoneinfo==0.2.1
+# This should be supported by zoneinfo in Python 3.9+
+backports.zoneinfo==0.2.1;python_version<"3.9"
 cachetools==5.3.1
 certifi==2023.07.22
 cffi==1.15.1

--- a/tools/cloud-workstations/Dockerfile
+++ b/tools/cloud-workstations/Dockerfile
@@ -39,20 +39,25 @@ RUN wget https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellch
 
 RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
 
-COPY tools/cloud-build/requirements.txt requirements.txt
+COPY tools/cloud-build/requirements.txt cloud_build_requirements.txt
+COPY docs/hybrid-slurm-cluster/requirements.txt slurm_requirements.txt
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r https://raw.githubusercontent.com/SchedMD/slurm-gcp/master/scripts/requirements.txt && \
-    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir -r cloud_build_requirements.txt && \
+    pip install --no-cache-dir -r slurm_requirements.txt && \
     rm -rf ~/.cache/pip/*
 
 # Get the HPC config files and store them in the correct locations for startup
 ARG CW_DIR=tools/cloud-workstations
 ARG HPC_FILE=configure-hpc-toolkit.sh
-ARG HPC_CONF_FILE=030_configure-hpc-toolkit.sh
+ARG HPC_CONF_FILE=030_configure-hpc-toolkit.sh 
 
 COPY $CW_DIR/$HPC_FILE /bin/
 COPY $CW_DIR/$HPC_CONF_FILE /etc/workstation-startup.d/
 
 RUN chmod a+x /bin/$HPC_FILE && \
     chmod a+x /etc/workstation-startup.d/$HPC_CONF_FILE
+
+RUN mkdir /etc/hpc-toolkit-config
+COPY $CW_DIR/code_oss_requirements.txt /etc/hpc-toolkit-config

--- a/tools/cloud-workstations/README.md
+++ b/tools/cloud-workstations/README.md
@@ -32,7 +32,7 @@ gcloud artifacts repositories create ${WORKSTATION_NAME} --repository-format=doc
 To build the Cloud workstation container as defined in the [Dockerfile](./Dockerfile), run the following command from the root of the HPC-Toolkit repo:
 
 ```sh
-gcloud builds submit --config=tools/cloud-workstations/workstation-image.yaml --substitutions _LOCATION=${LOCATION},_REPO=${REPO} --project ${PROJECT_ID}
+gcloud builds submit --config=tools/cloud-workstations/workstation-image.yaml --substitutions _LOCATION=${LOCATION},_REPO=${WORKSTATION_NAME} --project ${PROJECT_ID}
 ```
 
 ## Create the Cloud Workstations cluster and configuration

--- a/tools/cloud-workstations/code_oss_requirements.txt
+++ b/tools/cloud-workstations/code_oss_requirements.txt
@@ -1,0 +1,10 @@
+# Relevant extensions list for HPC Toolkit for code-oss on cloud workstations
+
+golang.go
+hashicorp.terraform
+ms-python.python
+ms-toolsai.jupyter
+ms-toolsai.jupyter-keymap
+ms-toolsai.jupyter-renderers
+ms-toolsai.vscode-jupyter-cell-tags
+ms-toolsai.vscode-jupyter-slideshow

--- a/tools/cloud-workstations/configure-hpc-toolkit.sh
+++ b/tools/cloud-workstations/configure-hpc-toolkit.sh
@@ -31,7 +31,7 @@ if [[ ! -f $FLAG ]]; then
 	echo "export PATH=$PATH:$HOME/go/bin" >>"$HOME"/.bashrc
 
 	# Set up Code OSS for golang
-	/opt/code-oss/bin/codeoss-cloudworkstations --install-extension golang.go
+	grep -v '^#' </etc/hpc-toolkit-config/code_oss_requirements.txt | xargs -L1 /opt/code-oss/bin/codeoss-cloudworkstations --install-extension
 	go install golang.org/x/tools/gopls@latest
 	go install github.com/ramya-rao-a/go-outline@v0.0.0-20210608161538-9736a4bde949
 	go install github.com/rogpeppe/godef@v1.1.2


### PR DESCRIPTION
Updates for easier setup of cloud workstations.  Sets up code-oss a little bit more and improves some dependencies.

Also added more pip requirements for slurm builds. Fixed a potential issue with one requirement for the frontend having to do with python versions and backports.zoneinfo
