### PR TITLE
Ignore exit code when collecting partition info in Slurm integration test

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -223,6 +223,7 @@
 
     - name: Get partition info after test
       ansible.builtin.command: sinfo
+      failed_when: False
       changed_when: False
       register: partition_post_run_output
 


### PR DESCRIPTION
Several recent integrations tests have failed to cleanup because this task attempts (and fails) to run `sinfo` on a cluster that did not successfully start. This will allow the `always` block to run to completion.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
