### PR TITLE
Fix HTCondor Windows download URI

### DIFF
--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -22,6 +22,8 @@
   hosts: all
   vars:
     enable_docker: true
+    htcondor_key: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key
+    docker_key: https://download.docker.com/linux/centos/gpg
   become: true
   module_defaults:
     ansible.builtin.yum:
@@ -31,13 +33,24 @@
     ansible.builtin.yum:
       name:
       - epel-release
+  - name: Directly install RPM verification keys
+    ansible.builtin.rpm_key:
+      state: present
+      key: "{{ item }}"
+    loop:
+    - "{{ htcondor_key }}"
+    - "{{ docker_key }}"
+    register: key_install
+    retries: 10
+    delay: 60
+    until: key_install is success
   - name: Enable HTCondor Feature Release repository
     ansible.builtin.yum_repository:
       name: htcondor-feature
       description: HTCondor Feature Releases (10.x.0)
       file: htcondor
       baseurl: https://research.cs.wisc.edu/htcondor/repo/10.x/el$releasever/$basearch/release
-      gpgkey: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key
+      gpgkey: "{{ htcondor_key }}"
       gpgcheck: true
       repo_gpgcheck: true
       priority: "90"
@@ -71,7 +84,7 @@
         baseurl: https://download.docker.com/linux/centos/$releasever/$basearch/stable
         enabled: yes
         gpgcheck: yes
-        gpgkey: https://download.docker.com/linux/centos/gpg
+        gpgkey: "{{ docker_key }}"
     - name: Install Docker
       ansible.builtin.yum:
         name:

--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -16,9 +16,9 @@ Remove-Item "$runtime_installer"
 # download HTCondor installer
 $htcondor_installer = 'C:\htcondor.msi'
 %{ if condor_version == "10.*" }
-Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/current/current/condor-Windows-x64.msi -OutFile "$htcondor_installer"
+Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/10.x/current/condor-Windows-x64.msi -OutFile "$htcondor_installer"
 %{ else ~}
-Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/current/${condor_version}/release/condor-${condor_version}-Windows-x64.msi -OutFile "$htcondor_installer"
+Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/10.x/${condor_version}/release/condor-${condor_version}-Windows-x64.msi -OutFile "$htcondor_installer"
 %{ endif ~}
 $args='/qn /l* condor-install-log.txt /i'
 $args=$args + " $htcondor_installer"

--- a/community/modules/scripts/htcondor-install/variables.tf
+++ b/community/modules/scripts/htcondor-install/variables.tf
@@ -24,4 +24,13 @@ variable "condor_version" {
   description = "Yum/DNF-compatible version string; leave unset to default to 10.x series (examples: \"10.5.1\",\"10.*\"))"
   type        = string
   default     = "10.*"
+
+  validation {
+    error_message = "var.condor_version must be set to \"10.*\" for latest 10.X release or to a specific \"10.x.y\" release."
+    condition = var.condor_version == "10.*" || (
+      length(split(".", var.condor_version)) == 3 && alltrue([
+        for v in split(".", var.condor_version) : can(tonumber(v))
+      ]) && split(".", var.condor_version)[0] == "10"
+    )
+  }
 }


### PR DESCRIPTION
Upon the release of HTCondor 23.0, the URLs have for the 10.x series have been reorganized. This does not impact Linux repositories, however it does affect the Windows MSI installer download.

In addition, this PR adds:

- validation for the user-supplied version string to enforce 10.x compatibility.
- addresses a problem where `dnf-automatic.service` interferes with GPG key verification by manually importing the keys prior to setting up the yum repositories and allowing key import to retry for up to 10 minutes. In practice, dnf-automatic is observed to take approximately 1 minute to perform a kernel upgrade

This as been manually tested against the following blueprint:

```yaml
blueprint_name: htc-htcondor

vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: example-pool
  region: us-central1
  zone: us-central1-f
  disk_size_gb: 100
  new_image_family: htc-example-10x
  new_windows_image_family: htc-example-win-10x
  spool_parent_dir: /shared

# Documentation for each of the modules used below can be found at
# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

deployment_groups:
- group: primary
  modules:
  - id: network1
    source: modules/network/vpc
    settings:
      enable_iap_rdp_ingress: true
      enable_iap_winrm_ingress: true
    outputs:
    - network_name

  - id: htcondor_install
    source: community/modules/scripts/htcondor-install
    settings:
      condor_version: 10.7.1

  - id: htcondor_install_script
    source: modules/scripts/startup-script
    use:
    - htcondor_install

  - id: windows_startup
    source: community/modules/scripts/windows-startup-script
    settings:
      install_nvidia_driver: true

  - id: spoolfs
    source: modules/file-system/filestore
    use:
    - network1
    settings:
      filestore_tier: ENTERPRISE
      local_mount: $(vars.spool_parent_dir)

- group: packer
  modules:
  - id: custom-image
    source: modules/packer/custom-image
    kind: packer
    use:
    - network1
    - htcondor_install_script
    settings:
      image_family: $(vars.new_image_family)
      source_image_family: hpc-rocky-linux-8
      disk_size: $(vars.disk_size_gb)

- group: packer-windows
  modules:
  - id: image-windows
    source: modules/packer/custom-image
    kind: packer
    use:
    - network1
    settings:
      image_family: $(vars.new_windows_image_family)
      source_image_family: windows-2016
      machine_type: n1-standard-16
      accelerator_type: nvidia-tesla-t4
      accelerator_count: 1
      disk_size: 75
      disk_type: pd-ssd
      state_timeout: 15m
      windows_startup_ps1:
      - $(windows_startup.windows_startup_ps1[0])
      - $(htcondor_install.windows_startup_ps1)
      - |
        Write-Output 'Hello, World!'
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
