### PR TITLE
Fix install script in ml-slurm example

### DIFF
--- a/examples/ml-slurm.yaml
+++ b/examples/ml-slurm.yaml
@@ -64,7 +64,7 @@ deployment_groups:
           set -e -o pipefail
 
           echo "deb https://packages.cloud.google.com/apt google-fast-socket main" > /etc/apt/sources.list.d/google-fast-socket.list
-          apt-get update
+          apt-get update --allow-releaseinfo-change
           apt-get install --assume-yes google-fast-socket
 
           CONDA_BASE=/opt/conda


### PR DESCRIPTION
apt-get update was causing an error during the packer image creation step. An upstream package, specifically `gcsfuse-bullseye`, changed it's Origin and Label. This allows for those values to be updated.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
