### PR TITLE
Test for tty before echo in /etc/profile.d scripts

### DIFF
--- a/community/modules/scripts/ramble-setup/main.tf
+++ b/community/modules/scripts/ramble-setup/main.tf
@@ -22,7 +22,7 @@ locals {
 locals {
   profile_script = <<-EOF
     if [ -f ${var.install_dir}/share/ramble/setup-env.sh ]; then
-          echo "** Ramble's python virtualenv (/usr/local/ramble-python) is actiavted. Call 'deactivate' to deactivate."
+          test -t 1 && echo "** Ramble's python virtualenv (/usr/local/ramble-python) is activated. Call 'deactivate' to deactivate."
           . /usr/local/ramble-python/bin/activate
           . ${var.install_dir}/share/ramble/setup-env.sh
     fi

--- a/community/modules/scripts/spack-setup/main.tf
+++ b/community/modules/scripts/spack-setup/main.tf
@@ -23,7 +23,7 @@ locals {
   profile_script = <<-EOF
     SPACK_PYTHON=${var.spack_virtualenv_path}/bin/python3
     if [ -f ${var.install_dir}/share/spack/setup-env.sh ]; then
-          echo "Running Spack setup, this may take a moment on first login."
+          test -t 1 && echo "Running Spack setup, this may take a moment on first login."
           . ${var.install_dir}/share/spack/setup-env.sh
     fi
   EOF


### PR DESCRIPTION
In spack-setup and ramble-setup modules, profile scripts have echo diag output to the terminal. This breaks some ssh and most scp connections.

Therefore, a test is added to ensure that tty output is available.

'test -t 1' is shell-agnostic and tests whether stdout is open.


