### PR TITLE
Improve VPC documentation

### DIFF
--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -213,13 +213,13 @@ No resources.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_nat_ips"></a> [nat\_ips](#output\_nat\_ips) | the external IPs assigned to the NAT |
-| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | The ID of the network created |
-| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | The name of the network created |
-| <a name="output_network_self_link"></a> [network\_self\_link](#output\_network\_self\_link) | The URI of the VPC being created |
-| <a name="output_subnetwork"></a> [subnetwork](#output\_subnetwork) | The primary subnetwork object created by the input variable primary\_subnetwork |
-| <a name="output_subnetwork_address"></a> [subnetwork\_address](#output\_subnetwork\_address) | The address range of the primary subnetwork |
-| <a name="output_subnetwork_name"></a> [subnetwork\_name](#output\_subnetwork\_name) | The name of the primary subnetwork |
-| <a name="output_subnetwork_self_link"></a> [subnetwork\_self\_link](#output\_subnetwork\_self\_link) | The self-link to the primary subnetwork |
-| <a name="output_subnetworks"></a> [subnetworks](#output\_subnetworks) | All subnetwork resources created by this module |
+| <a name="output_nat_ips"></a> [nat\_ips](#output\_nat\_ips) | External IPs of the Cloud NAT from which outbound internet traffic will arrive (empty list if no NAT is used) |
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | ID of the new VPC network |
+| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | Name of the new VPC network |
+| <a name="output_network_self_link"></a> [network\_self\_link](#output\_network\_self\_link) | Self link of the new VPC network |
+| <a name="output_subnetwork"></a> [subnetwork](#output\_subnetwork) | Primary subnetwork object |
+| <a name="output_subnetwork_address"></a> [subnetwork\_address](#output\_subnetwork\_address) | IP address range of the primary subnetwork |
+| <a name="output_subnetwork_name"></a> [subnetwork\_name](#output\_subnetwork\_name) | Name of the primary subnetwork |
+| <a name="output_subnetwork_self_link"></a> [subnetwork\_self\_link](#output\_subnetwork\_self\_link) | Self link of the primary subnetwork |
+| <a name="output_subnetworks"></a> [subnetworks](#output\_subnetworks) | Full list of subnetwork objects belonging to the new VPC network |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/network/vpc/outputs.tf
+++ b/modules/network/vpc/outputs.tf
@@ -15,54 +15,54 @@
 */
 
 output "network_name" {
-  description = "The name of the network created"
+  description = "Name of the new VPC network"
   value       = module.vpc.network_name
   depends_on  = [module.vpc, module.cloud_router]
 }
 
 output "network_id" {
-  description = "The ID of the network created"
+  description = "ID of the new VPC network"
   value       = module.vpc.network_id
   depends_on  = [module.vpc, module.cloud_router]
 }
 
 output "network_self_link" {
-  description = "The URI of the VPC being created"
+  description = "Self link of the new VPC network"
   value       = module.vpc.network_self_link
   depends_on  = [module.vpc, module.cloud_router]
 }
 
 output "subnetworks" {
-  description = "All subnetwork resources created by this module"
+  description = "Full list of subnetwork objects belonging to the new VPC network"
   value       = module.vpc.subnets
   depends_on  = [module.vpc, module.cloud_router]
 }
 
 output "subnetwork" {
-  description = "The primary subnetwork object created by the input variable primary_subnetwork"
+  description = "Primary subnetwork object"
   value       = local.output_primary_subnetwork
   depends_on  = [module.vpc, module.cloud_router]
 }
 
 output "subnetwork_name" {
-  description = "The name of the primary subnetwork"
+  description = "Name of the primary subnetwork"
   value       = local.output_primary_subnetwork_name
   depends_on  = [module.vpc, module.cloud_router]
 }
 
 output "subnetwork_self_link" {
-  description = "The self-link to the primary subnetwork"
+  description = "Self link of the primary subnetwork"
   value       = local.output_primary_subnetwork_self_link
   depends_on  = [module.vpc, module.cloud_router]
 }
 
 output "subnetwork_address" {
-  description = "The address range of the primary subnetwork"
+  description = "IP address range of the primary subnetwork"
   value       = local.output_primary_subnetwork_ip_cidr_range
   depends_on  = [module.vpc, module.cloud_router]
 }
 
 output "nat_ips" {
-  description = "the external IPs assigned to the NAT"
+  description = "External IPs of the Cloud NAT from which outbound internet traffic will arrive (empty list if no NAT is used)"
   value       = flatten([for ipmod in module.nat_ip_addresses : ipmod.addresses])
 }


### PR DESCRIPTION
- correct output variable description for primary subnetwork (it is no longer derived from var.primary_subnetwork)
- general text improvements

This is a sister commit to #1763 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
