### PR TITLE
Add build test for Go 1.18

### DIFF
--- a/tools/cloud-build/build-test-go1-18.yaml
+++ b/tools/cloud-build/build-test-go1-18.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+steps:
+- name: golang:1.18
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - make ghpc test-engine

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -33,6 +33,7 @@
 |------|------|
 | [google_cloudbuild_trigger.daily_project_cleanup](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.daily_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.pr_go_1_18_build_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_validation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.release_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |

--- a/tools/cloud-build/provision/pr-go1-18-build-test.tf
+++ b/tools/cloud-build/provision/pr-go1-18-build-test.tf
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloudbuild_trigger" "pr_go_1_18_build_test" {
+  name        = "PR-Go-1-18-Build-Test"
+  description = "Test that the PR builds with Go 1.18"
+
+  filename = "tools/cloud-build/provision/pr-go1-18-build-test.tf"
+
+  github {
+    owner = "GoogleCloudPlatform"
+    name  = "hpc-toolkit"
+    pull_request {
+      branch          = ".*"
+      comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
+    }
+  }
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}


### PR DESCRIPTION
Testing done:
```sh
$ gcloud builds submit . --config=tools/cloud-build/build-test-go1-18.yaml
...
$ terraform -chdir=tools/cloud-build/provision plan
Terraform will perform the following actions:

  # google_cloudbuild_trigger.pr_go_1_18_build_test will be created
  + resource "google_cloudbuild_trigger" "pr_go_1_18_build_test" {
      + create_time        = (known after apply)
      + description        = "Test that the PR builds with Go 1.18"
      + filename           = "tools/cloud-build/provision/pr-go1-18-build-test.tf"
      + id                 = (known after apply)
      + include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
      + location           = "global"
      + name               = "PR-Go-1-18-Build-Test"
      + project            = (known after apply)
      + trigger_id         = (known after apply)

      + approval_config {
          + approval_required = (known after apply)
        }

      + github {
          + name  = "hpc-toolkit"
          + owner = "GoogleCloudPlatform"

          + pull_request {
              + branch          = ".*"
              + comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
