### PR TITLE
Colorize cobra errors

### DIFF
--- a/cmd/color.go
+++ b/cmd/color.go
@@ -24,6 +24,11 @@ import (
 
 var noColorFlag bool = true
 
+func init() {
+	// Safety precaution in case `initColor` wasn't called.
+	color.NoColor = true
+}
+
 func addColorFlag(flagset *pflag.FlagSet) {
 	flagset.BoolVar(&noColorFlag, "no-color", true, "Disable colorized output.")
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -79,9 +79,9 @@ var (
 func runCreateCmd(cmd *cobra.Command, args []string) {
 	dc := expandOrDie(args[0])
 	deplName, err := dc.Config.DeploymentName()
-	cobra.CheckErr(err)
+	checkErr(err)
 	deplDir := filepath.Join(outputDir, deplName)
-	cobra.CheckErr(modulewriter.WriteDeployment(dc, deplDir, overwriteDeployment))
+	checkErr(modulewriter.WriteDeployment(dc, deplDir, overwriteDeployment))
 
 	fmt.Println("To deploy your infrastructure please run:")
 	fmt.Println()

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -49,6 +49,6 @@ var (
 
 func runExpandCmd(cmd *cobra.Command, args []string) {
 	dc := expandOrDie(args[0])
-	cobra.CheckErr(dc.ExportBlueprint(outputFilename))
-	fmt.Printf("Expanded Environment Definition created successfully, saved as %s.\n", outputFilename)
+	checkErr(dc.ExportBlueprint(outputFilename))
+	fmt.Printf(boldGreen("Expanded Environment Definition created successfully, saved as %s.\n"), outputFilename)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"hpc-toolkit/pkg/config"
 	"log"
 	"os"
 	"os/exec"
@@ -246,4 +247,13 @@ func execPath() string {
 		return nice
 	}
 	return args0
+}
+
+// checkErr is similar to cobra.CheckErr, but with renderError and log.Fatal
+// NOTE: this function uses empty YamlCtx, so if you have one, use renderError directly.
+func checkErr(err error) {
+	if err != nil {
+		msg := fmt.Sprintf("%s: %s", boldRed("Error"), renderError(err, config.YamlCtx{}))
+		log.Fatal(msg)
+	}
 }


### PR DESCRIPTION
Instead of using `cobra.CheckErr` that doesn't colorize use custom `cmd.checkErr` that does.

<img width="831" alt="Screenshot 2023-11-09 at 11 21 44 AM" src="https://github.com/GoogleCloudPlatform/hpc-toolkit/assets/1387442/617660df-082e-4ed3-99d7-94ceecac3609">
