### PR TITLE
Update ansible's usage of virtualenv to venv

### DIFF
--- a/community/modules/scripts/ramble-setup/templates/install_ramble_deps.yml.tpl
+++ b/community/modules/scripts/ramble-setup/templates/install_ramble_deps.yml.tpl
@@ -35,6 +35,7 @@
     ansible.builtin.pip:
       name: pip>=21.3.1
       virtualenv: "{{ ramble_virtualenv_path }}"
+      virtualenv_command: /usr/bin/python3 -m venv
 
   - name: Download ramble requirements file
     ansible.builtin.get_url:
@@ -45,3 +46,4 @@
     ansible.builtin.pip:
       requirements: /tmp/requirements.txt
       virtualenv: "{{ ramble_virtualenv_path }}"
+      virtualenv_command: /usr/bin/python3 -m venv

--- a/community/modules/scripts/spack-setup/scripts/install_spack_deps.yml
+++ b/community/modules/scripts/spack-setup/scripts/install_spack_deps.yml
@@ -41,8 +41,10 @@
     ansible.builtin.pip:
       name: pip>=21.3.1
       virtualenv: "{{ spack_virtualenv_path }}"
+      virtualenv_command: /usr/bin/python3 -m venv
 
   - name: Add google-cloud-storage to Spack virtualenv
     ansible.builtin.pip:
       name: google-cloud-storage
       virtualenv: "{{ spack_virtualenv_path }}"
+      virtualenv_command: /usr/bin/python3 -m venv


### PR DESCRIPTION
Because of a fix to install_ansible.sh, we need to switch to using venv in the ansible scripts (virtualenv is no longer installed in installed_ansible.sh).