### PR TITLE
Update slurm examples to turn GVNIC on by default

### DIFF
--- a/community/examples/AMD/hpc-amd-slurm.yaml
+++ b/community/examples/AMD/hpc-amd-slurm.yaml
@@ -173,11 +173,13 @@ deployment_groups:
         # Slurm installation
         family: slurm-gcp-5-9-hpc-centos-7
         project: schedmd-slurm-public
+
   - id: low_cost_node_group
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       machine_type: c2d-standard-4
       node_count_dynamic_max: 10
+      bandwidth_tier: gvnic_enabled
 
   - id: low_cost_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -193,6 +195,7 @@ deployment_groups:
     settings:
       machine_type: c2d-standard-112
       node_count_dynamic_max: 50
+      bandwidth_tier: gvnic_enabled
 
   # because is_default is set to true, jobs will run on this partition unless an
   # alternative partition is specified using, for example, "srun -p lowcost"

--- a/community/examples/hpc-slurm-chromedesktop.yaml
+++ b/community/examples/hpc-slurm-chromedesktop.yaml
@@ -81,6 +81,7 @@ deployment_groups:
     settings:
       machine_type: n2d-standard-16
       node_count_dynamic_max: 20
+      bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition

--- a/community/examples/hpc-slurm-gromacs.yaml
+++ b/community/examples/hpc-slurm-gromacs.yaml
@@ -93,6 +93,7 @@ deployment_groups:
     settings:
       partition_name: compute
       max_node_count: 20
+      bandwidth_tier: gvnic_enabled
 
   - id: slurm_controller
     source: community/modules/scheduler/SchedMD-slurm-on-gcp-controller

--- a/community/examples/hpc-slurm-legacy-sharedvpc.yaml
+++ b/community/examples/hpc-slurm-legacy-sharedvpc.yaml
@@ -77,6 +77,7 @@ deployment_groups:
     settings:
       partition_name: compute
       max_node_count: 20
+      bandwidth_tier: gvnic_enabled
 
   - id: slurm_controller
     source: community/modules/scheduler/SchedMD-slurm-on-gcp-controller

--- a/community/examples/hpc-slurm-legacy.yaml
+++ b/community/examples/hpc-slurm-legacy.yaml
@@ -69,6 +69,7 @@ deployment_groups:
       enable_placement: false
       exclusive: false
       machine_type: n2-standard-4
+      bandwidth_tier: gvnic_enabled
 
   # This compute_partition is far more performant than low_cost_partition.
   - id: compute_partition
@@ -81,6 +82,7 @@ deployment_groups:
     settings:
       max_node_count: 200
       partition_name: compute
+      bandwidth_tier: gvnic_enabled
 
   - id: slurm_controller
     source: community/modules/scheduler/SchedMD-slurm-on-gcp-controller

--- a/community/examples/hpc-slurm-ramble-gromacs.yaml
+++ b/community/examples/hpc-slurm-ramble-gromacs.yaml
@@ -114,6 +114,7 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: 20
+      bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition

--- a/community/examples/hpc-slurm-ubuntu2004.yaml
+++ b/community/examples/hpc-slurm-ubuntu2004.yaml
@@ -66,6 +66,7 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: 20
+      bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition

--- a/community/examples/hpc-slurm6.yaml
+++ b/community/examples/hpc-slurm6.yaml
@@ -60,6 +60,7 @@ deployment_groups:
     settings:
       name: ns2
       node_count_dynamic_max: 20
+      bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v6-partition

--- a/community/examples/htc-slurm.yaml
+++ b/community/examples/htc-slurm.yaml
@@ -75,6 +75,7 @@ deployment_groups:
     settings:
       name: c2s60
       node_count_dynamic_max: 200
+      bandwidth_tier: gvnic_enabled
 
   - id: compute_node_group_c2s30
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
@@ -82,6 +83,7 @@ deployment_groups:
       name: c2s30
       node_count_dynamic_max: 200
       machine_type: c2-standard-30
+      bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -107,6 +109,7 @@ deployment_groups:
       name: n2s2
       machine_type: n2-standard-2
       node_count_dynamic_max: 10
+      bandwidth_tier: gvnic_enabled
 
   - id: low_cost_node_group_n2s4
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
@@ -114,6 +117,7 @@ deployment_groups:
       name: n2s4
       machine_type: n2-standard-4
       node_count_dynamic_max: 10
+      bandwidth_tier: gvnic_enabled
 
   - id: low_cost_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition

--- a/community/examples/intel/hpc-intel-select-slurm.yaml
+++ b/community/examples/intel/hpc-intel-select-slurm.yaml
@@ -37,6 +37,7 @@ deployment_groups:
   modules:
   - id: network1
     source: modules/network/vpc
+
   - id: startup_controller
     source: modules/scripts/startup-script
     settings:
@@ -49,6 +50,7 @@ deployment_groups:
           google_install_mpi --prefix /apps --intel_compliance
     outputs:
     - startup_script
+
   - id: startup_compute
     source: modules/scripts/startup-script
     settings:
@@ -77,6 +79,7 @@ deployment_groups:
           clck -D ${FWD}.db -F ${FWD} -l debug
     outputs:
     - startup_script
+
 - group: build1
   modules:
   - id: controller-image
@@ -87,6 +90,7 @@ deployment_groups:
       source_image_project_id: [schedmd-slurm-public]
       source_image_family: schedmd-slurm-21-08-8-hpc-centos-7
       image_family: $(vars.controller_image.family)
+
 - group: build2
   modules:
   - id: compute-image
@@ -97,16 +101,19 @@ deployment_groups:
       source_image_project_id: [schedmd-slurm-public]
       source_image_family: schedmd-slurm-21-08-8-hpc-centos-7
       image_family: $(vars.compute_image.family)
+
 - group: cluster
   modules:
   - id: cluster-network
     source: modules/network/pre-existing-vpc
+
   - id: homefs
     source: modules/file-system/filestore
     use:
     - cluster-network
     settings:
       local_mount: /home
+
   # This debug_partition will work out of the box without requesting additional GCP quota.
   - id: debug_partition
     source: community/modules/compute/SchedMD-slurm-on-gcp-partition
@@ -120,6 +127,7 @@ deployment_groups:
       exclusive: false
       machine_type: n2-standard-4
       instance_image: $(vars.compute_image)
+
   - id: compute_partition
     source: community/modules/compute/SchedMD-slurm-on-gcp-partition
     use:
@@ -130,6 +138,8 @@ deployment_groups:
       instance_image: $(vars.compute_image)
       max_node_count: 100
       machine_type: c2-standard-60
+      bandwidth_tier: gvnic_enabled
+
   - id: slurm_controller
     source: community/modules/scheduler/SchedMD-slurm-on-gcp-controller
     use:
@@ -140,6 +150,7 @@ deployment_groups:
       login_node_count: 1
       instance_image: $(vars.controller_image)
       controller_machine_type: c2-standard-4
+
   - id: slurm_login
     source: community/modules/scheduler/SchedMD-slurm-on-gcp-login-node
     use:

--- a/community/examples/intel/hpc-slurm-daos.yaml
+++ b/community/examples/intel/hpc-slurm-daos.yaml
@@ -131,6 +131,7 @@ deployment_groups:
     settings:
       partition_name: compute
       max_node_count: 20
+      bandwidth_tier: gvnic_enabled
 
   - id: slurm_controller
     source: community/modules/scheduler/SchedMD-slurm-on-gcp-controller

--- a/community/examples/quantum-circuit-simulator.yaml
+++ b/community/examples/quantum-circuit-simulator.yaml
@@ -31,6 +31,7 @@ deployment_groups:
   modules:
   - id: network1
     source: modules/network/vpc
+
   - id: quantum-simulator-setup
     source: modules/scripts/startup-script
     settings:
@@ -120,6 +121,7 @@ deployment_groups:
           # also "warms up" the GPU to give reliable performance metrics
           conda activate qsim
           python /var/tmp/qsim-example.py
+
   - id: qsimvm
     source: modules/compute/vm-instance
     use:
@@ -133,6 +135,7 @@ deployment_groups:
       instance_image:
         project: ubuntu-os-cloud
         family: ubuntu-2004-lts
+
   - id: wait
     source: community/modules/scripts/wait-for-startup
     settings:

--- a/examples/cae/cae-slurm.yaml
+++ b/examples/cae/cae-slurm.yaml
@@ -186,7 +186,7 @@ deployment_groups:
       node_count_dynamic_max: 10
       machine_type: h3-standard-88
       disk_type: 'pd-balanced'
-      bandwidth_tier: 'gvnic_enabled'
+      bandwidth_tier: gvnic_enabled
 
   - id: h3_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -208,7 +208,7 @@ deployment_groups:
       node_count_dynamic_max: 10
       machine_type: c3-highmem-176
       disk_type: 'pd-balanced'
-      bandwidth_tier: 'tier_1_enabled'
+      bandwidth_tier: tier_1_enabled
 
   - id: c3_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition

--- a/examples/hpc-slurm.yaml
+++ b/examples/hpc-slurm.yaml
@@ -62,6 +62,7 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: 20
+      bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -80,6 +81,7 @@ deployment_groups:
       # H3 does not support pd-ssd and pd-standard
       # https://cloud.google.com/compute/docs/compute-optimized-machines#h3_disks
       disk_type: pd-balanced
+      bandwidth_tier: gvnic_enabled
 
   - id: h3_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -76,6 +76,7 @@ deployment_groups:
       disk_size_gb: $(vars.disk_size)
       instance_image: $(vars.custom_image)
       instance_image_custom: true
+      bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition


### PR DESCRIPTION
Update slurm examples to turn GVNIC on by default
