### PR TITLE
🌈 Add colorization to the output

### DIFF
--- a/cmd/color.go
+++ b/cmd/color.go
@@ -1,0 +1,39 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+var noColorFlag bool = true
+
+func addColorFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&noColorFlag, "no-color", true, "Disable colorized output.")
+}
+
+func initColor() {
+	colorlessStdout := !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())
+	colorlessStderr := !isatty.IsTerminal(os.Stderr.Fd()) && !isatty.IsCygwinTerminal(os.Stderr.Fd())
+	color.NoColor = noColorFlag || os.Getenv("TERM") == "dumb" || colorlessStdout || colorlessStderr
+
+}
+
+var boldRed = color.New(color.FgRed, color.Bold).SprintFunc()
+var boldGreen = color.New(color.FgGreen, color.Bold).SprintFunc()

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -51,6 +51,7 @@ func init() {
 			"Note: Terraform state IS preserved. \n"+
 			"Note: Terraform workspaces are NOT supported (behavior undefined). \n"+
 			"Note: Packer is NOT supported.")
+	addColorFlag(createCmd)
 	rootCmd.AddCommand(createCmd)
 }
 
@@ -85,7 +86,7 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 
 	fmt.Println("To deploy your infrastructure please run:")
 	fmt.Println()
-	fmt.Printf("./ghpc deploy %s\n", deplDir)
+	fmt.Printf(boldGreen("./ghpc deploy %s\n"), deplDir)
 	fmt.Println()
 	printAdvancedInstructionsMessage(deplDir)
 }
@@ -207,9 +208,10 @@ func renderRichError(err error, pos config.Pos, ctx config.YamlCtx) string {
 		spaces := strings.Repeat(" ", len(pref)+pos.Column-1)
 		arrow = spaces + "^"
 	}
-	return fmt.Sprintf(`Error: %s
+
+	return fmt.Sprintf(`%s: %s
 %s%s
-%s`, err, pref, ctx.Lines[line], arrow)
+%s`, boldRed("Error"), err, pref, ctx.Lines[line], arrow)
 }
 
 func setCLIVariables(bp *config.Blueprint, s []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,7 @@ func Execute() error {
 	// Don't prefix messages with data & time to improve readability.
 	// See https://pkg.go.dev/log#pkg-constants
 	log.SetFlags(0)
+	initColor()
 
 	mismatch, branch, hash, dir := checkGitHashMismatch()
 	if mismatch {

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,11 @@ require (
 )
 
 require (
+	github.com/fatih/color v1.7.0
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/terraform-exec v0.19.0
+	github.com/mattn/go-isatty v0.0.4
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 	google.golang.org/api v0.149.0
 )
@@ -35,6 +37,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/sync v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
@@ -419,7 +420,9 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
+github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=


### PR DESCRIPTION
Add color to the small set of outputs of `create` command.


<img width="868" alt="Screenshot 2023-11-07 at 4 50 38 PM" src="https://github.com/GoogleCloudPlatform/hpc-toolkit/assets/1387442/8a4492e7-7756-46c1-86f2-1832a63174b1">

<img width="864" alt="Screenshot 2023-11-07 at 4 49 49 PM" src="https://github.com/GoogleCloudPlatform/hpc-toolkit/assets/1387442/a756a0c1-f4a9-410e-a6d6-5af38d4048de">

Feature is hidden behind flag `--no-color=false` (default is `true`), also it is ignored if output doesn't support colors, see:

```
$ ./ghpc create tst.yaml -w --no-color=false 2> /tmp/out
$ cat /tmp/out
Error: invalid module id: "var" - Did you mean "vars"?
45:       node_count_dynamic_max: $(var.wut)
```

**NOTE:** All added dependencies are under `MIT` license.
