### PR TITLE
Add support for reading `metadata.yaml` in CFT-format, fallack to har…

### DIFF
--- a/pkg/modulereader/metadata.go
+++ b/pkg/modulereader/metadata.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modulereader
+
+import (
+	"errors"
+	"hpc-toolkit/pkg/sourcereader"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Metadata corresponds to BlueprintMetadata in CFT schema
+// See https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/cli/bpmetadata/schema/gcp-blueprint-metadata.json#L278
+type Metadata struct {
+	Spec MetadataSpec `yaml:"spec"`
+}
+
+// MetadataSpec corresponds to BlueprintMetadataSpec in CFT schema
+// See https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/cli/bpmetadata/schema/gcp-blueprint-metadata.json#L299
+type MetadataSpec struct {
+	Requirements MetadataRequirements `yaml:"requirements"`
+}
+
+// MetadataRequirements corresponds to BlueprintRequirements in CFT schema
+// See https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/cli/bpmetadata/schema/gcp-blueprint-metadata.json#L416
+type MetadataRequirements struct {
+	Services []string `yaml:"services"`
+}
+
+// GetMetadata reads and parses `metadata.yaml` from module root.
+// Expects source to be either a local or embedded path.
+func GetMetadata(source string) (Metadata, error) {
+	var err error
+	var data []byte
+	filePath := filepath.Join(source, "metadata.yaml")
+
+	switch {
+	case sourcereader.IsEmbeddedPath(source):
+		data, err = sourcereader.ModuleFS.ReadFile(filePath)
+	case sourcereader.IsLocalPath(source):
+		var absPath string
+		if absPath, err = filepath.Abs(filePath); err == nil {
+			data, err = os.ReadFile(absPath)
+		}
+	default:
+		err = errors.New("source must be local or embedded")
+	}
+	if err != nil {
+		return Metadata{}, err
+	}
+
+	var mtd Metadata
+	err = yaml.Unmarshal(data, &mtd)
+	return mtd, err
+}
+
+// GetMetadataSafe attempts to GetMetadata if it fails returns
+// hardcoded legacy metadata.
+func GetMetadataSafe(source string) Metadata {
+	if mtd, err := GetMetadata(source); err == nil {
+		return mtd
+	}
+	return legacyMetadata(source)
+}

--- a/pkg/modulereader/metadata_legacy.go
+++ b/pkg/modulereader/metadata_legacy.go
@@ -1,0 +1,192 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modulereader
+
+import (
+	"strings"
+)
+
+func legacyMetadata(source string) Metadata {
+	services := []string{}
+	if idx := strings.LastIndex(source, "community/modules/"); idx != -1 {
+		services = defaultAPIList(source[idx:])
+	} else if idx := strings.LastIndex(source, "modules/"); idx != -1 {
+		services = defaultAPIList(source[idx:])
+	}
+
+	return Metadata{
+		Spec: MetadataSpec{
+			Requirements: MetadataRequirements{
+				Services: services,
+			},
+		},
+	}
+}
+
+func defaultAPIList(source string) []string {
+	// API lists at
+	// https://console.cloud.google.com/apis/dashboard and
+	// https://console.cloud.google.com/apis/library
+	staticAPIMap := map[string][]string{
+		"community/modules/compute/SchedMD-slurm-on-gcp-partition": {
+			"compute.googleapis.com",
+		},
+		"community/modules/compute/htcondor-execute-point": {
+			"compute.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/compute/pbspro-execution": {
+			"compute.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/compute/schedmd-slurm-gcp-v5-partition": {
+			"compute.googleapis.com",
+		},
+		"community/modules/database/slurm-cloudsql-federation": {
+			"bigqueryconnection.googleapis.com",
+			"sqladmin.googleapis.com",
+		},
+		"community/modules/file-system/DDN-EXAScaler": {
+			"compute.googleapis.com",
+			"deploymentmanager.googleapis.com",
+			"iam.googleapis.com",
+			"runtimeconfig.googleapis.com",
+		},
+		"community/modules/file-system/Intel-DAOS": {
+			"compute.googleapis.com",
+			"iam.googleapis.com",
+			"secretmanager.googleapis.com",
+		},
+		"community/modules/file-system/nfs-server": {
+			"compute.googleapis.com",
+		},
+		"community/modules/project/new-project": {
+			"admin.googleapis.com",
+			"cloudresourcemanager.googleapis.com",
+			"cloudbilling.googleapis.com",
+			"iam.googleapis.com",
+		},
+		"community/modules/project/service-account": {
+			"iam.googleapis.com",
+		},
+		"community/modules/project/service-enablement": {
+			"serviceusage.googleapis.com",
+		},
+		"community/modules/scheduler/SchedMD-slurm-on-gcp-controller": {
+			"compute.googleapis.com",
+		},
+		"community/modules/scheduler/SchedMD-slurm-on-gcp-login-node": {
+			"compute.googleapis.com",
+		},
+		"community/modules/compute/gke-node-pool": {
+			"container.googleapis.com",
+		},
+		"community/modules/scheduler/gke-cluster": {
+			"container.googleapis.com",
+		},
+		"modules/scheduler/batch-job-template": {
+			"batch.googleapis.com",
+			"compute.googleapis.com",
+		},
+		"modules/scheduler/batch-login-node": {
+			"batch.googleapis.com",
+			"compute.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/scheduler/htcondor-access-point": {
+			"compute.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/scheduler/htcondor-central-manager": {
+			"compute.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/scheduler/htcondor-pool-secrets": {
+			"iam.googleapis.com",
+			"secretmanager.googleapis.com",
+		},
+		"community/modules/scheduler/htcondor-setup": {
+			"iam.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/scheduler/pbspro-client": {
+			"compute.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/scheduler/pbspro-server": {
+			"compute.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/scheduler/schedmd-slurm-gcp-v5-controller": {
+			"compute.googleapis.com",
+			"iam.googleapis.com",
+			"pubsub.googleapis.com",
+			"secretmanager.googleapis.com",
+		},
+		"community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid": {
+			"compute.googleapis.com",
+			"pubsub.googleapis.com",
+		},
+		"community/modules/scheduler/schedmd-slurm-gcp-v5-login": {
+			"compute.googleapis.com",
+		},
+		"community/modules/scripts/htcondor-install": {},
+		"community/modules/scripts/omnia-install":    {},
+		"community/modules/scripts/pbspro-preinstall": {
+			"iam.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"community/modules/scripts/pbspro-install": {},
+		"community/modules/scripts/pbspro-qmgr":    {},
+		"community/modules/scripts/spack-setup": {
+			"storage.googleapis.com",
+		},
+		"community/modules/scripts/wait-for-startup": {
+			"compute.googleapis.com",
+		},
+		"modules/compute/vm-instance": {
+			"compute.googleapis.com",
+		},
+		"modules/file-system/filestore": {
+			"file.googleapis.com",
+		},
+		"modules/file-system/cloud-storage-bucket": {
+			"storage.googleapis.com",
+		},
+		"modules/file-system/pre-existing-network-storage": {},
+		"modules/monitoring/dashboard": {
+			"stackdriver.googleapis.com",
+		},
+		"modules/network/pre-existing-vpc": {
+			"compute.googleapis.com",
+		},
+		"modules/network/vpc": {
+			"compute.googleapis.com",
+		},
+		"modules/packer/custom-image": {
+			"compute.googleapis.com",
+			"storage.googleapis.com",
+		},
+		"modules/scripts/startup-script": {
+			"storage.googleapis.com",
+		},
+	}
+
+	requiredAPIs, found := staticAPIMap[source]
+	if !found {
+		return []string{}
+	}
+	return requiredAPIs
+}

--- a/pkg/modulereader/modules/imaginarium/zebra/main.pkr.hcl
+++ b/pkg/modulereader/modules/imaginarium/zebra/main.pkr.hcl
@@ -1,0 +1,20 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module "test_module" {
+	source = "testSource"
+}
+data "test_data" "test_data_name" {
+	name = "test_data_name"
+}

--- a/pkg/modulereader/modules/imaginarium/zebra/variables.pkr.hcl
+++ b/pkg/modulereader/modules/imaginarium/zebra/variables.pkr.hcl
@@ -1,0 +1,18 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+variable "test_variable" {
+	description = "This is just a test"
+	type        = string
+}

--- a/pkg/modulereader/modules/test_role/test_module/metadata.yaml
+++ b/pkg/modulereader/modules/test_role/test_module/metadata.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+spec:
+  requirements:
+    services:
+    - room.service.vip
+    - protection.service.GCPD

--- a/pkg/sourcereader/embedded.go
+++ b/pkg/sourcereader/embedded.go
@@ -28,12 +28,11 @@ import (
 // hpc-toolkit/modules are not accessible at the package level.
 var ModuleFS BaseFS
 
-// BaseFS is an extension of the fs.FS interface with the functionality needed
-// in CopyDirFromModules. Works with embed.FS and afero.FS
+// BaseFS is an join interface with the functionality needed
+// in copyDirFromModules. Works with embed.FS and afero.FS
 type BaseFS interface {
-	fs.FS
-	ReadDir(string) ([]fs.DirEntry, error)
-	ReadFile(string) ([]byte, error)
+	fs.ReadDirFS
+	fs.ReadFileFS
 }
 
 // EmbeddedSourceReader reads modules from a local directory

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -311,7 +311,8 @@ func testApisEnabled(bp config.Blueprint, inputs config.Dict) error {
 	}
 	apis := map[string]bool{}
 	bp.WalkModules(func(m *config.Module) error {
-		for _, api := range m.InfoOrDie().RequiredApis {
+		services := m.InfoOrDie().Metadata.Spec.Requirements.Services
+		for _, api := range services {
 			apis[api] = true
 		}
 		return nil


### PR DESCRIPTION
…dcoded logic.

* Remove `RequiredApis` from `ModuleInfo`, replace with `Metadata`;
* Refactor `resreader_test.go` to re-use embedded files for localFS test;
* Use `LastIndex` instead `Index` on module source trimming to avoid potential errors;
* Move `defaultAPIList` to `metadata_legacy.go`.

Created BP:

```yaml
...
- id: gg
  source: github.com/terraform-google-modules/terraform-google-vm//modules/mig
```

Modified `metadata.go:GetMetadataSafe`:

```go
panic(fmt.Sprintf("%#v", mtd.Spec.Requirements.Services))
```

Got:

```sh
> make && ./ghpc create gg.yaml
panic: []string{"cloudresourcemanager.googleapis.com", "storage-api.googleapis.com", "serviceusage.googleapis.com", "compute.googleapis.com", "iam.googleapis.com"}
```

Matches: https://github.com/terraform-google-modules/terraform-google-vm/blob/master/modules/mig/metadata.yaml#L294

