### PR TITLE
Hotfix for vm-instance to allow image names to be used correctly

### DIFF
--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -89,13 +89,14 @@ locals {
 data "google_compute_image" "compute_image" {
   family  = try(var.instance_image.family, null)
   name    = try(var.instance_image.name, null)
-  project = var.instance_image.project
+  project = try(var.instance_image.project, null)
 }
 
 resource "null_resource" "image" {
   triggers = {
-    image   = var.instance_image.family,
-    project = var.instance_image.project
+    name    = try(var.instance_image.name, null),
+    family  = try(var.instance_image.family, null),
+    project = try(var.instance_image.project, null)
   }
 }
 

--- a/tools/validate_configs/test_configs/vm.yaml
+++ b/tools/validate_configs/test_configs/vm.yaml
@@ -31,10 +31,10 @@ deployment_groups:
     source: modules/network/pre-existing-vpc
 
   - source: ./modules/compute/vm-instance
-    id: compute_instances
+    id: compute_instances_family
     use: [network1]
     settings:
-      name_prefix: client-vm
+      name_prefix: client-vm-family
       instance_count: 1
       machine_type: n2-standard-2
       instance_image:
@@ -46,3 +46,14 @@ deployment_groups:
         #        --source-image-project=ubuntu-os-cloud --family myubuntu --project <project_id>
         # project: $(vars.project_id)
         # family: myubuntu
+
+  - source: ./modules/compute/vm-instance
+    id: compute_instances_name
+    use: [network1]
+    settings:
+      name_prefix: client-vm-name
+      instance_count: 1
+      machine_type: n2-standard-2
+      instance_image:
+        project: ubuntu-os-cloud
+        name: ubuntu-2004-focal-v20231101


### PR DESCRIPTION
Allows name or family to be used for the trigger, which was breaking the tests.  Exclusivity of the term is validated in variables.tf.  
