### PR TITLE
Removing automatic group write permission to mitigate regression tests

### DIFF
--- a/community/modules/scripts/spack-setup/main.tf
+++ b/community/modules/scripts/spack-setup/main.tf
@@ -40,7 +40,6 @@ locals {
     set -e
     . /etc/profile.d/spack.sh
     spack config --scope site add 'packages:all:permissions:read:world'
-    spack config --scope site add 'packages:all:permissions:write:group'
     spack gpg init
     spack compiler find --scope site
     ${local.add_google_mirror_script}

--- a/tools/cloud-build/daily-tests/tests/batch-mpi.yml
+++ b/tools/cloud-build/daily-tests/tests/batch-mpi.yml
@@ -14,7 +14,7 @@
 ---
 test_name: batch-mpi
 deployment_name: batch-mpi-{{ build }}
-zone: us-central1-c
+zone: us-west4-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/serverless-batch-mpi.yaml"
 network: "default"
@@ -25,3 +25,6 @@ post_deploy_tests:
 custom_vars:
   project: "{{ project }}"
   mounts: [/share]
+cli_deployment_vars:
+  region: us-west4
+  zone: "{{ zone }}"


### PR DESCRIPTION
This setting caused the following error when installing the krb5 package:

```
\"==> Error: Failed to install krb5 due to InvalidPermissionsError: Attempting to set suid with group writable\",",
\"==> Error: wrf-3.9.1.1-petbwx2ykaqbncwvlage5dctl7bixoo4: Package was not installed\",",
\"==> Error: [Errno 2] No such file or directory: '/share/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.2.0/krb5-1.19.3-6ewqp5dz2xtvrfa4vetjxmh337bbisid/'\",",
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
