### PR TITLE
Update stockout check to account for logging delay

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -209,15 +209,6 @@
       loop_control:
         loop_var: test
 
-    rescue:
-    - name: Set stockout check variable
-      ansible.builtin.set_fact:
-        stockout_test: true
-
-    - name: Trigger failure (rescue blocks otherwise revert failures)
-      ansible.builtin.fail:
-        msg: "Failed during the integration tests (see above)"
-
     ## Always cleanup, even on failure
     always:
     - name: Ensure all nodes are powered down
@@ -292,4 +283,3 @@
       vars:
         deployment_name: "{{ deployment_name }}"
         project: "{{ project }}"
-      when: stockout_test is defined

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -210,14 +210,9 @@
         loop_var: test
 
     rescue:
-    - name: Check for stockout errors
-      ansible.builtin.include_tasks:
-        file: tasks/check_stockout.yml
-        apply:
-          delegate_to: localhost
-      vars:
-        deployment_name: "{{ deployment_name }}"
-        project: "{{ project }}"
+    - name: Set stockout check variable
+      ansible.builtin.set_fact:
+        stockout_test: true
 
     - name: Trigger failure (rescue blocks otherwise revert failures)
       ansible.builtin.fail:
@@ -288,3 +283,13 @@
       vars:
         deployment_name: "{{ deployment_name }}"
         workspace: "{{ workspace }}"
+
+    - name: Check for stockout errors
+      ansible.builtin.include_tasks:
+        file: tasks/check_stockout.yml
+        apply:
+          delegate_to: localhost
+      vars:
+        deployment_name: "{{ deployment_name }}"
+        project: "{{ project }}"
+      when: stockout_test is defined

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
@@ -22,9 +22,10 @@
 - name: Check logs for stockout on compute nodes
   changed_when: false
   register: stockout
-  until: stockout.rc == 0
+  until: stockout.stdout != ""
   retries: 5
   delay: 10
+  failed_when: false
   ansible.builtin.command: >-
     gcloud logging --project {{ project }} read
     'protoPayload.response.error.errors.message="{{ item }}" AND protoPayload.request.instanceProperties.labels.value="{{ deployment_name }}"'
@@ -43,4 +44,4 @@
   when: item.stdout != ""
   with_items: "{{ stockout.results }}"
   loop_control:
-    label: "{{ item.item }}"
+    label: "{{ item.cmd }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
@@ -23,8 +23,8 @@
   changed_when: false
   register: stockout
   until: stockout.stdout != ""
-  retries: 5
-  delay: 10
+  retries: 2
+  delay: 5
   failed_when: false
   ansible.builtin.command: >-
     gcloud logging --project {{ project }} read

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/check_stockout.yml
@@ -22,9 +22,6 @@
 - name: Check logs for stockout on compute nodes
   changed_when: false
   register: stockout
-  until: stockout.stdout != ""
-  retries: 2
-  delay: 5
   failed_when: false
   ansible.builtin.command: >-
     gcloud logging --project {{ project }} read


### PR DESCRIPTION
There's a slight delay with logging that means that we won't necessarily see stockout messages immediately after an integration test fails.  To account for this, I've adjusted the stockout check to wait until we get some content back in stdout from the logging command.  This also required a `failed_when: false` as we're just checking for logs, nothing is actually failing if we don't find any stockout issues.

I've also updated the label to be the generated command, so we can debug if any issues come up with the stockout check, in the future.
