### PR TITLE
Differentiate between key and value part of maps item path

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -715,7 +715,7 @@ func (bp *Blueprint) evalVars() error {
 			}
 			if used[ref.Name] == 1 {
 				return BpError{
-					Root.Vars.Dot(n),
+					Root.Vars.Key(n),
 					fmt.Errorf("cyclic dependency detected: %q -> %q", n, ref.Name),
 				}
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1058,7 +1058,7 @@ func (s *MySuite) TestEvalVars(c *C) {
 		err := bp.evalVars()
 		var berr BpError
 		if errors.As(err, &berr) {
-			if berr.Path.String() != "vars.uro" && berr.Path.String() != "vars.ros" {
+			if berr.Path.String() != "vars#uro" && berr.Path.String() != "vars#ros" {
 				c.Error(berr, " should point to vars.uro or vars.ros")
 			}
 		} else {

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -56,6 +56,12 @@ func (p mapPath[E]) Dot(k string) E {
 	return e
 }
 
+func (p mapPath[E]) Key(k string) basePath {
+	var e basePath
+	initPath(&e, &p, fmt.Sprintf("#%s", k))
+	return e
+}
+
 func initPath(p any, prev any, piece string) {
 	r := reflect.Indirect(reflect.ValueOf(p))
 	ty := reflect.TypeOf(p).Elem()

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -41,6 +41,7 @@ func TestPath(t *testing.T) {
 		{r.Validators.At(2).Inputs, "validators[2].inputs"},
 		{r.Validators.At(2).Inputs.Dot("zebra"), "validators[2].inputs.zebra"},
 
+		{r.Vars.Key("red"), "vars#red"},
 		{r.Vars.Dot("red"), "vars.red"},
 
 		{r.Groups.At(3), "deployment_groups[3]"},
@@ -60,10 +61,12 @@ func TestPath(t *testing.T) {
 		{m.Outputs.At(2).Description, "deployment_groups[3].modules[1].outputs[2].description"},
 		{m.Outputs.At(2).Sensitive, "deployment_groups[3].modules[1].outputs[2].sensitive"},
 		{m.Settings, "deployment_groups[3].modules[1].settings"},
+		{m.Settings.Key("lime"), "deployment_groups[3].modules[1].settings#lime"},
 		{m.Settings.Dot("lime"), "deployment_groups[3].modules[1].settings.lime"},
 
 		{r.Backend.Type, "terraform_backend_defaults.type"},
 		{r.Backend.Configuration, "terraform_backend_defaults.configuration"},
+		{r.Backend.Configuration.Key("goo"), "terraform_backend_defaults.configuration#goo"},
 		{r.Backend.Configuration.Dot("goo"), "terraform_backend_defaults.configuration.goo"},
 	}
 	for _, tc := range tests {
@@ -87,6 +90,7 @@ func TestPathParent(t *testing.T) {
 		{r.Groups, r},
 		{r.Groups.At(3), r.Groups},
 		{r.Groups.At(3).Modules, r.Groups.At(3)},
+		{r.Vars.Key("red"), r.Vars},
 		{r.Vars.Dot("red"), r.Vars},
 	}
 	for _, tc := range tests {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -74,7 +74,7 @@ func validateVars(vars Dict) error {
 	// Check for any nil values
 	for key, val := range vars.Items() {
 		if val.IsNull() {
-			errs.At(Root.Vars.Dot(key), fmt.Errorf("deployment variable %s was not set", key))
+			errs.At(Root.Vars.Key(key), fmt.Errorf("deployment variable %s was not set", key))
 		}
 	}
 	return errs.OrNil()
@@ -145,7 +145,7 @@ func validateSettings(
 	}
 	errs := Errors{}
 	for k := range mod.Settings.Items() {
-		sp := p.Settings.Dot(k)
+		sp := p.Settings.Key(k)
 		// Setting name included a period
 		// The user was likely trying to set a subfield which is not supported.
 		// HCL does not support periods in variables names either:

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -36,7 +36,15 @@ func (p yPath) At(i int) yPath {
 	return yPath(fmt.Sprintf("%s[%d]", p, i))
 }
 
-// Dot is a builder method for a path of a child in a mapping.
+// Key is a builder method for a path of a child in a mapping, pointing at key
+func (p yPath) Key(k string) yPath {
+	if p == "" {
+		return yPath(k)
+	}
+	return yPath(fmt.Sprintf("%s#%s", p, k))
+}
+
+// Dot is a builder method for a path of a child in a mapping, pointing at value
 func (p yPath) Dot(k string) yPath {
 	if p == "" {
 		return yPath(k)
@@ -136,7 +144,9 @@ func NewYamlCtx(data []byte) YamlCtx {
 		m[p] = Pos{n.Line, n.Column}
 		if n.Kind == yaml.MappingNode {
 			for i := 0; i < len(n.Content); i += 2 {
-				walk(n.Content[i+1], p.Dot(n.Content[i].Value))
+				key := n.Content[i].Value
+				walk(n.Content[i], p.Key(key))
+				walk(n.Content[i+1], p.Dot(key))
 			}
 		} else if n.Kind == yaml.SequenceNode {
 			for i, c := range n.Content {

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -91,6 +91,7 @@ terraform_backend_defaults:
 		{Root.Validators, Pos{8, 1}},
 		{Root.Validators.At(0), Pos{8, 3}},
 		{Root.Validators.At(0).Inputs, Pos{10, 5}},
+		{Root.Validators.At(0).Inputs.Key("spice"), Pos{10, 5}},
 		{Root.Validators.At(0).Inputs.Dot("spice"), Pos{10, 12}},
 		{Root.Validators.At(0).Validator, Pos{8, 14}},
 		{Root.Validators.At(1), Pos{11, 3}},
@@ -98,6 +99,7 @@ terraform_backend_defaults:
 		{Root.Validators.At(1).Validator, Pos{11, 14}},
 		{Root.ValidationLevel, Pos{14, 19}},
 		{Root.Vars, Pos{17, 3}},
+		{Root.Vars.Key("red"), Pos{17, 3}},
 		{Root.Vars.Dot("red"), Pos{17, 8}},
 		{Root.Groups, Pos{20, 1}},
 		{Root.Groups.At(0), Pos{20, 3}},
@@ -106,6 +108,7 @@ terraform_backend_defaults:
 		{Root.Groups.At(0).Backend, Pos{22, 5}},
 		{Root.Groups.At(0).Backend.Type, Pos{22, 11}},
 		{Root.Groups.At(0).Backend.Configuration, Pos{24, 7}},
+		{Root.Groups.At(0).Backend.Configuration.Key("carrot"), Pos{24, 7}},
 		{Root.Groups.At(0).Backend.Configuration.Dot("carrot"), Pos{24, 15}},
 
 		{Root.Groups.At(0).Modules, Pos{26, 3}},
@@ -124,6 +127,7 @@ terraform_backend_defaults:
 		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Description, Pos{33, 20}},
 		{Root.Groups.At(0).Modules.At(0).Outputs.At(1).Sensitive, Pos{34, 18}},
 		{Root.Groups.At(0).Modules.At(0).Settings, Pos{36, 7}},
+		{Root.Groups.At(0).Modules.At(0).Settings.Key("dijon"), Pos{36, 7}},
 		{Root.Groups.At(0).Modules.At(0).Settings.Dot("dijon"), Pos{36, 14}},
 
 		{Root.Groups.At(1), Pos{38, 3}},

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -386,7 +386,7 @@ func testDeploymentVariableNotUsed(bp config.Blueprint, inputs config.Dict) erro
 	errs := config.Errors{}
 	for _, v := range bp.ListUnusedVariables() {
 		errs.At(
-			config.Root.Vars.Dot(v),
+			config.Root.Vars.Key(v),
 			fmt.Errorf("the variable %q was not used in this blueprint", v))
 	}
 	return errs.OrNil()


### PR DESCRIPTION
Currently error path points to a "value" part of key value path `Root.Group.At(i).Modules.At(j).Settings.Dot("scheduling")`. Split this path on two:

```py
...Settings.Key("scheduling")
...Settings.Dot("scheduling")
```

Example of problem:

```yaml
  settings:
    scheduling:
      maintenanceInterval: "PERIODIC"
```

Error:
```sh
Error: a setting was added that is not found in the module
200:         maintenanceInterval: "PERIODIC"
```

After fix:
```sh
Error: a setting was added that is not found in the module
199:       scheduling:
```
