### PR TITLE
Adds basic deploy/destroy test for storage-gke.yaml

### DIFF
--- a/tools/cloud-build/babysit_tests.py
+++ b/tools/cloud-build/babysit_tests.py
@@ -56,6 +56,10 @@ SELECTORS: Dict[str, Selector] = {
         "PR-test-chrome-remote-desktop",
         "PR-test-hpc-slurm-chromedesktop",
     ]),
+    "gke": selector_by_name([
+        "PR-test-gke",
+        "PR-test-gke-storage",
+    ]),
     "pr_legacy": selector_by_name([
         "PR-legacy-test-integration-group-1",
         "PR-legacy-test-integration-group-2",

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -27,6 +27,17 @@
     community.crypto.openssh_keypair:
       path: "/builder/home/.ssh/id_rsa"
 
+  ## Get builder IP address
+  - name: Get Builder IP
+    register: build_ip
+    changed_when: false
+    args:
+      executable: /bin/bash
+    ansible.builtin.shell: |
+      set -e -o pipefail
+      dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
+          awk -F'"' '{print $2}'
+
   ## Create cluster
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
@@ -79,15 +90,6 @@
         var: remote_ip
 
     ## Setup firewall for cloud build
-    - name: Get Builder IP
-      register: build_ip
-      changed_when: false
-      args:
-        executable: /bin/bash
-      ansible.builtin.shell: |
-        set -e -o pipefail
-        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
-            awk -F'"' '{print $2}'
     - name: Create firewall rule
       register: fw_result
       changed_when: fw_result.rc == 0

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -27,6 +27,17 @@
     community.crypto.openssh_keypair:
       path: "/builder/home/.ssh/id_rsa"
 
+  ## Get builder IP address
+  - name: Get Builder IP
+    register: build_ip
+    changed_when: false
+    args:
+      executable: /bin/bash
+    ansible.builtin.shell: |
+      set -e -o pipefail
+      dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
+          awk -F'"' '{print $2}'
+
   ## Create cluster
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
@@ -61,15 +72,6 @@
         groups: [remote_host]
       when: access_ip.stdout | ansible.utils.ipaddr
     ## Setup firewall for cloud build
-    - name: Get Builder IP
-      register: build_ip
-      changed_when: false
-      args:
-        executable: /bin/bash
-      ansible.builtin.shell: |
-        set -e -o pipefail
-        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
-            awk -F'"' '{print $2}'
     - name: Create firewall rule
       register: fw_result
       changed_when: fw_result.rc == 0

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -28,6 +28,17 @@
     community.crypto.openssh_keypair:
       path: "/builder/home/.ssh/id_rsa"
 
+  ## Get builder IP address
+  - name: Get Builder IP
+    register: build_ip
+    changed_when: false
+    args:
+      executable: /bin/bash
+    ansible.builtin.shell: |
+      set -e -o pipefail
+      dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
+          awk -F'"' '{print $2}'
+
   ## Create cluster
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
@@ -95,16 +106,6 @@
         var: controller_ip.stdout_lines
 
     ## Setup firewall for cloud build
-    - name: Get Builder IP
-      register: build_ip
-      changed_when: false
-      args:
-        executable: /bin/bash
-      ansible.builtin.shell: |
-        set -e -o pipefail
-        dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
-            awk -F'"' '{print $2}'
-
     - name: Create firewall rule
       register: fw_created
       changed_when: fw_created.rc == 0

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -1,0 +1,67 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+timeout: 14400s  # 4hr
+
+steps:
+## Test simple golang build
+- id: build_ghpc
+  waitFor: ["-"]
+  name: "golang:bullseye"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    cd /workspace
+    make
+- id: fetch_builder
+  waitFor: ["-"]
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - echo "done fetching builder"
+
+## Test GKE
+- id: gke-storage
+  waitFor: ["fetch_builder", "build_ghpc"]
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    SG_EXAMPLE=community/examples/storage-gke.yaml
+
+    # adding vm to act as remote node
+    echo '  - id: remote-node'                     >> $${SG_EXAMPLE}
+    echo '    source: modules/compute/vm-instance' >> $${SG_EXAMPLE}
+    echo '    use: [network1]'                     >> $${SG_EXAMPLE}
+    echo '    settings:'                           >> $${SG_EXAMPLE}
+    echo '      machine_type: e2-standard-2'       >> $${SG_EXAMPLE}
+    echo '      zone: us-central1-a'               >> $${SG_EXAMPLE}
+
+    # avoids conflict if both gke tests are run at the same time
+    sed -i "s/gke-subnet/gke-storage-subnet/" $${SG_EXAMPLE}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/gke-storage.yml"

--- a/tools/cloud-build/daily-tests/tests/gke-storage.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-storage.yml
@@ -1,0 +1,24 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+test_name: storage-gke
+deployment_name: gke-storage-{{ build }}
+zone: us-central1-a  # for remote node
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/community/examples/storage-gke.yaml"
+network: "{{ deployment_name }}-net"
+remote_node: "{{ deployment_name }}-0"
+post_deploy_tests: []
+cli_deployment_vars:
+  authorized_cidr: "{{ build_ip.stdout }}/32"

--- a/tools/cloud-build/daily-tests/tests/gke.yml
+++ b/tools/cloud-build/daily-tests/tests/gke.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-test_name: gke
+test_name: hpc-gke
 deployment_name: gke-{{ build }}
 zone: us-central1-a  # for remote node
 workspace: /workspace

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -1,4 +1,18 @@
+# Provisioning Cloud Build Triggers
+
 `provision` module creates CloudBuilds triggers and schedules.
+
+Usage:
+
+```sh
+cd tools/cloud-build/provision
+terraform init
+terraform plan
+terraform apply
+```
+
+When prompted for gcs bucket, use `<team name>-dev-automation`.\
+When prompted for project, use integration test project.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements


### PR DESCRIPTION
This change:
- Adds basic test for GKE Storage example
- Renames gke test 
- adds documentation to cloud build provision tool
- adds babysitter selector for gke

Notes on GKE Storage test:
- deployment requires that builder ip is allowlisted in the cluster. To accomplish this I have moved the "get builder ip" to before blueprint is created. For consistency I have done this in all integration tests. This is a no op.
- I change the name of the subnet in the blueprint (`s/gke-subnet/gke-storage-subnet/`) before running the test. This avoids clash if both gke tests are run at the same time. It is not possible to set this dynamically in the blueprint as the name is used as a key value (not supported by blueprint rendering).

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
