### PR TITLE
Applied recommended changes to gcsfuse and nfs scripts to fix apt-get update

### DIFF
--- a/community/modules/file-system/cloud-storage-bucket/scripts/install-gcs-fuse.sh
+++ b/community/modules/file-system/cloud-storage-bucket/scripts/install-gcs-fuse.sh
@@ -35,8 +35,8 @@ EOF
 		echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
 		curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
-		sudo apt-get update
-		sudo apt-get -y install gcsfuse
+		apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
+		apt-get -y install gcsfuse
 	else
 		echo 'Unsuported distribution'
 		return 1

--- a/community/modules/file-system/nfs-server/scripts/install-nfs-client.sh
+++ b/community/modules/file-system/nfs-server/scripts/install-nfs-client.sh
@@ -28,7 +28,7 @@ if [ ! "$(which mount.nfs)" ]; then
 		fi
 		yum install --disablerepo="*" --enablerepo=${enable_repo} -y nfs-utils
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
-		apt-get -y update
+		apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
 		apt-get -y install nfs-common
 	else
 		echo 'Unsuported distribution'

--- a/modules/file-system/filestore/scripts/install-nfs-client.sh
+++ b/modules/file-system/filestore/scripts/install-nfs-client.sh
@@ -28,7 +28,7 @@ if [ ! "$(which mount.nfs)" ]; then
 		fi
 		yum install --disablerepo="*" --enablerepo=${enable_repo} -y nfs-utils
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
-		apt-get -y update
+		apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
 		apt-get -y install nfs-common
 	else
 		echo 'Unsuported distribution'

--- a/modules/file-system/pre-existing-network-storage/scripts/install-gcs-fuse.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-gcs-fuse.sh
@@ -35,8 +35,8 @@ EOF
 		echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
 		curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
-		sudo apt-get update
-		sudo apt-get -y install gcsfuse
+		apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
+		apt-get -y install gcsfuse
 	else
 		echo 'Unsuported distribution'
 		return 1

--- a/modules/file-system/pre-existing-network-storage/scripts/install-nfs-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-nfs-client.sh
@@ -28,7 +28,7 @@ if [ ! "$(which mount.nfs)" ]; then
 		fi
 		yum install --disablerepo="*" --enablerepo=${enable_repo} -y nfs-utils
 	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
-		apt-get -y update
+		apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
 		apt-get -y install nfs-common
 	else
 		echo 'Unsuported distribution'


### PR DESCRIPTION
This should fix the issue where Debian/Ubuntu images with packages.cloud.google.com repos cached will fail to run apt-get update