### PR TITLE
Improve Spack and Ramble Refs

### DIFF
--- a/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
+++ b/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
@@ -53,9 +53,18 @@
     changed_when: lock_out.rc == 0
     failed_when: false
 
-  - name: Clones into installation directory
+  - name: Clone branch or tag into installation directory
     ansible.builtin.command: git clone --branch {{ git_ref }} {{ git_url }} {{ install_dir }}
+    failed_when: false
+    register: clone_res
     when: lock_out.rc == 0
+
+  - name: Clone commit hash into installation directory
+    ansible.builtin.command: "{{ item }}"
+    with_items:
+      - git clone {{ git_url }} {{ install_dir }}
+      - git --git-dir={{ install_dir }}/.git checkout {{ git_ref }}
+    when: lock_out.rc == 0 and clone_res.rc != 0
 
   - name: Set ownership and permissions
     ansible.builtin.file:

--- a/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
+++ b/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
@@ -53,9 +53,18 @@
     changed_when: lock_out.rc == 0
     failed_when: false
 
-  - name: Clones into installation directory
+  - name: Clone branch or tag into installation directory
     ansible.builtin.command: git clone --branch {{ git_ref }} {{ git_url }} {{ install_dir }}
+    failed_when: false
+    register: clone_res
     when: lock_out.rc == 0
+
+  - name: Clone commit hash into installation directory
+    ansible.builtin.command: "{{ item }}"
+    with_items:
+      - git clone {{ git_url }} {{ install_dir }}
+      - git --git-dir={{ install_dir }}/.git checkout {{ git_ref }}
+    when: lock_out.rc == 0 and clone_res.rc != 0
 
   - name: Set ownership and permissions
     ansible.builtin.file:


### PR DESCRIPTION
This PR should allow users of the Spack and Ramble modules to use commit hashes as refs for the version they procure.  

This was accomplished by ignoring errors on a bad `git clone --branch`, collecting the return code, and if it's not equal to 0, then it attempting to clone the repo and reset the repo to the ref.

Tested by deploying a modified hpc-slurm-gromacs blueprint. The tests varied the spack_ref field with `spack_ref: v0.19.0`, `spack_ref: 45accfa`, and without a ref specified.

After creation I checked `/sw/spack` directory to make sure that the branch matched the ref. All three matched with the ref that was selected.

Additionally I recorded the time to run the clone:

`spack_ref: v0.19.0`: 1'46"
`spack_ref: 45accfa`: 1'49"
no `spack_ref` specified: 1'55"
Original templates (single command): 1'44"

After reverting back to two tasks (`git clone --branch ref` with fail-through to `git clone ... && git checkout ref`, testing was done the same as above and the run times were not significantly different.

An unknown ref was also tested to ensure that the script failed during the second clone, which was successful.