### PR TITLE
Add name to triggers for vm-instance because that can be specified now

### DIFF
--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -94,7 +94,8 @@ data "google_compute_image" "compute_image" {
 
 resource "null_resource" "image" {
   triggers = {
-    image   = var.instance_image.family,
+    name    = var.instance_image.name,
+    family  = var.instance_image.family,
     project = var.instance_image.project
   }
 }


### PR DESCRIPTION
Add to vm-instance boot disk lifecycle to check on name changes as well.
