### PR TITLE
Hotfix: Update NVIDIA Grid drivers to 15.3

### DIFF
--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-grid-drivers.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-grid-drivers.yml
@@ -67,7 +67,13 @@
   - name: Install GRID driver if not existing
     when: nvidiasmi_result is failed
     block:
-    - name: Download GPU driver
+    - name: Download GPU driver 15.3
+      ansible.builtin.get_url:
+        url: https://storage.googleapis.com/nvidia-drivers-us-public/GRID/vGPU15.3/NVIDIA-Linux-x86_64-525.125.06-grid.run
+        dest: /tmp/
+        mode: "0755"
+        timeout: 30
+    - name: Download GPU driver 14.2
       ansible.builtin.get_url:
         url: https://storage.googleapis.com/nvidia-drivers-us-public/GRID/vGPU14.2/NVIDIA-Linux-x86_64-510.85.02-grid.run
         dest: /tmp/
@@ -83,7 +89,7 @@
       ansible.builtin.shell: |
         #jinja2: trim_blocks: "True"
         {% if ansible_distribution_release == "jammy" %}
-        CC=gcc-12 /tmp/NVIDIA-Linux-x86_64-510.85.02-grid.run --silent
+        CC=gcc-12 /tmp/NVIDIA-Linux-x86_64-525.125.06-grid.run --silent
         {% else %}
         /tmp/NVIDIA-Linux-x86_64-510.85.02-grid.run --silent
         {% endif %}


### PR DESCRIPTION
The Ubuntu base image was updated on 08/29, and our integration test for Chrome Remote Desktop started failing.  The error was likely caused by an incompatibility between an updated kernel and the NVIDIA Grid driver installer.

Updating the NVIDIA Grid driver installer to version 15.3 resolves the issue.