### PR TITLE
Re-raise error in rescue block of slurm integration test

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -168,7 +168,6 @@
     - name: Trigger failure (rescue blocks otherwise revert failures)
       ansible.builtin.fail:
         msg: "Failed while setting up test infrastructure"
-      when: true
 
 - name: Run Integration Tests
   hosts: remote_host
@@ -219,6 +218,10 @@
       vars:
         deployment_name: "{{ deployment_name }}"
         project: "{{ project }}"
+
+    - name: Trigger failure (rescue blocks otherwise revert failures)
+      ansible.builtin.fail:
+        msg: "Failed during the integration tests (see above)"
 
     ## Always cleanup, even on failure
     always:


### PR DESCRIPTION
Noticed during today's daily tests that if an integration test fails (specifically things like `test-mounts.yml`), the rescue block of the `slurm-integration-test.yml` blocks the error from propagating to cloud build so we don't notice it. 

This PR creates an error and propagates it upward similar to how it is done during the rescue block of the setup portion of the integration test.