### PR TITLE
Front End Deployment Unique Bucket Name

### DIFF
--- a/community/front-end/ofe/tf/main.tf
+++ b/community/front-end/ofe/tf/main.tf
@@ -47,8 +47,7 @@ EOT
   default_labels = {
     ghpcfe_id = var.deployment_name,
   }
-  labels         = merge(var.extra_labels, local.default_labels)
-  generated_uuid = uuid()
+  labels = merge(var.extra_labels, local.default_labels)
 }
 
 
@@ -67,9 +66,10 @@ module "control_bucket" {
   source  = "terraform-google-modules/cloud-storage/google"
   version = "~> 4.0"
 
-  project_id = var.project_id
-  names      = ["storage"]
-  prefix     = "${var.deployment_name}-${local.generated_uuid}"
+  project_id       = var.project_id
+  names            = ["storage"]
+  prefix           = var.deployment_name
+  randomize_suffix = true
   force_destroy = {
     storage = true
   }

--- a/community/front-end/ofe/tf/main.tf
+++ b/community/front-end/ofe/tf/main.tf
@@ -47,7 +47,8 @@ EOT
   default_labels = {
     ghpcfe_id = var.deployment_name,
   }
-  labels = merge(var.extra_labels, local.default_labels)
+  labels         = merge(var.extra_labels, local.default_labels)
+  generated_uuid = uuid()
 }
 
 
@@ -68,7 +69,7 @@ module "control_bucket" {
 
   project_id = var.project_id
   names      = ["storage"]
-  prefix     = var.deployment_name
+  prefix     = "${var.deployment_name}-${local.generated_uuid}"
   force_destroy = {
     storage = true
   }


### PR DESCRIPTION
A UUID has been added to the storage bucket name so that it's unique and the deployment doesn't fail if the name has already been taken