### PR TITLE
staticcheck. Fix errors

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,7 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -96,8 +96,8 @@ type DeploymentGroup struct {
 	Name             GroupName        `yaml:"group"`
 	TerraformBackend TerraformBackend `yaml:"terraform_backend,omitempty"`
 	Modules          []Module         `yaml:"modules"`
-	// DEPRECATED fields, keep in the struct for backwards compatibility
-	deprecatedKind interface{} `yaml:"kind,omitempty"`
+	// DEPRECATED fields
+	deprecatedKind interface{} `yaml:"kind,omitempty"` //lint:ignore U1000 keep in the struct for backwards compatibility
 }
 
 // Kind returns the kind of all the modules in the group.
@@ -408,7 +408,7 @@ func (dc DeploymentConfig) ExportBlueprint(outputFilename string) error {
 		return fmt.Errorf("%s: %w", errorMessages["yamlMarshalError"], err)
 	}
 
-	err = ioutil.WriteFile(outputFilename, d, 0644)
+	err = os.WriteFile(outputFilename, d, 0644)
 	if err != nil {
 		// hitting this error writing yaml
 		return fmt.Errorf("%s, Filename: %s: %w",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -100,7 +99,7 @@ func Test(t *testing.T) {
 
 // setup opens a temp file to store the yaml and saves it's name
 func setup() {
-	simpleYamlFile, err := ioutil.TempFile("", "*.yaml")
+	simpleYamlFile, err := os.CreateTemp("", "*.yaml")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -112,7 +111,7 @@ func setup() {
 	simpleYamlFile.Close()
 
 	// Create test directory with simple modules
-	tmpTestDir, err = ioutil.TempDir("", "ghpc_config_tests_*")
+	tmpTestDir, err = os.MkdirTemp("", "ghpc_config_tests_*")
 	if err != nil {
 		log.Fatalf("failed to create temp dir for config tests: %e", err)
 	}
@@ -728,7 +727,7 @@ func (s *MySuite) TestImportBlueprint_ExtraField_ThrowsError(c *C) {
 blueprint_name: hpc-cluster-high-io
 # line below is not in our schema
 dragon: "Lews Therin Telamon"`)
-	file, _ := ioutil.TempFile("", "*.yaml")
+	file, _ := os.CreateTemp("", "*.yaml")
 	file.Write(yaml)
 	filename := file.Name()
 	file.Close()

--- a/pkg/deploymentio/deploymentio_test.go
+++ b/pkg/deploymentio/deploymentio_test.go
@@ -16,7 +16,6 @@ package deploymentio
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -55,7 +54,7 @@ func Test(t *testing.T) {
 func setup() {
 	t := time.Now()
 	dirName := fmt.Sprintf("ghpc_deploymentio_test_%s", t.Format(time.RFC3339))
-	dir, err := ioutil.TempDir("", dirName)
+	dir, err := os.MkdirTemp("", dirName)
 	if err != nil {
 		log.Fatalf("modulewriter_test: %v", err)
 	}

--- a/pkg/deploymentio/local.go
+++ b/pkg/deploymentio/local.go
@@ -27,7 +27,7 @@ type Local struct{}
 
 func mkdirWrapper(directory string) error {
 	if err := os.MkdirAll(directory, 0755); err != nil {
-		return fmt.Errorf("Failed to create the directory %s: %v", directory, err)
+		return fmt.Errorf("failed to create the directory %s: %v", directory, err)
 	}
 
 	return nil
@@ -36,8 +36,7 @@ func mkdirWrapper(directory string) error {
 // CreateDirectory creates the directory
 func (b *Local) CreateDirectory(directory string) error {
 	if _, err := os.Stat(directory); !os.IsNotExist(err) {
-		return fmt.Errorf(
-			"The directory already exists: %s", directory)
+		return fmt.Errorf("the directory already exists: %s", directory)
 	}
 
 	// Create directory
@@ -57,11 +56,11 @@ func (b *Local) CopyFromPath(src string, dst string) error {
 func (b *Local) CopyFromFS(fs BaseFS, src string, dst string) error {
 	data, err := fs.ReadFile(src)
 	if err != nil {
-		return fmt.Errorf("Failed to read source file %s: err=%w", src, err)
+		return fmt.Errorf("failed to read source file %s: err=%w", src, err)
 	}
 
 	if err := os.WriteFile(dst, data, 0644); err != nil {
-		return fmt.Errorf("Failed to write data in destination file %s: err=%w", dst, err)
+		return fmt.Errorf("failed to write data in destination file %s: err=%w", dst, err)
 	}
 
 	return nil

--- a/pkg/deploymentio/local_test.go
+++ b/pkg/deploymentio/local_test.go
@@ -15,7 +15,6 @@
 package deploymentio
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -28,7 +27,7 @@ func (s *MySuite) TestCreateDirectoryLocal(c *C) {
 
 	// Try to create the exist directory
 	err := deploymentio.CreateDirectory(testDir)
-	expErr := "The directory already exists: .*"
+	expErr := "the directory already exists: .*"
 	c.Assert(err, ErrorMatches, expErr)
 
 	directoryName := "dir_TestCreateDirectoryLocal"
@@ -51,12 +50,12 @@ func (s *MySuite) TestCopyFromPathLocal(c *C) {
 	testDstFilename := filepath.Join(testDir, "testDst")
 	deploymentio.CopyFromPath(testSrcFilename, testDstFilename)
 
-	src, err := ioutil.ReadFile(testSrcFilename)
+	src, err := os.ReadFile(testSrcFilename)
 	if err != nil {
 		log.Fatalf("deploymentio_test: failed to read %s: %v", testSrcFilename, err)
 	}
 
-	dst, err := ioutil.ReadFile(testDstFilename)
+	dst, err := os.ReadFile(testDstFilename)
 	if err != nil {
 		log.Fatalf("deploymentio_test: failed to read %s: %v", testDstFilename, err)
 	}
@@ -75,7 +74,7 @@ func (s *MySuite) TestMkdirWrapper(c *C) {
 	_, err = os.Create(badMkdirWrapperDir)
 	c.Assert(err, IsNil)
 	err = mkdirWrapper(badMkdirWrapperDir)
-	expErr := "Failed to create the directory .*"
+	expErr := "failed to create the directory .*"
 	c.Assert(err, ErrorMatches, expErr)
 }
 

--- a/pkg/inspect/modules_test.go
+++ b/pkg/inspect/modules_test.go
@@ -89,12 +89,6 @@ func all(ps ...predicate) predicate {
 	}
 }
 
-func not(p predicate) predicate {
-	return func(mod modInfo) bool {
-		return !p(mod)
-	}
-}
-
 func hasInput(name string) predicate {
 	return func(mod modInfo) bool {
 		_, ok := mod.Input(name)
@@ -102,22 +96,9 @@ func hasInput(name string) predicate {
 	}
 }
 
-func hasOutput(name string) predicate {
-	return func(m modInfo) bool {
-		ind := slices.IndexFunc(m.Outputs, func(i modulereader.OutputInfo) bool { return i.Name == name })
-		return ind != -1
-	}
-}
-
-func ofRole(role string) predicate {
-	return func(mod modInfo) bool {
-		return mod.Role() == role
-	}
-}
-
 // Fails test if slice is empty, returns not empty slice as is.
 func notEmpty[E any](l []E, t *testing.T) []E {
-	if l == nil || len(l) == 0 {
+	if len(l) == 0 {
 		t.Fatal("Did not expect empty list")
 	}
 	return l

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -38,22 +38,22 @@ func getHCLInfo(source string) (ModuleInfo, error) {
 	if sourcereader.IsEmbeddedPath(source) {
 		wrapFS := tfconfig.WrapFS(sourcereader.ModuleFS)
 		if !tfconfig.IsModuleDirOnFilesystem(wrapFS, source) {
-			return ret, fmt.Errorf("Source is not a terraform or packer module: %s", source)
+			return ret, fmt.Errorf("source is not a terraform or packer module: %s", source)
 		}
 		module, _ = tfconfig.LoadModuleFromFilesystem(wrapFS, source)
 	} else {
 		fileInfo, err := os.Stat(source)
 		if os.IsNotExist(err) {
-			return ret, fmt.Errorf("Source to module does not exist: %s", source)
+			return ret, fmt.Errorf("source to module does not exist: %s", source)
 		}
 		if err != nil {
-			return ret, fmt.Errorf("Failed to read source of module: %s", source)
+			return ret, fmt.Errorf("failed to read source of module: %s", source)
 		}
 		if !fileInfo.IsDir() {
-			return ret, fmt.Errorf("Source of module must be a directory: %s", source)
+			return ret, fmt.Errorf("source of module must be a directory: %s", source)
 		}
 		if !tfconfig.IsModuleDir(source) {
-			return ret, fmt.Errorf("Source is not a terraform or packer module: %s", source)
+			return ret, fmt.Errorf("source is not a terraform or packer module: %s", source)
 		}
 		module, _ = tfconfig.LoadModule(source)
 	}

--- a/pkg/modulereader/metareader.go
+++ b/pkg/modulereader/metareader.go
@@ -26,5 +26,5 @@ type MetaReader struct {
 
 // GetInfo reades ModuleInfo for a meta module
 func (r MetaReader) GetInfo(source string) (ModuleInfo, error) {
-	return ModuleInfo{}, fmt.Errorf("Meta GetInfo not implemented: %s", source)
+	return ModuleInfo{}, fmt.Errorf("meta GetInfo not implemented: %s", source)
 }

--- a/pkg/modulereader/packerreader.go
+++ b/pkg/modulereader/packerreader.go
@@ -19,7 +19,6 @@ package modulereader
 import (
 	"fmt"
 	"hpc-toolkit/pkg/sourcereader"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -44,7 +43,7 @@ func addTfExtension(filename string) {
 }
 
 func getHCLFiles(dir string) []string {
-	allFiles, err := ioutil.ReadDir(dir)
+	allFiles, err := os.ReadDir(dir)
 	if err != nil {
 		log.Fatalf("Failed to read packer source directory at %s: %v", dir, err)
 	}
@@ -62,7 +61,7 @@ func getHCLFiles(dir string) []string {
 
 // GetInfo reads the ModuleInfo for a packer module
 func (r PackerReader) GetInfo(source string) (ModuleInfo, error) {
-	tmpDir, err := ioutil.TempDir("", "pkwriter-*")
+	tmpDir, err := os.MkdirTemp("", "pkwriter-*")
 	if err != nil {
 		return ModuleInfo{}, fmt.Errorf(
 			"failed to create temp directory for packer reader")

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -20,8 +20,8 @@ package modulereader
 import (
 	"fmt"
 	"hpc-toolkit/pkg/sourcereader"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 
 	"github.com/hashicorp/go-getter"
@@ -133,7 +133,7 @@ func GetModuleInfo(source string, kind string) (ModuleInfo, error) {
 	case sourcereader.IsEmbeddedPath(source) || sourcereader.IsLocalPath(source):
 		modPath = source
 	default:
-		tmpDir, err := ioutil.TempDir("", "module-*")
+		tmpDir, err := os.MkdirTemp("", "module-*")
 		if err != nil {
 			return ModuleInfo{}, err
 		}

--- a/pkg/modulereader/resreader_test.go
+++ b/pkg/modulereader/resreader_test.go
@@ -17,7 +17,6 @@ package modulereader
 import (
 	"embed"
 	"hpc-toolkit/pkg/sourcereader"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -160,12 +159,12 @@ func (s *MySuite) TestGetHCLInfo(c *C) {
 	// Invalid source path - path does not exists
 	fakePath := "./not/a/real/path"
 	_, err := getHCLInfo(fakePath)
-	expectedErr := "Source to module does not exist: .*"
+	expectedErr := "source to module does not exist: .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 	// Invalid source path - points to a file
 	pathToFile := filepath.Join(terraformDir, "main.tf")
 	_, err = getHCLInfo(pathToFile)
-	expectedErr = "Source of module must be a directory: .*"
+	expectedErr = "source of module must be a directory: .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Invalid source path - points to directory with no .tf files
@@ -175,7 +174,7 @@ func (s *MySuite) TestGetHCLInfo(c *C) {
 		log.Fatal("TestGetHCLInfo: Failed to create test directory.")
 	}
 	_, err = getHCLInfo(pathToEmptyDir)
-	expectedErr = "Source is not a terraform or packer module: .*"
+	expectedErr = "source is not a terraform or packer module: .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 }
 
@@ -219,7 +218,7 @@ func (s *MySuite) TestGetInfo_MetaReader(c *C) {
 	// Not implemented, expect that error
 	reader := MetaReader{}
 	_, err := reader.GetInfo("")
-	expErr := "Meta GetInfo not implemented: .*"
+	expErr := "meta GetInfo not implemented: .*"
 	c.Assert(err, ErrorMatches, expErr)
 }
 
@@ -265,7 +264,7 @@ func (s *MySuite) TestUnmarshalOutputInfo(c *C) {
 // Util Functions
 func copyEmbeddedModules() {
 	var err error
-	if tmpModuleDir, err = ioutil.TempDir("", "modulereader_tests_*"); err != nil {
+	if tmpModuleDir, err = os.MkdirTemp("", "modulereader_tests_*"); err != nil {
 		log.Fatalf(
 			"Failed to create temp dir for module in modulereader_test, %v", err)
 	}

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -27,7 +27,6 @@ import (
 	"hpc-toolkit/pkg/deploymentio"
 	"hpc-toolkit/pkg/sourcereader"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -265,7 +264,7 @@ func isOverwriteAllowed(depDir string, overwritingConfig *config.Blueprint, over
 		return false
 	}
 
-	files, err := ioutil.ReadDir(depDir)
+	files, err := os.ReadDir(depDir)
 	if err != nil {
 		return false
 	}
@@ -355,7 +354,7 @@ func prepDepDir(depDir string, overwrite bool) error {
 	}
 
 	// create new backup of deployment group directory
-	files, err := ioutil.ReadDir(depDir)
+	files, err := os.ReadDir(depDir)
 	if err != nil {
 		return fmt.Errorf("Error trying to read directories in %s, %w", depDir, err)
 	}

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -23,7 +23,6 @@ import (
 	"hpc-toolkit/pkg/deploymentio"
 	"hpc-toolkit/pkg/modulereader"
 	"hpc-toolkit/pkg/sourcereader"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -55,7 +54,7 @@ func Test(t *testing.T) {
 func setup() {
 	t := time.Now()
 	dirName := fmt.Sprintf("ghpc_modulewriter_test_%s", t.Format(time.RFC3339))
-	dir, err := ioutil.TempDir("", dirName)
+	dir, err := os.MkdirTemp("", dirName)
 	if err != nil {
 		log.Fatalf("modulewriter_test: %v", err)
 	}
@@ -170,7 +169,7 @@ func (s *MySuite) TestPrepDepDir_OverwriteRealDep(c *C) {
 	WriteDeployment(testDC, depDir, false /* overwrite */)
 
 	// confirm existence of resource groups (beyond .ghpc dir)
-	files, _ := ioutil.ReadDir(depDir)
+	files, _ := os.ReadDir(depDir)
 	c.Check(len(files) > 1, Equals, true)
 
 	err := prepDepDir(depDir, true /* overwrite */)
@@ -179,10 +178,10 @@ func (s *MySuite) TestPrepDepDir_OverwriteRealDep(c *C) {
 
 	// Check prev resource groups were moved
 	prevModuleDir := filepath.Join(depDir, HiddenGhpcDirName, prevDeploymentGroupDirName)
-	files1, _ := ioutil.ReadDir(prevModuleDir)
+	files1, _ := os.ReadDir(prevModuleDir)
 	c.Check(len(files1) > 0, Equals, true)
 
-	files2, _ := ioutil.ReadDir(depDir)
+	files2, _ := os.ReadDir(depDir)
 	c.Check(len(files2), Equals, 3) // .ghpc, .gitignore, and instructions file
 }
 
@@ -432,7 +431,7 @@ func (s *MySuite) TestCreateBaseFile(c *C) {
 	c.Assert(fi.Name(), Equals, baseFilename)
 	c.Assert(fi.Size() > 0, Equals, true)
 	c.Assert(fi.IsDir(), Equals, false)
-	b, _ := ioutil.ReadFile(goodPath)
+	b, _ := os.ReadFile(goodPath)
 	c.Assert(strings.Contains(string(b), "Licensed under the Apache License"),
 		Equals, true)
 
@@ -458,7 +457,7 @@ func (s *MySuite) TestAppendHCLToFile(c *C) {
 }
 
 func stringExistsInFile(str string, filename string) (bool, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -19,7 +19,6 @@ package modulewriter
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -374,7 +373,7 @@ func (w TFWriter) writeDeploymentGroup(
 func (w TFWriter) restoreState(deploymentDir string) error {
 	prevDeploymentGroupPath := filepath.Join(
 		deploymentDir, HiddenGhpcDirName, prevDeploymentGroupDirName)
-	files, err := ioutil.ReadDir(prevDeploymentGroupPath)
+	files, err := os.ReadDir(prevDeploymentGroupPath)
 	if err != nil {
 		return fmt.Errorf(
 			"Error trying to read previous modules in %s, %w",
@@ -387,8 +386,8 @@ func (w TFWriter) restoreState(deploymentDir string) error {
 			src := filepath.Join(prevDeploymentGroupPath, f.Name(), stateFile)
 			dest := filepath.Join(deploymentDir, f.Name(), stateFile)
 
-			if bytesRead, err := ioutil.ReadFile(src); err == nil {
-				err = ioutil.WriteFile(dest, bytesRead, 0644)
+			if bytesRead, err := os.ReadFile(src); err == nil {
+				err = os.WriteFile(dest, bytesRead, 0644)
 				if err != nil {
 					return fmt.Errorf("failed to write previous state file %s, %w", dest, err)
 				}

--- a/pkg/sourcereader/embedded.go
+++ b/pkg/sourcereader/embedded.go
@@ -17,7 +17,6 @@ package sourcereader
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -88,7 +87,7 @@ func copyDirFromModules(bfs BaseFS, source string, dest string) error {
 // works against embed.FS.
 // Open Issue: https://github.com/hashicorp/terraform-config-inspect/issues/68
 func copyFSToTempDir(bfs BaseFS, modulePath string) (string, error) {
-	tmpDir, err := ioutil.TempDir("", "tfconfig-module-*")
+	tmpDir, err := os.MkdirTemp("", "tfconfig-module-*")
 	if err != nil {
 		return tmpDir, err
 	}

--- a/pkg/sourcereader/embedded_test.go
+++ b/pkg/sourcereader/embedded_test.go
@@ -129,7 +129,7 @@ func (s *MySuite) TestGetModule_Embedded(c *C) {
 
 	// Invalid: Write to the same dest directory again
 	err = reader.GetModule("modules/network", dest)
-	expectedErr := "The directory already exists: .*"
+	expectedErr := "the directory already exists: .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Success

--- a/pkg/sourcereader/goget.go
+++ b/pkg/sourcereader/goget.go
@@ -17,7 +17,6 @@ package sourcereader
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -55,7 +54,7 @@ func getterClient(source string, dst string) getter.Client {
 
 // GetModule copies the git source to a provided destination (the deployment directory)
 func (r GoGetterSourceReader) GetModule(source string, dst string) error {
-	tmp, err := ioutil.TempDir("", "get-module-*")
+	tmp, err := os.MkdirTemp("", "get-module-*")
 	defer os.RemoveAll(tmp)
 	if err != nil {
 		return err

--- a/pkg/sourcereader/local_test.go
+++ b/pkg/sourcereader/local_test.go
@@ -103,7 +103,7 @@ func (s *MySuite) TestGetModule_Local(c *C) {
 
 	// Invalid: Write to the same dest directory again
 	err = reader.GetModule(terraformDir, dest)
-	expectedErr := "The directory already exists: .*"
+	expectedErr := "the directory already exists: .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Success

--- a/pkg/sourcereader/sourcereader_test.go
+++ b/pkg/sourcereader/sourcereader_test.go
@@ -16,7 +16,6 @@ package sourcereader
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -50,7 +49,7 @@ func Test(t *testing.T) {
 func setup() {
 	t := time.Now()
 	dirName := fmt.Sprintf("ghpc_sourcereader_test_%s", t.Format(time.RFC3339))
-	dir, err := ioutil.TempDir("", dirName)
+	dir, err := os.MkdirTemp("", dirName)
 	if err != nil {
 		log.Fatalf("sourcereader_test: %v", err)
 	}
@@ -168,5 +167,5 @@ func (s *MySuite) TestCopyFromPath(c *C) {
 
 	// Invalid: Specify the same destination path again
 	err = copyFromPath(terraformDir, dstPath)
-	c.Assert(err, ErrorMatches, "The directory already exists: .*")
+	c.Assert(err, ErrorMatches, "the directory already exists: .*")
 }

--- a/pkg/validators/quota_test.go
+++ b/pkg/validators/quota_test.go
@@ -208,7 +208,7 @@ requirements:
 		}, false},
 	}
 	for _, tc := range tests {
-		t.Run(fmt.Sprintf("%s", tc.yml), func(t *testing.T) {
+		t.Run(tc.yml, func(t *testing.T) {
 			var in config.Dict
 			bp := config.Blueprint{}
 			bp.Vars.


### PR DESCRIPTION
Fix errors pointed out by `staticcheck`. The majority of changes fall in of those categories:
* `ST1005` Incorrectly formatted error string;
* `U1000` Unused;
* `SA1019` Using a deprecated `ioutil`.

```sh
$ staticcheck ./...
$ # no more errors
```
