### PR TITLE
Add Path specialization that can be extended with cty.Path

### DIFF
--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -17,6 +17,9 @@ package config
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Path is unique identifier of a piece of configuration.
@@ -56,6 +59,49 @@ func (p mapPath[E]) Dot(k string) E {
 	return e
 }
 
+// ctyPath is a specialization of Path that can be extended with cty.Path
+type ctyPath struct{ basePath }
+
+// Cty builds a path chain that starts with p and each link corresponds to a step in cty.Path
+// If any step in cty.Path is not supported, the path chain will be built up to that point.
+// E.g.
+// Root.Vars.Dot("alpha").Cty(cty.Path{}.IndexInt(6)) == "vars.alpha[6]"
+func (p ctyPath) Cty(cp cty.Path) basePath {
+	cur := p.basePath
+	for _, s := range cp {
+		prev := cur
+		var nxt basePath
+		piece, err := ctyStepToString(s)
+		if err != nil {
+			return cur // fall back to longest path build up to this point
+		}
+		initPath(&nxt, &prev, piece)
+		cur = nxt
+	}
+	return cur
+}
+
+func ctyStepToString(s cty.PathStep) (string, error) {
+	switch s := s.(type) {
+	case cty.GetAttrStep:
+		return fmt.Sprintf(".%s", s.Name), nil // equivalent to mapPath.Dot
+	case cty.IndexStep:
+		switch s.Key.Type() {
+		case cty.Number:
+			return fmt.Sprintf("[%s]", s.Key.AsBigFloat().String()), nil // equivalent to arrayPath.At
+		case cty.String:
+			return fmt.Sprintf(".%s", s.Key.AsString()), nil // equivalent to mapPath.Dot
+		default:
+			return "", errors.New("key value not number or string")
+		}
+	default:
+		return "", errors.Errorf("unknown cty.PathStep type: %#v", s)
+	}
+}
+
+// initPath walks through all child paths of p and initializes them. E.g.
+// initPath(&Root, nil, "") will trigger
+// -> initPath(&Root.BlueprintName, &Root, "blueprint_name")
 func initPath(p any, prev any, piece string) {
 	r := reflect.Indirect(reflect.ValueOf(p))
 	ty := reflect.TypeOf(p).Elem()
@@ -98,7 +144,7 @@ type validatorCfgPath struct {
 	Skip      basePath `path:".skip"`
 }
 
-type dictPath struct{ mapPath[basePath] }
+type dictPath struct{ mapPath[ctyPath] }
 
 type backendPath struct {
 	basePath

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -16,6 +16,8 @@ package config
 
 import (
 	"testing"
+
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestPath(t *testing.T) {
@@ -42,6 +44,11 @@ func TestPath(t *testing.T) {
 		{r.Validators.At(2).Inputs.Dot("zebra"), "validators[2].inputs.zebra"},
 
 		{r.Vars.Dot("red"), "vars.red"},
+		{r.Vars.Dot("red").Cty(cty.Path{}), "vars.red"},
+		{r.Vars.Dot("red").Cty(cty.Path{}.IndexInt(6)), "vars.red[6]"},
+		{r.Vars.Dot("red").Cty(cty.Path{}.IndexInt(6).GetAttr("silver")), "vars.red[6].silver"},
+		{r.Vars.Dot("red").Cty(cty.Path{}.IndexInt(6).IndexString("silver")), "vars.red[6].silver"},
+		{r.Vars.Dot("red").Cty(cty.Path{}.IndexInt(6).Index(cty.True)), "vars.red[6]"}, // trim last piece as invalid
 
 		{r.Groups.At(3), "deployment_groups[3]"},
 		{r.Groups.At(3).Name, "deployment_groups[3].group"},
@@ -85,12 +92,17 @@ func TestPathParent(t *testing.T) {
 		want Path
 	}
 	r := Root
+	cp := cty.Path{} // empty cty.Path
 	tests := []test{
 		{r, nil},
 		{r.Groups, r},
 		{r.Groups.At(3), r.Groups},
 		{r.Groups.At(3).Modules, r.Groups.At(3)},
 		{r.Vars.Dot("red"), r.Vars},
+		{r.Vars.Dot("red").Cty(cp), r.Vars},
+		{r.Vars.Dot("red").Cty(cp.IndexInt(6)), r.Vars.Dot("red")},
+		{r.Vars.Dot("red").Cty(cp.IndexInt(6).IndexString("gg")), r.Vars.Dot("red").Cty(cp.IndexInt(6))},
+		{r.Vars.Dot("red").Cty(cp.IndexInt(6).IndexString("gg").Index(cty.True)), r.Vars.Dot("red").Cty(cp.IndexInt(6))},
 		{internalPath, nil},
 		{internalPath.Dot("gold"), internalPath},
 	}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -49,19 +49,20 @@ func validateGlobalLabels(vars Dict) error {
 		errs.At(p, errors.New("vars.labels cannot have more than 64 labels"))
 	}
 	for k, v := range labels.AsValueMap() {
-		// TODO: Use cty.Path to point to the specific label that is invalid
+		vp := p.Cty(cty.Path{}.IndexString(k))
 		if v.Type() != cty.String {
-			errs.At(p, errors.New("vars.labels must be a map of strings"))
+			errs.At(vp, errors.New("vars.labels must be a map of strings"))
+			continue
 		}
 		s := v.AsString()
 
 		// Check that label names are valid
 		if !isValidLabelName(k) {
-			errs.At(p, errors.Errorf("%s: '%s: %s'", errorMessages["labelNameReqs"], k, s))
+			errs.At(vp, errors.Errorf("%s: '%s: %s'", errorMessages["labelNameReqs"], k, s))
 		}
 		// Check that label values are valid
 		if !isValidLabelValue(s) {
-			errs.At(p, errors.Errorf("%s: '%s: %s'", errorMessages["labelValueReqs"], k, s))
+			errs.At(vp, errors.Errorf("%s: '%s: %s'", errorMessages["labelValueReqs"], k, s))
 		}
 	}
 	return errs.OrNil()


### PR DESCRIPTION
* Add Path specialization that can be extended with cty.Path;
* Point label validation to offending value;
* Fix panic if label is not a string.

```yaml
...
vars:
  labels:
    good: "clint"
    bad: [1, 2, 3]
    ugly: true
```

```sh
# Before
Error: vars.labels must be a map of strings
24:   labels:

# After
Error: vars.labels must be a map of strings
26:     bad: [1, 2, 3]
        ^
Error: vars.labels must be a map of strings
27:     ugly: true
        ^
```