### PR TITLE
Fix: error on second run when mirror is already defined

### DIFF
--- a/community/examples/hpc-slurm-gromacs.yaml
+++ b/community/examples/hpc-slurm-gromacs.yaml
@@ -69,7 +69,9 @@ deployment_groups:
                   all: '{name}/{version}-{compiler.name}-{compiler.version}'
       commands: |
         # Un-comment and update mirror_url to install from spack cache
-        # spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # if ! spack mirror list | grep -q gcs_cache; then
+        #   spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # fi
         # spack buildcache keys --install --trust
 
         spack config --scope defaults add config:build_stage:/sw/spack/spack-stage

--- a/community/examples/hpc-slurm-ramble-gromacs.yaml
+++ b/community/examples/hpc-slurm-ramble-gromacs.yaml
@@ -47,7 +47,9 @@ deployment_groups:
       log_file: /var/log/spack.log
       commands: |
         # Un-comment and update mirror_url to install from spack cache
-        # spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # if ! spack mirror list | grep -q gcs_cache; then
+        #   spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # fi
         # spack buildcache keys --install --trust
 
         spack config --scope defaults add config:build_stage:/opt/apps/spack/spack-stage

--- a/docs/tutorials/gromacs/spack-gromacs.yaml
+++ b/docs/tutorials/gromacs/spack-gromacs.yaml
@@ -83,7 +83,9 @@ deployment_groups:
               - - $^mpis
       commands: |
         # Un-comment and update mirror_url to install from spack cache
-        # spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # if ! spack mirror list | grep -q gcs_cache; then
+        #   spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # fi
         # spack buildcache keys --install --trust
 
         spack config --scope defaults add config:build_stage:/apps/spack/spack-stage

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -90,7 +90,9 @@ deployment_groups:
               unify: when_possible
       commands: |
         # Un-comment and update mirror_url to install from spack cache
-        # spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # if ! spack mirror list | grep -q gcs_cache; then
+        #   spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # fi
         # spack buildcache keys --install --trust
 
         spack config --scope defaults add config:build_stage:/apps/spack/spack-stage

--- a/docs/tutorials/wrfv3/spack-wrfv3.yaml
+++ b/docs/tutorials/wrfv3/spack-wrfv3.yaml
@@ -83,7 +83,9 @@ deployment_groups:
               - - $^mpis
       commands: |
         # Un-comment and update mirror_url to install from spack cache
-        # spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # if ! spack mirror list | grep -q gcs_cache; then
+        #   spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # fi
         # spack buildcache keys --install --trust
 
         spack config --scope defaults add config:build_stage:/apps/spack/spack-stage

--- a/examples/serverless-batch-mpi.yaml
+++ b/examples/serverless-batch-mpi.yaml
@@ -76,7 +76,9 @@ deployment_groups:
               - - $^mpis
       commands: |
         # Un-comment and update mirror_url to install from spack cache
-        # spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # if ! spack mirror list | grep -q gcs_cache; then
+        #   spack mirror add --scope site gcs_cache gs://optionally_set_spack_cache_bucket
+        # fi
         # spack buildcache keys --install --trust
 
         spack config --scope defaults add config:build_stage:/share/spack/spack-stage

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -56,7 +56,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=examples/serverless-batch-mpi.yaml
 
-    sed -i "s/# spack mirror add .*/spack mirror add --scope site gcs_cache $${SPACK_CACHE_WRF//\//\\\/}/" $${SG_EXAMPLE}
+    sed -i "s/#   spack mirror add .*/spack mirror add --scope site gcs_cache $${SPACK_CACHE_WRF//\//\\\/}/" $${SG_EXAMPLE}
     sed -i "s/# spack buildcache keys .*/spack buildcache keys --install --trust/" $${SG_EXAMPLE}
 
     echo '  - id: wait'                                           >> $${SG_EXAMPLE}

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -55,7 +55,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=community/examples/hpc-slurm-gromacs.yaml
 
-    sed -i "s/# spack mirror add .*/spack mirror add --scope site gcs_cache $${SPACK_CACHE_WRF//\//\\\/}/" $${SG_EXAMPLE}
+    sed -i "s/#   spack mirror add .*/spack mirror add --scope site gcs_cache $${SPACK_CACHE_WRF//\//\\\/}/" $${SG_EXAMPLE}
     sed -i "s/# spack buildcache keys .*/spack buildcache keys --install --trust/" $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \


### PR DESCRIPTION
Without conditional spack fails on second startup with error like "mirror already exists".

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
