### PR TITLE
Add Slurm V6 controller, partition & nodeset modules

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -1,0 +1,200 @@
+## Description
+
+This module creates a nodeset data structure intended to be input to the
+[schedmd-slurm-gcp-v6-partition](../schedmd-slurm-gcp-v6-partition/) module.
+
+Nodesets allow adding heterogeneous node types to a partition, and hence
+running jobs that mix multiple node characteristics. See the [heterogeneous jobs
+section][hetjobs] of the SchedMD documentation for more information.
+
+To specify nodes from a specific nodesets in a partition, the [`--nodelist`]
+(or `-w`) flag can be used, for example:
+
+```bash
+srun -N 3 -p compute --nodelist cluster-compute-group-[0-2] hostname
+```
+
+Where the 3 nodes will be selected from the nodes `cluster-compute-group-[0-2]`
+in the compute partition.
+
+Additionally, depending on how the nodes differ, a constraint can be added via
+the [`--constraint`] (or `-C`) flag or other flags such as `--mincpus` can be
+used to specify nodes with the desired characteristics.
+
+[`--nodelist`]: https://slurm.schedmd.com/srun.html#OPT_nodelist
+[`--constraint`]: https://slurm.schedmd.com/srun.html#OPT_constraint
+[hetjobs]: https://slurm.schedmd.com/heterogeneous_jobs.html
+
+### Example
+
+The following code snippet creates a partition module using the `nodeset`
+module as input with:
+
+* a max node count of 200
+* VM machine type of `c2-standard-30`
+* partition name of "compute"
+* default nodeset name of "ghpc"
+* connected to the `network` module via `use`
+* nodes mounted to homefs via `use`
+
+```yaml
+- id: nodeset
+  source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+  use:
+  - network
+  settings:
+    node_count_dynamic_max: 200
+    machine_type: c2-standard-30
+
+- id: compute_partition
+  source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+  use:
+  - homefs
+  - nodeset
+  settings:
+    partition_name: compute
+```
+
+## Custom Images
+
+For more information on creating valid custom images for the node group VM
+instances or for custom instance templates, see our [vm-images.md] documentation
+page.
+
+[vm-images.md]: ../../../../docs/vm-images.md#slurm-on-gcp-custom-images
+
+## GPU Support
+
+More information on GPU support in Slurm on GCP and other HPC Toolkit modules
+can be found at [docs/gpu-support.md](../../../../docs/gpu-support.md)
+
+### Compute VM Zone Policies
+
+The Slurm on GCP nodeset module allows you to specify additional zones in
+which to create VMs through [bulk creation][bulk]. This is valuable when
+configuring partitions with popular VM families and you desire access to
+more compute resources across zones.
+
+[bulk]: https://cloud.google.com/compute/docs/instances/multiple/about-bulk-creation
+[networkpricing]: https://cloud.google.com/vpc/network-pricing
+
+> **_WARNING:_** Lenient zone policies can lead to additional egress costs when
+> moving large amounts of data between zones in the same region. For example,
+> traffic between VMs and traffic from VMs to shared filesystems such as
+> Filestore. For more information on egress fees, see the
+> [Network Pricing][networkpricing] Google Cloud documentation.
+>
+> To avoid egress charges, ensure your compute nodes are created in a single
+> zone by setting var.zone and leaving var.zones to its default value of the
+> empty list.
+>
+> **_NOTE:_** If a new zone is added to the region while the cluster is active,
+> nodes in the partition may be created in that zone. In this case, the
+> partition may need to be redeployed to ensure the newly added zone is denied.
+
+In the zonal example below, the nodeset's zone implicitly defaults to the
+deployment variable `vars.zone`:
+
+```yaml
+vars:
+  zone: us-central1-f
+
+- id: zonal-nodeset
+  source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+```
+
+In the example below, we enable creation in additional zones:
+
+```yaml
+vars:
+  zone: us-central1-f
+
+- id: multi-zonal-nodeset
+  source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+  settings:
+    zones:
+    - us-central1-a
+    - us-central1-b
+```
+
+## Support
+The HPC Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
+modules. For support with the underlying modules, see the instructions in the
+[slurm-gcp README][slurm-gcp-readme].
+
+[slurm-on-gcp]: https://github.com/SchedMD/slurm-gcp
+[slurm-gcp-readme]: https://github.com/SchedMD/slurm-gcp#slurm-on-google-cloud-platform
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_disks"></a> [additional\_disks](#input\_additional\_disks) | Configurations of additional disks to be included on the partition nodes. (do not use "disk\_type: local-ssd"; known issue being addressed) | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    disk_size_gb = number<br>    disk_type    = string<br>    disk_labels  = map(string)<br>    auto_delete  = bool<br>    boot         = bool<br>  }))</pre> | `[]` | no |
+| <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Configures the network interface card and the maximum egress bandwidth for VMs.<br>  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.<br>  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.<br>  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).<br>  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.<br>  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.<br>  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details. | `string` | `"platform_default"` | no |
+| <a name="input_can_ip_forward"></a> [can\_ip\_forward](#input\_can\_ip\_forward) | Enable IP forwarding, for NAT instances for example. | `bool` | `false` | no |
+| <a name="input_disable_public_ips"></a> [disable\_public\_ips](#input\_disable\_public\_ips) | If set to false. The node group VMs will have a random public IP assigned to it. Ignored if access\_config is set. | `bool` | `true` | no |
+| <a name="input_disk_auto_delete"></a> [disk\_auto\_delete](#input\_disk\_auto\_delete) | Whether or not the boot disk should be auto-deleted. | `bool` | `true` | no |
+| <a name="input_disk_labels"></a> [disk\_labels](#input\_disk\_labels) | Labels specific to the boot disk. These will be merged with var.labels. | `map(string)` | `{}` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of boot disk to create for the partition compute nodes. | `number` | `50` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Boot disk type, can be either pd-ssd, pd-standard, pd-balanced, or pd-extreme. | `string` | `"pd-standard"` | no |
+| <a name="input_enable_confidential_vm"></a> [enable\_confidential\_vm](#input\_enable\_confidential\_vm) | Enable the Confidential VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables Google Cloud os-login for user login and authentication for VMs.<br>See https://cloud.google.com/compute/docs/oslogin | `bool` | `true` | no |
+| <a name="input_enable_placement"></a> [enable\_placement](#input\_enable\_placement) | Enable placement groups. | `bool` | `true` | no |
+| <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_smt"></a> [enable\_smt](#input\_enable\_smt) | Enables Simultaneous Multi-Threading (SMT) on instance. | `bool` | `false` | no |
+| <a name="input_enable_spot_vm"></a> [enable\_spot\_vm](#input\_enable\_spot\_vm) | Enable the partition to use spot VMs (https://cloud.google.com/spot-vms). | `bool` | `false` | no |
+| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br>    type  = string,<br>    count = number<br>  }))</pre> | `[]` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Defines the image that will be used in the Slurm node group VM instances.<br><br>Expected Fields:<br>name: The name of the image. Mutually exclusive with family.<br>family: The image family to use. Mutually exclusive with name.<br>project: The project where the image is hosted.<br><br>For more information on creating custom images that comply with Slurm on GCP<br>see the "Slurm on GCP Custom Images" section in docs/vm-images.md. | `map(string)` | <pre>{<br>  "family": "slurm-gcp-6-1-hpc-rocky-linux-8",<br>  "project": "schedmd-slurm-public"<br>}</pre> | no |
+| <a name="input_instance_image_custom"></a> [instance\_image\_custom](#input\_instance\_image\_custom) | A flag that designates that the user is aware that they are requesting<br>to use a custom and potentially incompatible image for this Slurm on<br>GCP module.<br><br>If the field is set to false, only the compatible families and project<br>names will be accepted.  The deployment will fail with any other image<br>family or name.  If set to true, no checks will be done.<br><br>See: https://goo.gle/hpc-slurm-images | `bool` | `false` | no |
+| <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Self link to a custom instance template. If set, other VM definition<br>variables such as machine\_type and instance\_image will be ignored in favor<br>of the provided instance template.<br><br>For more information on creating custom images for the instance template<br>that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section<br>in docs/vm-images.md. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to partition compute instances. Key-value pairs. | `map(string)` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes. | `string` | `"c2-standard-60"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the nodeset. | `string` | `"ghpc"` | no |
+| <a name="input_node_conf"></a> [node\_conf](#input\_node\_conf) | Map of Slurm node line configuration. | `map(any)` | `{}` | no |
+| <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of dynamic nodes allowed in this partition. | `number` | `1` | no |
+| <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |
+| <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Instance availability Policy.<br><br>Note: Placement groups are not supported when on\_host\_maintenance is set to<br>"MIGRATE" and will be deactivated regardless of the value of<br>enable\_placement. To support enable\_placement, ensure on\_host\_maintenance is<br>set to "TERMINATE". | `string` | `"TERMINATE"` | no |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Should use preemptibles to burst. | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | The default region for Cloud resources. | `string` | n/a | yes |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the compute instances. If not set, the<br>default compute service account for the given project will be used with the<br>"https://www.googleapis.com/auth/cloud-platform" scope. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>- enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>- enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>- enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
+| <a name="input_spot_instance_config"></a> [spot\_instance\_config](#input\_spot\_instance\_config) | Configuration for spot VMs. | <pre>object({<br>    termination_action = string<br>  })</pre> | `null` | no |
+| <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The project the subnetwork belongs to. | `string` | `""` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone in which to create compute VMs. Additional zones in the same region can be specified in var.zones. | `string` | n/a | yes |
+| <a name="input_zone_target_shape"></a> [zone\_target\_shape](#input\_zone\_target\_shape) | Strategy for distributing VMs across zones in a region.<br>ANY<br>  GCE picks zones for creating VM instances to fulfill the requested number of VMs<br>  within present resource constraints and to maximize utilization of unused zonal<br>  reservations.<br>ANY\_SINGLE\_ZONE (default)<br>  GCE always selects a single zone for all the VMs, optimizing for resource quotas,<br>  available reservations and general capacity.<br>BALANCED<br>  GCE prioritizes acquisition of resources, scheduling VMs in zones where resources<br>  are available while distributing VMs as evenly as possible across allowed zones<br>  to minimize the impact of zonal failure. | `string` | `"ANY_SINGLE_ZONE"` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | Additional nodes in which to allow creation of partition nodes. Google Cloud<br>will find zone based on availability, quota and reservations. | `set(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nodeset"></a> [nodeset](#output\_nodeset) | Details of the nodeset. Typically used as input to `schedmd-slurm-gcp-v6-partition`. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/gpu_definition.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/gpu_definition.tf
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+## Required variables:
+#  guest_accelerator
+#  machine_type
+
+locals {
+  # example state; terraform will ignore diffs if last element of URL matches
+  # guest_accelerator = [
+  #   {
+  #     count = 1
+  #     type  = "https://www.googleapis.com/compute/beta/projects/PROJECT/zones/ZONE/acceleratorTypes/nvidia-tesla-a100"
+  #   },
+  # ]
+  accelerator_machines = {
+    "a2-highgpu-1g"  = { type = "nvidia-tesla-a100", count = 1 },
+    "a2-highgpu-2g"  = { type = "nvidia-tesla-a100", count = 2 },
+    "a2-highgpu-4g"  = { type = "nvidia-tesla-a100", count = 4 },
+    "a2-highgpu-8g"  = { type = "nvidia-tesla-a100", count = 8 },
+    "a2-megagpu-16g" = { type = "nvidia-tesla-a100", count = 16 },
+    "a2-ultragpu-1g" = { type = "nvidia-a100-80gb", count = 1 },
+    "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
+    "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
+    "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
+    "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-12" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-16" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-24" = { type = "nvidia-l4", count = 2 },
+    "g2-standard-32" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-48" = { type = "nvidia-l4", count = 4 },
+    "g2-standard-96" = { type = "nvidia-l4", count = 8 },
+  }
+  generated_guest_accelerator = try([local.accelerator_machines[var.machine_type]], [])
+
+  # Select in priority order:
+  # (1) var.guest_accelerator if not empty
+  # (2) local.generated_guest_accelerator if not empty
+  # (3) default to empty list if both are empty
+  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
@@ -1,0 +1,79 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v6-nodeset", ghpc_role = "compute" })
+}
+
+locals {
+  additional_disks = [
+    for ad in var.additional_disks : {
+      disk_name    = ad.disk_name
+      device_name  = ad.device_name
+      disk_type    = ad.disk_type
+      disk_size_gb = ad.disk_size_gb
+      disk_labels  = merge(ad.disk_labels, local.labels)
+      auto_delete  = ad.auto_delete
+      boot         = ad.boot
+    }
+  ]
+
+  nodeset = {
+    node_count_static      = var.node_count_static
+    node_count_dynamic_max = var.node_count_dynamic_max
+    node_conf              = var.node_conf
+    nodeset_name           = var.name
+
+    disk_auto_delete = var.disk_auto_delete
+    disk_labels      = merge(local.labels, var.disk_labels)
+    disk_size_gb     = var.disk_size_gb
+    disk_type        = var.disk_type
+    additional_disks = local.additional_disks
+
+    bandwidth_tier = var.bandwidth_tier
+    can_ip_forward = var.can_ip_forward
+    disable_smt    = !var.enable_smt
+
+    enable_confidential_vm = var.enable_confidential_vm
+    enable_placement       = var.enable_placement
+    enable_public_ip       = !var.disable_public_ips
+    enable_oslogin         = var.enable_oslogin
+    enable_shielded_vm     = var.enable_shielded_vm
+    gpu                    = one(local.guest_accelerator)
+
+    instance_template = var.instance_template
+    labels            = local.labels
+    machine_type      = var.machine_type
+    metadata          = var.metadata
+    min_cpu_platform  = var.min_cpu_platform
+
+    on_host_maintenance      = var.on_host_maintenance
+    preemptible              = var.preemptible
+    region                   = var.region
+    service_account          = var.service_account
+    shielded_instance_config = var.shielded_instance_config
+    source_image_family      = local.source_image_family             # requires source_image_logic.tf
+    source_image_project     = local.source_image_project_normalized # requires source_image_logic.tf
+    source_image             = local.source_image                    # requires source_image_logic.tf
+    subnetwork_project       = var.subnetwork_project
+    subnetwork               = var.subnetwork_self_link
+    tags                     = var.tags
+    spot                     = var.enable_spot_vm
+    termination_action       = try(var.spot_instance_config.termination_action, null)
+
+    zones             = toset(concat([var.zone], tolist(var.zones)))
+    zone_target_shape = var.zone_target_shape
+  }
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "nodeset" {
+  description = "Details of the nodeset. Typically used as input to `schedmd-slurm-gcp-v6-partition`."
+  value       = local.nodeset
+
+  precondition {
+    condition = !contains([
+      "c3-:pd-standard",
+      "h3-:pd-standard",
+      "h3-:pd-ssd",
+    ], "${substr(var.machine_type, 0, 3)}:${var.disk_type}")
+    error_message = "A disk_type=${var.disk_type} cannot be used with machine_type=${var.machine_type}."
+  }
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/source_image_logic.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/source_image_logic.tf
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # Currently supported images and projects
+  known_project_families = {
+    schedmd-slurm-public = [
+      "slurm-gcp-6-1-debian-11",
+      "slurm-gcp-6-1-hpc-rocky-linux-8",
+      "slurm-gcp-6-1-ubuntu-2004-lts",
+      "slurm-gcp-6-1-ubuntu-2204-lts-arm64",
+      "slurm-gcp-6-1-hpc-centos-7-k80",
+      "slurm-gcp-6-1-hpc-centos-7"
+    ]
+  }
+
+  # This approach to "hacking" the project name allows a chain of Terraform
+  # calls to set the instance source_image (boot disk) with a "relative
+  # resource name" that passes muster with VPC Service Control rules
+  #
+  # https://github.com/terraform-google-modules/terraform-google-vm/blob/735bd415fc5f034d46aa0de7922e8fada2327c0c/modules/instance_template/main.tf#L28
+  # https://cloud.google.com/apis/design/resource_names#relative_resource_name
+  source_image_project_normalized = (can(var.instance_image.family) ?
+    "projects/${data.google_compute_image.slurm.project}/global/images/family" :
+    "projects/${data.google_compute_image.slurm.project}/global/images"
+  )
+  source_image_family = can(var.instance_image.family) ? data.google_compute_image.slurm.family : ""
+  source_image        = can(var.instance_image.name) ? data.google_compute_image.slurm.name : ""
+}
+
+data "google_compute_image" "slurm" {
+  family  = try(var.instance_image.family, null)
+  name    = try(var.instance_image.name, null)
+  project = var.instance_image.project
+
+  lifecycle {
+    precondition {
+      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+    }
+
+    postcondition {
+      condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
+      error_message = <<-EOD
+      Images in project ${self.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
+      EOD
+    }
+    postcondition {
+      condition     = !contains(keys(local.known_project_families), self.project) || try(contains(local.known_project_families[self.project], self.family), false)
+      error_message = <<-EOD
+      Image family ${self.family} published by SchedMD in project ${self.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
+      ${join("\n", [for p in try(local.known_project_families[self.project], []) : "\t\"${p}\""])}
+      EOD
+    }
+    postcondition {
+      condition     = var.disk_size_gb >= self.disk_size_gb
+      error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${self.disk_size_gb}GB), please increase the blueprint disk size"
+    }
+  }
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf
@@ -1,0 +1,388 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "name" {
+  description = "Name of the nodeset."
+  type        = string
+  default     = "ghpc"
+
+  validation {
+    condition     = can(regex("^[a-z](?:[a-z0-9]{0,5})$", var.name))
+    error_message = "Nodeset name (var.name) must begin with a letter, be fully alphanumeric and be 6 characters or less. Regexp: '^[a-z](?:[a-z0-9]{0,5})$'."
+  }
+}
+
+variable "node_conf" {
+  description = "Map of Slurm node line configuration."
+  type        = map(any)
+  default     = {}
+}
+
+variable "node_count_static" {
+  description = "Number of nodes to be statically created."
+  type        = number
+  default     = 0
+}
+
+variable "node_count_dynamic_max" {
+  description = "Maximum number of dynamic nodes allowed in this partition."
+  type        = number
+  default     = 1
+}
+
+## VM Definition
+variable "instance_template" {
+  description = <<-EOD
+    Self link to a custom instance template. If set, other VM definition
+    variables such as machine_type and instance_image will be ignored in favor
+    of the provided instance template.
+
+    For more information on creating custom images for the instance template
+    that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section
+    in docs/vm-images.md.
+    EOD
+  type        = string
+  default     = null
+}
+
+variable "machine_type" {
+  description = "Compute Platform machine type to use for this partition compute nodes."
+  type        = string
+  default     = "c2-standard-60"
+}
+
+variable "metadata" {
+  type        = map(string)
+  description = "Metadata, provided as a map."
+  default     = {}
+}
+
+variable "instance_image" {
+  description = <<-EOD
+    Defines the image that will be used in the Slurm node group VM instances.
+
+    Expected Fields:
+    name: The name of the image. Mutually exclusive with family.
+    family: The image family to use. Mutually exclusive with name.
+    project: The project where the image is hosted.
+
+    For more information on creating custom images that comply with Slurm on GCP
+    see the "Slurm on GCP Custom Images" section in docs/vm-images.md.
+    EOD
+  type        = map(string)
+  default = {
+    family  = "slurm-gcp-6-1-hpc-rocky-linux-8"
+    project = "schedmd-slurm-public"
+  }
+
+  validation {
+    condition     = can(coalesce(var.instance_image.project))
+    error_message = "In var.instance_image, the \"project\" field must be a string set to the Cloud project ID."
+  }
+
+  validation {
+    condition     = can(coalesce(var.instance_image.name)) != can(coalesce(var.instance_image.family))
+    error_message = "In var.instance_image, exactly one of \"family\" or \"name\" fields must be set to desired image family or name."
+  }
+}
+
+variable "instance_image_custom" {
+  description = <<-EOD
+    A flag that designates that the user is aware that they are requesting
+    to use a custom and potentially incompatible image for this Slurm on
+    GCP module.
+
+    If the field is set to false, only the compatible families and project
+    names will be accepted.  The deployment will fail with any other image
+    family or name.  If set to true, no checks will be done.
+
+    See: https://goo.gle/hpc-slurm-images
+    EOD
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "Network tag list."
+  default     = []
+}
+
+variable "disk_type" {
+  description = "Boot disk type, can be either pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  type        = string
+  default     = "pd-standard"
+
+  validation {
+    condition     = contains(["pd-ssd", "pd-standard", "pd-balanced", "pd-extreme"], var.disk_type)
+    error_message = "Variable disk_type must be one of pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  }
+}
+
+variable "disk_size_gb" {
+  description = "Size of boot disk to create for the partition compute nodes."
+  type        = number
+  default     = 50
+}
+
+variable "disk_auto_delete" {
+  type        = bool
+  description = "Whether or not the boot disk should be auto-deleted."
+  default     = true
+}
+
+variable "disk_labels" {
+  description = "Labels specific to the boot disk. These will be merged with var.labels."
+  type        = map(string)
+  default     = {}
+}
+
+variable "additional_disks" {
+  description = "Configurations of additional disks to be included on the partition nodes. (do not use \"disk_type: local-ssd\"; known issue being addressed)"
+  type = list(object({
+    disk_name    = string
+    device_name  = string
+    disk_size_gb = number
+    disk_type    = string
+    disk_labels  = map(string)
+    auto_delete  = bool
+    boot         = bool
+  }))
+  default = []
+}
+
+variable "enable_confidential_vm" {
+  type        = bool
+  description = "Enable the Confidential VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_shielded_vm" {
+  type        = bool
+  description = "Enable the Shielded VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "shielded_instance_config" {
+  type = object({
+    enable_integrity_monitoring = bool
+    enable_secure_boot          = bool
+    enable_vtpm                 = bool
+  })
+  description = <<-EOD
+    Shielded VM configuration for the instance. Note: not used unless
+    enable_shielded_vm is 'true'.
+    - enable_integrity_monitoring : Compare the most recent boot measurements to the
+      integrity policy baseline and return a pair of pass/fail results depending on
+      whether they match or not.
+    - enable_secure_boot : Verify the digital signature of all boot components, and
+      halt the boot process if signature verification fails.
+    - enable_vtpm : Use a virtualized trusted platform module, which is a
+      specialized computer chip you can use to encrypt objects like keys and
+      certificates.
+    EOD
+  default = {
+    enable_integrity_monitoring = true
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+  }
+}
+
+
+variable "enable_oslogin" {
+  type        = bool
+  description = <<-EOD
+    Enables Google Cloud os-login for user login and authentication for VMs.
+    See https://cloud.google.com/compute/docs/oslogin
+    EOD
+  default     = true
+}
+
+variable "can_ip_forward" {
+  description = "Enable IP forwarding, for NAT instances for example."
+  type        = bool
+  default     = false
+}
+
+variable "enable_smt" {
+  type        = bool
+  description = "Enables Simultaneous Multi-Threading (SMT) on instance."
+  default     = false
+}
+
+variable "labels" {
+  description = "Labels to add to partition compute instances. Key-value pairs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "min_cpu_platform" {
+  description = "The name of the minimum CPU platform that you want the instance to use."
+  type        = string
+  default     = null
+}
+
+variable "on_host_maintenance" {
+  type        = string
+  description = <<-EOD
+    Instance availability Policy.
+
+    Note: Placement groups are not supported when on_host_maintenance is set to
+    "MIGRATE" and will be deactivated regardless of the value of
+    enable_placement. To support enable_placement, ensure on_host_maintenance is
+    set to "TERMINATE".
+    EOD
+  default     = "TERMINATE"
+}
+
+variable "guest_accelerator" {
+  description = "List of the type and count of accelerator cards attached to the instance."
+  type = list(object({
+    type  = string,
+    count = number
+  }))
+  default  = []
+  nullable = false
+
+  validation {
+    condition     = length(var.guest_accelerator) <= 1
+    error_message = "The Slurm modules supports 0 or 1 models of accelerator card on each node."
+  }
+}
+
+variable "preemptible" {
+  description = "Should use preemptibles to burst."
+  type        = bool
+  default     = false
+}
+
+variable "service_account" {
+  type = object({
+    email  = string
+    scopes = set(string)
+  })
+  description = <<-EOD
+    Service account to attach to the compute instances. If not set, the
+    default compute service account for the given project will be used with the
+    "https://www.googleapis.com/auth/cloud-platform" scope.
+    EOD
+  default     = null
+}
+
+variable "enable_spot_vm" {
+  description = "Enable the partition to use spot VMs (https://cloud.google.com/spot-vms)."
+  type        = bool
+  default     = false
+}
+
+variable "spot_instance_config" {
+  description = "Configuration for spot VMs."
+  type = object({
+    termination_action = string
+  })
+  default = null
+}
+
+variable "bandwidth_tier" {
+  description = <<EOT
+  Configures the network interface card and the maximum egress bandwidth for VMs.
+  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.
+  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.
+  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).
+  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.
+  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.
+  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details.
+  EOT
+  type        = string
+  default     = "platform_default"
+
+  validation {
+    condition     = contains(["platform_default", "virtio_enabled", "gvnic_enabled", "tier_1_enabled"], var.bandwidth_tier)
+    error_message = "Allowed values for bandwidth_tier are 'platform_default', 'virtio_enabled', 'gvnic_enabled', or 'tier_1_enabled'."
+  }
+}
+
+variable "disable_public_ips" {
+  description = "If set to false. The node group VMs will have a random public IP assigned to it. Ignored if access_config is set."
+  type        = bool
+  default     = true
+}
+
+variable "enable_placement" {
+  description = "Enable placement groups."
+  type        = bool
+  default     = true
+}
+
+variable "region" {
+  description = "The default region for Cloud resources."
+  type        = string
+}
+
+
+variable "zone" {
+  description = "Zone in which to create compute VMs. Additional zones in the same region can be specified in var.zones."
+  type        = string
+}
+
+variable "zones" {
+  description = <<-EOD
+    Additional nodes in which to allow creation of partition nodes. Google Cloud
+    will find zone based on availability, quota and reservations.
+    EOD
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for x in var.zones : length(regexall("^[a-z]+-[a-z]+[0-9]-[a-z]$", x)) > 0
+    ])
+    error_message = "A value in var.zones is not a valid zone (example: us-central1-f)."
+  }
+}
+
+variable "zone_target_shape" {
+  description = <<EOD
+Strategy for distributing VMs across zones in a region.
+ANY
+  GCE picks zones for creating VM instances to fulfill the requested number of VMs
+  within present resource constraints and to maximize utilization of unused zonal
+  reservations.
+ANY_SINGLE_ZONE (default)
+  GCE always selects a single zone for all the VMs, optimizing for resource quotas,
+  available reservations and general capacity.
+BALANCED
+  GCE prioritizes acquisition of resources, scheduling VMs in zones where resources
+  are available while distributing VMs as evenly as possible across allowed zones
+  to minimize the impact of zonal failure.
+EOD
+  type        = string
+  default     = "ANY_SINGLE_ZONE"
+  validation {
+    condition     = contains(["ANY", "ANY_SINGLE_ZONE", "BALANCED"], var.zone_target_shape)
+    error_message = "Allowed values for zone_target_shape are \"ANY\", \"ANY_SINGLE_ZONE\", or \"BALANCED\"."
+  }
+}
+
+variable "subnetwork_self_link" {
+  type        = string
+  description = "Subnet to deploy to."
+  default     = null
+}
+
+variable "subnetwork_project" {
+  description = "The project the subnetwork belongs to."
+  type        = string
+  default     = ""
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset/v1.23.0"
+  }
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/README.md
@@ -1,0 +1,98 @@
+## Description
+
+This module creates a compute partition that can be used as input to the
+[schedmd-slurm-gcp-v6-controller](../../scheduler/schedmd-slurm-gcp-v6-controller/README.md).
+
+The partition module is designed to work alongside the
+[schedmd-slurm-gcp-v6-nodeset](../schedmd-slurm-gcp-v6-nodeset/README.md)
+module. A partition can be made up of one or
+more nodesets, provided either through `use` (preferred) or defined manually
+in the `nodeset` variable.
+
+### Example
+
+The following code snippet creates a partition module with:
+
+* 2 nodesets added via `use`.
+  * The first nodeset is made up of machines of type `c2-standard-30`.
+  * The second nodeset is made up of machines of type `c2-standard-60`.
+  * Both nodesets have a maximum count of 200 dynamically created nodes.
+* partition name of "compute".
+* connected to the `network` module via `use`.
+* nodes mounted to homefs via `use`.
+
+```yaml
+- id: nodeset_1
+  source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+  use:
+  - network
+  settings:
+    name: c30
+    node_count_dynamic_max: 200
+    machine_type: c2-standard-30
+
+- id: nodeset_2
+  source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+  use:
+  - network
+  settings:
+    name: c60
+    node_count_dynamic_max: 200
+    machine_type: c2-standard-60
+
+- id: compute_partition
+  source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+  use:
+  - homefs
+  - nodeset_1
+  - nodeset_2
+  settings:
+    partition_name: compute
+```
+
+## Support
+
+The HPC Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
+modules. For support with the underlying modules, see the instructions in the
+[slurm-gcp README][slurm-gcp-readme].
+
+[slurm-on-gcp]: https://github.com/SchedMD/slurm-gcp
+[slurm-gcp-readme]: https://github.com/SchedMD/slurm-gcp#slurm-on-google-cloud-platform
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_exclusive"></a> [exclusive](#input\_exclusive) | Exclusive job access to nodes. | `bool` | `true` | no |
+| <a name="input_is_default"></a> [is\_default](#input\_is\_default) | Sets this partition as the default partition by updating the partition\_conf.<br>If "Default" is already set in partition\_conf, this variable will have no effect. | `bool` | `false` | no |
+| <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured on the partition compute nodes. | <pre>list(object({<br>    server_ip             = string,<br>    remote_mount          = string,<br>    local_mount           = string,<br>    fs_type               = string,<br>    mount_options         = string,<br>    client_install_runner = map(string)<br>    mount_runner          = map(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_nodeset"></a> [nodeset](#input\_nodeset) | Define nodesets, as a list. | <pre>list(object({<br>    node_count_static      = optional(number, 0)<br>    node_count_dynamic_max = optional(number, 1)<br>    node_conf              = optional(map(string), {})<br>    nodeset_name           = string<br>    additional_disks = optional(list(object({<br>      disk_name    = optional(string)<br>      device_name  = optional(string)<br>      disk_size_gb = optional(number)<br>      disk_type    = optional(string)<br>      disk_labels  = optional(map(string), {})<br>      auto_delete  = optional(bool, true)<br>      boot         = optional(bool, false)<br>    })), [])<br>    bandwidth_tier         = optional(string, "platform_default")<br>    can_ip_forward         = optional(bool, false)<br>    disable_smt            = optional(bool, false)<br>    disk_auto_delete       = optional(bool, true)<br>    disk_labels            = optional(map(string), {})<br>    disk_size_gb           = optional(number)<br>    disk_type              = optional(string)<br>    enable_confidential_vm = optional(bool, false)<br>    enable_placement       = optional(bool, false)<br>    enable_public_ip       = optional(bool, false)<br>    enable_oslogin         = optional(bool, true)<br>    enable_shielded_vm     = optional(bool, false)<br>    gpu = optional(object({<br>      count = number<br>      type  = string<br>    }))<br>    instance_template   = optional(string)<br>    labels              = optional(map(string), {})<br>    machine_type        = optional(string)<br>    metadata            = optional(map(string), {})<br>    min_cpu_platform    = optional(string)<br>    network_tier        = optional(string, "STANDARD")<br>    on_host_maintenance = optional(string)<br>    preemptible         = optional(bool, false)<br>    region              = optional(string)<br>    service_account = optional(object({<br>      email  = optional(string)<br>      scopes = optional(list(string), ["https://www.googleapis.com/auth/cloud-platform"])<br>    }))<br>    shielded_instance_config = optional(object({<br>      enable_integrity_monitoring = optional(bool, true)<br>      enable_secure_boot          = optional(bool, true)<br>      enable_vtpm                 = optional(bool, true)<br>    }))<br>    source_image_family  = optional(string)<br>    source_image_project = optional(string)<br>    source_image         = optional(string)<br>    subnetwork_project   = optional(string)<br>    subnetwork           = optional(string)<br>    spot                 = optional(bool, false)<br>    tags                 = optional(list(string), [])<br>    termination_action   = optional(string)<br>    zones                = optional(list(string), [])<br>    zone_target_shape    = optional(string, "ANY_SINGLE_ZONE")<br>  }))</pre> | `[]` | no |
+| <a name="input_partition_conf"></a> [partition\_conf](#input\_partition\_conf) | Slurm partition configuration as a map.<br>See https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION | `map(string)` | `{}` | no |
+| <a name="input_partition_name"></a> [partition\_name](#input\_partition\_name) | The name of the slurm partition. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nodeset"></a> [nodeset](#output\_nodeset) | Details of a nodesets in this partition |
+| <a name="output_partitions"></a> [partitions](#output\_partitions) | Details of a slurm partition |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/main.tf
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+
+  use_placement = [for ns in var.partition_conf : ns.nodeset_name if ns.enable_placement]
+
+  partition = {
+    default              = var.is_default
+    enable_job_exclusive = var.exclusive
+    network_storage      = var.network_storage
+    partition_conf       = var.partition_conf
+    partition_name       = var.partition_name
+    partition_nodeset    = [for ns in var.nodeset : ns.nodeset_name]
+  }
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/outputs.tf
@@ -1,0 +1,40 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "partitions" {
+  description = "Details of a slurm partition"
+
+  value = [local.partition]
+
+  precondition {
+    condition     = (length(local.use_placement) == 0) || var.exclusive
+    error_message = "If any nodeset `enable_placement`, `var.exclusive` must be set true"
+  }
+
+  precondition {
+    condition     = (length(local.use_placement) == 0) || contains(["NO", "Exclusive"], lookup(var.partition_conf, "Oversubscribe", "NO"))
+    error_message = "If any nodeset `enable_placement`, var.partition_conf[\"Oversubscribe\"] should be either undefined, \"NO\", or \"Exclusive\"."
+  }
+
+  precondition {
+    condition     = (length(local.use_placement) == 0) || (lookup(var.partition_conf, "SuspendTime", null) == null)
+    error_message = "If any nodeset `enable_placement`, var.partition_conf[\"SuspendTime\"] should be undefined."
+  }
+}
+
+output "nodeset" {
+  description = "Details of a nodesets in this partition"
+
+  value = var.nodeset
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/variables.tf
@@ -1,0 +1,130 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "partition_name" {
+  description = "The name of the slurm partition."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z](?:[a-z0-9]*)$", var.partition_name))
+    error_message = "Variable 'partition_name' must be a match of regex '^[a-z](?:[a-z0-9]*)$'."
+  }
+}
+
+variable "partition_conf" {
+  description = <<-EOD
+    Slurm partition configuration as a map.
+    See https://slurm.schedmd.com/slurm.conf.html#SECTION_PARTITION-CONFIGURATION
+    EOD
+  type        = map(string)
+  default     = {}
+}
+
+variable "is_default" {
+  description = <<-EOD
+    Sets this partition as the default partition by updating the partition_conf.
+    If "Default" is already set in partition_conf, this variable will have no effect.
+    EOD
+  type        = bool
+  default     = false
+}
+
+variable "exclusive" {
+  description = "Exclusive job access to nodes."
+  type        = bool
+  default     = true
+}
+
+variable "network_storage" {
+  description = "An array of network attached storage mounts to be configured on the partition compute nodes."
+  type = list(object({
+    server_ip             = string,
+    remote_mount          = string,
+    local_mount           = string,
+    fs_type               = string,
+    mount_options         = string,
+    client_install_runner = map(string)
+    mount_runner          = map(string)
+  }))
+  default = []
+}
+
+variable "nodeset" {
+  description = "Define nodesets, as a list."
+  type = list(object({
+    node_count_static      = optional(number, 0)
+    node_count_dynamic_max = optional(number, 1)
+    node_conf              = optional(map(string), {})
+    nodeset_name           = string
+    additional_disks = optional(list(object({
+      disk_name    = optional(string)
+      device_name  = optional(string)
+      disk_size_gb = optional(number)
+      disk_type    = optional(string)
+      disk_labels  = optional(map(string), {})
+      auto_delete  = optional(bool, true)
+      boot         = optional(bool, false)
+    })), [])
+    bandwidth_tier         = optional(string, "platform_default")
+    can_ip_forward         = optional(bool, false)
+    disable_smt            = optional(bool, false)
+    disk_auto_delete       = optional(bool, true)
+    disk_labels            = optional(map(string), {})
+    disk_size_gb           = optional(number)
+    disk_type              = optional(string)
+    enable_confidential_vm = optional(bool, false)
+    enable_placement       = optional(bool, false)
+    enable_public_ip       = optional(bool, false)
+    enable_oslogin         = optional(bool, true)
+    enable_shielded_vm     = optional(bool, false)
+    gpu = optional(object({
+      count = number
+      type  = string
+    }))
+    instance_template   = optional(string)
+    labels              = optional(map(string), {})
+    machine_type        = optional(string)
+    metadata            = optional(map(string), {})
+    min_cpu_platform    = optional(string)
+    network_tier        = optional(string, "STANDARD")
+    on_host_maintenance = optional(string)
+    preemptible         = optional(bool, false)
+    region              = optional(string)
+    service_account = optional(object({
+      email  = optional(string)
+      scopes = optional(list(string), ["https://www.googleapis.com/auth/cloud-platform"])
+    }))
+    shielded_instance_config = optional(object({
+      enable_integrity_monitoring = optional(bool, true)
+      enable_secure_boot          = optional(bool, true)
+      enable_vtpm                 = optional(bool, true)
+    }))
+    source_image_family  = optional(string)
+    source_image_project = optional(string)
+    source_image         = optional(string)
+    subnetwork_project   = optional(string)
+    subnetwork           = optional(string)
+    spot                 = optional(bool, false)
+    tags                 = optional(list(string), [])
+    termination_action   = optional(string)
+    zones                = optional(list(string), [])
+    zone_target_shape    = optional(string, "ANY_SINGLE_ZONE")
+  }))
+  default = []
+
+  validation {
+    condition     = length(distinct([for x in var.nodeset : x.nodeset_name])) == length(var.nodeset)
+    error_message = "All nodesets must have a unique name."
+  }
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.3"
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.23.0"
+  }
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -1,0 +1,204 @@
+## Description
+
+This module creates a slurm controller node via the [SchedMD/slurm-gcp]
+[slurm\_controller\_instance] and [slurm\_instance\_template] modules.
+
+More information about Slurm On GCP can be found at the
+[project's GitHub page][SchedMD/slurm-gcp] and in the
+[Slurm on Google Cloud User Guide][slurm-ug].
+
+The [user guide][slurm-ug] provides detailed instructions on customizing and
+enhancing the Slurm on GCP cluster as well as recommendations on configuring the
+controller for optimal performance at different scales.
+
+[SchedMD/slurm-gcp]: https://github.com/SchedMD/slurm-gcp/tree/6.1.2
+[slurm\_controller\_instance]: https://github.com/SchedMD/slurm-gcp/tree/6.1.2/terraform/slurm_cluster/modules/slurm_controller_instance
+[slurm\_instance\_template]: https://github.com/SchedMD/slurm-gcp/tree/6.1.2/terraform/slurm_cluster/modules/slurm_instance_template
+[slurm-ug]: https://goo.gle/slurm-gcp-user-guide.
+[requirements.txt]: https://github.com/SchedMD/slurm-gcp/blob/6.1.2/scripts/requirements.txt
+[enable\_cleanup\_compute]: #input\_enable\_cleanup\_compute
+[enable\_cleanup\_subscriptions]: #input\_enable\_cleanup\_subscriptions
+[enable\_reconfigure]: #input\_enable\_reconfigure
+
+### Example
+
+```yaml
+- id: slurm_controller
+  source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+  use:
+  - network
+  - homefs
+  - compute_partition
+  settings:
+    machine_type: c2-standard-8
+```
+
+This creates a controller node with the following attributes:
+
+* connected to the primary subnetwork of `network`
+* the filesystem with the ID `homefs` (defined elsewhere in the blueprint)
+  mounted
+* One partition with the ID `compute_partition` (defined elsewhere in the
+  blueprint)
+* machine type upgraded from the default `c2-standard-4` to `c2-standard-8`
+
+### Live Cluster Reconfiguration
+
+The `schedmd-slurm-gcp-v6-controller` module supports the reconfiguration of
+partitions and slurm configuration in a running, active cluster.
+
+To reconfigure a running cluster:
+
+1. Edit the blueprint with the desired configuration changes
+2. Call `ghpc create <blueprint> -w` to overwrite the deployment directory
+3. Follow instructions in terminal to deploy
+
+The following are examples of updates that can be made to a running cluster:
+
+* Add or remove a partition to the cluster
+* Resize an existing partition
+* Attach new network storage to an existing partition
+
+> **NOTE**: Changing the VM `machine_type` of a partition may not work.
+> It is better to create a new partition and delete the old one.
+
+## Custom Images
+
+For more information on creating valid custom images for the controller VM
+instance or for custom instance templates, see our [vm-images.md] documentation
+page.
+
+[vm-images.md]: ../../../../docs/vm-images.md#slurm-on-gcp-custom-images
+
+## GPU Support
+
+More information on GPU support in Slurm on GCP and other HPC Toolkit modules
+can be found at [docs/gpu-support.md](../../../../docs/gpu-support.md)
+
+## Hybrid Slurm Clusters
+For more information on how to configure an on premise slurm cluster with hybrid
+cloud partitions, see the [schedmd-slurm-gcp-v5-hybrid] module and our
+extended instructions in our [docs](../../../../docs/hybrid-slurm-cluster/).
+
+[schedmd-slurm-gcp-v5-hybrid]: ../schedmd-slurm-gcp-v5-hybrid/README.md
+
+## Support
+The HPC Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
+modules. For support with the underlying modules, see the instructions in the
+[slurm-gcp README][slurm-gcp-readme].
+
+[slurm-on-gcp]: https://github.com/SchedMD/slurm-gcp
+[slurm-gcp-readme]: https://github.com/SchedMD/slurm-gcp#slurm-on-google-cloud-platform
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_slurm_cluster"></a> [slurm\_cluster](#module\_slurm\_cluster) | github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster | 6.1.2 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+| [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_disks"></a> [additional\_disks](#input\_additional\_disks) | List of maps of disks. | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    disk_type    = string<br>    disk_size_gb = number<br>    disk_labels  = map(string)<br>    auto_delete  = bool<br>    boot         = bool<br>  }))</pre> | `[]` | no |
+| <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Configures the network interface card and the maximum egress bandwidth for VMs.<br>  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.<br>  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.<br>  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).<br>  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.<br>  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.<br>  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details. | `string` | `"platform_default"` | no |
+| <a name="input_bucket_dir"></a> [bucket\_dir](#input\_bucket\_dir) | Bucket directory for cluster files to be put into. If not specified, then one will be chosen based on slurm\_cluster\_name. | `string` | `null` | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of GCS bucket.<br>Ignored when 'create\_bucket' is true. | `string` | `null` | no |
+| <a name="input_can_ip_forward"></a> [can\_ip\_forward](#input\_can\_ip\_forward) | Enable IP forwarding, for NAT instances for example. | `bool` | `false` | no |
+| <a name="input_cgroup_conf_tpl"></a> [cgroup\_conf\_tpl](#input\_cgroup\_conf\_tpl) | Slurm cgroup.conf template file path. | `string` | `null` | no |
+| <a name="input_cloud_parameters"></a> [cloud\_parameters](#input\_cloud\_parameters) | cloud.conf options. | <pre>object({<br>    no_comma_params = optional(bool, false)<br>    resume_rate     = optional(number, 0)<br>    resume_timeout  = optional(number, 300)<br>    suspend_rate    = optional(number, 0)<br>    suspend_timeout = optional(number, 300)<br>  })</pre> | `{}` | no |
+| <a name="input_cloudsql"></a> [cloudsql](#input\_cloudsql) | Use this database instead of the one on the controller.<br>  server\_ip : Address of the database server.<br>  user      : The user to access the database as.<br>  password  : The password, given the user, to access the given database. (sensitive)<br>  db\_name   : The database to access. | <pre>object({<br>    server_ip = string<br>    user      = string<br>    password  = string # sensitive<br>    db_name   = string<br>  })</pre> | `null` | no |
+| <a name="input_compute_startup_script"></a> [compute\_startup\_script](#input\_compute\_startup\_script) | Startup script used by the compute VMs. | `string` | `"# no-op"` | no |
+| <a name="input_compute_startup_scripts_timeout"></a> [compute\_startup\_scripts\_timeout](#input\_compute\_startup\_scripts\_timeout) | The timeout (seconds) applied to each script in compute\_startup\_scripts. If<br>any script exceeds this timeout, then the instance setup process is considered<br>failed and handled accordingly.<br><br>NOTE: When set to 0, the timeout is considered infinite and thus disabled. | `number` | `300` | no |
+| <a name="input_controller_startup_script"></a> [controller\_startup\_script](#input\_controller\_startup\_script) | Startup script used by the controller VM. | `string` | `"# no-op"` | no |
+| <a name="input_controller_startup_scripts_timeout"></a> [controller\_startup\_scripts\_timeout](#input\_controller\_startup\_scripts\_timeout) | The timeout (seconds) applied to each script in controller\_startup\_scripts. If<br>any script exceeds this timeout, then the instance setup process is considered<br>failed and handled accordingly.<br><br>NOTE: When set to 0, the timeout is considered infinite and thus disabled. | `number` | `300` | no |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Create GCS bucket instead of using an existing one. | `bool` | `true` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment. | `string` | n/a | yes |
+| <a name="input_disable_controller_public_ips"></a> [disable\_controller\_public\_ips](#input\_disable\_controller\_public\_ips) | If set to false. The controller will have a random public IP assigned to it. Ignored if access\_config is set. | `bool` | `true` | no |
+| <a name="input_disable_default_mounts"></a> [disable\_default\_mounts](#input\_disable\_default\_mounts) | Disable default global network storage from the controller<br>- /usr/local/etc/slurm<br>- /etc/munge<br>- /home<br>- /apps<br>Warning: If these are disabled, the slurm etc and munge dirs must be added<br>manually, or some other mechanism must be used to synchronize the slurm conf<br>files and the munge key across the cluster. | `bool` | `false` | no |
+| <a name="input_disable_smt"></a> [disable\_smt](#input\_disable\_smt) | Disables Simultaneous Multi-Threading (SMT) on instance. | `bool` | `true` | no |
+| <a name="input_disk_auto_delete"></a> [disk\_auto\_delete](#input\_disk\_auto\_delete) | Whether or not the boot disk should be auto-deleted. | `bool` | `true` | no |
+| <a name="input_disk_labels"></a> [disk\_labels](#input\_disk\_labels) | Labels specific to the boot disk. These will be merged with var.labels. | `map(string)` | `{}` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB. | `number` | `50` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Boot disk type, can be either pd-ssd, pd-standard, pd-balanced, or pd-extreme. | `string` | `"pd-ssd"` | no |
+| <a name="input_enable_bigquery_load"></a> [enable\_bigquery\_load](#input\_enable\_bigquery\_load) | Enables loading of cluster job usage into big query.<br><br>NOTE: Requires Google Bigquery API. | `bool` | `false` | no |
+| <a name="input_enable_cleanup_compute"></a> [enable\_cleanup\_compute](#input\_enable\_cleanup\_compute) | Enables automatic cleanup of compute nodes and resource policies (e.g.<br>placement groups) managed by this module, when cluster is destroyed.<br><br>NOTE: Requires Python and script dependencies.<br>*WARNING*: Toggling this may impact the running workload. Deployed compute nodes<br>may be destroyed and their jobs will be requeued. | `bool` | `false` | no |
+| <a name="input_enable_confidential_vm"></a> [enable\_confidential\_vm](#input\_enable\_confidential\_vm) | Enable the Confidential VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_debug_logging"></a> [enable\_debug\_logging](#input\_enable\_debug\_logging) | Enables debug logging mode. Not for production use. | `bool` | `false` | no |
+| <a name="input_enable_devel"></a> [enable\_devel](#input\_enable\_devel) | Enables development mode. Not for production use. | `bool` | `false` | no |
+| <a name="input_enable_login"></a> [enable\_login](#input\_enable\_login) | Enables the creation of login nodes and instance templates. | `bool` | `true` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables Google Cloud os-login for user login and authentication for VMs.<br>See https://cloud.google.com/compute/docs/oslogin | `bool` | `true` | no |
+| <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_epilog_scripts"></a> [epilog\_scripts](#input\_epilog\_scripts) | List of scripts to be used for Epilog. Programs for the slurmd to execute<br>on every node when a user's job completes.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_extra_logging_flags"></a> [extra\_logging\_flags](#input\_extra\_logging\_flags) | The list of extra flags for the logging system to use. See the logging\_flags variable in scripts/util.py to get the list of supported log flags. | `map(bool)` | `{}` | no |
+| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br>    type  = string,<br>    count = number<br>  }))</pre> | `[]` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Defines the image that will be used in the Slurm controller VM instance.<br><br>Expected Fields:<br>name: The name of the image. Mutually exclusive with family.<br>family: The image family to use. Mutually exclusive with name.<br>project: The project where the image is hosted.<br><br>For more information on creating custom images that comply with Slurm on GCP<br>see the "Slurm on GCP Custom Images" section in docs/vm-images.md. | `map(string)` | <pre>{<br>  "family": "slurm-gcp-6-1-hpc-rocky-linux-8",<br>  "project": "schedmd-slurm-public"<br>}</pre> | no |
+| <a name="input_instance_image_custom"></a> [instance\_image\_custom](#input\_instance\_image\_custom) | A flag that designates that the user is aware that they are requesting<br>to use a custom and potentially incompatible image for this Slurm on<br>GCP module.<br><br>If the field is set to false, only the compatible families and project<br>names will be accepted.  The deployment will fail with any other image<br>family or name.  If set to true, no checks will be done.<br><br>See: https://goo.gle/hpc-slurm-images | `bool` | `false` | no |
+| <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Self link to a custom instance template. If set, other VM definition<br>variables such as machine\_type and instance\_image will be ignored in favor<br>of the provided instance template.<br><br>For more information on creating custom images for the instance template<br>that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section<br>in docs/vm-images.md. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels, provided as a map. | `map(string)` | `{}` | no |
+| <a name="input_login_nodes"></a> [login\_nodes](#input\_login\_nodes) | List of slurm login instance definitions. | <pre>list(object({<br>    additional_disks = optional(list(object({<br>      disk_name    = optional(string)<br>      device_name  = optional(string)<br>      disk_size_gb = optional(number)<br>      disk_type    = optional(string)<br>      disk_labels  = optional(map(string), {})<br>      auto_delete  = optional(bool, true)<br>      boot         = optional(bool, false)<br>    })), [])<br>    bandwidth_tier         = optional(string, "platform_default")<br>    can_ip_forward         = optional(bool, false)<br>    disable_smt            = optional(bool, false)<br>    disk_auto_delete       = optional(bool, true)<br>    disk_labels            = optional(map(string), {})<br>    disk_size_gb           = optional(number)<br>    disk_type              = optional(string, "n1-standard-1")<br>    enable_confidential_vm = optional(bool, false)<br>    enable_public_ip       = optional(bool, false)<br>    enable_oslogin         = optional(bool, true)<br>    enable_shielded_vm     = optional(bool, false)<br>    gpu = optional(object({<br>      count = number<br>      type  = string<br>    }))<br>    group_name          = string<br>    instance_template   = optional(string)<br>    labels              = optional(map(string), {})<br>    machine_type        = optional(string)<br>    metadata            = optional(map(string), {})<br>    min_cpu_platform    = optional(string)<br>    network_tier        = optional(string, "STANDARD")<br>    num_instances       = optional(number, 1)<br>    on_host_maintenance = optional(string)<br>    preemptible         = optional(bool, false)<br>    region              = optional(string)<br>    service_account = optional(object({<br>      email  = optional(string)<br>      scopes = optional(list(string), ["https://www.googleapis.com/auth/cloud-platform"])<br>    }))<br>    shielded_instance_config = optional(object({<br>      enable_integrity_monitoring = optional(bool, true)<br>      enable_secure_boot          = optional(bool, true)<br>      enable_vtpm                 = optional(bool, true)<br>    }))<br>    source_image_family  = optional(string)<br>    source_image_project = optional(string)<br>    source_image         = optional(string)<br>    static_ips           = optional(list(string), [])<br>    subnetwork_project   = optional(string)<br>    subnetwork           = optional(string)<br>    spot                 = optional(bool, false)<br>    tags                 = optional(list(string), [])<br>    zone                 = optional(string)<br>    termination_action   = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_login_startup_script"></a> [login\_startup\_script](#input\_login\_startup\_script) | Startup script used by the login VMs. | `string` | `"# no-op"` | no |
+| <a name="input_login_startup_scripts_timeout"></a> [login\_startup\_scripts\_timeout](#input\_login\_startup\_scripts\_timeout) | The timeout (seconds) applied to each script in login\_startup\_scripts. If<br>any script exceeds this timeout, then the instance setup process is considered<br>failed and handled accordingly.<br><br>NOTE: When set to 0, the timeout is considered infinite and thus disabled. | `number` | `300` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to create. | `string` | `"c2-standard-4"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | Specifies a minimum CPU platform. Applicable values are the friendly names of<br>CPU platforms, such as Intel Haswell or Intel Skylake. See the complete list:<br>https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform | `string` | `null` | no |
+| <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured on all instances. | <pre>list(object({<br>    server_ip             = string,<br>    remote_mount          = string,<br>    local_mount           = string,<br>    fs_type               = string,<br>    mount_options         = string,<br>    client_install_runner = map(string) # TODO: is it used? should remove it?<br>    mount_runner          = map(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_nodeset"></a> [nodeset](#input\_nodeset) | Define nodesets, as a list. | <pre>list(object({<br>    node_count_static      = optional(number, 0)<br>    node_count_dynamic_max = optional(number, 1)<br>    node_conf              = optional(map(string), {})<br>    nodeset_name           = string<br>    additional_disks = optional(list(object({<br>      disk_name    = optional(string)<br>      device_name  = optional(string)<br>      disk_size_gb = optional(number)<br>      disk_type    = optional(string)<br>      disk_labels  = optional(map(string), {})<br>      auto_delete  = optional(bool, true)<br>      boot         = optional(bool, false)<br>    })), [])<br>    bandwidth_tier         = optional(string, "platform_default")<br>    can_ip_forward         = optional(bool, false)<br>    disable_smt            = optional(bool, false)<br>    disk_auto_delete       = optional(bool, true)<br>    disk_labels            = optional(map(string), {})<br>    disk_size_gb           = optional(number)<br>    disk_type              = optional(string)<br>    enable_confidential_vm = optional(bool, false)<br>    enable_placement       = optional(bool, false)<br>    enable_public_ip       = optional(bool, false)<br>    enable_oslogin         = optional(bool, true)<br>    enable_shielded_vm     = optional(bool, false)<br>    gpu = optional(object({<br>      count = number<br>      type  = string<br>    }))<br>    instance_template   = optional(string)<br>    labels              = optional(map(string), {})<br>    machine_type        = optional(string)<br>    metadata            = optional(map(string), {})<br>    min_cpu_platform    = optional(string)<br>    network_tier        = optional(string, "STANDARD")<br>    on_host_maintenance = optional(string)<br>    preemptible         = optional(bool, false)<br>    region              = optional(string)<br>    service_account = optional(object({<br>      email  = optional(string)<br>      scopes = optional(list(string), ["https://www.googleapis.com/auth/cloud-platform"])<br>    }))<br>    shielded_instance_config = optional(object({<br>      enable_integrity_monitoring = optional(bool, true)<br>      enable_secure_boot          = optional(bool, true)<br>      enable_vtpm                 = optional(bool, true)<br>    }))<br>    source_image_family  = optional(string)<br>    source_image_project = optional(string)<br>    source_image         = optional(string)<br>    subnetwork_project   = optional(string)<br>    subnetwork           = optional(string)<br>    spot                 = optional(bool, false)<br>    tags                 = optional(list(string), [])<br>    termination_action   = optional(string)<br>    zones                = optional(list(string), [])<br>    zone_target_shape    = optional(string, "ANY_SINGLE_ZONE")<br>  }))</pre> | `[]` | no |
+| <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Instance availability Policy. | `string` | `"MIGRATE"` | no |
+| <a name="input_partitions"></a> [partitions](#input\_partitions) | Cluster partitions as a list. See module slurm\_partition. | <pre>list(object({<br>    default              = optional(bool, false)<br>    enable_job_exclusive = optional(bool, false)<br>    network_storage = optional(list(object({<br>      server_ip     = string<br>      remote_mount  = string<br>      local_mount   = string<br>      fs_type       = string<br>      mount_options = string<br>    })), [])<br>    partition_conf        = optional(map(string), {})<br>    partition_name        = string<br>    partition_nodeset     = optional(list(string), [])<br>    partition_nodeset_dyn = optional(list(string), [])<br>    partition_nodeset_tpu = optional(list(string), [])<br>    resume_timeout        = optional(number)<br>    suspend_time          = optional(number, 300)<br>    suspend_timeout       = optional(number)<br>  }))</pre> | n/a | yes |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Allow the instance to be preempted. | `bool` | `false` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
+| <a name="input_prolog_scripts"></a> [prolog\_scripts](#input\_prolog\_scripts) | List of scripts to be used for Prolog. Programs for the slurmd to execute<br>whenever it is asked to run a job step from a new job allocation.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_region"></a> [region](#input\_region) | The default region to place resources in. | `string` | n/a | yes |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the controller instance. If not set, the<br>default compute service account for the given project will be used with the<br>"https://www.googleapis.com/auth/cloud-platform" scope. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>  enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>  enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>  enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
+| <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Cluster name, used for resource naming and slurm accounting. <br>If not provided it will default to the first 8 characters of the deployment name (removing any invalid characters). | `string` | `null` | no |
+| <a name="input_slurm_conf_tpl"></a> [slurm\_conf\_tpl](#input\_slurm\_conf\_tpl) | Slurm slurm.conf template file path. | `string` | `null` | no |
+| <a name="input_slurmdbd_conf_tpl"></a> [slurmdbd\_conf\_tpl](#input\_slurmdbd\_conf\_tpl) | Slurm slurmdbd.conf template file path. | `string` | `null` | no |
+| <a name="input_static_ips"></a> [static\_ips](#input\_static\_ips) | List of static IPs for VM instances. | `list(string)` | `[]` | no |
+| <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The project that subnetwork belongs to. | `string` | `null` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. Either network\_self\_link or subnetwork\_self\_link must be specified. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone where the instances should be created. If not specified, instances will be<br>spread across available zones in the region. | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/gpu_definition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/gpu_definition.tf
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+## Required variables:
+#  guest_accelerator
+#  machine_type
+
+locals {
+  # example state; terraform will ignore diffs if last element of URL matches
+  # guest_accelerator = [
+  #   {
+  #     count = 1
+  #     type  = "https://www.googleapis.com/compute/beta/projects/PROJECT/zones/ZONE/acceleratorTypes/nvidia-tesla-a100"
+  #   },
+  # ]
+  accelerator_machines = {
+    "a2-highgpu-1g"  = { type = "nvidia-tesla-a100", count = 1 },
+    "a2-highgpu-2g"  = { type = "nvidia-tesla-a100", count = 2 },
+    "a2-highgpu-4g"  = { type = "nvidia-tesla-a100", count = 4 },
+    "a2-highgpu-8g"  = { type = "nvidia-tesla-a100", count = 8 },
+    "a2-megagpu-16g" = { type = "nvidia-tesla-a100", count = 16 },
+    "a2-ultragpu-1g" = { type = "nvidia-a100-80gb", count = 1 },
+    "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
+    "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
+    "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
+    "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-12" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-16" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-24" = { type = "nvidia-l4", count = 2 },
+    "g2-standard-32" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-48" = { type = "nvidia-l4", count = 4 },
+    "g2-standard-96" = { type = "nvidia-l4", count = 8 },
+  }
+  generated_guest_accelerator = try([local.accelerator_machines[var.machine_type]], [])
+
+  # Select in priority order:
+  # (1) var.guest_accelerator if not empty
+  # (2) local.generated_guest_accelerator if not empty
+  # (3) default to empty list if both are empty
+  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/main.tf
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v6-controller", ghpc_role = "scheduler" })
+}
+
+locals {
+  ghpc_startup_script_controller = [{
+    filename = "ghpc_startup.sh"
+    content  = var.controller_startup_script
+  }]
+  ghpc_startup_script_login = [{
+    filename = "ghpc_startup.sh"
+    content  = var.login_startup_script
+  }]
+  ghpc_startup_script_compute = [{
+    filename = "ghpc_startup.sh"
+    content  = var.compute_startup_script
+  }]
+
+  # Since deployment name may be used to create a cluster name, we remove any invalid character from the beginning
+  # Also, slurm imposed a lot of restrictions to this name, so we format it to an acceptable string
+  tmp_cluster_name   = substr(replace(lower(var.deployment_name), "/^[^a-z]*|[^a-z0-9]/", ""), 0, 10)
+  slurm_cluster_name = coalesce(var.slurm_cluster_name, local.tmp_cluster_name)
+
+}
+
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}
+
+locals { # controller_instance_config
+  additional_disks = [
+    for ad in var.additional_disks : {
+      disk_name    = ad.disk_name
+      device_name  = ad.device_name
+      disk_type    = ad.disk_type
+      disk_size_gb = ad.disk_size_gb
+      disk_labels  = merge(ad.disk_labels, local.labels)
+      auto_delete  = ad.auto_delete
+      boot         = ad.boot
+    }
+  ]
+
+  controller_instance_config = {
+    disk_auto_delete = var.disk_auto_delete
+    disk_labels      = merge(var.disk_labels, local.labels)
+    disk_size_gb     = var.disk_size_gb
+    disk_type        = var.disk_type
+    additional_disks = local.additional_disks
+
+    can_ip_forward = var.can_ip_forward
+    disable_smt    = var.disable_smt
+
+    enable_confidential_vm   = var.enable_confidential_vm
+    enable_public_ip         = !var.disable_controller_public_ips
+    enable_oslogin           = var.enable_oslogin
+    enable_shielded_vm       = var.enable_shielded_vm
+    shielded_instance_config = var.shielded_instance_config
+
+    gpu               = one(local.guest_accelerator)
+    instance_template = var.instance_template
+    labels            = local.labels
+    machine_type      = var.machine_type
+    metadata          = var.metadata
+    min_cpu_platform  = var.min_cpu_platform
+
+    on_host_maintenance = var.on_host_maintenance
+    preemptible         = var.preemptible
+    region              = var.region
+    zone                = var.zone
+
+    service_account = coalesce(var.service_account, {
+      email  = data.google_compute_default_service_account.default.email
+      scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+    })
+
+    source_image_family  = local.source_image_family             # requires source_image_logic.tf
+    source_image_project = local.source_image_project_normalized # requires source_image_logic.tf
+    source_image         = local.source_image                    # requires source_image_logic.tf
+
+    static_ip      = try(var.static_ips[0], null)
+    bandwidth_tier = var.bandwidth_tier
+
+    subnetwork         = var.subnetwork_self_link
+    subnetwork_project = var.subnetwork_project
+
+    tags = var.tags
+  }
+}
+
+module "slurm_cluster" {
+  source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster?ref=6.1.2"
+
+  project_id         = var.project_id
+  slurm_cluster_name = local.slurm_cluster_name
+  region             = var.region
+
+  create_bucket = var.create_bucket
+  bucket_name   = var.bucket_name
+  bucket_dir    = var.bucket_dir
+
+  controller_instance_config = local.controller_instance_config
+
+  enable_login = var.enable_login
+  login_nodes  = var.login_nodes
+
+  nodeset = var.nodeset
+
+  partitions = var.partitions
+
+  enable_devel           = var.enable_devel
+  enable_debug_logging   = var.enable_debug_logging
+  extra_logging_flags    = var.extra_logging_flags
+  enable_cleanup_compute = var.enable_cleanup_compute
+  enable_bigquery_load   = var.enable_bigquery_load
+  cloud_parameters       = var.cloud_parameters
+  disable_default_mounts = var.disable_default_mounts
+
+  network_storage       = var.network_storage
+  login_network_storage = var.network_storage
+
+  slurmdbd_conf_tpl = var.slurmdbd_conf_tpl
+  slurm_conf_tpl    = var.slurm_conf_tpl
+  cgroup_conf_tpl   = var.cgroup_conf_tpl
+
+  controller_startup_scripts         = local.ghpc_startup_script_controller
+  controller_startup_scripts_timeout = var.controller_startup_scripts_timeout
+  login_startup_scripts              = local.ghpc_startup_script_login
+  login_startup_scripts_timeout      = var.login_startup_scripts_timeout
+  compute_startup_scripts            = local.ghpc_startup_script_compute
+  compute_startup_scripts_timeout    = var.compute_startup_scripts_timeout
+
+  prolog_scripts = var.prolog_scripts
+  epilog_scripts = var.epilog_scripts
+  cloudsql       = var.cloudsql
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/source_image_logic.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/source_image_logic.tf
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # Currently supported images and projects
+  known_project_families = {
+    schedmd-slurm-public = [
+      "slurm-gcp-6-1-debian-11",
+      "slurm-gcp-6-1-hpc-rocky-linux-8",
+      "slurm-gcp-6-1-ubuntu-2004-lts",
+      "slurm-gcp-6-1-ubuntu-2204-lts-arm64",
+      "slurm-gcp-6-1-hpc-centos-7-k80",
+      "slurm-gcp-6-1-hpc-centos-7"
+    ]
+  }
+
+  # This approach to "hacking" the project name allows a chain of Terraform
+  # calls to set the instance source_image (boot disk) with a "relative
+  # resource name" that passes muster with VPC Service Control rules
+  #
+  # https://github.com/terraform-google-modules/terraform-google-vm/blob/735bd415fc5f034d46aa0de7922e8fada2327c0c/modules/instance_template/main.tf#L28
+  # https://cloud.google.com/apis/design/resource_names#relative_resource_name
+  source_image_project_normalized = (can(var.instance_image.family) ?
+    "projects/${data.google_compute_image.slurm.project}/global/images/family" :
+    "projects/${data.google_compute_image.slurm.project}/global/images"
+  )
+  source_image_family = can(var.instance_image.family) ? data.google_compute_image.slurm.family : ""
+  source_image        = can(var.instance_image.name) ? data.google_compute_image.slurm.name : ""
+}
+
+data "google_compute_image" "slurm" {
+  family  = try(var.instance_image.family, null)
+  name    = try(var.instance_image.name, null)
+  project = var.instance_image.project
+
+  lifecycle {
+    precondition {
+      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+    }
+
+    postcondition {
+      condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
+      error_message = <<-EOD
+      Images in project ${self.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
+      EOD
+    }
+    postcondition {
+      condition     = !contains(keys(local.known_project_families), self.project) || try(contains(local.known_project_families[self.project], self.family), false)
+      error_message = <<-EOD
+      Image family ${self.family} published by SchedMD in project ${self.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
+      ${join("\n", [for p in try(local.known_project_families[self.project], []) : "\t\"${p}\""])}
+      EOD
+    }
+    postcondition {
+      condition     = var.disk_size_gb >= self.disk_size_gb
+      error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${self.disk_size_gb}GB), please increase the blueprint disk size"
+    }
+  }
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -1,0 +1,471 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+###########
+# GENERAL #
+###########
+
+variable "project_id" {
+  type        = string
+  description = "Project ID to create resources in."
+}
+
+variable "deployment_name" {
+  description = "Name of the deployment."
+  type        = string
+}
+
+variable "slurm_cluster_name" {
+  type        = string
+  description = <<-EOD
+    Cluster name, used for resource naming and slurm accounting. 
+    If not provided it will default to the first 8 characters of the deployment name (removing any invalid characters).
+  EOD
+  default     = null
+
+  validation {
+    condition     = var.slurm_cluster_name == null || can(regex("^[a-z](?:[a-z0-9]{0,9})$", var.slurm_cluster_name))
+    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z](?:[a-z0-9]{0,9})$'."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "The default region to place resources in."
+}
+
+variable "zone" {
+  type        = string
+  description = <<EOD
+Zone where the instances should be created. If not specified, instances will be
+spread across available zones in the region.
+EOD
+  default     = null
+}
+
+##########
+# BUCKET #
+##########
+
+variable "create_bucket" {
+  description = <<-EOD
+    Create GCS bucket instead of using an existing one.
+  EOD
+  type        = bool
+  default     = true
+}
+
+variable "bucket_name" {
+  description = <<-EOD
+    Name of GCS bucket.
+    Ignored when 'create_bucket' is true.
+  EOD
+  type        = string
+  default     = null
+}
+
+variable "bucket_dir" {
+  description = "Bucket directory for cluster files to be put into. If not specified, then one will be chosen based on slurm_cluster_name."
+  type        = string
+  default     = null
+}
+
+#####################
+# CONTROLLER: CLOUD # See variables_controller_instance.tf for the controller instance variables.
+#####################
+
+#########
+# LOGIN # TODO
+#########
+
+variable "enable_login" {
+  description = <<EOD
+Enables the creation of login nodes and instance templates.
+EOD
+  type        = bool
+  default     = true
+}
+
+# REVIEWER_NOTE: copied from V6 cluster module as is
+variable "login_nodes" {
+  description = "List of slurm login instance definitions."
+  type = list(object({
+    additional_disks = optional(list(object({
+      disk_name    = optional(string)
+      device_name  = optional(string)
+      disk_size_gb = optional(number)
+      disk_type    = optional(string)
+      disk_labels  = optional(map(string), {})
+      auto_delete  = optional(bool, true)
+      boot         = optional(bool, false)
+    })), [])
+    bandwidth_tier         = optional(string, "platform_default")
+    can_ip_forward         = optional(bool, false)
+    disable_smt            = optional(bool, false)
+    disk_auto_delete       = optional(bool, true)
+    disk_labels            = optional(map(string), {})
+    disk_size_gb           = optional(number)
+    disk_type              = optional(string, "n1-standard-1")
+    enable_confidential_vm = optional(bool, false)
+    enable_public_ip       = optional(bool, false)
+    enable_oslogin         = optional(bool, true)
+    enable_shielded_vm     = optional(bool, false)
+    gpu = optional(object({
+      count = number
+      type  = string
+    }))
+    group_name          = string
+    instance_template   = optional(string)
+    labels              = optional(map(string), {})
+    machine_type        = optional(string)
+    metadata            = optional(map(string), {})
+    min_cpu_platform    = optional(string)
+    network_tier        = optional(string, "STANDARD")
+    num_instances       = optional(number, 1)
+    on_host_maintenance = optional(string)
+    preemptible         = optional(bool, false)
+    region              = optional(string)
+    service_account = optional(object({
+      email  = optional(string)
+      scopes = optional(list(string), ["https://www.googleapis.com/auth/cloud-platform"])
+    }))
+    shielded_instance_config = optional(object({
+      enable_integrity_monitoring = optional(bool, true)
+      enable_secure_boot          = optional(bool, true)
+      enable_vtpm                 = optional(bool, true)
+    }))
+    source_image_family  = optional(string)
+    source_image_project = optional(string)
+    source_image         = optional(string)
+    static_ips           = optional(list(string), [])
+    subnetwork_project   = optional(string)
+    subnetwork           = optional(string)
+    spot                 = optional(bool, false)
+    tags                 = optional(list(string), [])
+    zone                 = optional(string)
+    termination_action   = optional(string)
+  }))
+  default = []
+}
+
+############
+# NODESETS #
+############
+# REVIEWER_NOTE: copied from V6 cluster module as is
+variable "nodeset" {
+  description = "Define nodesets, as a list."
+  type = list(object({
+    node_count_static      = optional(number, 0)
+    node_count_dynamic_max = optional(number, 1)
+    node_conf              = optional(map(string), {})
+    nodeset_name           = string
+    additional_disks = optional(list(object({
+      disk_name    = optional(string)
+      device_name  = optional(string)
+      disk_size_gb = optional(number)
+      disk_type    = optional(string)
+      disk_labels  = optional(map(string), {})
+      auto_delete  = optional(bool, true)
+      boot         = optional(bool, false)
+    })), [])
+    bandwidth_tier         = optional(string, "platform_default")
+    can_ip_forward         = optional(bool, false)
+    disable_smt            = optional(bool, false)
+    disk_auto_delete       = optional(bool, true)
+    disk_labels            = optional(map(string), {})
+    disk_size_gb           = optional(number)
+    disk_type              = optional(string)
+    enable_confidential_vm = optional(bool, false)
+    enable_placement       = optional(bool, false)
+    enable_public_ip       = optional(bool, false)
+    enable_oslogin         = optional(bool, true)
+    enable_shielded_vm     = optional(bool, false)
+    gpu = optional(object({
+      count = number
+      type  = string
+    }))
+    instance_template   = optional(string)
+    labels              = optional(map(string), {})
+    machine_type        = optional(string)
+    metadata            = optional(map(string), {})
+    min_cpu_platform    = optional(string)
+    network_tier        = optional(string, "STANDARD")
+    on_host_maintenance = optional(string)
+    preemptible         = optional(bool, false)
+    region              = optional(string)
+    service_account = optional(object({
+      email  = optional(string)
+      scopes = optional(list(string), ["https://www.googleapis.com/auth/cloud-platform"])
+    }))
+    shielded_instance_config = optional(object({
+      enable_integrity_monitoring = optional(bool, true)
+      enable_secure_boot          = optional(bool, true)
+      enable_vtpm                 = optional(bool, true)
+    }))
+    source_image_family  = optional(string)
+    source_image_project = optional(string)
+    source_image         = optional(string)
+    subnetwork_project   = optional(string)
+    subnetwork           = optional(string)
+    spot                 = optional(bool, false)
+    tags                 = optional(list(string), [])
+    termination_action   = optional(string)
+    zones                = optional(list(string), [])
+    zone_target_shape    = optional(string, "ANY_SINGLE_ZONE")
+  }))
+  default = []
+
+  validation {
+    condition     = length(distinct([for x in var.nodeset : x.nodeset_name])) == length(var.nodeset)
+    error_message = "All nodesets must have a unique name."
+  }
+}
+
+#############
+# PARTITION #
+#############
+# REVIEWER_NOTE: copied from V6 cluster module as is
+variable "partitions" {
+  description = <<EOD
+Cluster partitions as a list. See module slurm_partition.
+EOD
+  type = list(object({
+    default              = optional(bool, false)
+    enable_job_exclusive = optional(bool, false)
+    network_storage = optional(list(object({
+      server_ip     = string
+      remote_mount  = string
+      local_mount   = string
+      fs_type       = string
+      mount_options = string
+    })), [])
+    partition_conf        = optional(map(string), {})
+    partition_name        = string
+    partition_nodeset     = optional(list(string), [])
+    partition_nodeset_dyn = optional(list(string), [])
+    partition_nodeset_tpu = optional(list(string), [])
+    resume_timeout        = optional(number)
+    suspend_time          = optional(number, 300)
+    suspend_timeout       = optional(number)
+  }))
+
+  validation {
+    condition     = length(var.partitions) > 0
+    error_message = "Partitions cannot be empty."
+  }
+}
+
+#########
+# SLURM #
+#########
+
+variable "enable_devel" {
+  type        = bool
+  description = "Enables development mode. Not for production use."
+  default     = false
+}
+
+variable "enable_debug_logging" {
+  type        = bool
+  description = "Enables debug logging mode. Not for production use."
+  default     = false
+}
+
+variable "extra_logging_flags" {
+  type        = map(bool)
+  description = "The list of extra flags for the logging system to use. See the logging_flags variable in scripts/util.py to get the list of supported log flags."
+  default     = {}
+}
+
+variable "enable_cleanup_compute" {
+  description = <<EOD
+Enables automatic cleanup of compute nodes and resource policies (e.g.
+placement groups) managed by this module, when cluster is destroyed.
+
+NOTE: Requires Python and script dependencies.
+*WARNING*: Toggling this may impact the running workload. Deployed compute nodes
+may be destroyed and their jobs will be requeued.
+EOD
+  type        = bool
+  default     = false
+}
+
+variable "enable_bigquery_load" {
+  description = <<EOD
+Enables loading of cluster job usage into big query.
+
+NOTE: Requires Google Bigquery API.
+EOD
+  type        = bool
+  default     = false
+}
+
+variable "cloud_parameters" {
+  description = "cloud.conf options."
+  type = object({
+    no_comma_params = optional(bool, false)
+    resume_rate     = optional(number, 0)
+    resume_timeout  = optional(number, 300)
+    suspend_rate    = optional(number, 0)
+    suspend_timeout = optional(number, 300)
+  })
+  default = {}
+}
+
+variable "disable_default_mounts" {
+  description = <<-EOD
+    Disable default global network storage from the controller
+    - /usr/local/etc/slurm
+    - /etc/munge
+    - /home
+    - /apps
+    Warning: If these are disabled, the slurm etc and munge dirs must be added
+    manually, or some other mechanism must be used to synchronize the slurm conf
+    files and the munge key across the cluster.
+    EOD
+  type        = bool
+  default     = false
+}
+
+variable "network_storage" {
+  description = "An array of network attached storage mounts to be configured on all instances."
+  type = list(object({
+    server_ip             = string,
+    remote_mount          = string,
+    local_mount           = string,
+    fs_type               = string,
+    mount_options         = string,
+    client_install_runner = map(string) # TODO: is it used? should remove it?
+    mount_runner          = map(string)
+  }))
+  default = []
+}
+
+variable "slurmdbd_conf_tpl" {
+  description = "Slurm slurmdbd.conf template file path."
+  type        = string
+  default     = null
+}
+
+variable "slurm_conf_tpl" {
+  description = "Slurm slurm.conf template file path."
+  type        = string
+  default     = null
+}
+
+variable "cgroup_conf_tpl" {
+  description = "Slurm cgroup.conf template file path."
+  type        = string
+  default     = null
+}
+
+variable "controller_startup_script" {
+  description = "Startup script used by the controller VM."
+  type        = string
+  default     = "# no-op"
+}
+
+variable "controller_startup_scripts_timeout" {
+  description = <<EOD
+The timeout (seconds) applied to each script in controller_startup_scripts. If
+any script exceeds this timeout, then the instance setup process is considered
+failed and handled accordingly.
+
+NOTE: When set to 0, the timeout is considered infinite and thus disabled.
+EOD
+  type        = number
+  default     = 300
+}
+
+variable "login_startup_script" {
+  description = "Startup script used by the login VMs."
+  type        = string
+  default     = "# no-op"
+}
+
+variable "login_startup_scripts_timeout" {
+  description = <<EOD
+The timeout (seconds) applied to each script in login_startup_scripts. If
+any script exceeds this timeout, then the instance setup process is considered
+failed and handled accordingly.
+
+NOTE: When set to 0, the timeout is considered infinite and thus disabled.
+EOD
+  type        = number
+  default     = 300
+}
+
+variable "compute_startup_script" {
+  description = "Startup script used by the compute VMs."
+  type        = string
+  default     = "# no-op"
+}
+
+variable "compute_startup_scripts_timeout" {
+  description = <<EOD
+The timeout (seconds) applied to each script in compute_startup_scripts. If
+any script exceeds this timeout, then the instance setup process is considered
+failed and handled accordingly.
+
+NOTE: When set to 0, the timeout is considered infinite and thus disabled.
+EOD
+  type        = number
+  default     = 300
+}
+
+variable "prolog_scripts" {
+  description = <<EOD
+List of scripts to be used for Prolog. Programs for the slurmd to execute
+whenever it is asked to run a job step from a new job allocation.
+See https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog.
+EOD
+  type = list(object({
+    filename = string
+    content  = string
+  }))
+  default = []
+}
+
+variable "epilog_scripts" {
+  description = <<EOD
+List of scripts to be used for Epilog. Programs for the slurmd to execute
+on every node when a user's job completes.
+See https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog.
+EOD
+  type = list(object({
+    filename = string
+    content  = string
+  }))
+  default = []
+}
+
+variable "cloudsql" {
+  description = <<EOD
+Use this database instead of the one on the controller.
+  server_ip : Address of the database server.
+  user      : The user to access the database as.
+  password  : The password, given the user, to access the given database. (sensitive)
+  db_name   : The database to access.
+EOD
+  type = object({
+    server_ip = string
+    user      = string
+    password  = string # sensitive
+    db_name   = string
+  })
+  default   = null
+  sensitive = true
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables_controller_instance.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables_controller_instance.tf
@@ -1,0 +1,295 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "disk_type" {
+  type        = string
+  description = "Boot disk type, can be either pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  default     = "pd-ssd"
+
+  validation {
+    condition     = contains(["pd-ssd", "pd-standard", "pd-balanced", "pd-extreme"], var.disk_type)
+    error_message = "Variable disk_type must be one of pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  }
+}
+
+variable "disk_size_gb" {
+  type        = number
+  description = "Boot disk size in GB."
+  default     = 50
+}
+
+variable "disk_auto_delete" {
+  type        = bool
+  description = "Whether or not the boot disk should be auto-deleted."
+  default     = true
+}
+
+variable "disk_labels" {
+  description = "Labels specific to the boot disk. These will be merged with var.labels."
+  type        = map(string)
+  default     = {}
+}
+
+variable "additional_disks" {
+  type = list(object({
+    disk_name    = string
+    device_name  = string
+    disk_type    = string
+    disk_size_gb = number
+    disk_labels  = map(string)
+    auto_delete  = bool
+    boot         = bool
+  }))
+  description = "List of maps of disks."
+  default     = []
+}
+
+variable "disable_smt" {
+  type        = bool
+  description = "Disables Simultaneous Multi-Threading (SMT) on instance."
+  default     = true
+}
+
+variable "static_ips" {
+  type        = list(string)
+  description = "List of static IPs for VM instances."
+  default     = []
+  validation {
+    condition     = length(var.static_ips) <= 1
+    error_message = "The Slurm modules supports 0 or 1 static IPs on controller instance."
+  }
+}
+
+variable "bandwidth_tier" {
+  description = <<EOT
+  Configures the network interface card and the maximum egress bandwidth for VMs.
+  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.
+  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.
+  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).
+  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.
+  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.
+  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details.
+  EOT
+  type        = string
+  default     = "platform_default"
+
+  validation {
+    condition     = contains(["platform_default", "virtio_enabled", "gvnic_enabled", "tier_1_enabled"], var.bandwidth_tier)
+    error_message = "Allowed values for bandwidth_tier are 'platform_default', 'virtio_enabled', 'gvnic_enabled', or 'tier_1_enabled'."
+  }
+}
+
+variable "can_ip_forward" {
+  type        = bool
+  description = "Enable IP forwarding, for NAT instances for example."
+  default     = false
+}
+
+variable "disable_controller_public_ips" {
+  description = "If set to false. The controller will have a random public IP assigned to it. Ignored if access_config is set."
+  type        = bool
+  default     = true
+}
+
+variable "enable_oslogin" {
+  type        = bool
+  description = <<-EOD
+    Enables Google Cloud os-login for user login and authentication for VMs.
+    See https://cloud.google.com/compute/docs/oslogin
+    EOD
+  default     = true
+}
+
+variable "enable_confidential_vm" {
+  type        = bool
+  description = "Enable the Confidential VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_shielded_vm" {
+  type        = bool
+  description = "Enable the Shielded VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "shielded_instance_config" {
+  type = object({
+    enable_integrity_monitoring = bool
+    enable_secure_boot          = bool
+    enable_vtpm                 = bool
+  })
+  description = <<EOD
+Shielded VM configuration for the instance. Note: not used unless
+enable_shielded_vm is 'true'.
+  enable_integrity_monitoring : Compare the most recent boot measurements to the
+  integrity policy baseline and return a pair of pass/fail results depending on
+  whether they match or not.
+  enable_secure_boot : Verify the digital signature of all boot components, and
+  halt the boot process if signature verification fails.
+  enable_vtpm : Use a virtualized trusted platform module, which is a
+  specialized computer chip you can use to encrypt objects like keys and
+  certificates.
+EOD
+  default = {
+    enable_integrity_monitoring = true
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+  }
+}
+
+variable "guest_accelerator" {
+  description = "List of the type and count of accelerator cards attached to the instance."
+  type = list(object({
+    type  = string,
+    count = number
+  }))
+  default  = []
+  nullable = false
+
+  validation {
+    condition     = length(var.guest_accelerator) <= 1
+    error_message = "The Slurm modules supports 0 or 1 models of accelerator card on each node."
+  }
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels, provided as a map."
+  default     = {}
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type to create."
+  default     = "c2-standard-4"
+}
+
+variable "metadata" {
+  type        = map(string)
+  description = "Metadata, provided as a map."
+  default     = {}
+}
+
+variable "min_cpu_platform" {
+  type        = string
+  description = <<EOD
+Specifies a minimum CPU platform. Applicable values are the friendly names of
+CPU platforms, such as Intel Haswell or Intel Skylake. See the complete list:
+https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform
+EOD
+  default     = null
+}
+
+variable "preemptible" {
+  type        = bool
+  description = "Allow the instance to be preempted."
+  default     = false
+}
+
+variable "on_host_maintenance" {
+  type        = string
+  description = "Instance availability Policy."
+  default     = "MIGRATE"
+}
+
+variable "service_account" {
+  type = object({
+    email  = string
+    scopes = set(string)
+  })
+  description = <<-EOD
+    Service account to attach to the controller instance. If not set, the
+    default compute service account for the given project will be used with the
+    "https://www.googleapis.com/auth/cloud-platform" scope.
+    EOD
+  default     = null
+}
+
+variable "instance_template" {
+  description = <<-EOD
+    Self link to a custom instance template. If set, other VM definition
+    variables such as machine_type and instance_image will be ignored in favor
+    of the provided instance template.
+
+    For more information on creating custom images for the instance template
+    that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section
+    in docs/vm-images.md.
+    EOD
+  type        = string
+  default     = null
+}
+
+variable "instance_image" {
+  description = <<-EOD
+    Defines the image that will be used in the Slurm controller VM instance.
+
+    Expected Fields:
+    name: The name of the image. Mutually exclusive with family.
+    family: The image family to use. Mutually exclusive with name.
+    project: The project where the image is hosted.
+
+    For more information on creating custom images that comply with Slurm on GCP
+    see the "Slurm on GCP Custom Images" section in docs/vm-images.md.
+    EOD
+  type        = map(string)
+  default = {
+    family  = "slurm-gcp-6-1-hpc-rocky-linux-8"
+    project = "schedmd-slurm-public"
+  }
+
+  validation {
+    condition     = can(coalesce(var.instance_image.project))
+    error_message = "In var.instance_image, the \"project\" field must be a string set to the Cloud project ID."
+  }
+
+  validation {
+    condition     = can(coalesce(var.instance_image.name)) != can(coalesce(var.instance_image.family))
+    error_message = "In var.instance_image, exactly one of \"family\" or \"name\" fields must be set to desired image family or name."
+  }
+}
+
+variable "instance_image_custom" {
+  description = <<-EOD
+    A flag that designates that the user is aware that they are requesting
+    to use a custom and potentially incompatible image for this Slurm on
+    GCP module.
+
+    If the field is set to false, only the compatible families and project
+    names will be accepted.  The deployment will fail with any other image
+    family or name.  If set to true, no checks will be done.
+
+    See: https://goo.gle/hpc-slurm-images
+    EOD
+  type        = bool
+  default     = false
+}
+
+
+variable "tags" {
+  type        = list(string)
+  description = "Network tag list."
+  default     = []
+}
+
+variable "subnetwork_self_link" {
+  type        = string
+  description = "Subnet to deploy to. Either network_self_link or subnetwork_self_link must be specified."
+  default     = null
+}
+
+variable "subnetwork_project" {
+  type        = string
+  description = "The project that subnetwork belongs to."
+  default     = null
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-controller/v1.23.0"
+  }
+}

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -41,15 +41,21 @@ duplicates = [
         "community/modules/compute/schedmd-slurm-gcp-v5-node-group/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v5-login/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v5-controller/gpu_definition.tf",
+        "community/modules/compute/schedmd-slurm-gcp-v6-nodeset/gpu_definition.tf",
+        "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/gpu_definition.tf",
     ],
     [
         "community/modules/compute/gke-node-pool/threads_per_core_calc.tf",
         "modules/compute/vm-instance/threads_per_core_calc.tf",
     ],
-    [
+    [ # Slurm V5
         "community/modules/compute/schedmd-slurm-gcp-v5-node-group/source_image_logic.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v5-controller/source_image_logic.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v5-login/source_image_logic.tf",
+    ],
+    [ # Slurm V6
+        "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/source_image_logic.tf",
+        "community/modules/compute/schedmd-slurm-gcp-v6-nodeset/source_image_logic.tf",
     ],
     [
         "community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl",


### PR DESCRIPTION
# Changes from V5 to V6

## Login modules will be fed into controller module (in V5 it's other way around)

## REMOVED obsolete variables:
* `enable_slurm_gcp_plugins`
* `enable_reconfigure`
* `enable_cleanup_subscriptions`

## Added login startup script:
* added `login_startup_script` similar to compute and controller ones;

## New logging variables:
* `enable_debug_logging` & `extra_logging_flags`;

## Limit `static_ips` to just one element
SlurmV6 takes only one IP address in `static_ip`, so we need to limit `static_ips` to at most one element.

## Do not output anything from controller module.
* `cloud_logging_filter` & `pubsub_topic` were used for login module in V5 but dependency direction was changed in V6;
* `controller_instance_id` - doesn't seem to be used anywhere;

## `enable_placement` moved from partition to nodeset
## **network** moved from partition to nodeset

# TODOs:
## A3 effort
### Forward-port variables from V5 to V6:
* `additional_networks`
* `nic_type`
* `access_config`
* `total_egress_bandwidth_tier`
*

## Missing support for `reservation_name` - TODO

## SKIPPED (present in SchedMD code, but omitted in Toolkit):
* `login_network_storage` - use same logic as V5, use only common `network_storage`;
* `network_ip` - use same logic as V5, use `static_ips` instead;
* `spot` (+ `termination_action`) - not present in V5, omit in ToolkitV6, though SchedMD supports it. TODO(?); `controller` only, `nodeset` V6 will support it;
* `network(network_self_link)` - V6 cluster doesn't provide `network` variable. Fallback to just `subnetwork_self_link`. TODO;

## Allow many-to-many relation between nodeset and partition
Currently it's implicitly limited to many-nodesets to one-partition.
AI: after aggregation of all nodesets into a list, remove all duplicates.
