### PR TITLE
Update the install ramble deps runner based on the spack module

### DIFF
--- a/community/modules/scripts/ramble-setup/main.tf
+++ b/community/modules/scripts/ramble-setup/main.tf
@@ -17,6 +17,8 @@
 locals {
   profile_script = <<-EOF
     if [ -f ${var.install_dir}/share/ramble/setup-env.sh ]; then
+          echo "** Ramble's python virtualenv (/usr/local/ramble-python) is actiavted. Call 'deactivate' to deactivate."
+          . /usr/local/ramble-python/bin/activate
           . ${var.install_dir}/share/ramble/setup-env.sh
     fi
   EOF

--- a/community/modules/scripts/ramble-setup/templates/install_ramble_deps.yml.tpl
+++ b/community/modules/scripts/ramble-setup/templates/install_ramble_deps.yml.tpl
@@ -17,17 +17,24 @@
   hosts: localhost
   vars:
     ramble_ref: ${ramble_ref}
+    ramble_virtualenv_path: "/usr/local/ramble-python"
   tasks:
   - name: Install dependencies through system package manager
     ansible.builtin.package:
       name:
-      - python
+      - python3
       - python3-pip
       - git
+    register: package
+    changed_when: package.changed
+    retries: 5
+    delay: 10
+    until: package is success
 
   - name: Ensure a recent copy of pip
     ansible.builtin.pip:
       name: pip>=21.3.1
+      virtualenv: "{{ ramble_virtualenv_path }}"
 
   - name: Download ramble requirements file
     ansible.builtin.get_url:
@@ -37,3 +44,4 @@
   - name: Install ramble dependencies
     ansible.builtin.pip:
       requirements: /tmp/requirements.txt
+      virtualenv: "{{ ramble_virtualenv_path }}"


### PR DESCRIPTION
This merge updates the install_ramble_deps module, by changing the python package name, and using a venv for ramble (as is used in spack).

This fixes issues with the ramble module on rocky linux.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
