### PR TITLE
Upgrade HTCondor to LTS Release 23.0

### DIFF
--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -134,7 +134,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_condor_version"></a> [condor\_version](#input\_condor\_version) | Yum/DNF-compatible version string; leave unset to default to 10.x series (examples: "10.5.1","10.*")) | `string` | `"10.*"` | no |
+| <a name="input_condor_version"></a> [condor\_version](#input\_condor\_version) | Yum/DNF-compatible version string; leave unset to use latest 23.0 LTS release (examples: "23.0.0","23.*")) | `string` | `"23.*"` | no |
 | <a name="input_enable_docker"></a> [enable\_docker](#input\_enable\_docker) | Install and enable docker daemon alongside HTCondor | `bool` | `true` | no |
 
 ## Outputs

--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # The instructions for installing HTCondor may change with time, although we
-# anticipate that they will stay fixed for the 10.x releases. Find up-to-date
+# anticipate that they will stay fixed for the 23.0 releases. Find up-to-date
 # recommendations at:
 ## https://htcondor.readthedocs.io/en/latest/getting-htcondor/from-our-repositories.html
 
@@ -22,7 +22,7 @@
   hosts: all
   vars:
     enable_docker: true
-    htcondor_key: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key
+    htcondor_key: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-23.0-Key
     docker_key: https://download.docker.com/linux/centos/gpg
   become: true
   module_defaults:
@@ -47,26 +47,16 @@
   - name: Enable HTCondor Feature Release repository
     ansible.builtin.yum_repository:
       name: htcondor-feature
-      description: HTCondor Feature Releases (10.x.0)
+      description: HTCondor LTS Release (23.0)
       file: htcondor
-      baseurl: https://research.cs.wisc.edu/htcondor/repo/10.x/el$releasever/$basearch/release
+      baseurl: https://research.cs.wisc.edu/htcondor/repo/23.0/el$releasever/$basearch/release
       gpgkey: "{{ htcondor_key }}"
-      gpgcheck: true
-      repo_gpgcheck: true
-      priority: "90"
-  - name: Enable HTCondor Feature Release Updates repository
-    ansible.builtin.yum_repository:
-      name: htcondor-feature-update
-      description: HTCondor Feature Release Updates (10.x.y)
-      file: htcondor
-      baseurl: https://research.cs.wisc.edu/htcondor/repo/10.x/el$releasever/$basearch/update
-      gpgkey: https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-10.x-Key
       gpgcheck: true
       repo_gpgcheck: true
       priority: "90"
   - name: Install HTCondor
     ansible.builtin.yum:
-      name: condor-{{ condor_version | default("10.*") | string }}
+      name: condor-{{ condor_version | default("23.*") | string }}
       state: present
   - name: Ensure token directory
     ansible.builtin.file:

--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -16,9 +16,9 @@ Remove-Item "$runtime_installer"
 # download HTCondor installer
 $htcondor_installer = 'C:\htcondor.msi'
 %{ if condor_version == "10.*" }
-Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/10.x/current/condor-Windows-x64.msi -OutFile "$htcondor_installer"
+Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/23.0/current/condor-Windows-x64.msi -OutFile "$htcondor_installer"
 %{ else ~}
-Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/10.x/${condor_version}/release/condor-${condor_version}-Windows-x64.msi -OutFile "$htcondor_installer"
+Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/23.0/${condor_version}/release/condor-${condor_version}-Windows-x64.msi -OutFile "$htcondor_installer"
 %{ endif ~}
 $args='/qn /l* condor-install-log.txt /i'
 $args=$args + " $htcondor_installer"

--- a/community/modules/scripts/htcondor-install/variables.tf
+++ b/community/modules/scripts/htcondor-install/variables.tf
@@ -21,16 +21,17 @@ variable "enable_docker" {
 }
 
 variable "condor_version" {
-  description = "Yum/DNF-compatible version string; leave unset to default to 10.x series (examples: \"10.5.1\",\"10.*\"))"
+  description = "Yum/DNF-compatible version string; leave unset to use latest 23.0 LTS release (examples: \"23.0.0\",\"23.*\"))"
   type        = string
-  default     = "10.*"
+  default     = "23.*"
 
   validation {
-    error_message = "var.condor_version must be set to \"10.*\" for latest 10.X release or to a specific \"10.x.y\" release."
-    condition = var.condor_version == "10.*" || (
+    error_message = "var.condor_version must be set to \"23.*\" for latest 23.0 release or to a specific \"23.0.y\" release."
+    condition = var.condor_version == "23.*" || (
       length(split(".", var.condor_version)) == 3 && alltrue([
         for v in split(".", var.condor_version) : can(tonumber(v))
-      ]) && split(".", var.condor_version)[0] == "10"
+      ]) && split(".", var.condor_version)[0] == "23"
+      && split(".", var.condor_version)[1] == "0"
     )
   }
 }


### PR DESCRIPTION
The HTCondor 10.x series is no longer supported but has become (through their development process) the 23.0 release. This PR points to the new repositories.

I have manually verified Windows image building.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
