### PR TITLE
Improve pre existing vpc failure mechanism

### DIFF
--- a/modules/network/pre-existing-vpc/main.tf
+++ b/modules/network/pre-existing-vpc/main.tf
@@ -18,10 +18,28 @@
 data "google_compute_network" "vpc" {
   name    = var.network_name
   project = var.project_id
+
+  lifecycle {
+    postcondition {
+      condition     = self.self_link != null
+      error_message = "The network: ${var.network_name} could not be found in project: ${var.project_id}."
+    }
+  }
+}
+
+locals {
+  subnetwork_name = var.subnetwork_name != null ? var.subnetwork_name : var.network_name
 }
 
 data "google_compute_subnetwork" "primary_subnetwork" {
-  name    = var.subnetwork_name != null ? var.subnetwork_name : var.network_name
+  name    = local.subnetwork_name
   region  = var.region
   project = var.project_id
+
+  lifecycle {
+    postcondition {
+      condition     = self.self_link != null
+      error_message = "The subnetwork: ${local.subnetwork_name} could not be found in project: ${var.project_id} and region: ${var.region}."
+    }
+  }
 }


### PR DESCRIPTION
Changes pre-existing-vpc to check whether a network can be found using post-conditions. 

Prior to this PR, failure to find a valid network/subnetwork would present an error like this:

```
Error: terraform plan for deployment group small-hpc/primary failed; suggest running "ghpc export-outputs" on previous deployment groups to define inputs
exit status 1

Error: must provide either `self_link` or `name`

  with module.debug_partition.module.slurm_partition.data.google_compute_subnetwork.partition_subnetwork,
  on .terraform/modules/debug_partition.slurm_partition/terraform/slurm_cluster/modules/slurm_partition/main.tf line 100, in data "google_compute_subnetwork" "partition_subnetwork":
 100: data "google_compute_subnetwork" "partition_subnetwork" {


Error: Invalid function argument

  on .terraform/modules/slurm_login.slurm_login_instance/terraform/slurm_cluster/modules/slurm_login_instance/main.tf line 23, in locals:
  23:     length(regexall("/regions/([^/]*)", var.subnetwork)) > 0
    ├────────────────
    │ while calling regexall(pattern, string)
    │ var.subnetwork is null

Invalid value for "string" parameter: argument must not be null.
```

With the addition of the post-conditions, the error message looks like this when the network/subnetwork cannot be found.

```
Error: terraform plan for deployment group small-hpc/primary failed; suggest running "ghpc export-outputs" on previous deployment groups to define inputs
exit status 1

Error: Resource postcondition failed

  on modules/embedded/modules/network/pre-existing-vpc/main.tf line 24, in data "google_compute_network" "vpc":
  24:       condition     = self.self_link != null
    ├────────────────
    │ self.self_link is null

The network, bad-network, with the project ID dev-pool-prj3 could not be found.

Error: Resource postcondition failed

  on modules/embedded/modules/network/pre-existing-vpc/main.tf line 41, in data "google_compute_subnetwork" "primary_subnetwork":
  41:       condition     = self.self_link != null 
    ├────────────────
    │ self.self_link is null

The subnetwork, bad-subnetwork, could not be found.
```

TESTED:

The following cases were tested.
     - Blueprints with valid networks and subnetworks
     - Blueprints with valid a network and an invalid subnetwork
     - Blueprints with an invalid network and invalid subnetwork




