### PR TITLE
Prevent infra from being left behind; only run when var is populated

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -216,6 +216,7 @@
       ansible.builtin.command: sinfo -t 'POWERED_DOWN' --noheader --format "%n"
       register: final_node_count
       changed_when: False
+      when: initial_node_count is defined and initial_node_count.stdout_lines is iterable
       until: final_node_count.stdout_lines | length == initial_node_count.stdout_lines | length
       retries: 60
       delay: 15


### PR DESCRIPTION
Depending when failure occurs the variable may not be populated. This causes a failure of this task and leaves infra behind.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
