### PR TITLE
Reduce usage of `log.Fatal` in tests, use `c.Fatal` instead

### DIFF
--- a/pkg/deploymentio/local_test.go
+++ b/pkg/deploymentio/local_test.go
@@ -15,7 +15,6 @@
 package deploymentio
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 
@@ -44,7 +43,7 @@ func (s *MySuite) TestCopyFromPathLocal(c *C) {
 	testSrcFilename := filepath.Join(testDir, "testSrc")
 	str := []byte("TestCopyFromPathLocal")
 	if err := os.WriteFile(testSrcFilename, str, 0755); err != nil {
-		log.Fatalf("deploymentio_test: failed to create %s: %v", testSrcFilename, err)
+		c.Fatalf("deploymentio_test: failed to create %s: %v", testSrcFilename, err)
 	}
 
 	testDstFilename := filepath.Join(testDir, "testDst")
@@ -52,12 +51,12 @@ func (s *MySuite) TestCopyFromPathLocal(c *C) {
 
 	src, err := os.ReadFile(testSrcFilename)
 	if err != nil {
-		log.Fatalf("deploymentio_test: failed to read %s: %v", testSrcFilename, err)
+		c.Fatalf("deploymentio_test: failed to read %s: %v", testSrcFilename, err)
 	}
 
 	dst, err := os.ReadFile(testDstFilename)
 	if err != nil {
-		log.Fatalf("deploymentio_test: failed to read %s: %v", testDstFilename, err)
+		c.Fatalf("deploymentio_test: failed to read %s: %v", testDstFilename, err)
 	}
 
 	c.Assert(string(src), Equals, string(dst))

--- a/pkg/modulereader/resreader_test.go
+++ b/pkg/modulereader/resreader_test.go
@@ -171,7 +171,7 @@ func (s *MySuite) TestGetHCLInfo(c *C) {
 	pathToEmptyDir := filepath.Join(packerDir, "emptyDir")
 	err = os.Mkdir(pathToEmptyDir, 0755)
 	if err != nil {
-		log.Fatal("TestGetHCLInfo: Failed to create test directory.")
+		c.Fatal("TestGetHCLInfo: Failed to create test directory.")
 	}
 	_, err = getHCLInfo(pathToEmptyDir)
 	expectedErr = "source is not a terraform or packer module: .*"

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -251,7 +251,7 @@ func (s *MySuite) TestCreateGroupDirs(c *C) {
 	// Setup
 	testDeployDir := filepath.Join(testDir, "test_createGroupDirs")
 	if err := os.Mkdir(testDeployDir, 0755); err != nil {
-		log.Fatal("Failed to create test deployment directory for createGroupDirs")
+		c.Fatal("Failed to create test deployment directory for createGroupDirs")
 	}
 	groupNames := []config.GroupName{"group0", "group1", "group2"}
 
@@ -469,7 +469,7 @@ func (s *MySuite) TestWriteMain(c *C) {
 	testMainDir := filepath.Join(testDir, "TestWriteMain")
 	mainFilePath := filepath.Join(testMainDir, "main.tf")
 	if err := os.Mkdir(testMainDir, 0755); err != nil {
-		log.Fatal("Failed to create test dir for creating main.tf file")
+		c.Fatal("Failed to create test dir for creating main.tf file")
 	}
 
 	// Simple success
@@ -519,7 +519,7 @@ func (s *MySuite) TestWriteOutputs(c *C) {
 	testOutputsDir := filepath.Join(testDir, "TestWriteOutputs")
 	outputsFilePath := filepath.Join(testOutputsDir, "outputs.tf")
 	if err := os.Mkdir(testOutputsDir, 0755); err != nil {
-		log.Fatal("Failed to create test directory for creating outputs.tf file")
+		c.Fatal("Failed to create test directory for creating outputs.tf file")
 	}
 
 	// Simple success, no modules
@@ -555,7 +555,7 @@ func (s *MySuite) TestWriteVariables(c *C) {
 	testVarDir := filepath.Join(testDir, "TestWriteVariables")
 	varsFilePath := filepath.Join(testVarDir, "variables.tf")
 	if err := os.Mkdir(testVarDir, 0755); err != nil {
-		log.Fatal("Failed to create test directory for creating variables.tf file")
+		c.Fatal("Failed to create test directory for creating variables.tf file")
 	}
 
 	noIntergroupVars := []modulereader.VarInfo{}
@@ -590,7 +590,7 @@ func (s *MySuite) TestWriteProviders(c *C) {
 	testProvDir := filepath.Join(testDir, "TestWriteProviders")
 	provFilePath := filepath.Join(testProvDir, "providers.tf")
 	if err := os.Mkdir(testProvDir, 0755); err != nil {
-		log.Fatal("Failed to create test directory for creating providers.tf file")
+		c.Fatal("Failed to create test directory for creating providers.tf file")
 	}
 
 	// Simple success, empty vars
@@ -635,15 +635,15 @@ func (s *MySuite) TestWriteDeploymentGroup_PackerWriter(c *C) {
 	testVars := config.NewDict(map[string]cty.Value{"deployment_name": cty.StringVal(deploymentName)})
 	deploymentDir := filepath.Join(testDir, deploymentName)
 	if err := deploymentio.CreateDirectory(deploymentDir); err != nil {
-		log.Fatal(err)
+		c.Fatal(err)
 	}
 	groupDir := filepath.Join(deploymentDir, "packerGroup")
 	if err := deploymentio.CreateDirectory(groupDir); err != nil {
-		log.Fatal(err)
+		c.Fatal(err)
 	}
 	moduleDir := filepath.Join(groupDir, "testPackerModule")
 	if err := deploymentio.CreateDirectory(moduleDir); err != nil {
-		log.Fatal(err)
+		c.Fatal(err)
 	}
 
 	testPackerModule := config.Module{
@@ -690,7 +690,7 @@ func (s *MySuite) TestWritePackerAutoVars(c *C) {
 
 	testPackerTemplateDir := filepath.Join(testDir, "TestWritePackerTemplate")
 	if err := os.Mkdir(testPackerTemplateDir, 0755); err != nil {
-		log.Fatalf("Failed to create test dir for creating %s file", packerAutoVarFilename)
+		c.Fatalf("Failed to create test dir for creating %s file", packerAutoVarFilename)
 	}
 	err = writePackerAutovars(vars.Items(), testPackerTemplateDir)
 	c.Assert(err, IsNil)

--- a/pkg/sourcereader/embedded_test.go
+++ b/pkg/sourcereader/embedded_test.go
@@ -15,7 +15,6 @@
 package sourcereader
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 
@@ -63,7 +62,7 @@ func (s *MySuite) TestCopyDirFromModules(c *C) {
 	testModFS := getTestFS()
 	copyDir := filepath.Join(testDir, "TestCopyDirFromModules")
 	if err := os.Mkdir(copyDir, 0755); err != nil {
-		log.Fatal(err)
+		c.Fatal(err)
 	}
 
 	// Success

--- a/pkg/sourcereader/goget_test.go
+++ b/pkg/sourcereader/goget_test.go
@@ -15,7 +15,6 @@
 package sourcereader
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 
@@ -26,7 +25,7 @@ func (s *MySuite) TestCopyGitModules(c *C) {
 	// Setup
 	destDir := filepath.Join(testDir, "TestCopyGitRepository")
 	if err := os.Mkdir(destDir, 0755); err != nil {
-		log.Fatal(err)
+		c.Fatal(err)
 	}
 	reader := GoGetterSourceReader{}
 


### PR DESCRIPTION
With `log.Fatal`
```sh
=== RUN   Test
2023/11/21 21:21:28 Oopsy
FAIL    hpc-toolkit/pkg/config  0.058s
```

With `c.Fatal`
```sh
=== RUN   Test

----------------------------------------------------------------------
FAIL: /usr/local/google/home/orlov/wp/hpc-toolkit/pkg/config/config_test.go:1069: MySuite.TestFatal

/usr/local/google/home/orlov/wp/hpc-toolkit/pkg/config/config_test.go:1070:
    c.Fatal("Oopsy")
... Error: Oopsy

OOPS: 38 passed, 1 FAILED
```
