### PR TITLE
Forces VMs to be replaced when placement policy is destroyed

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -195,6 +195,7 @@ limitations under the License.
 | [google-beta_google_compute_resource_policy.placement_policy](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_resource_policy) | resource |
 | [google_compute_disk.boot_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [null_resource.image](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.replace_vm_trigger_from_placement](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_image.compute_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 
 ## Inputs

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -235,6 +235,10 @@ resource "google_compute_instance" "compute_vm" {
       metadata["ssh-keys"],
     ]
 
+    replace_triggered_by = [
+      google_compute_resource_policy.placement_policy
+    ]
+
     precondition {
       condition     = (length(var.network_interfaces) == 0) != (var.network_self_link == null && var.subnetwork_self_link == null)
       error_message = "Exactly one of network_interfaces or network_self_link/subnetwork_self_link must be specified."

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -135,6 +135,15 @@ resource "google_compute_resource_policy" "placement_policy" {
   }
 }
 
+resource "null_resource" "replace_vm_trigger_from_placement" {
+  triggers = {
+    vm_count                  = try(tostring(var.placement_policy.vm_count), "")
+    availability_domain_count = try(tostring(var.placement_policy.availability_domain_count), "")
+    max_distance              = try(tostring(var.placement_policy.max_distance), "")
+    collocation               = try(var.placement_policy.collocation, "")
+  }
+}
+
 resource "google_compute_instance" "compute_vm" {
   project  = var.project_id
   provider = google-beta
@@ -236,7 +245,7 @@ resource "google_compute_instance" "compute_vm" {
     ]
 
     replace_triggered_by = [
-      google_compute_resource_policy.placement_policy
+      null_resource.replace_vm_trigger_from_placement
     ]
 
     precondition {


### PR DESCRIPTION
Tested: 
- Deploy VM with no placement
- Add placement with max_distance: 1; re-deploy
- Edit `max_distance` from 1 -> 2; re-deploy
- remove placement; re-deploy

Each time it recognizes that VM must be destroyed.

Note: If one does not turn `auto_delete_boot_disk: false` you will still get an error on second apply as it will not find disk. This can be worked around by doing another apply. This disk issue is a known pain point that is unrelated to the placement policy error.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
