### PR TITLE
Update install_ansible.sh to install python3-venv and be compatible with Debian 12

### DIFF
--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -15,6 +15,8 @@
 
 REQ_ANSIBLE_VERSION=2.11
 REQ_ANSIBLE_PIP_VERSION=4.10.0
+REQ_PIP_WHEEL_VERSION=0.41.2
+REQ_PIP_SETUPTOOLS_VERSION=59.6.0
 REQ_PIP_MAJOR_VERSION=21
 REQ_PYTHON3_VERSION=6
 
@@ -183,6 +185,8 @@ main() {
 	if [ "${pip_major_version}" -lt "${REQ_PIP_MAJOR_VERSION}" ]; then
 		${venv_python_path} -m pip install --upgrade pip
 	fi
+
+	${venv_python_path} -m pip install -U wheel==${REQ_PIP_WHEEL_VERSION} setuptools==${REQ_PIP_SETUPTOOLS_VERSION}
 
 	# configure ansible to always use correct Python binary
 	if [ ! -f /etc/ansible/ansible.cfg ]; then


### PR DESCRIPTION
This change is a precursor to the Debian 12 update to CRD, which will be updated to be rebased off this branch.

This change is necessary because Debian 12's python environment is externally managed and using pip to install virtualenv breaks during the startup scripts.  Instead, I've moved to installing python3-venv through apt and updating pip from within the virtual environment.  

Additionally, at least on the Ubuntu image, python3-venv isn't immediately available with the apt list, so an apt-update is required before installing any packages.