### PR TITLE
Slurm6. Deprecate `enable_login`, only consider presence of `login_nodes`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -174,7 +174,6 @@ limitations under the License.
 | <a name="input_enable_confidential_vm"></a> [enable\_confidential\_vm](#input\_enable\_confidential\_vm) | Enable the Confidential VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
 | <a name="input_enable_debug_logging"></a> [enable\_debug\_logging](#input\_enable\_debug\_logging) | Enables debug logging mode. Not for production use. | `bool` | `false` | no |
 | <a name="input_enable_devel"></a> [enable\_devel](#input\_enable\_devel) | Enables development mode. Not for production use. | `bool` | `false` | no |
-| <a name="input_enable_login"></a> [enable\_login](#input\_enable\_login) | Enables the creation of login nodes and instance templates. | `bool` | `true` | no |
 | <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables Google Cloud os-login for user login and authentication for VMs.<br>See https://cloud.google.com/compute/docs/oslogin | `bool` | `true` | no |
 | <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
 | <a name="input_epilog_scripts"></a> [epilog\_scripts](#input\_epilog\_scripts) | List of scripts to be used for Epilog. Programs for the slurmd to execute<br>on every node when a user's job completes.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
@@ -16,10 +16,10 @@
 module "slurm_login_template" {
   source = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=6.2.0"
 
-  for_each = var.enable_login ? {
+  for_each = {
     for x in var.login_nodes : x.group_name => x
     if(x.instance_template == null || x.instance_template == "")
-  } : {}
+  }
 
   project_id          = var.project_id
   slurm_cluster_name  = local.slurm_cluster_name
@@ -61,7 +61,7 @@ module "slurm_login_template" {
 # INSTANCE
 module "slurm_login_instance" {
   source   = "github.com/SchedMD/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_login_instance?ref=6.2.0"
-  for_each = var.enable_login ? { for x in var.login_nodes : x.group_name => x } : {}
+  for_each = { for x in var.login_nodes : x.group_name => x }
 
   project_id         = var.project_id
   slurm_cluster_name = local.slurm_cluster_name

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -91,14 +91,6 @@ variable "bucket_dir" {
 # LOGIN #
 #########
 
-variable "enable_login" {
-  description = <<EOD
-Enables the creation of login nodes and instance templates.
-EOD
-  type        = bool
-  default     = true
-}
-
 variable "login_nodes" {
   description = "List of slurm login instance definitions."
   type = list(object({


### PR DESCRIPTION
**NOTE:** motivation to have it in a first place is not clear.