### PR TITLE
Incorporate usage into resource requirements validation

### DIFF
--- a/pkg/validators/quota_test.go
+++ b/pkg/validators/quota_test.go
@@ -148,6 +148,7 @@ func TestValidateServiceLimits(t *testing.T) {
 			Aggregation: "SUM",
 		},
 	}
+	up := usageProvider{}
 
 	want := []QuotaError{
 		{Metric: "pony", Dimensions: map[string]string{"green": "eggs"}, EffectiveLimit: 3, Requested: 4},
@@ -159,7 +160,7 @@ func TestValidateServiceLimits(t *testing.T) {
 			ConsumerQuotaLimits: []*sub.ConsumerQuotaLimit{
 				{Metric: "pony", QuotaBuckets: buckets}},
 		},
-	})
+	}, &up)
 
 	if err != nil {
 		t.Errorf("got unexpected error: %s", err)


### PR DESCRIPTION
* Incorporate usage into resource requirements validation
* Fill in default values for quota validation inputs

```
...blueprint...
validators:
- validator: test_resource_requirements
  inputs:
    requirements:
    - metric: "compute.googleapis.com/disks_total_storage"
      required:  900000
```

```
validator "test_resource_requirements" failed:
not sufficient limit for resource "compute.googleapis.com/disks_total_storage", limit=4096 < requested=900000
not sufficient limit for resource "compute.googleapis.com/disks_total_storage" in map[region:us-central1], limit=102400 < requested=900000 + usage=756

One or more blueprint validators has failed...
```