### PR TITLE
Improve A3 VM family support

### DIFF
--- a/community/modules/compute/htcondor-execute-point/gpu_definition.tf
+++ b/community/modules/compute/htcondor-execute-point/gpu_definition.tf
@@ -36,6 +36,7 @@ locals {
     "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
     "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
     "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
     "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-12" = { type = "nvidia-l4", count = 1 },

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/gpu_definition.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/gpu_definition.tf
@@ -36,6 +36,7 @@ locals {
     "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
     "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
     "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
     "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-12" = { type = "nvidia-l4", count = 1 },

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/gpu_definition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/gpu_definition.tf
@@ -36,6 +36,7 @@ locals {
     "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
     "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
     "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
     "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-12" = { type = "nvidia-l4", count = 1 },

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/gpu_definition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/gpu_definition.tf
@@ -36,6 +36,7 @@ locals {
     "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
     "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
     "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
     "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-12" = { type = "nvidia-l4", count = 1 },

--- a/modules/compute/vm-instance/gpu_definition.tf
+++ b/modules/compute/vm-instance/gpu_definition.tf
@@ -36,6 +36,7 @@ locals {
     "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
     "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
     "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
     "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
     "g2-standard-12" = { type = "nvidia-l4", count = 1 },


### PR DESCRIPTION
Include A3 VM family in GPU normalizing code that ensures machines with implicit and explicit accelerators are treated on equal footing within Terraform modules.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
