### PR TITLE
Implement Custom Logging

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/modulewriter"
 	"hpc-toolkit/pkg/validators"
 	"log"
@@ -83,31 +84,31 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 	deplDir := filepath.Join(outputDir, deplName)
 	checkErr(modulewriter.WriteDeployment(dc, deplDir, overwriteDeployment))
 
-	fmt.Println("To deploy your infrastructure please run:")
-	fmt.Println()
-	fmt.Printf(boldGreen("%s deploy %s\n"), execPath(), deplDir)
-	fmt.Println()
+	logging.Info("To deploy your infrastructure please run:")
+	logging.Info("")
+	logging.Info(boldGreen("%s deploy %s"), execPath(), deplDir)
+	logging.Info("")
 	printAdvancedInstructionsMessage(deplDir)
 }
 
 func printAdvancedInstructionsMessage(deplDir string) {
-	fmt.Println("Find instructions for cleanly destroying infrastructure and advanced manual")
-	fmt.Println("deployment instructions at:")
-	fmt.Println()
-	fmt.Printf("%s\n", modulewriter.InstructionsPath(deplDir))
+	logging.Info("Find instructions for cleanly destroying infrastructure and advanced manual")
+	logging.Info("deployment instructions at:")
+	logging.Info("")
+	logging.Info(modulewriter.InstructionsPath(deplDir))
 }
 
 func expandOrDie(path string) config.DeploymentConfig {
 	dc, ctx, err := config.NewDeploymentConfig(path)
 	if err != nil {
-		log.Fatal(renderError(err, ctx))
+		logging.Fatal(renderError(err, ctx))
 	}
 	// Set properties from CLI
 	if err := setCLIVariables(&dc.Config, cliVariables); err != nil {
-		log.Fatalf("Failed to set the variables at CLI: %v", err)
+		logging.Fatal("Failed to set the variables at CLI: %v", err)
 	}
 	if err := setBackendConfig(&dc.Config, cliBEConfigVars); err != nil {
-		log.Fatalf("Failed to set the backend config at CLI: %v", err)
+		logging.Fatal("Failed to set the backend config at CLI: %v", err)
 	}
 	if err := setValidationLevel(&dc.Config, validationLevel); err != nil {
 		log.Fatal(err)
@@ -116,13 +117,13 @@ func expandOrDie(path string) config.DeploymentConfig {
 		log.Fatal(err)
 	}
 	if dc.Config.GhpcVersion != "" {
-		fmt.Printf("ghpc_version setting is ignored.")
+		logging.Info("ghpc_version setting is ignored.")
 	}
 	dc.Config.GhpcVersion = GitCommitInfo
 
 	// Expand the blueprint
 	if err := dc.ExpandConfig(); err != nil {
-		log.Fatal(renderError(err, ctx))
+		logging.Fatal(renderError(err, ctx))
 	}
 
 	validateMaybeDie(dc.Config, ctx)
@@ -134,29 +135,29 @@ func validateMaybeDie(bp config.Blueprint, ctx config.YamlCtx) {
 	if err == nil {
 		return
 	}
-	log.Println(renderError(err, ctx))
+	logging.Error(renderError(err, ctx))
 
-	log.Println("One or more blueprint validators has failed. See messages above for suggested")
-	log.Println("actions. General troubleshooting guidance and instructions for configuring")
-	log.Println("validators are shown below.")
-	log.Println("")
-	log.Println("- https://goo.gle/hpc-toolkit-troubleshooting")
-	log.Println("- https://goo.gle/hpc-toolkit-validation")
-	log.Println("")
-	log.Println("Validators can be silenced or treated as warnings or errors:")
-	log.Println("")
-	log.Println("- https://goo.gle/hpc-toolkit-validation-levels")
-	log.Println("")
+	logging.Error("One or more blueprint validators has failed. See messages above for suggested")
+	logging.Error("actions. General troubleshooting guidance and instructions for configuring")
+	logging.Error("validators are shown below.")
+	logging.Error("")
+	logging.Error("- https://goo.gle/hpc-toolkit-troubleshooting")
+	logging.Error("- https://goo.gle/hpc-toolkit-validation")
+	logging.Error("")
+	logging.Error("Validators can be silenced or treated as warnings or errors:")
+	logging.Error("")
+	logging.Error("- https://goo.gle/hpc-toolkit-validation-levels")
+	logging.Error("")
 
 	switch bp.ValidationLevel {
 	case config.ValidationWarning:
 		{
-			log.Println(boldYellow("Validation failures were treated as a warning, continuing to create blueprint."))
-			log.Println("")
+			logging.Error(boldYellow("Validation failures were treated as a warning, continuing to create blueprint."))
+			logging.Error("")
 		}
 	case config.ValidationError:
 		{
-			log.Fatal(boldRed("validation failed due to the issues listed above"))
+			logging.Fatal(boldRed("validation failed due to the issues listed above"))
 		}
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -18,9 +18,9 @@ package cmd
 import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/modulewriter"
 	"hpc-toolkit/pkg/shell"
-	"log"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -98,7 +98,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 			checkErr(fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind().String()))
 		}
 	}
-	fmt.Println("\n###############################")
+	logging.Info("\n###############################")
 	printAdvancedInstructionsMessage(deploymentRoot)
 }
 
@@ -131,15 +131,15 @@ func deployPackerGroup(moduleDir string) error {
 	}
 	buildImage := applyBehavior == shell.AutomaticApply || shell.ApplyChangesChoice(c)
 	if buildImage {
-		log.Printf("initializing packer module at %s", moduleDir)
+		logging.Info("initializing packer module at %s", moduleDir)
 		if err := shell.ExecPackerCmd(moduleDir, false, "init", "."); err != nil {
 			return err
 		}
-		log.Printf("validating packer module at %s", moduleDir)
+		logging.Info("validating packer module at %s", moduleDir)
 		if err := shell.ExecPackerCmd(moduleDir, false, "validate", "."); err != nil {
 			return err
 		}
-		log.Printf("building image using packer module at %s", moduleDir)
+		logging.Info("building image using packer module at %s", moduleDir)
 		if err := shell.ExecPackerCmd(moduleDir, true, "build", "."); err != nil {
 			return err
 		}

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -16,7 +16,7 @@
 package cmd
 
 import (
-	"fmt"
+	"hpc-toolkit/pkg/logging"
 
 	"github.com/spf13/cobra"
 )
@@ -50,5 +50,5 @@ var (
 func runExpandCmd(cmd *cobra.Command, args []string) {
 	dc := expandOrDie(args[0])
 	checkErr(dc.ExportBlueprint(outputFilename))
-	fmt.Printf(boldGreen("Expanded Environment Definition created successfully, saved as %s.\n"), outputFilename)
+	logging.Info(boldGreen("Expanded Environment Definition created successfully, saved as %s."), outputFilename)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
 	"log"
 	"os"
 	"os/exec"
@@ -49,7 +50,7 @@ var (
 HPC deployments on the Google Cloud Platform.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
-				log.Fatalf("cmd.Help function failed: %s", err)
+				logging.Fatal("cmd.Help function failed: %s", err)
 			}
 		},
 		Version:     "v1.25.0",
@@ -66,12 +67,9 @@ func init() {
 
 // Execute the root command
 func Execute() error {
-	// Don't prefix messages with data & time to improve readability.
-	// See https://pkg.go.dev/log#pkg-constants
-	log.SetFlags(0)
 	mismatch, branch, hash, dir := checkGitHashMismatch()
 	if mismatch {
-		fmt.Fprintf(os.Stderr, "WARNING: ghpc binary was built from a different commit (%s/%s) than the current git branch in %s (%s/%s). You can rebuild the binary by running 'make'\n",
+		logging.Error("WARNING: ghpc binary was built from a different commit (%s/%s) than the current git branch in %s (%s/%s). You can rebuild the binary by running 'make'",
 			GitBranch, GitCommitHash[0:7], dir, branch, hash[0:7])
 	}
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+var (
+	infolog  *log.Logger
+	errorlog *log.Logger
+	fatallog *log.Logger
+)
+
+func init() {
+	infolog = log.New(os.Stdout, "", 0)
+	errorlog = log.New(os.Stderr, "", 0)
+	fatallog = log.New(os.Stderr, "", 0)
+}
+
+// Info prints info to stdout
+func Info(f string, a ...any) {
+	msg := fmt.Sprintf(f, a...)
+	infolog.Println(msg)
+}
+
+// Error prints info to stderr but does not end the program
+func Error(f string, a ...any) {
+	msg := fmt.Sprintf(f, a...)
+	errorlog.Println(msg)
+}
+
+// Fatal prints info to stderr and ends the program
+func Fatal(f string, a ...any) {
+	msg := fmt.Sprintf(f, a...)
+	fatallog.Println(msg)
+	os.Exit(1)
+}

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -16,8 +16,8 @@ package modulereader
 
 import (
 	"fmt"
+	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/sourcereader"
-	"log"
 	"os"
 
 	"github.com/hashicorp/hcl/v2"
@@ -106,7 +106,7 @@ func getCtyType(hclType string) (cty.Type, error) {
 func NormalizeType(hclType string) string {
 	ctyType, err := getCtyType(hclType)
 	if err != nil {
-		log.Printf("Failed to parse HCL type='%s', got %v", hclType, err)
+		logging.Error("Failed to parse HCL type='%s', got %v", hclType, err)
 		return hclType
 	}
 	return typeexpr.TypeString(ctyType)

--- a/pkg/modulereader/packerreader.go
+++ b/pkg/modulereader/packerreader.go
@@ -18,8 +18,8 @@ package modulereader
 
 import (
 	"fmt"
+	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/sourcereader"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -36,7 +36,7 @@ func NewPackerReader() PackerReader {
 func addTfExtension(filename string) {
 	newFilename := fmt.Sprintf("%s.tf", filename)
 	if err := os.Rename(filename, newFilename); err != nil {
-		log.Fatalf(
+		logging.Fatal(
 			"failed to add .tf extension to %s needed to get info on packer module: %v",
 			filename, err)
 	}
@@ -45,7 +45,7 @@ func addTfExtension(filename string) {
 func getHCLFiles(dir string) []string {
 	allFiles, err := os.ReadDir(dir)
 	if err != nil {
-		log.Fatalf("Failed to read packer source directory at %s: %v", dir, err)
+		logging.Fatal("Failed to read packer source directory at %s: %v", dir, err)
 	}
 	var hclFiles []string
 	for _, f := range allFiles {

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -19,8 +19,8 @@ package modulereader
 
 import (
 	"fmt"
+	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/sourcereader"
-	"log"
 	"os"
 	"path"
 
@@ -180,7 +180,7 @@ var kinds = map[string]ModReader{
 func Factory(kind string) ModReader {
 	r, ok := kinds[kind]
 	if !ok {
-		log.Fatalf("Invalid request to create a reader of kind %s", kind)
+		logging.Fatal("Invalid request to create a reader of kind %s", kind)
 	}
 	return r
 }

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -19,6 +19,7 @@ package shell
 import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
 	"log"
 	"os"
 	"path/filepath"
@@ -95,7 +96,7 @@ func CheckWritableDir(path string) error {
 // skip making the proposed changes and continue execution (in deploy command)
 // only if the user responds with "y" or "yes" (case-insensitive)
 func ApplyChangesChoice(c ProposedChanges) bool {
-	log.Printf("Summary of proposed changes: %s", strings.TrimSpace(c.Summary))
+	logging.Info("Summary of proposed changes: %s", strings.TrimSpace(c.Summary))
 	var userResponse string
 
 	for {
@@ -116,9 +117,9 @@ Please select an option [d,a,s,c]: `)
 		case "c":
 			return false
 		case "d":
-			fmt.Println(c.Full)
+			logging.Info(c.Full)
 		case "s":
-			log.Fatal("user chose to stop execution of ghpc rather than make proposed changes to infrastructure")
+			logging.Fatal("user chose to stop execution of ghpc rather than make proposed changes to infrastructure")
 		}
 	}
 }


### PR DESCRIPTION
This PR implements a custom logging system to reduce the following print statements.

- fmt.Print
- fmt.Printf
- fmt.Println
- log.Fatal (Note: cases in which the error object was passed as the parameter were not replaced)
- log.Fatalf
- log.Printf
- log.Println

The custom logging system implemented has 3 levels.
1. Info - writes to stdout
2. Warn - writes to stderr
3. Fatal - writes to stderr and exits program
