### PR TITLE
Added bucket force_destroy variable to HCLS blueprint

### DIFF
--- a/docs/videos/healthcare-and-life-sciences/README.md
+++ b/docs/videos/healthcare-and-life-sciences/README.md
@@ -115,8 +115,9 @@ storage intact and b) you can build software before you deploy your cluster.
    ```
 
    The `bucket_force_delete` variable makes it easier to tear down the
-   deployment. If it is set to `false`, buckets with objects (files) will not be
-   deleted and the `./ghpc destroy` command will fail partway through.
+   deployment. If it is set to the default value of `false`, buckets with
+   objects (files) will not be deleted and the `./ghpc destroy` command will
+   fail partway through.
 
    If the data stored in the buckets should be preseverved, remove the
    `--vars bucket_force_delete=true` portion of the command or set it to `false`

--- a/docs/videos/healthcare-and-life-sciences/README.md
+++ b/docs/videos/healthcare-and-life-sciences/README.md
@@ -104,11 +104,22 @@ storage intact and b) you can build software before you deploy your cluster.
    make
    ```
 
-1. Generate the deployment folder after replacing `<project>` with the project id.
+1. Generate the deployment folder after replacing `<project>` with the project
+   id.
+
+   If you are running this as a test, and don't care about the files created in
+   the cloud buckets being destroyed, it is recommneded you run:
 
    ```bash
-   ./ghpc create docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml -w --vars project_id=<project>
+   ./ghpc create docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml -w --vars project_id=<project> --vars bucket_force_delete=true
    ```
+
+   The `bucket_force_delete` variable makes it easier to tear down the
+   deployment. If it is set to `false`, buckets with objects (files) will not be
+   deleted and the `./ghpc destroy` command will fail partway through.
+
+   If the data stored in the buckets should be preseverved, remove the
+   `--vars bucket_force_delete=true` portion of the command or set it to `false`
 
 1. Deploy the `enable_apis` group
 
@@ -238,8 +249,10 @@ destroyed first. You can use the following commands to destroy the deployment.
 ```
 
 > [!NOTE]
-> You may have to clean out items added to the Cloud Storage buckets before
-> terraform will be able to destroy them.
+> If you did not create the deployment with `bucket_force_destroy` set to true,
+> you may have to clean out items added to the Cloud Storage buckets before
+> terraform will be able to destroy them.  This can be done on the GCP Cloud
+> Console.
 
 ## Water Benchmark Example
 

--- a/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
+++ b/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
@@ -21,6 +21,7 @@ vars:
   deployment_name: hcls-01
   region: us-central1
   zone: us-central1-c
+  bucket_force_destroy: false
 
 deployment_groups:
 - group: enable_apis
@@ -78,6 +79,7 @@ deployment_groups:
       name_prefix: hcls-user-provided-software
       random_suffix: true
       local_mount: /user_provided_software
+      force_destroy: $(vars.bucket_force_destroy)
     outputs: [gcs_bucket_path]
 
   - id: bucket-input
@@ -87,6 +89,7 @@ deployment_groups:
       random_suffix: true
       local_mount: /data_input
       mount_options: defaults,_netdev,implicit_dirs,allow_other,dir_mode=0777,file_mode=766
+      force_destroy: $(vars.bucket_force_destroy)
 
   - id: bucket-output
     source: community/modules/file-system/cloud-storage-bucket
@@ -95,6 +98,7 @@ deployment_groups:
       random_suffix: true
       local_mount: /data_output
       mount_options: defaults,_netdev,implicit_dirs,allow_other,dir_mode=0777,file_mode=766
+      force_destroy: $(vars.bucket_force_destroy)
 
 - group: software_installation
   modules:


### PR DESCRIPTION
The HCLS blueprint will fail during destruction if a user follows the instructions in the associated README, as there will be objects in the buckets.  This adds the option to force the destruction of the buckets as this is an example that does not produce results users would want to keep.

Also updated associated documentation to recommend that users enable this variable.
