### PR TITLE
Pin Spack version as tutorials were designed with previous version of Spack

### DIFF
--- a/docs/tutorials/gromacs/spack-gromacs.yaml
+++ b/docs/tutorials/gromacs/spack-gromacs.yaml
@@ -36,6 +36,7 @@ deployment_groups:
     source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
+      spack_ref: v0.19.0
 
   - id: spack-execute
     source: community/modules/scripts/spack-execute

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -36,6 +36,7 @@ deployment_groups:
     source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
+      spack_ref: v0.19.0
 
   - id: spack-execute
     source: community/modules/scripts/spack-execute

--- a/docs/tutorials/wrfv3/spack-wrfv3.yaml
+++ b/docs/tutorials/wrfv3/spack-wrfv3.yaml
@@ -36,6 +36,7 @@ deployment_groups:
     source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
+      spack_ref: v0.19.0
 
   - id: spack-execute
     source: community/modules/scripts/spack-execute


### PR DESCRIPTION
The Gromacs tutorial build fails using Spack v0.20.0, which is defaut. I have tested all three builds with v0.19.0 and all three succeeded. 

I have opened tasks for a more holistic update to these tutorials, which is outside of the scope of this fix.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
