### PR TITLE
Slurm6. Add basic example and integration test

### DIFF
--- a/community/examples/hpc-slurm6.yaml
+++ b/community/examples/hpc-slurm6.yaml
@@ -1,0 +1,82 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: hpc-slurm6
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: slurm-gcp-v6
+  region: us-west4
+  zone: us-west4-c
+  instance_image:
+    family: slurm-gcp-6-1-hpc-rocky-linux-8
+    project: schedmd-slurm-public
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  - id: debug_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      name: ns1
+      node_count_dynamic_max: 4
+      machine_type: n2-standard-2
+      enable_placement: false  # the default is: true
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use:
+    - debug_nodeset
+    settings:
+      partition_name: debug
+      exclusive: false  # allows nodes to stay up after jobs are done
+      is_default: true
+
+  - id: compute_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      name: ns2
+      node_count_dynamic_max: 20
+
+  - id: compute_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use:
+    - compute_nodeset
+    settings:
+      partition_name: compute
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      group_name: login
+      machine_type: n2-standard-4
+      disable_login_public_ips: false
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - network
+    - debug_partition
+    - compute_partition
+    - slurm_login
+    settings:
+      disable_controller_public_ips: false

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -1,0 +1,55 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags: [slurm6, rocky8]
+timeout: 14400s  # 4hr
+steps:
+## Test simple golang build
+- id: build_ghpc
+  waitFor: ["-"]
+  name: "golang:bullseye"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    cd /workspace
+    make
+- id: fetch_builder
+  waitFor: ["-"]
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - echo "done fetching builder"
+
+## Test Slurm v6 rocky8 Example
+- id: slurm-gcp-v6-rocky8
+  waitFor: ["fetch_builder", "build_ghpc"]
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
@@ -1,0 +1,40 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+test_name: hpc-slurm6-rocky8
+deployment_name: "rock-8-{{ build }}"
+# Manually adding the slurm_cluster_name for use in node names, which filters
+# non-alphanumeric chars and is capped at 10 chars.
+slurm_cluster_name: "rock8{{ build[0:5] }}"
+
+cli_deployment_vars:
+   region: us-west4
+   zone: us-west4-c
+
+zone: us-west4-c
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm6.yaml"
+network: "{{ deployment_name }}-net"
+max_nodes: 5
+# Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
+login_node: "{{ slurm_cluster_name }}-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+post_deploy_tests:
+- test-partitions.yml
+custom_vars:
+   partitions:
+   - compute
+   - debug


### PR DESCRIPTION
* Add Slurm6 example to community;
* Add integration test for this example.

**NOTE**: `network_storage` on partition nodes are flaky, do not include it into example/test. Add after fixed.