### PR TITLE
Update instance image family to slurm-gcp-5-8 version

### DIFF
--- a/community/examples/AMD/hpc-amd-slurm.yaml
+++ b/community/examples/AMD/hpc-amd-slurm.yaml
@@ -171,7 +171,7 @@ deployment_groups:
         # these images must match the images used by Slurm modules below because
         # we are building OpenMPI with PMI support in libaries contained in
         # Slurm installation
-        family: slurm-gcp-5-7-hpc-centos-7
+        family: slurm-gcp-5-8-hpc-centos-7
         project: schedmd-slurm-public
   - id: low_cost_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group

--- a/community/examples/hpc-slurm-ubuntu2004.yaml
+++ b/community/examples/hpc-slurm-ubuntu2004.yaml
@@ -24,7 +24,7 @@ vars:
   instance_image:
     # Please refer to the following link for the latest images:
     # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
-    family: slurm-gcp-5-7-ubuntu-2004-lts
+    family: slurm-gcp-5-8-ubuntu-2004-lts
     project: schedmd-slurm-public
   instance_image_custom: true
 

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -24,7 +24,7 @@ vars:
   gpu_zones: [us-central1-a, us-central1-b, us-central1-c, us-central1-f]
   # Visit https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#published-image-family
   # for a list of valid family options with Slurm
-  family: slurm-gcp-5-7-hpc-centos-7
+  family: slurm-gcp-5-8-hpc-centos-7
   project: schedmd-slurm-public
   # Set to true for active cluster reconfiguration.
   # Note that setting this option requires additional dependencies to be installed locally.

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -58,7 +58,7 @@ deployment_groups:
     settings:
       source_image_project_id: [schedmd-slurm-public]
       # see latest in https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#published-image-family
-      source_image_family: slurm-gcp-5-7-hpc-centos-7
+      source_image_family: slurm-gcp-5-8-hpc-centos-7
       # You can find size of source image by using following command
       # gcloud compute images describe-from-family <source_image_family> --project schedmd-slurm-public
       disk_size: $(vars.disk_size)

--- a/examples/ml-slurm.yaml
+++ b/examples/ml-slurm.yaml
@@ -134,7 +134,7 @@ deployment_groups:
       omit_external_ip: false
       source_image_project_id: [schedmd-slurm-public]
       # see latest in https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#published-image-family
-      source_image_family: slurm-gcp-5-7-debian-11
+      source_image_family: slurm-gcp-5-8-debian-11
       # You can find size of source image by using following command
       # gcloud compute images describe-from-family <source_image_family> --project schedmd-slurm-public
       disk_size: $(vars.disk_size_gb)

--- a/tools/cloud-build/daily-tests/blueprints/lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-slurm.yaml
@@ -82,7 +82,7 @@ deployment_groups:
   #   settings:
   #     node_count_dynamic_max: $(vars.num_nodes)
   #     instance_image:
-  #       family: slurm-gcp-5-7-ubuntu-2004-lts
+  #       family: slurm-gcp-5-8-ubuntu-2004-lts
   #       project: schedmd-slurm-public
   #     instance_image_custom: true
 
@@ -101,7 +101,7 @@ deployment_groups:
     settings:
       node_count_dynamic_max: $(vars.num_nodes)
       instance_image:
-        family: slurm-gcp-5-7-hpc-rocky-linux-8
+        family: slurm-gcp-5-8-hpc-rocky-linux-8
         project: schedmd-slurm-public
       instance_image_custom: true
 
@@ -120,7 +120,7 @@ deployment_groups:
     settings:
       node_count_dynamic_max: $(vars.num_nodes)
       instance_image:
-        family: slurm-gcp-5-7-hpc-centos-7
+        family: slurm-gcp-5-8-hpc-centos-7
         project: schedmd-slurm-public
       instance_image_custom: true
 

--- a/tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/slurm-filestore.yaml
@@ -25,10 +25,10 @@ vars:
   instance_image:
     # Please refer to the following link for the latest images:
     # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
-    # family: slurm-gcp-5-7-ubuntu-2004-lts
-    # family: slurm-gcp-5-7-hpc-centos-7
-    family: slurm-gcp-5-7-hpc-rocky-linux-8
-    # family: slurm-gcp-5-7-debian-11
+    # family: slurm-gcp-5-8-ubuntu-2004-lts
+    # family: slurm-gcp-5-8-hpc-centos-7
+    family: slurm-gcp-5-8-hpc-rocky-linux-8
+    # family: slurm-gcp-5-8-debian-11
     project: schedmd-slurm-public
   instance_image_custom: true
 

--- a/tools/validate_configs/os_compatibility_tests/slurm-lustre.yaml
+++ b/tools/validate_configs/os_compatibility_tests/slurm-lustre.yaml
@@ -25,9 +25,9 @@ vars:
   instance_image:
     # Please refer to the following link for the latest images:
     # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
-    # family: slurm-gcp-5-7-ubuntu-2004-lts
-    # family: slurm-gcp-5-7-hpc-centos-7
-    family: slurm-gcp-5-7-hpc-rocky-linux-8
+    # family: slurm-gcp-5-8-ubuntu-2004-lts
+    # family: slurm-gcp-5-8-hpc-centos-7
+    family: slurm-gcp-5-8-hpc-rocky-linux-8
     project: schedmd-slurm-public
   instance_image_custom: true
 

--- a/tools/validate_configs/os_compatibility_tests/slurm-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/slurm-startup.yaml
@@ -25,10 +25,10 @@ vars:
   instance_image:
     # Please refer to the following link for the latest images:
     # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
-    # family: slurm-gcp-5-7-ubuntu-2004-lts
-    # family: slurm-gcp-5-7-hpc-centos-7
-    family: slurm-gcp-5-7-hpc-rocky-linux-8
-    # family: slurm-gcp-5-7-debian-11
+    # family: slurm-gcp-5-8-ubuntu-2004-lts
+    # family: slurm-gcp-5-8-hpc-centos-7
+    family: slurm-gcp-5-8-hpc-rocky-linux-8
+    # family: slurm-gcp-5-8-debian-11
     project: schedmd-slurm-public
   instance_image_custom: true
 

--- a/tools/validate_configs/test_configs/node-groups.yaml
+++ b/tools/validate_configs/test_configs/node-groups.yaml
@@ -64,7 +64,7 @@ deployment_groups:
       name: c30
       machine_type: c2-standard-30
       instance_image:
-        family: slurm-gcp-5-7-debian-11
+        family: slurm-gcp-5-8-debian-11
         project: schedmd-slurm-public
       instance_image_custom: true
 
@@ -83,7 +83,7 @@ deployment_groups:
       name: cd112
       machine_type: c2d-standard-112
       instance_image:
-        family: slurm-gcp-5-7-hpc-centos-7
+        family: slurm-gcp-5-8-hpc-centos-7
         project: schedmd-slurm-public
       instance_image_custom: true
       enable_smt: true

--- a/tools/validate_configs/test_configs/slurm-static-test.yaml
+++ b/tools/validate_configs/test_configs/slurm-static-test.yaml
@@ -25,10 +25,10 @@ vars:
   instance_image:
     # Please refer to the following link for the latest images:
     # https://github.com/SchedMD/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
-    # family: slurm-gcp-5-7-ubuntu-2004-lts
-    # family: slurm-gcp-5-7-hpc-centos-7
-    family: slurm-gcp-5-7-hpc-rocky-linux-8
-    # family: slurm-gcp-5-7-debian-11
+    # family: slurm-gcp-5-8-ubuntu-2004-lts
+    # family: slurm-gcp-5-8-hpc-centos-7
+    family: slurm-gcp-5-8-hpc-rocky-linux-8
+    # family: slurm-gcp-5-8-debian-11
     project: schedmd-slurm-public
   instance_image_custom: true
   enable_reconfigure: true


### PR DESCRIPTION
This updates instance image family to slurm-gcp-5-8 version for hpc-enterprise-slurm, lustre-slurm and hpc-slurm-ubuntu2004 blueprint.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
