### PR TITLE
Add `staticcheck` in place of deprecated `go-lint`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,10 @@ repos:
   hooks:
   - id: go-critic
     args: [-disable, "#experimental,sloppyTypeAssert"]
+- repo: https://github.com/Bahjat/pre-commit-golang
+  rev: v1.0.2
+  hooks:
+  - id: go-static-check
 - repo: https://github.com/adrienverge/yamllint
   rev: v1.32.0
   hooks:


### PR DESCRIPTION
https://github.com/golang/lint
> Golint is [deprecated and frozen](https://github.com/golang/go/issues/38968). There's no drop-in replacement for it, but tools such as [Staticcheck](https://staticcheck.io/) and `go vet` should be used instead.

* `go-vet` is already part of our pre-commit;
* add `go-static-check` to pre-commit hooks, all `staticcheck` are addressed in #1961 