### PR TITLE
Add minimal implementation of nodeset, partirion, controller, and clu…

### DIFF
--- a/community/modules/slurm/cluster/README.md
+++ b/community/modules/slurm/cluster/README.md
@@ -1,0 +1,40 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_slurm_cluster"></a> [slurm\_cluster](#module\_slurm\_cluster) | github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster | 6.1.1 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_controller"></a> [controller](#input\_controller) | Controller configuration. DO NOT configure manually, use `controller` module instead. | `any` | <pre>{<br>  "disk_type": "pd-standard",<br>  "machine_type": "n1-standard-4"<br>}</pre> | no |
+| <a name="input_debug_mode"></a> [debug\_mode](#input\_debug\_mode) | Developer debug mode:<br>- Do not create cluster resources.<br>- Output `debug` variable containing cluster configuration. | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | Cluster name, used for resource naming and slurm accounting. | `string` | n/a | yes |
+| <a name="input_nodeset"></a> [nodeset](#input\_nodeset) | Nodesets configuration. DO NOT configure manually, use `nodeset` module instead. | `list(any)` | `[]` | no |
+| <a name="input_partition"></a> [partition](#input\_partition) | Partitions configuration. DO NOT configure manually, use `partition` module instead. | `list(any)` | `[]` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region to create resources in. | `string` | n/a | yes |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_debug"></a> [debug](#output\_debug) | Debug output, present IFF var.debug\_mode is true |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/slurm/cluster/main.tf
+++ b/community/modules/slurm/cluster/main.tf
@@ -1,0 +1,157 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This modules translate from the Toolkit format to the SchedMD format,
+# the example of such translation is `guest_accelerator` to `gpu`.
+#
+# The variables during translation go through the following steps signaled by name suffix:
+# 1. var.X - intake in the Toolkit format;
+# 2. local.X - var.X OR default_X;
+# 3. local.X_full - local.X augmented with default values, 
+#      e.g. `network_storage` from `cluster` is propogated to `partition`.
+# 4. local.X_out - local.X_full translated to the SchedMD format.
+
+locals { # Nodeset
+  nodeset_default = [{
+    name         = "defaultns",
+    machine_type = "n1-standard-4",
+    # TODO: specify more
+  }]
+  # Use jsonencode/decode to workaround Terraform's types consistency check.
+  nodeset = jsondecode(length(var.nodeset) == 0 ?
+  jsonencode(local.nodeset_default) : jsonencode(var.nodeset))
+
+  nodeset_full = [for ns in local.nodeset : merge(ns, {
+    region               = coalesce(try(ns.region, null), var.region),
+    subnetwork_self_link = coalesce(try(ns.subnetwork_self_link, null), var.subnetwork_self_link), # 
+    instance_image       = coalesce(try(ns.instance_image, null), {}),
+    # TODO: service_account, instance_image
+  })]
+
+
+  nodeset_out = [
+    for ns in local.nodeset_full : merge(ns, {
+      # Specify only fields different accross the formats, 
+      # the rest will be merged straight from `ns`.
+      nodeset_name = ns.name
+      disable_smt  = !try(ns.enable_smt, false)
+      gpu          = one(try(ns.guest_accelerator, []))
+
+      source_image_family  = lookup(ns.instance_image, "family", "")
+      source_image_project = lookup(ns.instance_image, "project", "") # TODO: use normalized project
+      source_image         = lookup(ns.instance_image, "name", "")
+
+      # subnetwork_project - omit as we use subnewtork self_link
+      subnetwork = ns.subnetwork_self_link
+      spot       = try(ns.enable_spot_vm, false)
+
+      termination_action = try(ns.spot_instance_config.termination_action, null)
+  })]
+}
+
+locals { # Partition
+  partition_default = [{
+    name              = "default"
+    is_default        = true
+    exclusive         = true
+    partition_nodeset = [for ns in local.nodeset_out : ns.nodeset_name]
+  }]
+  # Use jsonencode/decode to workaround Terraform's types consistency check.
+  partitions = jsondecode(length(var.partition) == 0 ? jsonencode(local.partition_default) : jsonencode(var.partition))
+  partitions_full = [for p in local.partitions : merge(p, {
+    # TODO: network_storage
+  })]
+  partitions_out = [
+    for p in local.partitions_full : merge(p, {
+      # Specify only fields different accross the formats, 
+      # the rest will be merged straight from `p`.
+      default              = p.is_default,
+      enable_job_exclusive = p.exclusive,
+      partition_name       = p.name,
+    })
+  ]
+}
+
+locals {                      # Controller
+  controller = var.controller # var.controller default value is sufficient
+  controller_full = merge(local.controller, {
+    region               = coalesce(try(local.controller.region, null), var.region),
+    subnetwork_self_link = coalesce(try(local.controller.subnetwork_self_link, null), var.subnetwork_self_link),
+    instance_image       = coalesce(try(local.controller.instance_image, null), {}),
+    # TODO: service_account, instance_image, network_storage
+  })
+  cf = local.controller_full # alias for shortness
+  controller_out = merge(local.cf, {
+    # Specify only fields different accross the formats, 
+    # the rest will be merged straight from `controller_full`.
+    disable_smt          = !try(local.cf.enable_smt, false)
+    gpu                  = one(try(local.cf.guest_accelerator, []))
+    source_image_family  = lookup(local.cf.instance_image, "family", "")
+    source_image_project = lookup(local.cf.instance_image, "project", "") # TODO: use normalized project
+    source_image         = lookup(local.cf.instance_image, "name", "")
+
+    # subnetwork_project - omit as we use subnewtork self_link
+    subnetwork = local.cf.subnetwork_self_link
+    spot       = try(local.cf.enable_spot_vm, false)
+
+    termination_action = try(local.cf.spot_instance_config.termination_action, null)
+  })
+
+}
+
+module "slurm_cluster" {
+  count = var.debug_mode ? 0 : 1
+
+  source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster?ref=6.1.1"
+
+  project_id         = var.project_id
+  slurm_cluster_name = var.name
+  region             = var.region
+  # TODO: BUCKET
+  # TODO: CONTROLLER: CLOUD
+  controller_instance_config = local.controller_out
+
+  # TODO: CONTROLLER: HYBRID
+  # TODO: LOGIN
+  enable_login = false
+  nodeset      = local.nodeset_out
+  # TODO: nodeset_dyn
+  # TODO: nodeset_tpu
+  partitions = local.partitions_out
+  # TODO: SLURM
+  enable_devel = true
+
+  # TODO: move to null resource
+  # lifecycle {
+  #    precondition {
+  #     condition     = length(local.nodeset_out) == length(
+  #       flatten([for p in local.partitions_out : p.partition_nodeset])
+  #     )
+  #     error_message = "Each nodeset must be assigned to an exactly one partition."
+  #    }
+  # }
+  # TODO: preconditions to add:
+  # * If var.partition are specified => var.nodeset must be empty
+}
+
+locals {
+  debug_output = var.debug_mode ? {
+    project_id                 = var.project_id
+    slurm_cluster_name         = var.name
+    region                     = var.region
+    controller_instance_config = local.controller_out
+    nodeset                    = local.nodeset_out
+    partitions                 = local.partitions_out
+  } : null
+}

--- a/community/modules/slurm/cluster/outputs.tf
+++ b/community/modules/slurm/cluster/outputs.tf
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "debug" {
+  description = "Debug output, present IFF var.debug_mode is true"
+  value       = local.debug_output
+}

--- a/community/modules/slurm/cluster/variables.tf
+++ b/community/modules/slurm/cluster/variables.tf
@@ -1,0 +1,101 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########## GENERAL 
+variable "project_id" {
+  type        = string
+  description = "Project ID to create resources in."
+}
+
+variable "region" {
+  type        = string
+  description = "Region to create resources in."
+}
+
+
+variable "name" {
+  type        = string
+  description = "Cluster name, used for resource naming and slurm accounting."
+
+  validation {
+    condition     = can(regex("^[a-z](?:[a-z0-9]{0,9})$", var.name))
+    error_message = "Variable 'name' must be a match of regex '^[a-z](?:[a-z0-9]{0,9})$'."
+  }
+}
+
+
+variable "subnetwork_self_link" {
+  type        = string
+  description = "Subnet to deploy to."
+}
+
+########## BUCKET
+# TODO
+
+########## CONTROLLER: CLOUD  
+variable "controller" {
+  description = <<-EOD
+    Controller configuration. DO NOT configure manually, use `controller` module instead.
+    EOD
+  type        = any
+  default = {
+    machine_type = "n1-standard-4"
+    disk_type    = "pd-standard"
+  }
+
+  validation {
+    condition     = !contains(["c3-:pd-standard", "h3-:pd-standard", "h3-:pd-ssd"], "${substr(var.controller.machine_type, 0, 3)}:${var.controller.disk_type}")
+    error_message = "A disk_type=${var.controller.disk_type} cannot be used with machine_type=${var.controller.machine_type}."
+  }
+}
+
+########## CONTROLLER: HYBRID 
+# TODO
+
+########## LOGIN 
+# TODO
+
+########## NODESETS
+variable "nodeset" {
+  description = <<-EOD
+    Nodesets configuration. DO NOT configure manually, use `nodeset` module instead.
+    EOD
+  type        = list(any)
+  default     = []
+  validation {
+    condition     = length(distinct([for x in var.nodeset : x.name])) == length(var.nodeset)
+    error_message = "All nodesets must have a unique name."
+  }
+}
+
+########## PARTITION
+variable "partition" {
+  description = <<-EOD
+    Partitions configuration. DO NOT configure manually, use `partition` module instead.
+    EOD
+  type        = list(any)
+  default     = []
+}
+
+########## SLURM: TODO
+
+variable "debug_mode" {
+  description = <<EOD
+Developer debug mode:
+- Do not create cluster resources.
+- Output `debug` variable containing cluster configuration.
+EOD
+  type        = bool
+  default     = false
+}

--- a/community/modules/slurm/cluster/versions.tf
+++ b/community/modules/slurm/cluster/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.3.0"
+}

--- a/community/modules/slurm/controller/README.md
+++ b/community/modules/slurm/controller/README.md
@@ -1,0 +1,61 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_disks"></a> [additional\_disks](#input\_additional\_disks) | Configurations of additional disks to be included on the instance. (do not use "disk\_type: local-ssd"; known issue being addressed) | <pre>list(object({<br>    disk_name    = optional(string)<br>    device_name  = optional(string)<br>    disk_size_gb = optional(number)<br>    disk_type    = optional(string)<br>    disk_labels  = optional(map(string), {})<br>    auto_delete  = optional(bool, true)<br>    boot         = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Configures the network interface card and the maximum egress bandwidth for VMs.<br>  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.<br>  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.<br>  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).<br>  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.<br>  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.<br>  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details. | `string` | `"platform_default"` | no |
+| <a name="input_can_ip_forward"></a> [can\_ip\_forward](#input\_can\_ip\_forward) | Enable IP forwarding, for NAT instances for example. | `bool` | `false` | no |
+| <a name="input_disk_auto_delete"></a> [disk\_auto\_delete](#input\_disk\_auto\_delete) | Whether or not the boot disk should be auto-deleted. | `bool` | `true` | no |
+| <a name="input_disk_labels"></a> [disk\_labels](#input\_disk\_labels) | Labels specific to the boot disk. These will be merged with var.labels. | `map(string)` | `{}` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of boot disk to create for the partition compute nodes. | `number` | `50` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Boot disk type, can be either pd-ssd, pd-standard, pd-balanced, or pd-extreme. | `string` | `"pd-standard"` | no |
+| <a name="input_enable_confidential_vm"></a> [enable\_confidential\_vm](#input\_enable\_confidential\_vm) | Enable the Confidential VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables Google Cloud os-login for user login and authentication for VMs.<br>See https://cloud.google.com/compute/docs/oslogin | `bool` | `true` | no |
+| <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | If set to true. The VM will have a random public IP assigned to it | `bool` | `false` | no |
+| <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_smt"></a> [enable\_smt](#input\_enable\_smt) | Enables Simultaneous Multi-Threading (SMT) on instance. | `bool` | `false` | no |
+| <a name="input_enable_spot_vm"></a> [enable\_spot\_vm](#input\_enable\_spot\_vm) | Enable the partition to use spot VMs (https://cloud.google.com/spot-vms). | `bool` | `false` | no |
+| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br>    type  = string,<br>    count = number<br>  }))</pre> | `[]` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Defines the image that will be used on VM instances. <br><br>Expected Fields:<br>name: The name of the image. Mutually exclusive with family.<br>family: The image family to use. Mutually exclusive with name.<br>project: The project where the image is hosted.<br><br>For more information on creating custom images that comply with Slurm on GCP<br>see the "Slurm on GCP Custom Images" section in docs/vm-images.md. | `map(string)` | `{}` | no |
+| <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Self link to a custom instance template. If set, other VM definition<br>variables such as machine\_type and instance\_image will be ignored in favor<br>of the provided instance template.<br><br>For more information on creating custom images for the instance template<br>that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section<br>in docs/vm-images.md. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to partition compute instances. Key-value pairs. | `map(string)` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to create. | `string` | `"c2-standard-4"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
+| <a name="input_network_ip"></a> [network\_ip](#input\_network\_ip) | Private IP address to assign to the instance if desired. | `string` | `""` | no |
+| <a name="input_network_tier"></a> [network\_tier](#input\_network\_tier) | The networking tier used for configuring this instance. This field can take the following values: PREMIUM, FIXED\_STANDARD or STANDARD.<br>Ignored if enable\_public\_ip is false. | `string` | `"STANDARD"` | no |
+| <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Instance availability Policy.<br><br>Note: Placement groups are not supported when on\_host\_maintenance is set to<br>"MIGRATE" and will be deactivated regardless of the value of<br>enable\_placement. To support enable\_placement, ensure on\_host\_maintenance is<br>set to "TERMINATE". | `string` | `"TERMINATE"` | no |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Should use preemptibles to burst. | `bool` | `false` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the compute instances. If not set, the<br>default compute service account for the given project will be used with the<br>"https://www.googleapis.com/auth/cloud-platform" scope. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>- enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>- enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>- enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
+| <a name="input_spot_instance_config"></a> [spot\_instance\_config](#input\_spot\_instance\_config) | Configuration for spot VMs. | <pre>object({<br>    termination_action = string<br>  })</pre> | `null` | no |
+| <a name="input_static_ip"></a> [static\_ip](#input\_static\_ip) | Static IP for controller instance. | `string` | `null` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone where the instances should be created. If not specified, instances will be<br>spread across available zones in the region. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_controller"></a> [controller](#output\_controller) | Controller configuration, to be used by the cluster module. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/slurm/controller/gpu_definition.tf
+++ b/community/modules/slurm/controller/gpu_definition.tf
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+## Required variables:
+#  guest_accelerator
+#  machine_type
+
+locals {
+  # example state; terraform will ignore diffs if last element of URL matches
+  # guest_accelerator = [
+  #   {
+  #     count = 1
+  #     type  = "https://www.googleapis.com/compute/beta/projects/PROJECT/zones/ZONE/acceleratorTypes/nvidia-tesla-a100"
+  #   },
+  # ]
+  accelerator_machines = {
+    "a2-highgpu-1g"  = { type = "nvidia-tesla-a100", count = 1 },
+    "a2-highgpu-2g"  = { type = "nvidia-tesla-a100", count = 2 },
+    "a2-highgpu-4g"  = { type = "nvidia-tesla-a100", count = 4 },
+    "a2-highgpu-8g"  = { type = "nvidia-tesla-a100", count = 8 },
+    "a2-megagpu-16g" = { type = "nvidia-tesla-a100", count = 16 },
+    "a2-ultragpu-1g" = { type = "nvidia-a100-80gb", count = 1 },
+    "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
+    "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
+    "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-12" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-16" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-24" = { type = "nvidia-l4", count = 2 },
+    "g2-standard-32" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-48" = { type = "nvidia-l4", count = 4 },
+    "g2-standard-96" = { type = "nvidia-l4", count = 8 },
+  }
+  generated_guest_accelerator = try([local.accelerator_machines[var.machine_type]], [])
+
+  # Select in priority order:
+  # (1) var.guest_accelerator if not empty
+  # (2) local.generated_guest_accelerator if not empty
+  # (3) default to empty list if both are empty
+  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+}

--- a/community/modules/slurm/controller/main.tf
+++ b/community/modules/slurm/controller/main.tf
@@ -1,0 +1,59 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  # TODO: encahnce labels with role and module name
+  labels = var.labels
+}
+
+
+locals {
+  additional_disks = var.additional_disks # TODO: add labels
+
+  controller = {
+    additional_disks = local.additional_disks
+    bandwidth_tier   = var.bandwidth_tier
+    can_ip_forward   = var.can_ip_forward
+    enable_smt       = var.enable_smt
+
+    disk_auto_delete = var.disk_auto_delete
+    disk_labels      = merge(local.labels, var.disk_labels)
+    disk_size_gb     = var.disk_size_gb
+    disk_type        = var.disk_type
+
+    enable_confidential_vm   = var.enable_confidential_vm
+    enable_public_ip         = var.enable_public_ip
+    enable_oslogin           = var.enable_oslogin
+    enable_shielded_vm       = var.enable_shielded_vm
+    guest_accelerator        = local.guest_accelerator
+    instance_template        = var.instance_template
+    labels                   = local.labels
+    machine_type             = var.machine_type
+    metadata                 = var.metadata
+    min_cpu_platform         = var.min_cpu_platform
+    network_ip               = var.network_ip
+    network_tier             = var.network_tier
+    on_host_maintenance      = var.on_host_maintenance
+    preemptible              = var.preemptible
+    service_account          = var.service_account
+    shielded_instance_config = var.shielded_instance_config
+    instance_image           = var.instance_image
+    enable_spot_vm           = var.enable_spot_vm
+    static_ip                = var.static_ip
+    subnetwork_self_link     = var.subnetwork_self_link
+    tags                     = var.tags
+    spot_instance_config     = var.spot_instance_config
+    zone                     = var.zone
+  }
+}

--- a/community/modules/slurm/controller/outputs.tf
+++ b/community/modules/slurm/controller/outputs.tf
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "controller" {
+  description = <<-EOD
+    Controller configuration, to be used by the cluster module.
+  EOD
+  value       = local.controller
+}

--- a/community/modules/slurm/controller/variables.tf
+++ b/community/modules/slurm/controller/variables.tf
@@ -1,0 +1,44 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type to create."
+  default     = "c2-standard-4"
+}
+
+variable "zone" {
+  type        = string
+  description = <<EOD
+Zone where the instances should be created. If not specified, instances will be
+spread across available zones in the region.
+EOD
+  default     = null
+}
+
+variable "network_ip" {
+  type        = string
+  description = "Private IP address to assign to the instance if desired."
+  default     = ""
+}
+
+variable "static_ip" {
+  type        = string
+  description = "Static IP for controller instance."
+  default     = null
+}
+
+# IMPORTANT: See `variables_instance.tf` for more instance variables.
+# The majority of instance properties are shared by nodeset, controller, and login nodes.
+# For the sake of consistenct we define them in identicaly replicated `variables_instance.tf`.

--- a/community/modules/slurm/controller/variables_instance.tf
+++ b/community/modules/slurm/controller/variables_instance.tf
@@ -1,0 +1,286 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "disk_labels" {
+  description = "Labels specific to the boot disk. These will be merged with var.labels."
+  type        = map(string)
+  default     = {}
+}
+
+variable "disk_size_gb" {
+  description = "Size of boot disk to create for the partition compute nodes."
+  type        = number
+  default     = 50
+}
+
+variable "disk_type" {
+  description = "Boot disk type, can be either pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  type        = string
+  default     = "pd-standard"
+
+  validation {
+    condition     = contains(["pd-ssd", "pd-standard", "pd-balanced", "pd-extreme"], var.disk_type)
+    error_message = "Variable disk_type must be one of pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  }
+}
+
+variable "disk_auto_delete" {
+  type        = bool
+  description = "Whether or not the boot disk should be auto-deleted."
+  default     = true
+}
+
+variable "additional_disks" {
+  description = "Configurations of additional disks to be included on the instance. (do not use \"disk_type: local-ssd\"; known issue being addressed)"
+  type = list(object({
+    disk_name    = optional(string)
+    device_name  = optional(string)
+    disk_size_gb = optional(number)
+    disk_type    = optional(string)
+    disk_labels  = optional(map(string), {})
+    auto_delete  = optional(bool, true)
+    boot         = optional(bool, false)
+  }))
+  default = []
+}
+
+variable "bandwidth_tier" {
+  description = <<EOT
+  Configures the network interface card and the maximum egress bandwidth for VMs.
+  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.
+  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.
+  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).
+  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.
+  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.
+  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details.
+  EOT
+  type        = string
+  default     = "platform_default"
+
+  validation {
+    condition     = contains(["platform_default", "virtio_enabled", "gvnic_enabled", "tier_1_enabled"], var.bandwidth_tier)
+    error_message = "Allowed values for bandwidth_tier are 'platform_default', 'virtio_enabled', 'gvnic_enabled', or 'tier_1_enabled'."
+  }
+}
+
+variable "can_ip_forward" {
+  description = "Enable IP forwarding, for NAT instances for example."
+  type        = bool
+  default     = false
+}
+
+variable "enable_smt" {
+  type        = bool
+  description = "Enables Simultaneous Multi-Threading (SMT) on instance."
+  default     = false
+}
+
+
+variable "enable_confidential_vm" {
+  type        = bool
+  description = "Enable the Confidential VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_shielded_vm" {
+  type        = bool
+  description = "Enable the Shielded VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_oslogin" {
+  type        = bool
+  description = <<-EOD
+    Enables Google Cloud os-login for user login and authentication for VMs.
+    See https://cloud.google.com/compute/docs/oslogin
+    EOD
+  default     = true
+}
+
+variable "enable_public_ip" { # REVIEW_NOTE: change from V5 `disable_public_ips`
+  description = "If set to true. The VM will have a random public IP assigned to it"
+  type        = bool
+  default     = false
+}
+
+variable "instance_template" {
+  description = <<-EOD
+    Self link to a custom instance template. If set, other VM definition
+    variables such as machine_type and instance_image will be ignored in favor
+    of the provided instance template.
+
+    For more information on creating custom images for the instance template
+    that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section
+    in docs/vm-images.md.
+    EOD
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Labels to add to partition compute instances. Key-value pairs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "metadata" {
+  type        = map(string)
+  description = "Metadata, provided as a map."
+  default     = {}
+}
+
+variable "min_cpu_platform" {
+  description = "The name of the minimum CPU platform that you want the instance to use."
+  type        = string
+  default     = null
+}
+
+variable "on_host_maintenance" {
+  type        = string
+  description = <<-EOD
+    Instance availability Policy.
+
+    Note: Placement groups are not supported when on_host_maintenance is set to
+    "MIGRATE" and will be deactivated regardless of the value of
+    enable_placement. To support enable_placement, ensure on_host_maintenance is
+    set to "TERMINATE".
+    EOD
+  default     = "TERMINATE"
+}
+
+variable "network_tier" { # REVIEWER_NOTE: instead of V5 access_config
+  type        = string
+  description = <<-EOD
+    The networking tier used for configuring this instance. This field can take the following values: PREMIUM, FIXED_STANDARD or STANDARD.
+    Ignored if enable_public_ip is false.
+  EOD
+  default     = "STANDARD"
+
+  validation {
+    condition     = var.network_tier == null ? true : contains(["PREMIUM", "FIXED_STANDARD", "STANDARD"], var.network_tier)
+    error_message = "Allow values are: 'PREMIUM', 'FIXED_STANDARD', 'STANDARD'."
+  }
+}
+
+variable "preemptible" {
+  description = "Should use preemptibles to burst."
+  type        = bool
+  default     = false
+}
+
+variable "service_account" {
+  type = object({
+    email  = string
+    scopes = set(string)
+  })
+  description = <<-EOD
+    Service account to attach to the compute instances. If not set, the
+    default compute service account for the given project will be used with the
+    "https://www.googleapis.com/auth/cloud-platform" scope.
+    EOD
+  default     = null
+}
+
+variable "shielded_instance_config" {
+  type = object({
+    enable_integrity_monitoring = bool
+    enable_secure_boot          = bool
+    enable_vtpm                 = bool
+  })
+  description = <<-EOD
+    Shielded VM configuration for the instance. Note: not used unless
+    enable_shielded_vm is 'true'.
+    - enable_integrity_monitoring : Compare the most recent boot measurements to the
+      integrity policy baseline and return a pair of pass/fail results depending on
+      whether they match or not.
+    - enable_secure_boot : Verify the digital signature of all boot components, and
+      halt the boot process if signature verification fails.
+    - enable_vtpm : Use a virtualized trusted platform module, which is a
+      specialized computer chip you can use to encrypt objects like keys and
+      certificates.
+    EOD
+  default = {
+    enable_integrity_monitoring = true
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+  }
+}
+
+variable "instance_image" {
+  # TODO: It's TF 1.3+, use object with optional fields instead.
+  description = <<-EOD
+    Defines the image that will be used on VM instances. 
+
+    Expected Fields:
+    name: The name of the image. Mutually exclusive with family.
+    family: The image family to use. Mutually exclusive with name.
+    project: The project where the image is hosted.
+
+    For more information on creating custom images that comply with Slurm on GCP
+    see the "Slurm on GCP Custom Images" section in docs/vm-images.md.
+    EOD
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = length(var.instance_image) == 0 || (
+    can(var.instance_image["family"]) || can(var.instance_image["name"])) == can(var.instance_image["project"])
+    error_message = "The \"project\" is required if \"family\" or \"name\" are provided in var.instance_image."
+  }
+  validation {
+    condition     = length(var.instance_image) == 0 || can(var.instance_image["family"]) != can(var.instance_image["name"])
+    error_message = "Exactly one of \"family\" and \"name\" must be provided in var.instance_image."
+  }
+}
+
+variable "enable_spot_vm" {
+  description = "Enable the partition to use spot VMs (https://cloud.google.com/spot-vms)."
+  type        = bool
+  default     = false
+}
+
+variable "spot_instance_config" {
+  description = "Configuration for spot VMs."
+  type = object({
+    termination_action = string
+  })
+  default = null
+}
+
+variable "subnetwork_self_link" {
+  type        = string
+  description = "Subnet to deploy to."
+  default     = null
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "Network tag list."
+  default     = []
+}
+
+variable "guest_accelerator" {
+  description = "List of the type and count of accelerator cards attached to the instance."
+  type = list(object({
+    type  = string,
+    count = number
+  }))
+  default  = []
+  nullable = false
+
+  validation {
+    condition     = length(var.guest_accelerator) <= 1
+    error_message = "The Slurm modules supports 0 or 1 models of accelerator card on each node."
+  }
+}

--- a/community/modules/slurm/controller/versions.tf
+++ b/community/modules/slurm/controller/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.3.0"
+}

--- a/community/modules/slurm/nodeset/README.md
+++ b/community/modules/slurm/nodeset/README.md
@@ -1,0 +1,66 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_disks"></a> [additional\_disks](#input\_additional\_disks) | Configurations of additional disks to be included on the instance. (do not use "disk\_type: local-ssd"; known issue being addressed) | <pre>list(object({<br>    disk_name    = optional(string)<br>    device_name  = optional(string)<br>    disk_size_gb = optional(number)<br>    disk_type    = optional(string)<br>    disk_labels  = optional(map(string), {})<br>    auto_delete  = optional(bool, true)<br>    boot         = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Configures the network interface card and the maximum egress bandwidth for VMs.<br>  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.<br>  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.<br>  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).<br>  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.<br>  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.<br>  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details. | `string` | `"platform_default"` | no |
+| <a name="input_can_ip_forward"></a> [can\_ip\_forward](#input\_can\_ip\_forward) | Enable IP forwarding, for NAT instances for example. | `bool` | `false` | no |
+| <a name="input_disk_auto_delete"></a> [disk\_auto\_delete](#input\_disk\_auto\_delete) | Whether or not the boot disk should be auto-deleted. | `bool` | `true` | no |
+| <a name="input_disk_labels"></a> [disk\_labels](#input\_disk\_labels) | Labels specific to the boot disk. These will be merged with var.labels. | `map(string)` | `{}` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of boot disk to create for the partition compute nodes. | `number` | `50` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Boot disk type, can be either pd-ssd, pd-standard, pd-balanced, or pd-extreme. | `string` | `"pd-standard"` | no |
+| <a name="input_enable_confidential_vm"></a> [enable\_confidential\_vm](#input\_enable\_confidential\_vm) | Enable the Confidential VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables Google Cloud os-login for user login and authentication for VMs.<br>See https://cloud.google.com/compute/docs/oslogin | `bool` | `true` | no |
+| <a name="input_enable_placement"></a> [enable\_placement](#input\_enable\_placement) | Enables compact placement policy for instances.<br>Use compact policies when you want VMs to be located close to each other for low network latency between the VMs.<br>See https://cloud.google.com/compute/docs/instances/define-instance-placement for details. | `bool` | `true` | no |
+| <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | If set to true. The VM will have a random public IP assigned to it | `bool` | `false` | no |
+| <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_smt"></a> [enable\_smt](#input\_enable\_smt) | Enables Simultaneous Multi-Threading (SMT) on instance. | `bool` | `false` | no |
+| <a name="input_enable_spot_vm"></a> [enable\_spot\_vm](#input\_enable\_spot\_vm) | Enable the partition to use spot VMs (https://cloud.google.com/spot-vms). | `bool` | `false` | no |
+| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br>    type  = string,<br>    count = number<br>  }))</pre> | `[]` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Defines the image that will be used on VM instances. <br><br>Expected Fields:<br>name: The name of the image. Mutually exclusive with family.<br>family: The image family to use. Mutually exclusive with name.<br>project: The project where the image is hosted.<br><br>For more information on creating custom images that comply with Slurm on GCP<br>see the "Slurm on GCP Custom Images" section in docs/vm-images.md. | `map(string)` | `{}` | no |
+| <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Self link to a custom instance template. If set, other VM definition<br>variables such as machine\_type and instance\_image will be ignored in favor<br>of the provided instance template.<br><br>For more information on creating custom images for the instance template<br>that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section<br>in docs/vm-images.md. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to partition compute instances. Key-value pairs. | `map(string)` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes. | `string` | `"c2-standard-60"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the node set. | `string` | n/a | yes |
+| <a name="input_network_tier"></a> [network\_tier](#input\_network\_tier) | The networking tier used for configuring this instance. This field can take the following values: PREMIUM, FIXED\_STANDARD or STANDARD.<br>Ignored if enable\_public\_ip is false. | `string` | `"STANDARD"` | no |
+| <a name="input_node_conf"></a> [node\_conf](#input\_node\_conf) | Map of Slurm node line configuration. | `map(any)` | `{}` | no |
+| <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of nodes allowed in this partition to be created dynamically. | `number` | `1` | no |
+| <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |
+| <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Instance availability Policy.<br><br>Note: Placement groups are not supported when on\_host\_maintenance is set to<br>"MIGRATE" and will be deactivated regardless of the value of<br>enable\_placement. To support enable\_placement, ensure on\_host\_maintenance is<br>set to "TERMINATE". | `string` | `"TERMINATE"` | no |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Should use preemptibles to burst. | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region to create resources in. | `string` | n/a | yes |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the compute instances. If not set, the<br>default compute service account for the given project will be used with the<br>"https://www.googleapis.com/auth/cloud-platform" scope. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>- enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>- enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>- enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
+| <a name="input_spot_instance_config"></a> [spot\_instance\_config](#input\_spot\_instance\_config) | Configuration for spot VMs. | <pre>object({<br>    termination_action = string<br>  })</pre> | `null` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
+| <a name="input_zone_target_shape"></a> [zone\_target\_shape](#input\_zone\_target\_shape) | Strategy for distributing VMs across zones in a region.<br>ANY<br>  GCE picks zones for creating VM instances to fulfill the requested number of VMs<br>  within present resource constraints and to maximize utilization of unused zonal<br>  reservations.<br>ANY\_SINGLE\_ZONE (default)<br>  GCE always selects a single zone for all the VMs, optimizing for resource quotas,<br>  available reservations and general capacity.<br>BALANCED<br>  GCE prioritizes acquisition of resources, scheduling VMs in zones where resources<br>  are available while distributing VMs as evenly as possible across allowed zones<br>  to minimize the impact of zonal failure. | `string` | `"ANY_SINGLE_ZONE"` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | Zones in which to allow creation of nodes. Google Cloud<br>will find zone based on availability, quota and reservations. | `set(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nodeset"></a> [nodeset](#output\_nodeset) | Nodeset configuration, to be used by the cluster or partition modules. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/slurm/nodeset/gpu_definition.tf
+++ b/community/modules/slurm/nodeset/gpu_definition.tf
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+## Required variables:
+#  guest_accelerator
+#  machine_type
+
+locals {
+  # example state; terraform will ignore diffs if last element of URL matches
+  # guest_accelerator = [
+  #   {
+  #     count = 1
+  #     type  = "https://www.googleapis.com/compute/beta/projects/PROJECT/zones/ZONE/acceleratorTypes/nvidia-tesla-a100"
+  #   },
+  # ]
+  accelerator_machines = {
+    "a2-highgpu-1g"  = { type = "nvidia-tesla-a100", count = 1 },
+    "a2-highgpu-2g"  = { type = "nvidia-tesla-a100", count = 2 },
+    "a2-highgpu-4g"  = { type = "nvidia-tesla-a100", count = 4 },
+    "a2-highgpu-8g"  = { type = "nvidia-tesla-a100", count = 8 },
+    "a2-megagpu-16g" = { type = "nvidia-tesla-a100", count = 16 },
+    "a2-ultragpu-1g" = { type = "nvidia-a100-80gb", count = 1 },
+    "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
+    "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
+    "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-12" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-16" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-24" = { type = "nvidia-l4", count = 2 },
+    "g2-standard-32" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-48" = { type = "nvidia-l4", count = 4 },
+    "g2-standard-96" = { type = "nvidia-l4", count = 8 },
+  }
+  generated_guest_accelerator = try([local.accelerator_machines[var.machine_type]], [])
+
+  # Select in priority order:
+  # (1) var.guest_accelerator if not empty
+  # (2) local.generated_guest_accelerator if not empty
+  # (3) default to empty list if both are empty
+  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+}

--- a/community/modules/slurm/nodeset/main.tf
+++ b/community/modules/slurm/nodeset/main.tf
@@ -1,0 +1,65 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  # TODO: encahnce labels with role and module name
+  labels = var.labels
+}
+
+locals {
+
+  additional_disks = var.additional_disks # TODO: add labels
+  # TODO: make local.common_instance_settings object to merge in here, place in replicated file
+  nodeset = {
+    node_count_static      = var.node_count_static
+    node_count_dynamic_max = var.node_count_dynamic_max
+    node_conf              = var.node_conf
+    name                   = var.name
+
+    additional_disks = local.additional_disks
+    bandwidth_tier   = var.bandwidth_tier
+    can_ip_forward   = var.can_ip_forward
+    enable_smt       = var.enable_smt
+
+    disk_auto_delete         = var.disk_auto_delete
+    disk_labels              = merge(local.labels, var.disk_labels)
+    disk_size_gb             = var.disk_size_gb
+    disk_type                = var.disk_type
+    enable_confidential_vm   = var.enable_confidential_vm
+    enable_placement         = var.enable_placement
+    enable_public_ip         = var.enable_public_ip
+    enable_oslogin           = var.enable_oslogin
+    enable_shielded_vm       = var.enable_shielded_vm
+    guest_accelerator        = local.guest_accelerator
+    instance_template        = var.instance_template
+    labels                   = local.labels
+    machine_type             = var.machine_type
+    metadata                 = var.metadata
+    min_cpu_platform         = var.min_cpu_platform
+    network_tier             = var.network_tier
+    on_host_maintenance      = var.on_host_maintenance
+    preemptible              = var.preemptible
+    region                   = var.region
+    service_account          = var.service_account
+    shielded_instance_config = var.shielded_instance_config
+    instance_image           = var.instance_image
+
+    subnetwork_self_link = var.subnetwork_self_link
+    enable_spot_vm       = var.enable_spot_vm
+    tags                 = var.tags
+    spot_instance_config = var.spot_instance_config
+    zones                = var.zones
+    zone_target_shape    = var.zone_target_shape
+  }
+}

--- a/community/modules/slurm/nodeset/outputs.tf
+++ b/community/modules/slurm/nodeset/outputs.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "nodeset" {
+  description = <<-EOD
+    Nodeset configuration, to be used by the cluster or partition modules.
+  EOD
+  value       = local.nodeset
+
+  precondition {
+    condition = !contains([
+      "c3-:pd-standard",
+      "h3-:pd-standard",
+      "h3-:pd-ssd",
+    ], "${substr(var.machine_type, 0, 3)}:${var.disk_type}")
+    error_message = "A disk_type=${var.disk_type} cannot be used with machine_type=${var.machine_type}."
+  }
+}

--- a/community/modules/slurm/nodeset/variables.tf
+++ b/community/modules/slurm/nodeset/variables.tf
@@ -1,0 +1,102 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "region" {
+  type        = string
+  description = "Region to create resources in."
+}
+
+variable "name" {
+  description = "Name of the node set."
+  type        = string
+}
+
+variable "node_conf" {
+  description = "Map of Slurm node line configuration."
+  type        = map(any)
+  default     = {}
+}
+
+variable "node_count_static" {
+  description = "Number of nodes to be statically created."
+  type        = number
+  default     = 0
+}
+
+variable "node_count_dynamic_max" {
+  description = "Maximum number of nodes allowed in this partition to be created dynamically."
+  type        = number
+  default     = 1
+}
+
+# Instance properties
+
+variable "machine_type" {
+  description = "Compute Platform machine type to use for this partition compute nodes."
+  type        = string
+  default     = "c2-standard-60"
+}
+
+variable "zones" {
+  description = <<-EOD
+    Zones in which to allow creation of nodes. Google Cloud
+    will find zone based on availability, quota and reservations.
+    EOD
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for x in var.zones : length(regexall("^[a-z]+-[a-z]+[0-9]-[a-z]$", x)) > 0
+    ])
+    error_message = "A value in var.zones is not a valid zone (example: us-central1-f)."
+  }
+}
+
+variable "zone_target_shape" {
+  description = <<EOD
+Strategy for distributing VMs across zones in a region.
+ANY
+  GCE picks zones for creating VM instances to fulfill the requested number of VMs
+  within present resource constraints and to maximize utilization of unused zonal
+  reservations.
+ANY_SINGLE_ZONE (default)
+  GCE always selects a single zone for all the VMs, optimizing for resource quotas,
+  available reservations and general capacity.
+BALANCED
+  GCE prioritizes acquisition of resources, scheduling VMs in zones where resources
+  are available while distributing VMs as evenly as possible across allowed zones
+  to minimize the impact of zonal failure.
+EOD
+  type        = string
+  default     = "ANY_SINGLE_ZONE"
+  validation {
+    condition     = contains(["ANY", "ANY_SINGLE_ZONE", "BALANCED"], var.zone_target_shape)
+    error_message = "Allowed values for zone_target_shape are \"ANY\", \"ANY_SINGLE_ZONE\", or \"BALANCED\"."
+  }
+}
+
+variable "enable_placement" { # REVIEWER_NOTE: moved down from partition
+  description = <<-EOD
+    Enables compact placement policy for instances.
+    Use compact policies when you want VMs to be located close to each other for low network latency between the VMs.
+    See https://cloud.google.com/compute/docs/instances/define-instance-placement for details.
+  EOD
+  type        = bool
+  default     = true
+}
+
+# IMPORTANT: See `variables_instance.tf` for more instance variables.
+# The majority of instance properties are shared by nodeset, controller, and login nodes.
+# For the sake of consistenct we define them in identicaly replicated `variables_instance.tf`.

--- a/community/modules/slurm/nodeset/variables_instance.tf
+++ b/community/modules/slurm/nodeset/variables_instance.tf
@@ -1,0 +1,286 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "disk_labels" {
+  description = "Labels specific to the boot disk. These will be merged with var.labels."
+  type        = map(string)
+  default     = {}
+}
+
+variable "disk_size_gb" {
+  description = "Size of boot disk to create for the partition compute nodes."
+  type        = number
+  default     = 50
+}
+
+variable "disk_type" {
+  description = "Boot disk type, can be either pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  type        = string
+  default     = "pd-standard"
+
+  validation {
+    condition     = contains(["pd-ssd", "pd-standard", "pd-balanced", "pd-extreme"], var.disk_type)
+    error_message = "Variable disk_type must be one of pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  }
+}
+
+variable "disk_auto_delete" {
+  type        = bool
+  description = "Whether or not the boot disk should be auto-deleted."
+  default     = true
+}
+
+variable "additional_disks" {
+  description = "Configurations of additional disks to be included on the instance. (do not use \"disk_type: local-ssd\"; known issue being addressed)"
+  type = list(object({
+    disk_name    = optional(string)
+    device_name  = optional(string)
+    disk_size_gb = optional(number)
+    disk_type    = optional(string)
+    disk_labels  = optional(map(string), {})
+    auto_delete  = optional(bool, true)
+    boot         = optional(bool, false)
+  }))
+  default = []
+}
+
+variable "bandwidth_tier" {
+  description = <<EOT
+  Configures the network interface card and the maximum egress bandwidth for VMs.
+  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.
+  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.
+  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).
+  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.
+  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.
+  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details.
+  EOT
+  type        = string
+  default     = "platform_default"
+
+  validation {
+    condition     = contains(["platform_default", "virtio_enabled", "gvnic_enabled", "tier_1_enabled"], var.bandwidth_tier)
+    error_message = "Allowed values for bandwidth_tier are 'platform_default', 'virtio_enabled', 'gvnic_enabled', or 'tier_1_enabled'."
+  }
+}
+
+variable "can_ip_forward" {
+  description = "Enable IP forwarding, for NAT instances for example."
+  type        = bool
+  default     = false
+}
+
+variable "enable_smt" {
+  type        = bool
+  description = "Enables Simultaneous Multi-Threading (SMT) on instance."
+  default     = false
+}
+
+
+variable "enable_confidential_vm" {
+  type        = bool
+  description = "Enable the Confidential VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_shielded_vm" {
+  type        = bool
+  description = "Enable the Shielded VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_oslogin" {
+  type        = bool
+  description = <<-EOD
+    Enables Google Cloud os-login for user login and authentication for VMs.
+    See https://cloud.google.com/compute/docs/oslogin
+    EOD
+  default     = true
+}
+
+variable "enable_public_ip" { # REVIEW_NOTE: change from V5 `disable_public_ips`
+  description = "If set to true. The VM will have a random public IP assigned to it"
+  type        = bool
+  default     = false
+}
+
+variable "instance_template" {
+  description = <<-EOD
+    Self link to a custom instance template. If set, other VM definition
+    variables such as machine_type and instance_image will be ignored in favor
+    of the provided instance template.
+
+    For more information on creating custom images for the instance template
+    that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section
+    in docs/vm-images.md.
+    EOD
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Labels to add to partition compute instances. Key-value pairs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "metadata" {
+  type        = map(string)
+  description = "Metadata, provided as a map."
+  default     = {}
+}
+
+variable "min_cpu_platform" {
+  description = "The name of the minimum CPU platform that you want the instance to use."
+  type        = string
+  default     = null
+}
+
+variable "on_host_maintenance" {
+  type        = string
+  description = <<-EOD
+    Instance availability Policy.
+
+    Note: Placement groups are not supported when on_host_maintenance is set to
+    "MIGRATE" and will be deactivated regardless of the value of
+    enable_placement. To support enable_placement, ensure on_host_maintenance is
+    set to "TERMINATE".
+    EOD
+  default     = "TERMINATE"
+}
+
+variable "network_tier" { # REVIEWER_NOTE: instead of V5 access_config
+  type        = string
+  description = <<-EOD
+    The networking tier used for configuring this instance. This field can take the following values: PREMIUM, FIXED_STANDARD or STANDARD.
+    Ignored if enable_public_ip is false.
+  EOD
+  default     = "STANDARD"
+
+  validation {
+    condition     = var.network_tier == null ? true : contains(["PREMIUM", "FIXED_STANDARD", "STANDARD"], var.network_tier)
+    error_message = "Allow values are: 'PREMIUM', 'FIXED_STANDARD', 'STANDARD'."
+  }
+}
+
+variable "preemptible" {
+  description = "Should use preemptibles to burst."
+  type        = bool
+  default     = false
+}
+
+variable "service_account" {
+  type = object({
+    email  = string
+    scopes = set(string)
+  })
+  description = <<-EOD
+    Service account to attach to the compute instances. If not set, the
+    default compute service account for the given project will be used with the
+    "https://www.googleapis.com/auth/cloud-platform" scope.
+    EOD
+  default     = null
+}
+
+variable "shielded_instance_config" {
+  type = object({
+    enable_integrity_monitoring = bool
+    enable_secure_boot          = bool
+    enable_vtpm                 = bool
+  })
+  description = <<-EOD
+    Shielded VM configuration for the instance. Note: not used unless
+    enable_shielded_vm is 'true'.
+    - enable_integrity_monitoring : Compare the most recent boot measurements to the
+      integrity policy baseline and return a pair of pass/fail results depending on
+      whether they match or not.
+    - enable_secure_boot : Verify the digital signature of all boot components, and
+      halt the boot process if signature verification fails.
+    - enable_vtpm : Use a virtualized trusted platform module, which is a
+      specialized computer chip you can use to encrypt objects like keys and
+      certificates.
+    EOD
+  default = {
+    enable_integrity_monitoring = true
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+  }
+}
+
+variable "instance_image" {
+  # TODO: It's TF 1.3+, use object with optional fields instead.
+  description = <<-EOD
+    Defines the image that will be used on VM instances. 
+
+    Expected Fields:
+    name: The name of the image. Mutually exclusive with family.
+    family: The image family to use. Mutually exclusive with name.
+    project: The project where the image is hosted.
+
+    For more information on creating custom images that comply with Slurm on GCP
+    see the "Slurm on GCP Custom Images" section in docs/vm-images.md.
+    EOD
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = length(var.instance_image) == 0 || (
+    can(var.instance_image["family"]) || can(var.instance_image["name"])) == can(var.instance_image["project"])
+    error_message = "The \"project\" is required if \"family\" or \"name\" are provided in var.instance_image."
+  }
+  validation {
+    condition     = length(var.instance_image) == 0 || can(var.instance_image["family"]) != can(var.instance_image["name"])
+    error_message = "Exactly one of \"family\" and \"name\" must be provided in var.instance_image."
+  }
+}
+
+variable "enable_spot_vm" {
+  description = "Enable the partition to use spot VMs (https://cloud.google.com/spot-vms)."
+  type        = bool
+  default     = false
+}
+
+variable "spot_instance_config" {
+  description = "Configuration for spot VMs."
+  type = object({
+    termination_action = string
+  })
+  default = null
+}
+
+variable "subnetwork_self_link" {
+  type        = string
+  description = "Subnet to deploy to."
+  default     = null
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "Network tag list."
+  default     = []
+}
+
+variable "guest_accelerator" {
+  description = "List of the type and count of accelerator cards attached to the instance."
+  type = list(object({
+    type  = string,
+    count = number
+  }))
+  default  = []
+  nullable = false
+
+  validation {
+    condition     = length(var.guest_accelerator) <= 1
+    error_message = "The Slurm modules supports 0 or 1 models of accelerator card on each node."
+  }
+}

--- a/community/modules/slurm/nodeset/versions.tf
+++ b/community/modules/slurm/nodeset/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.3.0"
+}

--- a/community/modules/slurm/partition/README.md
+++ b/community/modules/slurm/partition/README.md
@@ -1,0 +1,40 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_exclusive"></a> [exclusive](#input\_exclusive) | Exclusive job access to nodes. | `bool` | `true` | no |
+| <a name="input_is_default"></a> [is\_default](#input\_is\_default) | If this is true, jobs submitted without a partition specification will utilize this partition.<br>This sets 'Default' in partition\_conf.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_Default for details. | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the slurm partition. | `string` | n/a | yes |
+| <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | A list of network attached storage mounts to be configured on the partition compute nodes. | <pre>list(object({<br>    server_ip     = string,<br>    remote_mount  = string,<br>    local_mount   = string,<br>    fs_type       = string,<br>    mount_options = string, # REVIEWER_NOTE: removed runners<br>  }))</pre> | `[]` | no |
+| <a name="input_nodeset"></a> [nodeset](#input\_nodeset) | A list of nodesets associated with this partition. <br>DO NOT specifi manually, use the nodeset module instead. | `list(any)` | `[]` | no |
+| <a name="input_partition_conf"></a> [partition\_conf](#input\_partition\_conf) | Slurm partition configuration as a map.<br>See https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION | `map(string)` | `{}` | no |
+| <a name="input_resume_timeout"></a> [resume\_timeout](#input\_resume\_timeout) | Maximum time permitted (in seconds) between when a node resume request is issued and when the node is actually available for use.<br>If null is given, then a smart default will be chosen depending on nodesets in partition.<br>This sets 'ResumeTimeout' in partition\_conf.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_ResumeTimeout_1 for details. | `number` | `null` | no |
+| <a name="input_suspend_time"></a> [suspend\_time](#input\_suspend\_time) | Nodes which remain idle or down for this number of seconds will be placed into power save mode by SuspendProgram.<br>This sets 'SuspendTime' in partition\_conf.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_SuspendTime_1 for details.<br>NOTE: use value -1 to exclude partition from suspend. | `number` | `300` | no |
+| <a name="input_suspend_timeout"></a> [suspend\_timeout](#input\_suspend\_timeout) | Maximum time permitted (in seconds) between when a node suspend request is issued and when the node is shutdown.<br>If null is given, then a smart default will be chosen depending on nodesets in partition.<br>This sets 'SuspendTimeout' in partition\_conf.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_SuspendTimeout_1 for details. | `number` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nodeset"></a> [nodeset](#output\_nodeset) | Nodesets configuration, to be used by the cluster module. |
+| <a name="output_partition"></a> [partition](#output\_partition) | Parition configuration, to be used by the cluster module. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/slurm/partition/main.tf
+++ b/community/modules/slurm/partition/main.tf
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  # TODO: add default nodeset
+
+  partition = {
+    name                  = var.name
+    is_default            = var.is_default
+    exclusive             = var.exclusive
+    network_storage       = var.network_storage
+    partition_conf        = var.partition_conf
+    partition_nodeset     = [for ns in var.nodeset : ns.name]
+    partition_nodeset_dyn = [] # TODO: add
+    partition_nodeset_tpu = [] # TODO: add
+    resume_timeout        = var.resume_timeout
+    suspend_time          = var.suspend_time
+    suspend_timeout       = var.suspend_timeout
+  }
+}

--- a/community/modules/slurm/partition/outputs.tf
+++ b/community/modules/slurm/partition/outputs.tf
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "partition" {
+  description = <<-EOD
+    Parition configuration, to be used by the cluster module.
+  EOD
+  value       = local.partition
+}
+
+output "nodeset" {
+  description = <<-EOD
+    Nodesets configuration, to be used by the cluster module.
+  EOD
+  value       = var.nodeset
+}

--- a/community/modules/slurm/partition/variables.tf
+++ b/community/modules/slurm/partition/variables.tf
@@ -1,0 +1,124 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "name" { # REVIEWER_NOTE: `name` instead of `partition_name` + removed length restriction
+  description = "The name of the slurm partition."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z](?:[a-z0-9]*)$", var.name))
+    error_message = "Variable 'name' must be composed of only alphanumeric characters and start with a letter. Regexp: '^[a-z](?:[a-z0-9]*)$'."
+  }
+}
+
+
+variable "is_default" {
+  description = <<-EOD
+    If this is true, jobs submitted without a partition specification will utilize this partition.
+    This sets 'Default' in partition_conf.
+    See https://slurm.schedmd.com/slurm.conf.html#OPT_Default for details.
+    EOD
+  type        = bool
+  default     = false
+}
+
+variable "exclusive" {
+  description = "Exclusive job access to nodes."
+  type        = bool
+  default     = true
+}
+
+variable "network_storage" {
+  description = "A list of network attached storage mounts to be configured on the partition compute nodes."
+  type = list(object({
+    server_ip     = string,
+    remote_mount  = string,
+    local_mount   = string,
+    fs_type       = string,
+    mount_options = string, # REVIEWER_NOTE: removed runners
+  }))
+  default = []
+}
+
+variable "partition_conf" {
+  description = <<-EOD
+    Slurm partition configuration as a map.
+    See https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION
+    EOD
+  type        = map(string)
+  default     = {}
+}
+
+variable "resume_timeout" {
+  description = <<-EOD
+    Maximum time permitted (in seconds) between when a node resume request is issued and when the node is actually available for use.
+    If null is given, then a smart default will be chosen depending on nodesets in partition.
+    This sets 'ResumeTimeout' in partition_conf.
+    See https://slurm.schedmd.com/slurm.conf.html#OPT_ResumeTimeout_1 for details.
+  EOD
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.resume_timeout == null ? true : var.resume_timeout > 0
+    error_message = "Value must be > 0."
+  }
+}
+
+variable "suspend_time" {
+  description = <<-EOD
+    Nodes which remain idle or down for this number of seconds will be placed into power save mode by SuspendProgram.
+    This sets 'SuspendTime' in partition_conf.
+    See https://slurm.schedmd.com/slurm.conf.html#OPT_SuspendTime_1 for details.
+    NOTE: use value -1 to exclude partition from suspend.
+  EOD
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.suspend_time >= -1
+    error_message = "Value must be >= -1."
+  }
+}
+
+variable "suspend_timeout" {
+  description = <<-EOD
+    Maximum time permitted (in seconds) between when a node suspend request is issued and when the node is shutdown.
+    If null is given, then a smart default will be chosen depending on nodesets in partition.
+    This sets 'SuspendTimeout' in partition_conf.
+    See https://slurm.schedmd.com/slurm.conf.html#OPT_SuspendTimeout_1 for details.
+  EOD
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.suspend_timeout == null ? true : var.suspend_timeout > 0
+    error_message = "Value must be > 0."
+  }
+}
+
+
+variable "nodeset" {
+  description = <<-EOT
+    A list of nodesets associated with this partition. 
+    DO NOT specifi manually, use the nodeset module instead.
+    EOT
+  type        = list(any) # TODO: add note about source of truth
+  default     = []
+
+  validation {
+    condition     = length(distinct([for ns in var.nodeset : ns.name])) == length(var.nodeset)
+    error_message = "All nodesets must have a unique name."
+  }
+}

--- a/community/modules/slurm/partition/versions.tf
+++ b/community/modules/slurm/partition/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.3.0"
+}

--- a/community/modules/slurm/tests/bp.yaml
+++ b/community/modules/slurm/tests/bp.yaml
@@ -1,0 +1,77 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+blueprint_name: test
+vars:
+  project_id: zoro
+  region: narnia
+  deployment_name: test
+  debug_mode: true
+  # can't use real network modules while having deterministic test,
+  # specify explicit subnetwork_self_link instead
+  subnet_sl: projects/zoro/regions/narnia/subnetworks/default
+
+deployment_groups:
+- group: primary
+  modules:
+
+  - id: test1 # Minimal cluster
+    source: ./community/modules/slurm/cluster
+    settings:
+      name: test1
+      subnetwork_self_link: $(vars.subnet_sl)
+    outputs: [debug]
+
+
+  - id: ns1
+    source: ./community/modules/slurm/nodeset
+    settings:
+      name: ns1
+      machine_type: c2-standard-4
+
+  - id: test2 # Cluster with explicit nodeset
+    source: ./community/modules/slurm/cluster
+    use: [ns1]
+    settings:
+      name: test2
+      subnetwork_self_link: $(vars.subnet_sl)
+    outputs: [debug]
+
+  - id: pt1
+    source: ./community/modules/slurm/partition
+    use: [ns1]
+    settings:
+      name: pt1
+
+  - id: test3 # Cluster with explicit partition
+    source: ./community/modules/slurm/cluster
+    use: [pt1]
+    settings:
+      name: test3
+      subnetwork_self_link: $(vars.subnet_sl)
+    outputs: [debug]
+
+  - id: cntrl1
+    source: ./community/modules/slurm/controller
+    settings:
+      machine_type: c2-standard-4
+      disk_type: pd-ssd
+
+  - id: test4 # All settings
+    source: ./community/modules/slurm/cluster
+    use: [pt1, cntrl1]
+    settings:
+      name: test4
+      subnetwork_self_link: $(vars.subnet_sl)
+    outputs: [debug]

--- a/community/modules/slurm/tests/expectations/debug_test1
+++ b/community/modules/slurm/tests/expectations/debug_test1
@@ -1,0 +1,51 @@
+{
+  "controller_instance_config" = {
+    "disable_smt" = true
+    "disk_type" = "pd-standard"
+    "gpu" = null
+    "instance_image" = {}
+    "machine_type" = "n1-standard-4"
+    "region" = "narnia"
+    "source_image" = ""
+    "source_image_family" = ""
+    "source_image_project" = ""
+    "spot" = false
+    "subnetwork" = "projects/zoro/regions/narnia/subnetworks/default"
+    "subnetwork_self_link" = "projects/zoro/regions/narnia/subnetworks/default"
+    "termination_action" = null
+  }
+  "nodeset" = [
+    {
+      "disable_smt" = true
+      "gpu" = null
+      "instance_image" = {}
+      "machine_type" = "n1-standard-4"
+      "name" = "defaultns"
+      "nodeset_name" = "defaultns"
+      "region" = "narnia"
+      "source_image" = ""
+      "source_image_family" = ""
+      "source_image_project" = ""
+      "spot" = false
+      "subnetwork" = "projects/zoro/regions/narnia/subnetworks/default"
+      "subnetwork_self_link" = "projects/zoro/regions/narnia/subnetworks/default"
+      "termination_action" = null
+    },
+  ]
+  "partitions" = [
+    {
+      "default" = true
+      "enable_job_exclusive" = true
+      "exclusive" = true
+      "is_default" = true
+      "name" = "default"
+      "partition_name" = "default"
+      "partition_nodeset" = [
+        "defaultns",
+      ]
+    },
+  ]
+  "project_id" = "zoro"
+  "region" = "narnia"
+  "slurm_cluster_name" = "test1"
+}

--- a/community/modules/slurm/tests/expectations/debug_test2
+++ b/community/modules/slurm/tests/expectations/debug_test2
@@ -1,0 +1,94 @@
+{
+  "controller_instance_config" = {
+    "disable_smt" = true
+    "disk_type" = "pd-standard"
+    "gpu" = null
+    "instance_image" = {}
+    "machine_type" = "n1-standard-4"
+    "region" = "narnia"
+    "source_image" = ""
+    "source_image_family" = ""
+    "source_image_project" = ""
+    "spot" = false
+    "subnetwork" = "projects/zoro/regions/narnia/subnetworks/default"
+    "subnetwork_self_link" = "projects/zoro/regions/narnia/subnetworks/default"
+    "termination_action" = null
+  }
+  "nodeset" = [
+    {
+      "additional_disks" = []
+      "bandwidth_tier" = "platform_default"
+      "can_ip_forward" = false
+      "disable_smt" = true
+      "disk_auto_delete" = true
+      "disk_labels" = {
+        "ghpc_blueprint" = "test"
+        "ghpc_deployment" = "test"
+        "ghpc_role" = "slurm"
+      }
+      "disk_size_gb" = 50
+      "disk_type" = "pd-standard"
+      "enable_confidential_vm" = false
+      "enable_oslogin" = true
+      "enable_placement" = true
+      "enable_public_ip" = false
+      "enable_shielded_vm" = false
+      "enable_smt" = false
+      "enable_spot_vm" = false
+      "gpu" = null
+      "guest_accelerator" = []
+      "instance_image" = {}
+      "instance_template" = null
+      "labels" = {
+        "ghpc_blueprint" = "test"
+        "ghpc_deployment" = "test"
+        "ghpc_role" = "slurm"
+      }
+      "machine_type" = "c2-standard-4"
+      "metadata" = {}
+      "min_cpu_platform" = null
+      "name" = "ns1"
+      "network_tier" = "STANDARD"
+      "node_conf" = {}
+      "node_count_dynamic_max" = 1
+      "node_count_static" = 0
+      "nodeset_name" = "ns1"
+      "on_host_maintenance" = "TERMINATE"
+      "preemptible" = false
+      "region" = "narnia"
+      "service_account" = null
+      "shielded_instance_config" = {
+        "enable_integrity_monitoring" = true
+        "enable_secure_boot" = true
+        "enable_vtpm" = true
+      }
+      "source_image" = ""
+      "source_image_family" = ""
+      "source_image_project" = ""
+      "spot" = false
+      "spot_instance_config" = null
+      "subnetwork" = "projects/zoro/regions/narnia/subnetworks/default"
+      "subnetwork_self_link" = "projects/zoro/regions/narnia/subnetworks/default"
+      "tags" = []
+      "termination_action" = null
+      "zone_target_shape" = "ANY_SINGLE_ZONE"
+      "zones" = []
+    },
+  ]
+  "partitions" = [
+    {
+      "default" = true
+      "enable_job_exclusive" = true
+      "exclusive" = true
+      "is_default" = true
+      "name" = "default"
+      "partition_name" = "default"
+      "partition_nodeset" = [
+        "ns1",
+      ]
+    },
+  ]
+  "project_id" = "zoro"
+  "region" = "narnia"
+  "slurm_cluster_name" = "test2"
+}

--- a/community/modules/slurm/tests/expectations/debug_test3
+++ b/community/modules/slurm/tests/expectations/debug_test3
@@ -1,0 +1,101 @@
+{
+  "controller_instance_config" = {
+    "disable_smt" = true
+    "disk_type" = "pd-standard"
+    "gpu" = null
+    "instance_image" = {}
+    "machine_type" = "n1-standard-4"
+    "region" = "narnia"
+    "source_image" = ""
+    "source_image_family" = ""
+    "source_image_project" = ""
+    "spot" = false
+    "subnetwork" = "projects/zoro/regions/narnia/subnetworks/default"
+    "subnetwork_self_link" = "projects/zoro/regions/narnia/subnetworks/default"
+    "termination_action" = null
+  }
+  "nodeset" = [
+    {
+      "additional_disks" = []
+      "bandwidth_tier" = "platform_default"
+      "can_ip_forward" = false
+      "disable_smt" = true
+      "disk_auto_delete" = true
+      "disk_labels" = {
+        "ghpc_blueprint" = "test"
+        "ghpc_deployment" = "test"
+        "ghpc_role" = "slurm"
+      }
+      "disk_size_gb" = 50
+      "disk_type" = "pd-standard"
+      "enable_confidential_vm" = false
+      "enable_oslogin" = true
+      "enable_placement" = true
+      "enable_public_ip" = false
+      "enable_shielded_vm" = false
+      "enable_smt" = false
+      "enable_spot_vm" = false
+      "gpu" = null
+      "guest_accelerator" = []
+      "instance_image" = {}
+      "instance_template" = null
+      "labels" = {
+        "ghpc_blueprint" = "test"
+        "ghpc_deployment" = "test"
+        "ghpc_role" = "slurm"
+      }
+      "machine_type" = "c2-standard-4"
+      "metadata" = {}
+      "min_cpu_platform" = null
+      "name" = "ns1"
+      "network_tier" = "STANDARD"
+      "node_conf" = {}
+      "node_count_dynamic_max" = 1
+      "node_count_static" = 0
+      "nodeset_name" = "ns1"
+      "on_host_maintenance" = "TERMINATE"
+      "preemptible" = false
+      "region" = "narnia"
+      "service_account" = null
+      "shielded_instance_config" = {
+        "enable_integrity_monitoring" = true
+        "enable_secure_boot" = true
+        "enable_vtpm" = true
+      }
+      "source_image" = ""
+      "source_image_family" = ""
+      "source_image_project" = ""
+      "spot" = false
+      "spot_instance_config" = null
+      "subnetwork" = "projects/zoro/regions/narnia/subnetworks/default"
+      "subnetwork_self_link" = "projects/zoro/regions/narnia/subnetworks/default"
+      "tags" = []
+      "termination_action" = null
+      "zone_target_shape" = "ANY_SINGLE_ZONE"
+      "zones" = []
+    },
+  ]
+  "partitions" = [
+    {
+      "default" = false
+      "enable_job_exclusive" = true
+      "exclusive" = true
+      "is_default" = false
+      "name" = "pt1"
+      "network_storage" = []
+      "partition_conf" = {}
+      "partition_name" = "pt1"
+      "partition_nodeset" = [
+        "ns1",
+      ]
+      "partition_nodeset_dyn" = []
+      "partition_nodeset_tpu" = []
+      "resume_timeout" = null
+      "suspend_time" = 300
+      "suspend_timeout" = null
+    },
+  ]
+  "project_id" = "zoro"
+  "region" = "narnia"
+  "slurm_cluster_name" = "test3"
+}

--- a/community/modules/slurm/tests/expectations/debug_test4
+++ b/community/modules/slurm/tests/expectations/debug_test4
@@ -1,0 +1,140 @@
+{
+  "controller_instance_config" = {
+    "additional_disks" = tolist([])
+    "bandwidth_tier" = "platform_default"
+    "can_ip_forward" = false
+    "disable_smt" = true
+    "disk_auto_delete" = true
+    "disk_labels" = tomap({
+      "ghpc_blueprint" = "test"
+      "ghpc_deployment" = "test"
+      "ghpc_role" = "slurm"
+    })
+    "disk_size_gb" = 50
+    "disk_type" = "pd-ssd"
+    "enable_confidential_vm" = false
+    "enable_oslogin" = true
+    "enable_public_ip" = false
+    "enable_shielded_vm" = false
+    "enable_smt" = false
+    "enable_spot_vm" = false
+    "gpu" = null
+    "guest_accelerator" = []
+    "instance_image" = tomap({})
+    "instance_template" = tostring(null)
+    "labels" = tomap({
+      "ghpc_blueprint" = "test"
+      "ghpc_deployment" = "test"
+      "ghpc_role" = "slurm"
+    })
+    "machine_type" = "c2-standard-4"
+    "metadata" = tomap({})
+    "min_cpu_platform" = tostring(null)
+    "network_ip" = ""
+    "network_tier" = "STANDARD"
+    "on_host_maintenance" = "TERMINATE"
+    "preemptible" = false
+    "region" = "narnia"
+    "service_account" = null /* object */
+    "shielded_instance_config" = {
+      "enable_integrity_monitoring" = true
+      "enable_secure_boot" = true
+      "enable_vtpm" = true
+    }
+    "source_image" = ""
+    "source_image_family" = ""
+    "source_image_project" = ""
+    "spot" = false
+    "spot_instance_config" = null /* object */
+    "static_ip" = tostring(null)
+    "subnetwork" = "projects/zoro/regions/narnia/subnetworks/default"
+    "subnetwork_self_link" = "projects/zoro/regions/narnia/subnetworks/default"
+    "tags" = tolist([])
+    "termination_action" = null
+    "zone" = tostring(null)
+  }
+  "nodeset" = [
+    {
+      "additional_disks" = []
+      "bandwidth_tier" = "platform_default"
+      "can_ip_forward" = false
+      "disable_smt" = true
+      "disk_auto_delete" = true
+      "disk_labels" = {
+        "ghpc_blueprint" = "test"
+        "ghpc_deployment" = "test"
+        "ghpc_role" = "slurm"
+      }
+      "disk_size_gb" = 50
+      "disk_type" = "pd-standard"
+      "enable_confidential_vm" = false
+      "enable_oslogin" = true
+      "enable_placement" = true
+      "enable_public_ip" = false
+      "enable_shielded_vm" = false
+      "enable_smt" = false
+      "enable_spot_vm" = false
+      "gpu" = null
+      "guest_accelerator" = []
+      "instance_image" = {}
+      "instance_template" = null
+      "labels" = {
+        "ghpc_blueprint" = "test"
+        "ghpc_deployment" = "test"
+        "ghpc_role" = "slurm"
+      }
+      "machine_type" = "c2-standard-4"
+      "metadata" = {}
+      "min_cpu_platform" = null
+      "name" = "ns1"
+      "network_tier" = "STANDARD"
+      "node_conf" = {}
+      "node_count_dynamic_max" = 1
+      "node_count_static" = 0
+      "nodeset_name" = "ns1"
+      "on_host_maintenance" = "TERMINATE"
+      "preemptible" = false
+      "region" = "narnia"
+      "service_account" = null
+      "shielded_instance_config" = {
+        "enable_integrity_monitoring" = true
+        "enable_secure_boot" = true
+        "enable_vtpm" = true
+      }
+      "source_image" = ""
+      "source_image_family" = ""
+      "source_image_project" = ""
+      "spot" = false
+      "spot_instance_config" = null
+      "subnetwork" = "projects/zoro/regions/narnia/subnetworks/default"
+      "subnetwork_self_link" = "projects/zoro/regions/narnia/subnetworks/default"
+      "tags" = []
+      "termination_action" = null
+      "zone_target_shape" = "ANY_SINGLE_ZONE"
+      "zones" = []
+    },
+  ]
+  "partitions" = [
+    {
+      "default" = false
+      "enable_job_exclusive" = true
+      "exclusive" = true
+      "is_default" = false
+      "name" = "pt1"
+      "network_storage" = []
+      "partition_conf" = {}
+      "partition_name" = "pt1"
+      "partition_nodeset" = [
+        "ns1",
+      ]
+      "partition_nodeset_dyn" = []
+      "partition_nodeset_tpu" = []
+      "resume_timeout" = null
+      "suspend_time" = 300
+      "suspend_timeout" = null
+    },
+  ]
+  "project_id" = "zoro"
+  "region" = "narnia"
+  "slurm_cluster_name" = "test4"
+}

--- a/community/modules/slurm/tests/test.sh
+++ b/community/modules/slurm/tests/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+validator_to_skip="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region"
+tmpdir=$(mktemp -d)
+tstdir="community/modules/slurm/tests"
+
+./ghpc create -l ERROR \
+	--skip-validators="${validator_to_skip}" \
+	"${tstdir}/bp.yaml" -o "${tmpdir}" >/dev/null
+
+depldir="${tmpdir}/test/primary"
+terraform -chdir="${depldir}" init >/dev/null
+terraform -chdir="${depldir}" validate >/dev/null
+terraform -chdir="${depldir}" apply --auto-approve >/dev/null
+
+for expectations in "$tstdir"/expectations/*; do
+	vn=$(basename "$expectations")
+	vn="${vn%.*}" # trim extension
+	output="${tmpdir}/out_${vn}"
+	terraform -chdir="${depldir}" output "${vn}" >"${output}"
+	diff --color "${output}" "${expectations}" || {
+		echo "FAIL: ${output} does not match ${expectations}"
+		exit 1 # TODO: don't terminate after first failure
+	}
+	echo "PASS: ${vn}"
+done
+
+rm -rf "${tmpdir}"

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -41,6 +41,8 @@ duplicates = [
         "community/modules/compute/schedmd-slurm-gcp-v5-node-group/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v5-login/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v5-controller/gpu_definition.tf",
+        "community/modules/slurm/controller/gpu_definition.tf",
+        "community/modules/slurm/nodeset/gpu_definition.tf",
     ],
     [
         "community/modules/compute/gke-node-pool/threads_per_core_calc.tf",
@@ -58,6 +60,10 @@ duplicates = [
     [
         "community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl",
         "community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl",
+    ],
+    [
+        "community/modules/slurm/nodeset/variables_instance.tf",
+        "community/modules/slurm/controller/variables_instance.tf",
     ],
 ]
 


### PR DESCRIPTION
Add minimal implementation of nodeset, partirion, controller, and cluster of Slurm V6 modules.

Enables user to specify small (1) number of modules to setup cluster:
```yaml
- id: cluster
  source: community/modules/slurm/cluster
  use: [net]
  settings: { name: gg }
```


**To reviewer:**
* See "UX" section of design document and tests (`community/modules/slurm/tests/bp.yaml`) for context on allowed usage patterns.
* `controller/main.tf` is only complex part of PR, everything else is boilerplate;
* `controller`, `partition` and `nodeset` only work is to take settings, pack into object and pass to `controller`;
* `variables_instance.tf` are shared among `controller` & `nodeset` for consistency;
* `README.md` & `gpu_definition.tf` can be ignored; 

**Request to review**: 
`cluster/main.tf` at `locals { # Nodeset` contains multiple "hacks":
* `jsondecode/decode` to allow usage of maps & objects together - needed to avoid enumaration of ALL fields in `nodeset_default`;
 * `merge(X, {S = coalesce(try(X.S, null), default_S)}),` for overriding `null`-valued `X.S` with `default_S`;
 

**Testing:**

```sh
$ community/modules/slurm/tests/test.sh
PASS: debug_test1
PASS: debug_test2
PASS: debug_test3
PASS: debug_test4
```

Manually deployed cluster with following BP, and run `srun -N 1 -p debug hostname`

```yaml
  modules:
  - id: nw
    source: modules/network/vpc

  - id: ns
    source: ./community/modules/slurm/nodeset
    settings: { name: ns, machine_type: n2-standard-2 }

  - id: pt
    source: ./community/modules/slurm/partition
    use: [ns]
    settings: { name: debug }

  - id: cluster
    source: ./community/modules/slurm/cluster
    use: [nw, pt]
    settings: { name: gg }
```
