### PR TITLE
Hotfix: Update NVIDIA Grid drivers to 15.3

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ HPC deployments on the Google Cloud Platform.`,
 				log.Fatalf("cmd.Help function failed: %s", err)
 			}
 		},
-		Version:     "v1.22.0",
+		Version:     "v1.22.1",
 		Annotations: annotation,
 	}
 )

--- a/community/modules/compute/gke-node-pool/versions.tf
+++ b/community/modules/compute/gke-node-pool/versions.tf
@@ -26,6 +26,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.22.1"
   }
 }

--- a/community/modules/compute/htcondor-execute-point/versions.tf
+++ b/community/modules/compute/htcondor-execute-point/versions.tf
@@ -25,6 +25,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.22.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.22.1"
   }
   required_version = ">= 1.1"
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.22.1"
   }
   required_version = ">= 0.13.0"
 }

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -30,10 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.22.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.22.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/community/modules/file-system/cloud-storage-bucket/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.22.1"
   }
   required_version = ">= 0.14.0"
 }

--- a/community/modules/file-system/gke-persistent-volume/versions.tf
+++ b/community/modules/file-system/gke-persistent-volume/versions.tf
@@ -29,6 +29,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-persistent-volume/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-persistent-volume/v1.22.1"
   }
 }

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-grid-drivers.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-grid-drivers.yml
@@ -67,7 +67,13 @@
   - name: Install GRID driver if not existing
     when: nvidiasmi_result is failed
     block:
-    - name: Download GPU driver
+    - name: Download GPU driver 15.3
+      ansible.builtin.get_url:
+        url: https://storage.googleapis.com/nvidia-drivers-us-public/GRID/vGPU15.3/NVIDIA-Linux-x86_64-525.125.06-grid.run
+        dest: /tmp/
+        mode: "0755"
+        timeout: 30
+    - name: Download GPU driver 14.2
       ansible.builtin.get_url:
         url: https://storage.googleapis.com/nvidia-drivers-us-public/GRID/vGPU14.2/NVIDIA-Linux-x86_64-510.85.02-grid.run
         dest: /tmp/
@@ -83,7 +89,7 @@
       ansible.builtin.shell: |
         #jinja2: trim_blocks: "True"
         {% if ansible_distribution_release == "jammy" %}
-        CC=gcc-12 /tmp/NVIDIA-Linux-x86_64-510.85.02-grid.run --silent
+        CC=gcc-12 /tmp/NVIDIA-Linux-x86_64-525.125.06-grid.run --silent
         {% else %}
         /tmp/NVIDIA-Linux-x86_64-510.85.02-grid.run --silent
         {% endif %}

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/gke-cluster/versions.tf
+++ b/community/modules/scheduler/gke-cluster/versions.tf
@@ -26,6 +26,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.22.1"
   }
 }

--- a/community/modules/scheduler/htcondor-access-point/versions.tf
+++ b/community/modules/scheduler/htcondor-access-point/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.22.1"
   }
 
   required_version = ">= 1.1"

--- a/community/modules/scheduler/htcondor-central-manager/versions.tf
+++ b/community/modules/scheduler/htcondor-central-manager/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.22.1"
   }
 
   required_version = ">= 1.1.0"

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.22.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scheduler/htcondor-setup/versions.tf
+++ b/community/modules/scheduler/htcondor-setup/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-setup/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-setup/v1.22.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-controller/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-controller/v1.22.1"
   }
   required_version = ">= 1.1"
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-login/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-login/v1.22.1"
   }
   required_version = ">= 1.1"
 }

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scripts/windows-startup-script/versions.tf
+++ b/community/modules/scripts/windows-startup-script/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -31,10 +31,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.22.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.22.1"
   }
 
   required_version = ">= 1.2.0"

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.22.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scheduler/batch-login-node/versions.tf
+++ b/modules/scheduler/batch-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.22.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.22.0"
+    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.22.1"
   }
 
   required_version = ">= 0.14.0"


### PR DESCRIPTION
The Ubuntu base image was updated on 08/29, and our integration test for Chrome Remote Desktop started failing. The error was likely caused by an incompatibility between an updated kernel and the NVIDIA Grid driver installer.

Updating the NVIDIA Grid driver installer to version 15.3 resolves the issue.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
