### PR TITLE
Warn user that Spack setup takes a few seconds

### DIFF
--- a/community/modules/scripts/spack-setup/main.tf
+++ b/community/modules/scripts/spack-setup/main.tf
@@ -23,6 +23,7 @@ locals {
   profile_script = <<-EOF
     SPACK_PYTHON=${var.spack_virtualenv_path}/bin/python3
     if [ -f ${var.install_dir}/share/spack/setup-env.sh ]; then
+          echo "Running Spack setup, this may take a moment on first login."
           . ${var.install_dir}/share/spack/setup-env.sh
     fi
   EOF


### PR DESCRIPTION
Currently it feels like first login is hanging. This message lets the user know why.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
