### PR TITLE
Revert "Add name to triggers for vm-instance because that can be specified now"

### DIFF
--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -94,8 +94,7 @@ data "google_compute_image" "compute_image" {
 
 resource "null_resource" "image" {
   triggers = {
-    name    = var.instance_image.name,
-    family  = var.instance_image.family,
+    image   = var.instance_image.family,
     project = var.instance_image.project
   }
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/hpc-toolkit#1923

Breaks develop because if name isn't specified, terraform dies on apply.