### PR TITLE
Fill in default values for quota validation inputs

### DIFF
--- a/pkg/validators/quota.go
+++ b/pkg/validators/quota.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"strings"
 	"time"
 
 	"github.com/zclconf/go-cty/cty"
@@ -291,40 +292,107 @@ type rrInputs struct {
 	IgnoreUsage  bool                  `cty:"ignore_usage"`
 }
 
-func parseResourceRequirementsInputs(inputs config.Dict) (rrInputs, error) {
-	ty := cty.ObjectWithOptionalAttrs(map[string]cty.Type{
-		"requirements": cty.List(cty.Object(map[string]cty.Type{
-			"metric":      cty.String,
-			"service":     cty.String,
-			"consumer":    cty.String,
-			"required":    cty.Number,
-			"aggregation": cty.String,
-			"dimensions":  cty.Map(cty.String),
-		})),
+func ifNull(v cty.Value, d cty.Value) cty.Value {
+	if v.IsNull() {
+		return d
+	}
+	return v
+}
+
+func extractServiceName(metric string) (string, error) {
+	// metric is in the form of "service.googleapis.com/metric"
+	// we want to extract the "service.googleapis.com" part
+	parts := strings.Split(metric, "/")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("can not deduce service from metric %q", metric)
+	}
+	return parts[0], nil
+}
+
+func parseResourceRequirementsInputs(bp config.Blueprint, inputs config.Dict) (rrInputs, error) {
+	// sanitize inputs dict by matching with type
+	rty := cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+		"metric":      cty.String,
+		"service":     cty.String,
+		"consumer":    cty.String,
+		"required":    cty.Number,
+		"aggregation": cty.String,
+		"dimensions":  cty.Map(cty.String),
+	},
+		/*optional=*/ []string{"service", "consumer", "aggregation", "dimensions"})
+	ity := cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+		"requirements": cty.List(rty),
 		"ignore_usage": cty.Bool,
 	},
-		/*optional=*/ []string{}) // TODO: make ignore_usage optional
-	clean, err := convert.Convert(inputs.AsObject(), ty)
+		/*optional=*/ []string{"ignore_usage"})
+	clean, err := convert.Convert(inputs.AsObject(), ity)
 	if err != nil {
 		return rrInputs{}, err
 	}
+
+	// fill in default values
+	ignoreUsage := ifNull(clean.GetAttr("ignore_usage"), cty.False)
+	projectID, err := bp.ProjectID()
+	if err != nil {
+		return rrInputs{}, err
+	}
+	reqs := []cty.Value{}
+	rit := clean.GetAttr("requirements").ElementIterator()
+	for rit.Next() {
+		_, r := rit.Element()
+		defConsumer := fmt.Sprintf("projects/%s", projectID)
+		defService, err := extractServiceName(r.GetAttr("metric").AsString())
+		if err != nil {
+			return rrInputs{}, err
+		}
+		defDims := map[string]cty.Value{}
+		if bp.Vars.Has("region") {
+			defDims["region"] = bp.Vars.Get("region")
+		}
+		if bp.Vars.Has("zone") {
+			defDims["zone"] = bp.Vars.Get("zone")
+		}
+		defDimsVal := cty.MapValEmpty(cty.String)
+		if len(defDims) > 0 {
+			defDimsVal = cty.MapVal(defDims)
+		}
+
+		reqs = append(reqs, cty.ObjectVal(map[string]cty.Value{
+			"metric":      r.GetAttr("metric"),
+			"service":     ifNull(r.GetAttr("service"), cty.StringVal(defService)),
+			"consumer":    ifNull(r.GetAttr("consumer"), cty.StringVal(defConsumer)),
+			"required":    r.GetAttr("required"),
+			"aggregation": ifNull(r.GetAttr("aggregation"), cty.StringVal("SUM")),
+			"dimensions":  ifNull(r.GetAttr("dimensions"), defDimsVal),
+		}))
+	}
+
+	reqsVal := cty.ListValEmpty(rty)
+	if len(reqs) > 0 {
+		reqsVal = cty.ListVal(reqs)
+	}
+
+	full := cty.ObjectVal(map[string]cty.Value{
+		"requirements": reqsVal,
+		"ignore_usage": ignoreUsage,
+	})
+
 	var s rrInputs
-	return s, gocty.FromCtyValue(clean, &s)
+	return s, gocty.FromCtyValue(full, &s)
 }
 
 func testResourceRequirements(bp config.Blueprint, inputs config.Dict) error {
-	in, err := parseResourceRequirementsInputs(inputs)
+	in, err := parseResourceRequirementsInputs(bp, inputs)
 	if err != nil {
 		return err
 	}
 	errs := config.Errors{}
 	up := usageProvider{}
 	if !in.IgnoreUsage {
-		pv := bp.Vars.Get("project_id")
-		if pv.Type() != cty.String {
-			errs.Add(fmt.Errorf("the variable `project_id` is either not set or is not a string"))
-		} else {
-			up, err = newUsageProvider(pv.AsString())
+		p, err := bp.ProjectID()
+		errs.Add(err)
+		if p != "" {
+			up, err = newUsageProvider(p)
 			errs.Add(err) // don't terminate fallback to ignore usage
 		}
 	}

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -305,9 +305,9 @@ func testApisEnabled(bp config.Blueprint, inputs config.Dict) error {
 	if err := checkInputs(inputs, []string{}); err != nil {
 		return err
 	}
-	pv := bp.Vars.Get("project_id")
-	if pv.Type() != cty.String {
-		return fmt.Errorf("the deployment variable `project_id` is either not set or is not a string")
+	p, err := bp.ProjectID()
+	if err != nil {
+		return err
 	}
 	apis := map[string]bool{}
 	bp.WalkModules(func(m *config.Module) error {
@@ -316,7 +316,7 @@ func testApisEnabled(bp config.Blueprint, inputs config.Dict) error {
 		}
 		return nil
 	})
-	return TestApisEnabled(pv.AsString(), maps.Keys(apis))
+	return TestApisEnabled(p, maps.Keys(apis))
 }
 
 func testProjectExists(bp config.Blueprint, inputs config.Dict) error {


### PR DESCRIPTION
* Fill in default values for quota validation inputs;
* Fix false-positive "test_deployment_variable_not_used";
* Add `Blueprint.ProjectID` method.

Default values:
```yaml
ignore_usage: false
service:    extracted prefix of metric
consumer:    "projects/%s" % var.project_id
aggregation: SUM
dimensions:  {region: var.region, zone: var.sone}
```

```yaml
vars:
  project_id: X
  deployment_name: tst
  region: europe-west1
  num_nodes: 9

...

validators:
- validator: test_resource_requirements
  inputs:
    requirements:
    - metric: compute.googleapis.com/disks_total_storage
      required: ((var.num_nodes * 100000))
```
```sh
validator "test_resource_requirements" failed:
not enough quota for resource "compute.googleapis.com/disks_total_storage", limit=4096 < requested=900000
not enough quota for resource "compute.googleapis.com/disks_total_storage" in map[region:europe-west1], limit=102400 < requested=900000 + usage=256

One or more blueprint validators has failed...
```