### PR TITLE
Bump minimum Golang version 1.18 -> 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module hpc-toolkit
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/compute v1.23.0 // indirect

--- a/tools/cloud-build/build-test-go.yaml
+++ b/tools/cloud-build/build-test-go.yaml
@@ -15,7 +15,7 @@
 ---
 
 steps:
-- name: golang:1.18
+- name: golang:${_GO_VERSION}
   entrypoint: /bin/bash
   args:
   - -c

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -47,7 +47,7 @@ When prompted for project, use integration test project.
 |------|------|
 | [google_cloudbuild_trigger.daily_project_cleanup](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.daily_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
-| [google_cloudbuild_trigger.pr_go_1_18_build_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.pr_go_build_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_ofe_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_validation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |

--- a/tools/cloud-build/provision/pr-go-build-test.tf
+++ b/tools/cloud-build/provision/pr-go-build-test.tf
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_cloudbuild_trigger" "pr_go_1_18_build_test" {
-  name        = "PR-Go-1-18-build-test"
-  description = "Test that the PR builds with Go 1.18"
 
-  filename = "tools/cloud-build/build-test-go1-18.yaml"
+resource "google_cloudbuild_trigger" "pr_go_build_test" {
+  for_each = toset(["1.20", "1.21"])
+
+  name        = "PR-Go-${replace(each.key, ".", "-")}-build-test"
+  description = "Test that the PR builds with Go ${each.key}"
+
+  filename = "tools/cloud-build/build-test-go.yaml"
 
   github {
     owner = "GoogleCloudPlatform"
@@ -27,4 +30,8 @@ resource "google_cloudbuild_trigger" "pr_go_1_18_build_test" {
     }
   }
   include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+
+  substitutions = {
+    _GO_VERSION = each.key
+  }
 }


### PR DESCRIPTION
* Bump minimum Golang version 1.18 -> 1.20;
* Replace Go build test 1.18 with 1.20 & 1.21.
```
Apply complete! Resources: 2 added, 0 changed, 1 destroyed.
```
