### PR TITLE
Fix name of HTCondor yum repository Ansible task

### DIFF
--- a/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
+++ b/community/modules/scripts/htcondor-install/files/install-htcondor.yaml
@@ -44,7 +44,7 @@
     retries: 10
     delay: 60
     until: key_install is success
-  - name: Enable HTCondor Feature Release repository
+  - name: Enable HTCondor LTS Release repository
     ansible.builtin.yum_repository:
       name: htcondor-feature
       description: HTCondor LTS Release (23.0)


### PR DESCRIPTION
This is a very simple PR to properly name the task that sets up the HTCondor yum repository. We no longer use the "Feature" (development) branch, but the "LTS" (Long Term Support) branch.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
