### PR TITLE
Install specific version of shellcheck on cloud workstation first boot

### DIFF
--- a/tools/cloud-workstations/configure-hpc-toolkit.sh
+++ b/tools/cloud-workstations/configure-hpc-toolkit.sh
@@ -36,5 +36,11 @@ if [[ ! -f $FLAG ]]; then
 	go install github.com/ramya-rao-a/go-outline@v0.0.0-20210608161538-9736a4bde949
 	go install github.com/rogpeppe/godef@v1.1.2
 	go install golang.org/x/tools/cmd/guru@latest
+
+	# Install compatible version of shellcheck
+	SHELLCHECK_VERSION=v0.9.0
+	wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv
+	cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/bin/
+
 	touch "$FLAG"
 fi


### PR DESCRIPTION
`apt` will only install up to version v0.7.0 which gives spirous outputs. This is the method we use to install shellcheck on our builder.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
