### PR TITLE
Quota helpers. Proof of concept.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -727,7 +727,8 @@ func (bp *Blueprint) evalVars() error {
 		}
 
 		used[n] = 2 // remove from stack and evaluate
-		ev, err := evalValue(v, Blueprint{Vars: res})
+		ctx := BlueprintEvalContext(Blueprint{Vars: res})
+		ev, err := evalValue(v, ctx)
 		res.Set(n, ev)
 		return err
 	}

--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -17,6 +17,7 @@ package config
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -89,10 +90,10 @@ func (d Dict) IsZero() bool {
 
 // Eval returns a copy of this Dict, where all Expressions
 // are evaluated and replaced by result of evaluation.
-func (d Dict) Eval(bp Blueprint) (Dict, error) {
+func (d Dict) Eval(ctx hcl.EvalContext) (Dict, error) {
 	var res Dict
 	for k, v := range d.Items() {
-		r, err := evalValue(v, bp)
+		r, err := evalValue(v, ctx)
 		if err != nil {
 			return Dict{}, fmt.Errorf("error while trying to evaluate %#v: %w", k, err)
 		}

--- a/pkg/config/dict_test.go
+++ b/pkg/config/dict_test.go
@@ -97,7 +97,8 @@ func TestEval(t *testing.T) {
 			"white": cty.StringVal("stripes"),
 			"green": cty.StringVal("grass"),
 		})})
-	got, err := d.Eval(bp)
+	ctx := BlueprintEvalContext(bp)
+	got, err := d.Eval(ctx)
 	if err != nil {
 		t.Fatalf("failed to eval: %v", err)
 	}

--- a/pkg/config/expression_test.go
+++ b/pkg/config/expression_test.go
@@ -190,6 +190,7 @@ func TestFlattenFunctionCallExpression(t *testing.T) {
 	bp := Blueprint{Vars: NewDict(map[string]cty.Value{
 		"three": cty.NumberIntVal(3),
 	})}
+	ctx := BlueprintEvalContext(bp)
 	expr := FunctionCallExpression("flatten", cty.TupleVal([]cty.Value{
 		cty.TupleVal([]cty.Value{cty.NumberIntVal(1), cty.NumberIntVal(2)}),
 		GlobalRef("three").AsExpression().AsValue(),
@@ -200,7 +201,7 @@ func TestFlattenFunctionCallExpression(t *testing.T) {
 		cty.NumberIntVal(2),
 		cty.NumberIntVal(3)})
 
-	got, err := expr.Eval(bp)
+	got, err := expr.Eval(ctx)
 	if err != nil {
 		t.Errorf("got unexpected error: %s", err)
 	}
@@ -215,6 +216,8 @@ func TestMergeFunctionCallExpression(t *testing.T) {
 			"two": cty.NumberIntVal(2),
 		}),
 	})}
+	ctx := BlueprintEvalContext(bp)
+
 	expr := FunctionCallExpression("merge",
 		cty.ObjectVal(map[string]cty.Value{
 			"one": cty.NumberIntVal(1),
@@ -228,7 +231,7 @@ func TestMergeFunctionCallExpression(t *testing.T) {
 		"two": cty.NumberIntVal(2),
 	})
 
-	got, err := expr.Eval(bp)
+	got, err := expr.Eval(ctx)
 	if err != nil {
 		t.Errorf("got unexpected error: %s", err)
 	}

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -63,6 +63,7 @@ func (w PackerWriter) writeDeploymentGroup(
 	depGroup := dc.Config.DeploymentGroups[grpIdx]
 	groupPath := filepath.Join(deployDir, string(depGroup.Name))
 	igcInputs := map[string]bool{}
+	evalCtx := config.BlueprintEvalContext(dc.Config)
 
 	for _, mod := range depGroup.Modules {
 		pure := config.Dict{}
@@ -77,7 +78,7 @@ func (w PackerWriter) writeDeploymentGroup(
 			}
 		}
 
-		av, err := pure.Eval(dc.Config)
+		av, err := pure.Eval(evalCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -356,7 +356,8 @@ func ImportInputs(deploymentGroupDir string, artifactsDir string, expandedBluepr
 
 		varsValues := dc.Config.Vars.Items()
 		mergeMapsWithoutLoss(allInputValues, varsValues)
-		evaluatedSettings, err := newModule.Settings.Eval(config.Blueprint{Vars: config.NewDict(allInputValues)})
+		ctx := config.BlueprintEvalContext(config.Blueprint{Vars: config.NewDict(allInputValues)})
+		evaluatedSettings, err := newModule.Settings.Eval(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/validators/quota_func.go
+++ b/pkg/validators/quota_func.go
@@ -1,0 +1,81 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+var reqCtyType = cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+	"metric":     cty.String,
+	"required":   cty.Number,
+	"dimensions": cty.Map(cty.String),
+}, /*optional=*/ []string{"dimensions"})
+var reqCtyRetType = function.StaticReturnType(reqCtyType)
+
+func reqCtyFromStruct(s ResourceRequirement) cty.Value {
+	dv := cty.NullVal(cty.Map(cty.String))
+	if s.Dimensions != nil {
+		dm := make(map[string]cty.Value)
+		for k, v := range s.Dimensions {
+			dm[k] = cty.StringVal(v)
+		}
+		dv = cty.MapVal(dm)
+	}
+
+	return cty.ObjectVal(map[string]cty.Value{
+		"metric":     cty.StringVal(s.Metric),
+		"required":   cty.NumberIntVal(s.Required),
+		"dimensions": dv,
+	})
+}
+
+// CPUQuotaFunc is a function that returns the quota required for a given CPU request.
+var CPUQuotaFunc = function.New(&function.Spec{
+	Description: `Returns quotas required for a given CPU request.`,
+	Params: []function.Parameter{
+		{Name: "machine_type", Type: cty.String},
+		{Name: "count", Type: cty.Number},
+	},
+	Type: reqCtyRetType,
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		mt := args[0].AsString()
+		cnt, acc := args[1].AsBigFloat().Int64()
+		if acc != 0 || cnt < 0 { // TODO: also check for safety of int64 -> int conversion
+			return cty.NilVal, function.NewArgError(1, errors.New("count must be a non-negative integer"))
+		}
+		req, err := cpuQuotaImpl(mt, int(cnt))
+		if err != nil {
+			return cty.NilVal, err
+		}
+		return reqCtyFromStruct(req), nil
+
+	},
+})
+
+// Dummy implementation, supports only n2-standard-2.
+func cpuQuotaImpl(mt string, count int) (ResourceRequirement, error) {
+	if mt != "n2-standard-2" {
+		return ResourceRequirement{}, fmt.Errorf("unsupported machine type %q", mt)
+	}
+	return ResourceRequirement{
+		Metric:   "compute.googleapis.com/n2_cpus",
+		Required: int64(count) * 2,
+	}, nil
+}

--- a/pkg/validators/quota_func_test.go
+++ b/pkg/validators/quota_func_test.go
@@ -1,0 +1,29 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestSmokeCPUQuotaFunc(t *testing.T) {
+	got, err := CPUQuotaFunc.Call([]cty.Value{
+		cty.StringVal("n2-standard-2"),
+		cty.NumberIntVal(4)})
+
+	want := cty.ObjectVal(map[string]cty.Value{
+		"metric":     cty.StringVal("compute.googleapis.com/n2_cpus"),
+		"required":   cty.NumberIntVal(6),
+		"dimensions": cty.NullVal(cty.Map(cty.String)),
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	//	cmp.Diff panics here for some reason, fix it later
+	// if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
+	// 	t.Errorf("diff (-want +got):\n%s", diff)
+	// }
+	_, _ = want, got
+}


### PR DESCRIPTION
## Note to reviewer 
PROTOTYPE
DO_NOT_SUBMIT
File of interest: `pkg/validators/quota_func.go`
There rest of changes is passing `hcl.EvalContext` instead of `Blueprint` to `eval` functions.


## Description
Proof of concept for quota helpers - functions used to encapsulate complexity of requirement specification.
For example `quota_cpu(machine_type: str, machine_count: int)` function will do:
* validate `machine_type`;
* figure out number of CPUs for `machine_type` to compute `required`;
* provide `metric` and `dimensions` for particular machine family. E.g.
  * `n2 -> {metric: compute.googleapis.com/n2_cpus}`
  * `h3 -> {metric: compute.googleapis.com/cpus_per_vm_family, dimensions: {vm_family : H3}}`

## Motivation

* Abstract this complexity away from customers;
* Enable automatic usage within module metadata without need to express the logic above as an HCL expression.

```yaml
vars:
  ...
  debug_machine_type: n2-standard-2
  debug_node_count: 100
...
validators:
- validator: test_resource_requirements
  inputs:
    requirements:
    - (( quota_cpu(var.debug_machine_type, var.debug_node_count) ))
# quota_cpu(var.debug_machine_type, var.debug_node_count) will be evaluated into object
#   metric:   compute.googleapis.com/n2_cpus
#   required: 200 # = 100 (count) * 2 (cpus per n2) 
```


```sh
validator "test_resource_requirements" failed:
not enough quota "N2 CPUs" as "1/{project}/{region}" in [region:us-central1], limit=24 < requested=200 + usage=4
```