### PR TITLE
Front End Teardown Success Bug Fix

### DIFF
--- a/community/front-end/ofe/teardown.sh
+++ b/community/front-end/ofe/teardown.sh
@@ -69,6 +69,7 @@ tfdestroy() {
 
 		# -- Start the deployment using Terraform
 		#
+		set -o pipefail
 		terraform destroy -auto-approve | tee tfdestroy.log
 	)
 }


### PR DESCRIPTION
Fixes a bug where the `terraform destroy` command will always return a 0 exit status code because of the successful pipe to `tfdestroy.log`