### PR TITLE
Rename tests

### DIFF
--- a/tools/cloud-build/daily-tests/tests/batch-mpi.yml
+++ b/tools/cloud-build/daily-tests/tests/batch-mpi.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-test_name: batch-mpi
+test_name: serverless-batch-mpi
 deployment_name: batch-mpi-{{ build }}
 zone: us-west4-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml
+++ b/tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-test_name: chrome-remote-desktop
+test_name: remote-desktop
 deployment_name: chrome-remote-desktop-{{ build }}
 zone: us-central1-f
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/cloud-batch.yml
+++ b/tools/cloud-build/daily-tests/tests/cloud-batch.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-test_name: cloud-batch
+test_name: serverless-batch
 deployment_name: cloud-batch-{{ build }}
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/high-io-slurm-gcp-v5.yml
+++ b/tools/cloud-build/daily-tests/tests/high-io-slurm-gcp-v5.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: high-io-slurm-gcp-v5
+test_name: hpc-cluster-high-io-v5
 deployment_name: "io-v5-{{ build }}"
 slurm_cluster_name: "iov5{{ build[0:6] }}"
 zone: us-west4-c

--- a/tools/cloud-build/daily-tests/tests/hpc-high-io.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-high-io.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: hpc-high-io
+test_name: hpc-slurm-legacy
 deployment_name: "hpc-high-io-{{ build }}"
 zone: us-west4-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
@@ -13,8 +13,9 @@
 # limitations under the License.
 ---
 
-test_name: hpc-slurm-chromedesktop
+test_name: slurm-crd
 deployment_name: "slm-crd-{{ build }}"
+
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.
 slurm_cluster_name: "slmcrd{{ build[0:4] }}"

--- a/tools/cloud-build/daily-tests/tests/htcondor.yml
+++ b/tools/cloud-build/daily-tests/tests/htcondor.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: htcondor
+test_name: htc-htcondor
 deployment_name: "htcondor-{{ build }}"
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/lustre-slurm.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 
-test_name: lustre-vm
+test_name: test-slurm-lustre
 deployment_name: "lustr-{{ build }}"
 region: us-central1
 zone: us-central1-c

--- a/tools/cloud-build/daily-tests/tests/lustre-vm.yml
+++ b/tools/cloud-build/daily-tests/tests/lustre-vm.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: lustre-vm
+test_name: test-workstation-lustre
 deployment_name: "lustre-vm-{{ build }}"
 zone: us-central1-a
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/monitoring.yml
+++ b/tools/cloud-build/daily-tests/tests/monitoring.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: monitoring
+test_name: blueprint-monitoring
 deployment_name: monitoring-{{ build }}
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/omnia.yml
+++ b/tools/cloud-build/daily-tests/tests/omnia.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: omnia
+test_name: omnia-cluster
 deployment_name: "omnia-{{ build }}"
 zone: us-west3-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/packer.yml
+++ b/tools/cloud-build/daily-tests/tests/packer.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: packer
+test_name: image-builder
 deployment_name: pkr{{ build }}
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/pbspro.yml
+++ b/tools/cloud-build/daily-tests/tests/pbspro.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-test_name: pbspro
+test_name: pbs
 deployment_name: pbs-{{ build }}
 zone: us-central1-c
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/qsim.yml
+++ b/tools/cloud-build/daily-tests/tests/qsim.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: qsim
+test_name: quantum-circuit
 deployment_name: "qsim-{{ build }}"
 zone: us-central1-f
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: slurm-gcp-v5-hpc-centos7
+test_name: hpc-slurm
 deployment_name: "cent-v5-{{ build }}"
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-startup-scripts.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-startup-scripts.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: slurm-gcp-v5-startup-scripts
+test_name: hpc-cluster-slurm-v5
 deployment_name: "ss-v5-{{ build }}"
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: slurm-gcp-v5-ubuntu2004
+test_name: hpc-slurm-ubuntu2004
 deployment_name: "ubun-v5-{{ build }}"
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.

--- a/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
+++ b/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
@@ -14,7 +14,7 @@
 
 ---
 
-test_name: spack-gromacs
+test_name: hpc-slurm-gromacs
 deployment_name: "spack-gromacs-{{ build }}"
 zone: us-central1-c
 workspace: /workspace


### PR DESCRIPTION
Renames the test names to match the blueprint names so the tgz file and the terraform backend state file can be uploaded to the same folder. 
