### PR TITLE
Attach a (free) license to every built VM image

### DIFF
--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -121,6 +121,9 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
+  image_licenses = [
+    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
+  ]
 }
 
 build {

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -82,6 +82,10 @@ locals {
   enable_integrity_monitoring = var.enable_shielded_vm && var.shielded_instance_config.enable_integrity_monitoring
   enable_secure_boot          = var.enable_shielded_vm && var.shielded_instance_config.enable_secure_boot
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
+
+  image_licenses = [
+    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
+  ]
 }
 
 source "googlecompute" "toolkit_image" {
@@ -121,9 +125,7 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
-  image_licenses = [
-    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
-  ]
+  image_licenses              = local.image_licenses
 }
 
 build {

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -121,6 +121,9 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
+  image_licenses = [
+    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
+  ]
 }
 
 build {

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -82,6 +82,10 @@ locals {
   enable_integrity_monitoring = var.enable_shielded_vm && var.shielded_instance_config.enable_integrity_monitoring
   enable_secure_boot          = var.enable_shielded_vm && var.shielded_instance_config.enable_secure_boot
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
+
+  image_licenses = [
+    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
+  ]
 }
 
 source "googlecompute" "toolkit_image" {
@@ -121,9 +125,7 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
-  image_licenses = [
-    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
-  ]
+  image_licenses              = local.image_licenses
 }
 
 build {

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -121,6 +121,9 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
+  image_licenses = [
+    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
+  ]
 }
 
 build {

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -82,6 +82,10 @@ locals {
   enable_integrity_monitoring = var.enable_shielded_vm && var.shielded_instance_config.enable_integrity_monitoring
   enable_secure_boot          = var.enable_shielded_vm && var.shielded_instance_config.enable_secure_boot
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
+
+  image_licenses = [
+    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
+  ]
 }
 
 source "googlecompute" "toolkit_image" {
@@ -121,9 +125,7 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
-  image_licenses = [
-    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
-  ]
+  image_licenses              = local.image_licenses
 }
 
 build {


### PR DESCRIPTION
This PR ensures that a (free) license is attached to each VM image built using the HPC Toolkit.  I have tested this by deploying the `image-builder.yaml` example blueprint: `<repo-root>/examples/image-builder.yaml`.