### PR TITLE
Exposed force_destroy to blueprints for cloud buckets

### DIFF
--- a/community/modules/file-system/cloud-storage-bucket/README.md
+++ b/community/modules/file-system/cloud-storage-bucket/README.md
@@ -134,6 +134,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment; used as part of name of the GCS bucket. | `string` | n/a | yes |
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | If true will destroy bucket with all objects stored within. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the GCS bucket. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | The mount point where the contents of the device may be accessed after mounting. | `string` | `"/mnt"` | no |
 | <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | Mount options to be put in fstab. Note: `implicit_dirs` makes it easier to work with objects added by other tools, but there is a performance impact. See: [more information](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#implicit-directories) | `string` | `"defaults,_netdev,implicit_dirs"` | no |

--- a/community/modules/file-system/cloud-storage-bucket/main.tf
+++ b/community/modules/file-system/cloud-storage-bucket/main.tf
@@ -40,4 +40,5 @@ resource "google_storage_bucket" "bucket" {
   location                    = var.region
   storage_class               = "REGIONAL"
   labels                      = local.labels
+  force_destroy               = var.force_destroy
 }

--- a/community/modules/file-system/cloud-storage-bucket/variables.tf
+++ b/community/modules/file-system/cloud-storage-bucket/variables.tf
@@ -63,3 +63,9 @@ variable "random_suffix" {
   type        = bool
   default     = false
 }
+
+variable "force_destroy" {
+  description = "If true will destroy bucket with all objects stored within."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Exposed force-destroy for situations of buckets that may contain junk information or are just being used for testing. 
