### PR TITLE
Add resource requirements validator

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -136,12 +136,12 @@ func (s *MySuite) TestRenderError(c *C) {
 		got := renderError(err, config.YamlCtx{})
 		c.Check(got, Equals, "arbuz")
 	}
-	{ // has pos, but context is missing
+	{ // has pos, but context doesn't contain it
 		ctx := config.NewYamlCtx([]byte(``))
 		pth := config.Root.Vars.Dot("kale")
 		err := config.BpError{Path: pth, Err: errors.New("arbuz")}
 		got := renderError(err, ctx)
-		c.Check(got, Equals, "vars.kale: arbuz")
+		c.Check(got, Equals, "arbuz")
 	}
 	{ // has pos, has context
 		ctx := config.NewYamlCtx([]byte(`

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -214,6 +214,7 @@ const (
 	testZoneInRegionName              = "test_zone_in_region"
 	testModuleNotUsedName             = "test_module_not_used"
 	testDeploymentVariableNotUsedName = "test_deployment_variable_not_used"
+	testResourceRequirementsName      = "test_resource_requirements"
 )
 
 func implementations() map[string]func(config.Blueprint, config.Dict) error {
@@ -225,6 +226,7 @@ func implementations() map[string]func(config.Blueprint, config.Dict) error {
 		testZoneInRegionName:              testZoneInRegion,
 		testModuleNotUsedName:             testModuleNotUsed,
 		testDeploymentVariableNotUsedName: testDeploymentVariableNotUsed,
+		testResourceRequirementsName:      testResourceRequirements,
 	}
 }
 


### PR DESCRIPTION
**NOTE:** The validation logic has been already implemented, this PR is mostly extracting strict `struct` config from free form `crt.ObjectVal Validator.Input` and minor changes to error-rendering.

```
...blueprint.yaml...

validators:
- validator: test_resource_requirements
  inputs:
    ignore_usage: true
    requirements:
    - metric: "compute.googleapis.com/disks_total_storage"
      service:  "compute.googleapis.com"
      consumer: "projects/X"
      required:  900000
      dimensions: { "region": "us-east1" }
      aggregation: "SUM"
```

```
validator "test_resource_requirements" failed:
not sufficient limit for resource "compute.googleapis.com/disks_total_storage", limit=4096 < requested=900000
not sufficient limit for resource "compute.googleapis.com/disks_total_storage" in map[region:us-east1], limit=102400 < requested=900000

One or more blueprint validators has failed...
```