### PR TITLE
Remove error-prone `errorMessage` map, remove deprecated `go-lint`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,6 @@ repos:
   hooks:
   - id: go-fmt
   - id: go-vet
-  - id: go-lint
   - id: go-imports
   - id: go-cyclo
     args: [-over=15]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,37 +35,8 @@ const (
 	expectedVarFormat        string = "$(vars.var_name) or $(module_id.output_name)"
 	expectedModFormat        string = "$(module_id) or $(group_id.module_id)"
 	unexpectedConnectionKind string = "connectionKind must be useConnection or deploymentConnection"
-	maxHintDist              int    = 3 // Maximum levenshtein distance where we suggest a hint
+	maxHintDist              int    = 3 // Maximum Levenshtein distance where we suggest a hint
 )
-
-var errorMessages = map[string]string{
-	// config
-	"fileLoadError":    "failed to read the input yaml",
-	"yamlMarshalError": "failed to export the configuration to a blueprint yaml file",
-	"fileSaveError":    "failed to write the expanded yaml",
-	// expand
-	"missingSetting":  "a required setting is missing from a module",
-	"invalidVar":      "invalid variable definition in",
-	"varNotFound":     "Could not find source of variable",
-	"intergroupOrder": "References to outputs from other groups must be to earlier groups",
-	"noOutput":        "Output not found for a variable",
-	"cannotUsePacker": "Packer modules cannot be used by other modules",
-	// validator
-	"emptyID":            "a module id cannot be empty",
-	"emptySource":        "a module source cannot be empty",
-	"wrongKind":          "a module kind is invalid",
-	"extraSetting":       "a setting was added that is not found in the module",
-	"settingWithPeriod":  "a setting name contains a period, which is not supported; variable subfields cannot be set independently in a blueprint.",
-	"settingInvalidChar": "a setting name must begin with a non-numeric character and all characters must be either letters, numbers, dashes ('-') or underscores ('_').",
-	"duplicateGroup":     "group names must be unique",
-	"duplicateID":        "module IDs must be unique",
-	"emptyGroupName":     "group name must be set for each deployment group",
-	"invalidOutput":      "requested output was not found in the module",
-	"valueNotString":     "value was not of type string",
-	"valueEmptyString":   "value is an empty string",
-	"labelNameReqs":      "name must begin with a lowercase letter, can only contain lowercase letters, numeric characters, underscores and dashes, and must be between 1 and 63 characters long",
-	"labelValueReqs":     "value can only contain lowercase letters, numeric characters, underscores and dashes, and must be between 0 and 63 characters long",
-}
 
 // map[moved module path]replacing module path
 var movedModules = map[string]string{
@@ -81,7 +52,7 @@ type GroupName string
 // Validate checks that the group name is valid
 func (n GroupName) Validate() error {
 	if n == "" {
-		return errors.New(errorMessages["emptyGroupName"])
+		return EmptyGroupName
 	}
 
 	if !regexp.MustCompile(`^\w(-*\w)*$`).MatchString(string(n)) {
@@ -405,14 +376,14 @@ func (dc DeploymentConfig) ExportBlueprint(outputFilename string) error {
 	d := buf.Bytes()
 
 	if err != nil {
-		return fmt.Errorf("%s: %w", errorMessages["yamlMarshalError"], err)
+		return fmt.Errorf("%s: %w", errMsgYamlMarshalError, err)
 	}
 
 	err = ioutil.WriteFile(outputFilename, d, 0644)
 	if err != nil {
 		// hitting this error writing yaml
 		return fmt.Errorf("%s, Filename: %s: %w",
-			errorMessages["fileSaveError"], outputFilename, err)
+			errMsgYamlSaveError, outputFilename, err)
 	}
 	return nil
 }
@@ -437,7 +408,7 @@ func checkModulesAndGroups(bp Blueprint) error {
 		errs.At(pg.Name, grp.Name.Validate())
 
 		if seenGrp[grp.Name] {
-			errs.At(pg.Name, fmt.Errorf("%s: %s used more than once", errorMessages["duplicateGroup"], grp.Name))
+			errs.At(pg.Name, fmt.Errorf("%s: %s used more than once", errMsgDuplicateGroup, grp.Name))
 		}
 		seenGrp[grp.Name] = true
 
@@ -450,7 +421,7 @@ func checkModulesAndGroups(bp Blueprint) error {
 		for im, mod := range grp.Modules {
 			pm := pg.Modules.At(im)
 			if seenMod[mod.ID] {
-				errs.At(pm.ID, fmt.Errorf("%s: %s used more than once", errorMessages["duplicateID"], mod.ID))
+				errs.At(pm.ID, fmt.Errorf("%s: %s used more than once", errMsgDuplicateID, mod.ID))
 			}
 			seenMod[mod.ID] = true
 			errs.Add(validateModule(pm, mod, bp))
@@ -562,7 +533,7 @@ func (bp *Blueprint) DeploymentName() (string, error) {
 	if !bp.Vars.Has("deployment_name") {
 		return "", BpError{path, InputValueError{
 			inputKey: "deployment_name",
-			cause:    errorMessages["varNotFound"],
+			cause:    errMsgVarNotFound,
 		}}
 	}
 
@@ -570,7 +541,7 @@ func (bp *Blueprint) DeploymentName() (string, error) {
 	if v.Type() != cty.String {
 		return "", BpError{path, InputValueError{
 			inputKey: "deployment_name",
-			cause:    errorMessages["valueNotString"],
+			cause:    errMsgValueNotString,
 		}}
 	}
 
@@ -578,7 +549,7 @@ func (bp *Blueprint) DeploymentName() (string, error) {
 	if len(s) == 0 {
 		return "", BpError{path, InputValueError{
 			inputKey: "deployment_name",
-			cause:    errorMessages["valueEmptyString"],
+			cause:    errMsgValueEmptyString,
 		}}
 	}
 
@@ -586,7 +557,7 @@ func (bp *Blueprint) DeploymentName() (string, error) {
 	if !isValidLabelValue(s) {
 		return "", BpError{path, InputValueError{
 			inputKey: "deployment_name",
-			cause:    errorMessages["labelValueReqs"],
+			cause:    errMsgLabelValueReqs,
 		}}
 	}
 
@@ -612,14 +583,14 @@ func (bp *Blueprint) checkBlueprintName() error {
 	if len(bp.BlueprintName) == 0 {
 		return BpError{Root.BlueprintName, InputValueError{
 			inputKey: "blueprint_name",
-			cause:    errorMessages["valueEmptyString"],
+			cause:    errMsgValueEmptyString,
 		}}
 	}
 
 	if !isValidLabelValue(bp.BlueprintName) {
 		return BpError{Root.BlueprintName, InputValueError{
 			inputKey: "blueprint_name",
-			cause:    errorMessages["labelValueReqs"],
+			cause:    errMsgLabelValueReqs,
 		}}
 	}
 

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -17,6 +17,8 @@ package config
 import (
 	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // BpError is an error wrapper to augment Path
@@ -132,3 +134,32 @@ func (e *Errors) At(path Path, err error) *Errors {
 func (e *Errors) Any() bool {
 	return len(e.Errors) > 0
 }
+
+// Sentinel errors
+var EmptyModuleID = errors.New("a module id cannot be empty")
+var EmptyModuleSource = errors.New("a module source cannot be empty")
+var InvalidModuleKind = errors.New("a module kind is invalid")
+var UnknownModuleSetting = errors.New("a setting was added that is not found in the module")
+var ModuleSettingWithPeriod = errors.New("a setting name contains a period, which is not supported; variable subfields cannot be set independently in a blueprint.")
+var ModuleSettingInvalidChar = errors.New("a setting name must begin with a non-numeric character and all characters must be either letters, numbers, dashes ('-') or underscores ('_').")
+var EmptyGroupName = errors.New("group name must be set for each deployment group")
+
+// Error messages
+const (
+	errMsgFileLoadError    = string("failed to read the input yaml")
+	errMsgYamlMarshalError = string("failed to export the configuration to a blueprint yaml file")
+	errMsgYamlSaveError    = string("failed to write the expanded yaml")
+	errMsgMissingSetting   = string("a required setting is missing from a module")
+	errMsgInvalidVar       = string("invalid variable definition in")
+	errMsgVarNotFound      = string("could not find source of variable")
+	errMsgIntergroupOrder  = string("references to outputs from other groups must be to earlier groups")
+	errMsgNoOutput         = string("output not found for a variable")
+	errMsgCannotUsePacker  = string("Packer modules cannot be used by other modules")
+	errMsgDuplicateGroup   = string("group names must be unique")
+	errMsgDuplicateID      = string("module IDs must be unique")
+	errMsgInvalidOutput    = string("requested output was not found in the module")
+	errMsgValueNotString   = string("value was not of type string")
+	errMsgValueEmptyString = string("value is an empty string")
+	errMsgLabelNameReqs    = string("name must begin with a lowercase letter, can only contain lowercase letters, numeric characters, underscores and dashes, and must be between 1 and 63 characters long")
+	errMsgLabelValueReqs   = string("value can only contain lowercase letters, numeric characters, underscores and dashes, and must be between 0 and 63 characters long")
+)

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -86,7 +86,7 @@ func validateModuleInputs(mp modulePath, m Module, bp Blueprint) error {
 		if !m.Settings.Has(input.Name) {
 			if input.Required {
 				errs.At(ip, fmt.Errorf("%s: Module ID: %s Setting: %s",
-					errorMessages["missingSetting"], m.ID, input.Name))
+					errMsgMissingSetting, m.ID, input.Name))
 			}
 			continue
 		}
@@ -322,7 +322,7 @@ func validateModuleReference(bp Blueprint, from Module, toID ModuleID) error {
 	}
 
 	if to.Kind == PackerKind {
-		return fmt.Errorf("%s: %s", errorMessages["cannotUsePacker"], to.ID)
+		return fmt.Errorf("%s: %s", errMsgCannotUsePacker, to.ID)
 	}
 
 	fg := bp.ModuleGroupOrDie(from.ID)
@@ -330,7 +330,7 @@ func validateModuleReference(bp Blueprint, from Module, toID ModuleID) error {
 	fgi := slices.IndexFunc(bp.DeploymentGroups, func(g DeploymentGroup) bool { return g.Name == fg.Name })
 	tgi := slices.IndexFunc(bp.DeploymentGroups, func(g DeploymentGroup) bool { return g.Name == tg.Name })
 	if tgi > fgi {
-		return fmt.Errorf("%s: %s is in a later group", errorMessages["intergroupOrder"], to.ID)
+		return fmt.Errorf("%s: %s is in a later group", errMsgIntergroupOrder, to.ID)
 	}
 	return nil
 }
@@ -362,7 +362,7 @@ func validateModuleSettingReference(bp Blueprint, mod Module, r Reference) error
 	}
 	found := slices.ContainsFunc(mi.Outputs, func(o modulereader.OutputInfo) bool { return o.Name == r.Name })
 	if !found {
-		return fmt.Errorf("%s: module %s did not have output %s", errorMessages["noOutput"], tm.ID, r.Name)
+		return fmt.Errorf("%s: module %s did not have output %s", errMsgNoOutput, tm.ID, r.Name)
 	}
 	return nil
 }

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -438,7 +438,7 @@ func (s *MySuite) TestValidateModuleReference(c *C) {
 
 	{ // An intergroup reference from group 0 to module 1 in 1 (bad due to group ordering)
 		err := validateModuleReference(bp, a, y.ID)
-		c.Check(err, ErrorMatches, fmt.Sprintf("%s: .*", errorMessages["intergroupOrder"]))
+		c.Check(err, ErrorMatches, fmt.Sprintf("%s: .*", errMsgIntergroupOrder))
 	}
 
 	// A target module that doesn't exist (bad)

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -82,7 +82,7 @@ func extractSimpleVarExpression(s string) (string, error) {
 	}
 	contents := simpleVariableExp.FindStringSubmatch(s)
 	if len(contents) != 2 { // Should always be (match, contents) here
-		return "", fmt.Errorf("%s %s, failed to extract contents: %v", errorMessages["invalidVar"], s, contents)
+		return "", fmt.Errorf("%s %s, failed to extract contents: %v", errMsgInvalidVar, s, contents)
 	}
 	return contents[1], nil
 }

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -58,11 +58,11 @@ func validateGlobalLabels(vars Dict) error {
 
 		// Check that label names are valid
 		if !isValidLabelName(k) {
-			errs.At(vp, errors.Errorf("%s: '%s: %s'", errorMessages["labelNameReqs"], k, s))
+			errs.At(vp, errors.Errorf("%s: '%s: %s'", errMsgLabelNameReqs, k, s))
 		}
 		// Check that label values are valid
 		if !isValidLabelValue(s) {
-			errs.At(vp, errors.Errorf("%s: '%s: %s'", errorMessages["labelValueReqs"], k, s))
+			errs.At(vp, errors.Errorf("%s: '%s: %s'", errMsgLabelValueReqs, k, s))
 		}
 	}
 	return errs.OrNil()
@@ -84,13 +84,13 @@ func validateVars(vars Dict) error {
 func validateModule(p modulePath, m Module, bp Blueprint) error {
 	// Source/Kind validations are required to pass to perform other validations
 	if m.Source == "" {
-		return BpError{p.Source, fmt.Errorf(errorMessages["emptySource"])}
+		return BpError{p.Source, EmptyModuleSource}
 	}
 	if err := checkMovedModule(m.Source); err != nil {
 		return BpError{p.Source, err}
 	}
 	if !IsValidModuleKind(m.Kind.String()) {
-		return BpError{p.Kind, fmt.Errorf(errorMessages["wrongKind"])}
+		return BpError{p.Kind, InvalidModuleKind}
 	}
 	info, err := modulereader.GetModuleInfo(m.Source, m.Kind.kind)
 	if err != nil {
@@ -99,7 +99,7 @@ func validateModule(p modulePath, m Module, bp Blueprint) error {
 
 	errs := Errors{}
 	if m.ID == "" {
-		errs.At(p.ID, fmt.Errorf(errorMessages["emptyID"]))
+		errs.At(p.ID, EmptyModuleID)
 	}
 	if m.ID == "vars" { // invalid module ID
 		errs.At(p.ID, errors.New("module id cannot be 'vars'"))
@@ -119,7 +119,7 @@ func validateOutputs(p modulePath, mod Module, info modulereader.ModuleInfo) err
 	// Ensure output exists in the underlying modules
 	for io, output := range mod.Outputs {
 		if _, ok := outputs[output.Name]; !ok {
-			err := fmt.Errorf("%s, module: %s output: %s", errorMessages["invalidOutput"], mod.ID, output.Name)
+			err := fmt.Errorf("%s, module: %s output: %s", errMsgInvalidOutput, mod.ID, output.Name)
 			errs.At(p.Outputs.At(io), err)
 		}
 	}
@@ -152,17 +152,17 @@ func validateSettings(
 		// HCL does not support periods in variables names either:
 		// https://hcl.readthedocs.io/en/latest/language_design.html#language-keywords-and-identifiers
 		if strings.Contains(k, ".") {
-			errs.At(sp, errors.New(errorMessages["settingWithPeriod"]))
+			errs.At(sp, ModuleSettingWithPeriod)
 			continue // do not perform other validations
 		}
 		// Setting includes invalid characters
 		if !regexp.MustCompile(`^[a-zA-Z-_][a-zA-Z0-9-_]*$`).MatchString(k) {
-			errs.At(sp, errors.New(errorMessages["settingInvalidChar"]))
+			errs.At(sp, ModuleSettingInvalidChar)
 			continue // do not perform other validations
 		}
 		// Setting not found
 		if _, ok := cVars.Inputs[k]; !ok {
-			errs.At(sp, errors.New(errorMessages["extraSetting"]))
+			errs.At(sp, UnknownModuleSetting)
 			continue // do not perform other validations
 		}
 

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -55,7 +55,7 @@ type Pos struct {
 func importBlueprint(f string) (Blueprint, YamlCtx, error) {
 	data, err := os.ReadFile(f)
 	if err != nil {
-		return Blueprint{}, YamlCtx{}, fmt.Errorf("%s, filename=%s: %v", errorMessages["fileLoadError"], f, err)
+		return Blueprint{}, YamlCtx{}, fmt.Errorf("%s, filename=%s: %v", errMsgFileLoadError, f, err)
 	}
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)


### PR DESCRIPTION
* Remove error-prone `errorMessage` map, replace with named constants and sentinel errors;
* Remove deprecated `go-lint` hook, rely on `go vet` instead.
