### PR TITLE
Guide user to solution when long family format

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/source_image_logic.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/source_image_logic.tf
@@ -47,6 +47,11 @@ data "google_compute_image" "slurm" {
   project = var.instance_image.project
 
   lifecycle {
+    precondition {
+      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+    }
+
     postcondition {
       condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
       error_message = <<-EOD

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
@@ -100,13 +100,13 @@ variable "instance_image" {
   }
 
   validation {
-    condition     = can(var.instance_image.project) && try(var.instance_image.project, "") != ""
-    error_message = "The \"project\" field is required for var.instance_image and cannot be the empty string."
+    condition     = can(coalesce(var.instance_image.project))
+    error_message = "In var.instance_image, the \"project\" field must be a string set to the Cloud project ID."
   }
 
   validation {
-    condition     = can(var.instance_image.name) != can(var.instance_image.family)
-    error_message = "Exactly one of \"family\" and \"name\" must be provided in var.instance_image."
+    condition     = can(coalesce(var.instance_image.name)) != can(coalesce(var.instance_image.family))
+    error_message = "In var.instance_image, exactly one of \"family\" or \"name\" fields must be set to desired image family or name."
   }
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/source_image_logic.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/source_image_logic.tf
@@ -47,6 +47,11 @@ data "google_compute_image" "slurm" {
   project = var.instance_image.project
 
   lifecycle {
+    precondition {
+      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+    }
+
     postcondition {
       condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
       error_message = <<-EOD

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
@@ -549,13 +549,13 @@ variable "instance_image" {
   }
 
   validation {
-    condition     = can(var.instance_image.project) && try(var.instance_image.project, "") != ""
-    error_message = "The \"project\" field is required for var.instance_image and cannot be the empty string."
+    condition     = can(coalesce(var.instance_image.project))
+    error_message = "In var.instance_image, the \"project\" field must be a string set to the Cloud project ID."
   }
 
   validation {
-    condition     = can(var.instance_image.name) != can(var.instance_image.family)
-    error_message = "Exactly one of \"family\" and \"name\" must be provided in var.instance_image."
+    condition     = can(coalesce(var.instance_image.name)) != can(coalesce(var.instance_image.family))
+    error_message = "In var.instance_image, exactly one of \"family\" or \"name\" fields must be set to desired image family or name."
   }
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/source_image_logic.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/source_image_logic.tf
@@ -47,6 +47,11 @@ data "google_compute_image" "slurm" {
   project = var.instance_image.project
 
   lifecycle {
+    precondition {
+      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+    }
+
     postcondition {
       condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
       error_message = <<-EOD

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
@@ -298,13 +298,13 @@ variable "instance_image" {
   }
 
   validation {
-    condition     = can(var.instance_image.project) && try(var.instance_image.project, "") != ""
-    error_message = "The \"project\" field is required for var.instance_image and cannot be the empty string."
+    condition     = can(coalesce(var.instance_image.project))
+    error_message = "In var.instance_image, the \"project\" field must be a string set to the Cloud project ID."
   }
 
   validation {
-    condition     = can(var.instance_image.name) != can(var.instance_image.family)
-    error_message = "Exactly one of \"family\" and \"name\" must be provided in var.instance_image."
+    condition     = can(coalesce(var.instance_image.name)) != can(coalesce(var.instance_image.family))
+    error_message = "In var.instance_image, exactly one of \"family\" or \"name\" fields must be set to desired image family or name."
   }
 }
 


### PR DESCRIPTION
The upstream Slurm modules were written to require a "long" project ID when using image familes:

```hcl
projects/${actual_project_id}/global/images/family
```

This format is not an actual project ID and is likely incompatible with other Toolkit modules, so it would break usage of `instance_image` as a deployment variable in the `vars` dictionary. It is effectively a workaround for constraints imposed by the [implementation of the upstream CFT instance_template module](https://github.com/terraform-google-modules/terraform-google-vm/blob/85fd51e618211a2333e3fb3b6a8d2addf74e2ad0/modules/instance_template/main.tf#L28). This module probably merits improvement, but its working to produces a valid value for the Compute Engine API's image parameter. It has many valid format and one of them is:

```hcl
projects/${actual_project_id}/global/images/family/${image_family_name}
```

Support for user specification of the project in this format was unintentionally dropped in bf729bdb. This commit adds validation to test when a user has provided this special ID format and guides them to use the simple project ID. The logic of constructing the special format is implemented entirely within the module.

In coding this solution, I came to the conclusion that the logic of validating the project's string contents is best done by the data source itself (via API failures) or via preconditions rather than validation blocks in the variable. Reasoning: you need lots of `try` functions in the validation blocks because the existence of the `project` field is not yet guaranteed. So the validation blocks now only service to guarantee the required fields of the `map(string)` variable.

After this change, the following error message will appear once for every Slurm module that uses the long format ID:

```
Error: Resource precondition failed

  on modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/source_image_logic.tf line 51, in data "google_compute_image" "slurm":
  51:       condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
    ├────────────────
    │ var.instance_image.project is "projects/schedmd-slurm-public/global/images/family"

The "project" field in var.instance_image no longer supports a long-form
ending in "family". Specify only the project ID.
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
