### PR TITLE
Improvements to hpc-enterprise blueprint

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -130,7 +130,7 @@ deployment_groups:
       enable_placement: false  # the default is: true
       is_default: true
       partition_conf:
-        SuspendTime: 1200 # time (in secs) the nodes in this partition stay active after their tasks have completed
+        SuspendTime: 300 # time (in secs) the nodes in this partition stay active after their tasks have completed
 
   - id: c2_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -184,6 +184,13 @@
 
     ## Always cleanup, even on failure
     always:
+    - name: Get partition info after test
+      ansible.builtin.command: sinfo
+      changed_when: False
+      register: partition_post_run_output
+    - name: Print Slurm sinfo output
+      ansible.builtin.debug:
+        var: partition_post_run_output.stdout_lines
     - name: Recover Setup Log
       become: true
       changed_when: false

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-partitions.yml
@@ -71,5 +71,5 @@
   register: final_node_count
   changed_when: False
   until: final_node_count.stdout_lines | length == initial_node_count.stdout_lines | length
-  retries: 40
+  retries: 60
   delay: 15


### PR DESCRIPTION
- print sinfo after Slurm partition test
- decrease the n2 node wait time to 300s
- increased the timeout for node cleanup to 15 minutes, instead of 10.
