### PR TITLE
Move to using replication.auto to avoid deprecated variable

### DIFF
--- a/community/modules/scheduler/htcondor-pool-secrets/README.md
+++ b/community/modules/scheduler/htcondor-pool-secrets/README.md
@@ -119,14 +119,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83, <5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83, <5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.84 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/community/modules/scheduler/htcondor-pool-secrets/main.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/main.tf
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret" "pool_password" {
   labels = local.labels
 
   replication {
-    automatic = true
+    auto {}
   }
 }
 
@@ -98,7 +98,7 @@ resource "google_secret_manager_secret" "execute_point_idtoken" {
   labels = local.labels
 
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.83, <5.0"
+      version = ">= 4.84"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Stop using the deprecated `automatic` variable which allows compatibility with terraform provider v5.0.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
