### PR TITLE
Simplified Script Warning

### DIFF
--- a/modules/scripts/startup-script/files/running-script-warning.sh
+++ b/modules/scripts/startup-script/files/running-script-warning.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WARNING=$(
+	cat <<EOF
+** NOTICE **: System services may not be running until startup scripts complete.
+The output of the command below will end with "Finished Google Compute Engine 
+Startup Scripts." when they are complete. Please review the output for any 
+errors which may indicate that services are unhealthy. 
+
+sudo journalctl -b 0 -u google-startup-scripts.service
+EOF
+)
+
+echo
+echo "${WARNING}"
+echo

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -26,6 +26,14 @@ locals {
     destination = "install_cloud_ops_agent_automatic.sh"
   }] : []
 
+  warnings = [
+    {
+      type        = "data"
+      content     = file("${path.module}/files/running-script-warning.sh")
+      destination = "/etc/profile.d/99-running-script-warning.sh"
+    }
+  ]
+
   configure_ssh = length(var.configure_ssh_host_patterns) > 0
   host_args = {
     host_name_prefix = var.configure_ssh_host_patterns
@@ -57,7 +65,6 @@ locals {
     }
   ] : []
 
-
   has_ansible_runners = anytrue([for r in var.runners : r.type == "ansible-local"]) || local.configure_ssh
   install_ansible     = var.install_ansible == null ? local.has_ansible_runners : var.install_ansible
   ansible_installer = local.install_ansible ? [{
@@ -67,7 +74,7 @@ locals {
     args        = var.ansible_virtualenv_path
   }] : []
 
-  runners = concat(local.ops_agent_installer, local.ansible_installer, local.configure_ssh_runners, var.runners)
+  runners = concat(local.warnings, local.ops_agent_installer, local.ansible_installer, local.configure_ssh_runners, var.runners)
 
   bucket_regex               = "^gs://([^/]*)/*(.*)"
   gcs_bucket_path_trimmed    = var.gcs_bucket_path == null ? null : trimsuffix(var.gcs_bucket_path, "/")

--- a/modules/scripts/startup-script/templates/startup-script-custom.tpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tpl
@@ -38,6 +38,7 @@ stdlib::runner() {
   stdlib::info "=== $object finished with exit_code=$exit_code ==="
   if [ "$exit_code" -ne "0" ] ; then
     stdlib::error "=== execution of $object failed, exiting ==="
+    stdlib::announce_runners_end "$exit_code"
     exit $exit_code
   fi
 }
@@ -46,10 +47,12 @@ stdlib::load_runners(){
   tmpdir="$(mktemp -d)"
 
   stdlib::debug "=== BEGIN Running runners ==="
+  stdlib::announce_runners_start
 
   %{for r in runners ~}
   stdlib::runner "${r.type}" "${r.object}" "${r.destination}" $${tmpdir} "${r.args}"
   %{endfor ~}
 
+  stdlib::announce_runners_end "0"
   stdlib::debug "=== END Running runners ==="
 }


### PR DESCRIPTION
Stage 1 of the script warning.  Adds simple warnings when  startup scripts start and end, and warning to terminal when users log in, letting them know that there the system uses startup scripts for configuration and how to check if they're still running.