### PR TITLE
Render YAML-parsing errors in "rich" way

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -100,7 +100,7 @@ func printAdvancedInstructionsMessage(deplDir string) {
 func expandOrDie(path string) config.DeploymentConfig {
 	dc, ctx, err := config.NewDeploymentConfig(path)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(renderError(err, ctx))
 	}
 	// Set properties from CLI
 	if err := setCLIVariables(&dc.Config, cliVariables); err != nil {
@@ -193,11 +193,23 @@ func renderError(err error, ctx config.YamlCtx) string {
 }
 
 func renderRichError(err error, pos config.Pos, ctx config.YamlCtx) string {
+	line := pos.Line - 1
+	if line < 0 {
+		line = 0
+	}
+	if line >= len(ctx.Lines) {
+		line = len(ctx.Lines) - 1
+	}
+
 	pref := fmt.Sprintf("%d: ", pos.Line)
-	arrow := strings.Repeat(" ", len(pref)+pos.Column-1) + "^"
+	arrow := " "
+	if pos.Column > 0 {
+		spaces := strings.Repeat(" ", len(pref)+pos.Column-1)
+		arrow = spaces + "^"
+	}
 	return fmt.Sprintf(`Error: %s
 %s%s
-%s`, err, pref, ctx.Lines[pos.Line-1], arrow)
+%s`, err, pref, ctx.Lines[line], arrow)
 }
 
 func setCLIVariables(bp *config.Blueprint, s []string) error {

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -137,14 +137,14 @@ func (s *MySuite) TestRenderError(c *C) {
 		c.Check(got, Equals, "arbuz")
 	}
 	{ // has pos, but context doesn't contain it
-		ctx := config.NewYamlCtx([]byte(``))
+		ctx, _ := config.NewYamlCtx([]byte(``))
 		pth := config.Root.Vars.Dot("kale")
 		err := config.BpError{Path: pth, Err: errors.New("arbuz")}
 		got := renderError(err, ctx)
 		c.Check(got, Equals, "arbuz")
 	}
 	{ // has pos, has context
-		ctx := config.NewYamlCtx([]byte(`
+		ctx, _ := config.NewYamlCtx([]byte(`
 vars:
   kale: dos`))
 		pth := config.Root.Vars.Dot("kale")
@@ -161,5 +161,6 @@ func (s *MySuite) TestValidateMaybeDie(c *C) {
 		Validators:      []config.Validator{{Validator: "invalid"}},
 		ValidationLevel: config.ValidationWarning,
 	}
-	validateMaybeDie(bp, config.NewYamlCtx([]byte{})) // smoke test
+	ctx, _ := config.NewYamlCtx([]byte{})
+	validateMaybeDie(bp, ctx) // smoke test
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,10 +40,9 @@ const (
 
 var errorMessages = map[string]string{
 	// config
-	"fileLoadError":      "failed to read the input yaml",
-	"yamlUnmarshalError": "failed to parse the blueprint in %s, check YAML syntax for errors, err=%w",
-	"yamlMarshalError":   "failed to export the configuration to a blueprint yaml file",
-	"fileSaveError":      "failed to write the expanded yaml",
+	"fileLoadError":    "failed to read the input yaml",
+	"yamlMarshalError": "failed to export the configuration to a blueprint yaml file",
+	"fileSaveError":    "failed to write the expanded yaml",
 	// expand
 	"missingSetting":  "a required setting is missing from a module",
 	"invalidVar":      "invalid variable definition in",
@@ -384,7 +383,7 @@ func checkMovedModule(source string) error {
 func NewDeploymentConfig(configFilename string) (DeploymentConfig, YamlCtx, error) {
 	bp, ctx, err := importBlueprint(configFilename)
 	if err != nil {
-		return DeploymentConfig{}, YamlCtx{}, err
+		return DeploymentConfig{}, ctx, err
 	}
 	// if the validation level has been explicitly set to an invalid value
 	// in YAML blueprint then silently default to validationError
@@ -558,14 +557,15 @@ func isValidLabelValue(value string) bool {
 
 // DeploymentName returns the deployment_name from the config and does approperate checks.
 func (bp *Blueprint) DeploymentName() (string, error) {
+	path := Root.Vars.Dot("deployment_name")
+
 	if !bp.Vars.Has("deployment_name") {
-		return "", InputValueError{
+		return "", BpError{path, InputValueError{
 			inputKey: "deployment_name",
 			cause:    errorMessages["varNotFound"],
-		}
+		}}
 	}
 
-	path := Root.Vars.Dot("deployment_name")
 	v := bp.Vars.Get("deployment_name")
 	if v.Type() != cty.String {
 		return "", BpError{path, InputValueError{

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -115,12 +115,12 @@ type groupPath struct {
 
 type modulePath struct {
 	basePath
-	Source   basePath               `path:".source"`
-	Kind     basePath               `path:".kind"`
-	ID       basePath               `path:".id"`
-	Use      arrayPath[backendPath] `path:".use"`
-	Outputs  arrayPath[outputPath]  `path:".outputs"`
-	Settings dictPath               `path:".settings"`
+	Source   basePath              `path:".source"`
+	Kind     basePath              `path:".kind"`
+	ID       basePath              `path:".id"`
+	Use      arrayPath[basePath]   `path:".use"`
+	Outputs  arrayPath[outputPath] `path:".outputs"`
+	Settings dictPath              `path:".settings"`
 }
 
 type outputPath struct {
@@ -132,6 +132,9 @@ type outputPath struct {
 
 // Root is a starting point for creating a Blueprint Path
 var Root rootPath
+
+// internalPath is to be used to report problems outside of Blueprint schema (e.g. YAML parsing error position)
+var internalPath = mapPath[basePath]{basePath{nil, "__internal_path__"}}
 
 func init() {
 	initPath(&Root, nil, "")

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -65,6 +65,9 @@ func TestPath(t *testing.T) {
 		{r.Backend.Type, "terraform_backend_defaults.type"},
 		{r.Backend.Configuration, "terraform_backend_defaults.configuration"},
 		{r.Backend.Configuration.Dot("goo"), "terraform_backend_defaults.configuration.goo"},
+
+		{internalPath, "__internal_path__"},
+		{internalPath.Dot("a"), "__internal_path__.a"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.want, func(t *testing.T) {
@@ -88,6 +91,8 @@ func TestPathParent(t *testing.T) {
 		{r.Groups.At(3), r.Groups},
 		{r.Groups.At(3).Modules, r.Groups.At(3)},
 		{r.Vars.Dot("red"), r.Vars},
+		{internalPath, nil},
+		{internalPath.Dot("gold"), internalPath},
 	}
 	for _, tc := range tests {
 		t.Run(tc.p.String(), func(t *testing.T) {

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -138,7 +138,10 @@ terraform_backend_defaults:
 		{Root.Backend.Type, Pos{44, 9}},
 	}
 
-	ctx := NewYamlCtx([]byte(data))
+	ctx, err := NewYamlCtx([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, tc := range tests {
 		t.Run(tc.path.String(), func(t *testing.T) {
 			got, ok := ctx.Pos(tc.path)


### PR DESCRIPTION
* Make `NewYamlCtx` to always return meaningfull context that can be used to render YAML parsing errors;

* Parse `yaml.v3` error messages to extract line#;

* Add special type of `Path` to be used to point places outside of Blueprint schema;

* Do not add "arrow ^" if `Column == 0`;

* UNRELATED: supply `deployment_name is not set`-error with path.

```yaml
...
eldorado{}
...
```

```sh
# BEFORE
failed to parse the blueprint in tst.yaml, check YAML syntax for errors, err=yaml: line 6: could not find expected ':'

# AFTER
Error: YAML parsing error: could not find expected ':'
6: eldorado{}
```

```yaml
...
deployment_groups:
- group: primary
  shmodule: 8
  modules:
  - id: homefs
    source:
      type: git
```

```sh
# BEFORE
failed to parse the blueprint in tst.yaml, check YAML syntax for errors, err=yaml: unmarshal errors:
  line 9: field shmodule not found in type config.DeploymentGroup
  line 13: cannot unmarshal !!map into string

# AFTER
Error: YAML parsing error: field shmodule not found in type config.DeploymentGroup
9:   shmodule: 8

Error: YAML parsing error: cannot unmarshal !!map into string
13:       type: git
```
