### PR TITLE
Freeze golang docker image version

### DIFF
--- a/tools/cloud-build/Dockerfile
+++ b/tools/cloud-build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Getting Terraform and Packer
-FROM golang:bullseye
+FROM golang:1.18-bullseye
 ARG TFLINT_VERSION
 ARG SHELLCHECK_VERSION
 


### PR DESCRIPTION
**Motivation:** To detect if we became incompatible with declared minimal version of Go.

**Testing done:**
Build `hpc-toolkit-builder` locally and run `pre-commit run --all-files` on `develop`.
