### PR TITLE
Integration task for bulk insert  stockout errors

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -267,6 +267,15 @@
       ansible.builtin.debug:
         var: suspend_output.stdout_lines
 
+    - name: Check for stockout errors
+      ansible.builtin.include_tasks:
+        file: tasks/check_stockout.yml
+        apply:
+          delegate_to: localhost
+      vars:
+        slurm_cluster_name: "{{ slurm_cluster_name }}"
+        project: "{{ project }}"
+
     - name: Cleanup firewall and infrastructure
       ansible.builtin.include_tasks:
         file: tasks/rescue_ghpc_failure.yml

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -210,6 +210,16 @@
       loop_control:
         loop_var: test
 
+    rescue:
+    - name: Check for stockout errors
+      ansible.builtin.include_tasks:
+        file: tasks/check_stockout.yml
+        apply:
+          delegate_to: localhost
+      vars:
+        slurm_cluster_name: "{{ slurm_cluster_name }}"
+        project: "{{ project }}"
+
     ## Always cleanup, even on failure
     always:
     - name: Ensure all nodes are powered down
@@ -266,15 +276,6 @@
     - name: Print Slurm suspend.log
       ansible.builtin.debug:
         var: suspend_output.stdout_lines
-
-    - name: Check for stockout errors
-      ansible.builtin.include_tasks:
-        file: tasks/check_stockout.yml
-        apply:
-          delegate_to: localhost
-      vars:
-        slurm_cluster_name: "{{ slurm_cluster_name }}"
-        project: "{{ project }}"
 
     - name: Cleanup firewall and infrastructure
       ansible.builtin.include_tasks:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
@@ -18,25 +18,33 @@
     that:
     - project is defined
 
-- name: Check compute stockout
-  changed_when: false
-  register: stockout
-  until: stockout.rc == 0
-  retries: 5
-  delay: 10
+- name: Check for capacity issues on compute nodes
   vars:
-    stockout_string: Region does not currently have sufficient capacity for the requested resources.
-  ansible.builtin.command: >-
-    gcloud logging --project {{ project }} read
-    'protoPayload.response.error.errors.message="{{ stockout_string }}" AND protoPayload.request.perInstanceProperties.key=~".*{{ slurm_cluster_name }}.*"'
-    --flatten="protoPayload.request.perInstanceProperties"
-    --format='table(protoPayload.request.perInstanceProperties.key:label=INSTANCE_ID,protoPayload.response.error.errors.message.list():label=ERROR_MESSAGE)'
-    --limit=5
+    check_strings:
+    - Region does not currently have sufficient capacity for the requested resources.
+    - No eligible zone could be found in this region for given properties
   when: slurm_cluster_name is defined
+  block:
+  - name: Check logs for stockout on compute nodes
+    changed_when: false
+    register: stockout
+    until: stockout.rc == 0
+    retries: 5
+    delay: 10
+    ansible.builtin.command: >-
+      gcloud logging --project {{ project }} read
+      'protoPayload.response.error.errors.message="{{ item }}" AND protoPayload.request.perInstanceProperties.key=~".*{{ slurm_cluster_name }}.*"'
+      --flatten="protoPayload.request.perInstanceProperties"
+      --format='table(protoPayload.request.perInstanceProperties.key:label=INSTANCE_ID,protoPayload.response.error.errors.message.list():label=ERROR_MESSAGE)'
+      --limit=5
+    with_items: "{{ check_strings }}"
 
-- name: Log stockout error
-  ansible.builtin.debug:
-    msg: |
-      "Abbreviated listing of nodes that could not be created:"
-      "{{ stockout.stdout }}"
-  when: stockout is defined
+  - name: Log compute stockout error
+    ansible.builtin.debug:
+      msg: |
+        "Abbreviated listing of nodes that could not be created:"
+        "{{ item.stdout }}"
+    when: item.stdout != ""
+    with_items: "{{ stockout.results }}"
+    loop_control:
+      label: "{{ item.item }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - project is defined
+
+- name: Check compute stockout
+  changed_when: false
+  register: stockout
+  until: stockout.rc == 0
+  retries: 5
+  delay: 10
+  vars:
+    stockout_string: Region does not currently have sufficient capacity for the requested resources.
+  ansible.builtin.command: >-
+    gcloud logging --project {{ project }} read
+    'protoPayload.response.error.errors.message="{{ stockout_string }}" AND protoPayload.request.perInstanceProperties.key=~".*{{ slurm_cluster_name }}.*"'
+    --flatten="protoPayload.request.perInstanceProperties"
+    --format='table(protoPayload.request.perInstanceProperties.key:label=INSTANCE_ID,protoPayload.response.error.errors.message.list():label=ERROR_MESSAGE)'
+    --limit=5
+  when: slurm_cluster_name is defined
+
+- name: Log stockout error
+  ansible.builtin.debug:
+    msg: |
+      "Abbreviated listing of nodes that could not be created:"
+      "{{ stockout.stdout }}"
+  when: stockout is defined


### PR DESCRIPTION
A small task to check for bulk insert stockouts.  Should be extensible for other kinds of stock out or at lease provides a template.  Could potentially be used for retrying when stockouts occur.
