### PR TITLE
Fix HCLS collisions

### DIFF
--- a/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
+++ b/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml
@@ -281,6 +281,7 @@ deployment_groups:
     - bucket-output
     - bucket-software
     settings:
+      add_deployment_name_before_prefix: true
       name_prefix: chrome-remote-desktop
       install_nvidia_driver: true
       startup_script: |


### PR DESCRIPTION
By adding the `add_deployment_name_before_prefix` to the CRD module, the collisions on chrome-remote-desktop in the HCLS blueprint integration tests should be fixed.  
