### PR TITLE
Do not set role-label in expand, rely on module embedded labels

### DIFF
--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "custom-image", ghpc_role = "packer" })
+
   # construct a unique image name from the image family
   image_family       = var.image_family != null ? var.image_family : var.deployment_name
   image_name_default = "${local.image_family}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
@@ -93,7 +96,7 @@ source "googlecompute" "toolkit_image" {
   project_id                  = var.project_id
   image_name                  = local.image_name
   image_family                = local.image_family
-  image_labels                = var.labels
+  image_labels                = local.labels
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
   accelerator_count           = var.accelerator_count
@@ -116,7 +119,7 @@ source "googlecompute" "toolkit_image" {
   winrm_insecure              = local.winrm_insecure
   winrm_use_ssl               = local.winrm_use_ssl
   zone                        = var.zone
-  labels                      = var.labels
+  labels                      = local.labels
   metadata                    = local.metadata
   startup_script_file         = var.startup_script_file
   wrap_startup_script         = var.wrap_startup_script

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -268,8 +268,7 @@ func (s *MySuite) TestCombineLabels(c *C) {
 		ID:     "coral",
 		Settings: NewDict(map[string]cty.Value{
 			"labels": cty.ObjectVal(map[string]cty.Value{
-				"magenta":   cty.StringVal("orchid"),
-				"ghpc_role": cty.StringVal("maroon"),
+				"magenta": cty.StringVal("orchid"),
 			}),
 		}),
 	}
@@ -305,25 +304,18 @@ func (s *MySuite) TestCombineLabels(c *C) {
 	labelsRef := GlobalRef("labels").AsExpression().AsValue()
 
 	lime := dc.Config.DeploymentGroups[0]
-	// Labels are set and override role
+	// Labels are set
 	coral = lime.Modules[0]
 	c.Check(coral.Settings.Get("labels"), DeepEquals, FunctionCallExpression(
 		"merge",
 		labelsRef,
-		cty.ObjectVal(map[string]cty.Value{
-			"ghpc_role": cty.StringVal("blue")}),
-		cty.ObjectVal(map[string]cty.Value{
-			"ghpc_role": cty.StringVal("maroon"),
-			"magenta":   cty.StringVal("orchid")}),
+		cty.ObjectVal(map[string]cty.Value{"magenta": cty.StringVal("orchid")}),
 	).AsValue())
 
-	// Labels are not set, infer role from module.source
+	// Labels are not set
 	khaki = lime.Modules[1]
-	c.Check(khaki.Settings.Get("labels"), DeepEquals, FunctionCallExpression(
-		"merge",
-		labelsRef,
-		cty.ObjectVal(map[string]cty.Value{"ghpc_role": cty.StringVal("brown")}),
-	).AsValue())
+	c.Check(khaki.Settings.Get("labels"), DeepEquals, labelsRef)
+
 	// No labels input
 	silver = lime.Modules[2]
 	c.Check(silver.Settings.Get("labels"), DeepEquals, cty.NilVal)

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -56,10 +56,7 @@ deployment_groups:
           - network0
         settings:
           deployment_name: ((var.deployment_name ))
-          labels: |-
-            ((merge(var.labels, {
-              ghpc_role = "file-system"
-            }) ))
+          labels: ((var.labels ))
           local_mount: /home
           network_id: ((module.network0.network_id ))
           project_id: ((var.project_id ))
@@ -72,10 +69,7 @@ deployment_groups:
           - network0
         settings:
           deployment_name: ((var.deployment_name ))
-          labels: |-
-            ((merge(var.labels, {
-              ghpc_role = "file-system"
-            }) ))
+          labels: ((var.labels ))
           local_mount: /projects
           network_id: ((module.network0.network_id ))
           project_id: ((var.project_id ))
@@ -90,10 +84,7 @@ deployment_groups:
             sensitive: true
         settings:
           deployment_name: ((var.deployment_name ))
-          labels: |-
-            ((merge(var.labels, {
-              ghpc_role = "scripts"
-            }) ))
+          labels: ((var.labels ))
           project_id: ((var.project_id ))
           region: ((var.region ))
           runners:
@@ -122,10 +113,7 @@ deployment_groups:
           - windows_startup
         settings:
           deployment_name: ((var.deployment_name ))
-          labels: |-
-            ((merge(var.labels, {
-              ghpc_role = "packer"
-            })))
+          labels: ((var.labels ))
           project_id: ((var.project_id ))
           startup_script: ((module.script.startup_script))
           subnetwork_name: ((module.network0.subnetwork_name))

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/defaults.auto.pkrvars.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/defaults.auto.pkrvars.hcl
@@ -19,7 +19,6 @@ deployment_name = "golden_copy_deployment"
 labels = {
   ghpc_blueprint  = "igc"
   ghpc_deployment = "golden_copy_deployment"
-  ghpc_role       = "packer"
 }
 
 project_id = "invalid-project"

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "custom-image", ghpc_role = "packer" })
+
   # construct a unique image name from the image family
   image_family       = var.image_family != null ? var.image_family : var.deployment_name
   image_name_default = "${local.image_family}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
@@ -93,7 +96,7 @@ source "googlecompute" "toolkit_image" {
   project_id                  = var.project_id
   image_name                  = local.image_name
   image_family                = local.image_family
-  image_labels                = var.labels
+  image_labels                = local.labels
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
   accelerator_count           = var.accelerator_count
@@ -116,7 +119,7 @@ source "googlecompute" "toolkit_image" {
   winrm_insecure              = local.winrm_insecure
   winrm_use_ssl               = local.winrm_use_ssl
   zone                        = var.zone
-  labels                      = var.labels
+  labels                      = local.labels
   metadata                    = local.metadata
   startup_script_file         = var.startup_script_file
   wrap_startup_script         = var.wrap_startup_script

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/main.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/main.tf
@@ -26,37 +26,31 @@ module "network0" {
 module "homefs" {
   source          = "./modules/embedded/modules/file-system/filestore"
   deployment_name = var.deployment_name
-  labels = merge(var.labels, {
-    ghpc_role = "file-system"
-  })
-  local_mount = "/home"
-  network_id  = module.network0.network_id
-  project_id  = var.project_id
-  region      = var.region
-  zone        = var.zone
+  labels          = var.labels
+  local_mount     = "/home"
+  network_id      = module.network0.network_id
+  project_id      = var.project_id
+  region          = var.region
+  zone            = var.zone
 }
 
 module "projectsfs" {
   source          = "./modules/embedded/modules/file-system/filestore"
   deployment_name = var.deployment_name
-  labels = merge(var.labels, {
-    ghpc_role = "file-system"
-  })
-  local_mount = "/projects"
-  network_id  = module.network0.network_id
-  project_id  = var.project_id
-  region      = var.region
-  zone        = var.zone
+  labels          = var.labels
+  local_mount     = "/projects"
+  network_id      = module.network0.network_id
+  project_id      = var.project_id
+  region          = var.region
+  zone            = var.zone
 }
 
 module "script" {
   source          = "./modules/embedded/modules/scripts/startup-script"
   deployment_name = var.deployment_name
-  labels = merge(var.labels, {
-    ghpc_role = "scripts"
-  })
-  project_id = var.project_id
-  region     = var.region
+  labels          = var.labels
+  project_id      = var.project_id
+  region          = var.region
   runners = [{
     content     = "#!/bin/bash\necho \"Hello, World!\"\n"
     destination = "hello.sh"

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
@@ -58,10 +58,7 @@ deployment_groups:
           - network0
         settings:
           deployment_name: ((var.deployment_name ))
-          labels: |-
-            ((merge(var.labels, {
-              ghpc_role = "file-system"
-            }) ))
+          labels: ((var.labels ))
           local_mount: /home
           name: ((module.network0.subnetwork_name))
           network_id: ((module.network0.network_id))

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/one/main.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/one/main.tf
@@ -17,13 +17,11 @@
 module "homefs" {
   source          = "./modules/embedded/modules/file-system/filestore"
   deployment_name = var.deployment_name
-  labels = merge(var.labels, {
-    ghpc_role = "file-system"
-  })
-  local_mount = "/home"
-  name        = var.subnetwork_name_network0
-  network_id  = var.network_id_network0
-  project_id  = var.project_id
-  region      = var.region
-  zone        = var.zone
+  labels          = var.labels
+  local_mount     = "/home"
+  name            = var.subnetwork_name_network0
+  network_id      = var.network_id_network0
+  project_id      = var.project_id
+  region          = var.region
+  zone            = var.zone
 }

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
@@ -50,10 +50,7 @@ deployment_groups:
           - network
         settings:
           deployment_name: ((var.deployment_name ))
-          labels: |-
-            ((merge(var.labels, {
-              ghpc_role = "file-system"
-            }) ))
+          labels: ((var.labels ))
           local_mount: /first
           network_id: ((module.network.network_id ))
           project_id: ((var.project_id ))
@@ -66,10 +63,7 @@ deployment_groups:
           - network
         settings:
           deployment_name: ((var.deployment_name ))
-          labels: |-
-            ((merge(var.labels, {
-              ghpc_role = "file-system"
-            }) ))
+          labels: ((var.labels ))
           local_mount: /first
           network_id: ((module.network.network_id ))
           project_id: ((var.project_id ))
@@ -84,8 +78,6 @@ deployment_groups:
           deployment_name: ((var.deployment_name ))
           labels: |-
             ((merge(var.labels, {
-              ghpc_role = "compute"
-              }, {
               green = "sleeves"
             }) ))
           network_storage: ((flatten([module.first-fs.network_storage]) ))
@@ -100,10 +92,7 @@ deployment_groups:
           - second-fs
         settings:
           deployment_name: ((var.deployment_name ))
-          labels: |-
-            ((merge(var.labels, {
-              ghpc_role = "compute"
-            }) ))
+          labels: ((var.labels ))
           network_storage: ((flatten([module.second-fs.network_storage, flatten([module.first-fs.network_storage])]) ))
           project_id: ((var.project_id ))
           region: ((var.region ))

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/main.tf
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/main.tf
@@ -24,35 +24,29 @@ module "network" {
 module "first-fs" {
   source          = "./modules/embedded/modules/file-system/filestore"
   deployment_name = var.deployment_name
-  labels = merge(var.labels, {
-    ghpc_role = "file-system"
-  })
-  local_mount = "/first"
-  network_id  = module.network.network_id
-  project_id  = var.project_id
-  region      = var.region
-  zone        = var.zone
+  labels          = var.labels
+  local_mount     = "/first"
+  network_id      = module.network.network_id
+  project_id      = var.project_id
+  region          = var.region
+  zone            = var.zone
 }
 
 module "second-fs" {
   source          = "./modules/embedded/modules/file-system/filestore"
   deployment_name = var.deployment_name
-  labels = merge(var.labels, {
-    ghpc_role = "file-system"
-  })
-  local_mount = "/first"
-  network_id  = module.network.network_id
-  project_id  = var.project_id
-  region      = var.region
-  zone        = var.zone
+  labels          = var.labels
+  local_mount     = "/first"
+  network_id      = module.network.network_id
+  project_id      = var.project_id
+  region          = var.region
+  zone            = var.zone
 }
 
 module "first-vm" {
   source          = "./modules/embedded/modules/compute/vm-instance"
   deployment_name = var.deployment_name
   labels = merge(var.labels, {
-    ghpc_role = "compute"
-    }, {
     green = "sleeves"
   })
   network_storage = flatten([module.first-fs.network_storage])
@@ -64,9 +58,7 @@ module "first-vm" {
 module "second-vm" {
   source          = "./modules/embedded/modules/compute/vm-instance"
   deployment_name = var.deployment_name
-  labels = merge(var.labels, {
-    ghpc_role = "compute"
-  })
+  labels          = var.labels
   network_storage = flatten([module.second-fs.network_storage, flatten([module.first-fs.network_storage])])
   project_id      = var.project_id
   region          = var.region

--- a/tools/validate_configs/golden_copies/expectations/text_escape/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/.ghpc/artifacts/expanded_blueprint.yaml
@@ -45,8 +45,6 @@ deployment_groups:
           image_name: \((cat /dog))
           labels: |-
             ((merge(var.labels, {
-              ghpc_role = "packer"
-              }, {
               brown = "$(fox)"
             })))
           project_id: ((var.project_id))

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/defaults.auto.pkrvars.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/defaults.auto.pkrvars.hcl
@@ -24,7 +24,6 @@ labels = {
   brown           = "$(fox)"
   ghpc_blueprint  = "text_escape"
   ghpc_deployment = "golden_copy_deployment"
-  ghpc_role       = "packer"
   ñred            = "ñblue"
 }
 

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "custom-image", ghpc_role = "packer" })
+
   # construct a unique image name from the image family
   image_family       = var.image_family != null ? var.image_family : var.deployment_name
   image_name_default = "${local.image_family}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
@@ -93,7 +96,7 @@ source "googlecompute" "toolkit_image" {
   project_id                  = var.project_id
   image_name                  = local.image_name
   image_family                = local.image_family
-  image_labels                = var.labels
+  image_labels                = local.labels
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
   accelerator_count           = var.accelerator_count
@@ -116,7 +119,7 @@ source "googlecompute" "toolkit_image" {
   winrm_insecure              = local.winrm_insecure
   winrm_use_ssl               = local.winrm_use_ssl
   zone                        = var.zone
-  labels                      = var.labels
+  labels                      = local.labels
   metadata                    = local.metadata
   startup_script_file         = var.startup_script_file
   wrap_startup_script         = var.wrap_startup_script


### PR DESCRIPTION
**Release note:**

---

`ghpc` will no longer populate `ghpc_role` label based on module source path for third-party modules. Please take care of setting it yourself if you rely on this label.

---

* Do not set role-label in expand, rely on module embedded labels;
* Add ghpc labels to packer module.
