### PR TITLE
Fix HCLS and gcs fuse installation

### DIFF
--- a/community/modules/file-system/cloud-storage-bucket/scripts/install-gcs-fuse.sh
+++ b/community/modules/file-system/cloud-storage-bucket/scripts/install-gcs-fuse.sh
@@ -32,7 +32,7 @@ EOF
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
 		RELEASE=$(lsb_release -c -s)
 		export GCSFUSE_REPO="gcsfuse-${RELEASE}"
-		echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+		echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
 		curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 		sudo apt-get update

--- a/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
+++ b/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
@@ -284,8 +284,6 @@ deployment_groups:
       name_prefix: chrome-remote-desktop
       install_nvidia_driver: true
       startup_script: |
-        sudo apt-get update
-        sudo apt-get -y upgrade
         find /user_provided_software -name vmd-1.9.*.bin.LINUXAMD64*.tar.gz -exec tar xvzf '{}' -C . \;
         cd vmd-1.9.*/
         ./configure

--- a/modules/file-system/pre-existing-network-storage/scripts/install-gcs-fuse.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-gcs-fuse.sh
@@ -32,7 +32,7 @@ EOF
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
 		RELEASE=$(lsb_release -c -s)
 		export GCSFUSE_REPO="gcsfuse-${RELEASE}"
-		echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+		echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
 		curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 		sudo apt-get update


### PR DESCRIPTION
Fix/Improve HCLS blueprint consistency by removing `apt-get upgrade`.  When upgrading bad packages or incompatibilities can be introduced.

While fixing this, ran into an issue where the gcsfuse install broke from a bad gateway.  Apparently the fix was switching from http to https on the apt list creation.