### PR TITLE
Refactor `pkg/deploymentio` tests

### DIFF
--- a/pkg/deploymentio/deploymentio_test.go
+++ b/pkg/deploymentio/deploymentio_test.go
@@ -15,11 +15,7 @@
 package deploymentio
 
 import (
-	"fmt"
-	"log"
-	"os"
 	"testing"
-	"time"
 
 	"github.com/spf13/afero"
 	. "gopkg.in/check.v1"
@@ -40,36 +36,12 @@ const (
 `
 )
 
-var testDir string
+type zeroSuite struct{}
 
-// Setup GoCheck
-type MySuite struct{}
-
-var _ = Suite(&MySuite{})
+var _ = Suite(&zeroSuite{})
 
 func Test(t *testing.T) {
 	TestingT(t)
-}
-
-func setup() {
-	t := time.Now()
-	dirName := fmt.Sprintf("ghpc_deploymentio_test_%s", t.Format(time.RFC3339))
-	dir, err := os.MkdirTemp("", dirName)
-	if err != nil {
-		log.Fatalf("modulewriter_test: %v", err)
-	}
-	testDir = dir
-}
-
-func teardown() {
-	os.RemoveAll(testDir)
-}
-
-func TestMain(m *testing.M) {
-	setup()
-	code := m.Run()
-	teardown()
-	os.Exit(code)
 }
 
 func getTestFS() afero.IOFS {
@@ -82,7 +54,7 @@ func getTestFS() afero.IOFS {
 	return afero.NewIOFS(aferoFS)
 }
 
-func (s *MySuite) TestGetDeploymentioLocal(c *C) {
+func (s *zeroSuite) TestGetDeploymentioLocal(c *C) {
 	deploymentio := GetDeploymentioLocal()
 	c.Assert(deploymentio, Equals, deploymentios["local"])
 }

--- a/pkg/deploymentio/local_test.go
+++ b/pkg/deploymentio/local_test.go
@@ -21,83 +21,83 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *MySuite) TestCreateDirectoryLocal(c *C) {
-	deploymentio := GetDeploymentioLocal()
+func (s *zeroSuite) TestCreateDirectoryLocal(c *C) {
+	dio := GetDeploymentioLocal()
+	dir := c.MkDir()
 
-	// Try to create the exist directory
-	err := deploymentio.CreateDirectory(testDir)
-	expErr := "the directory already exists: .*"
-	c.Assert(err, ErrorMatches, expErr)
-
-	directoryName := "dir_TestCreateDirectoryLocal"
-	createdDir := filepath.Join(testDir, directoryName)
-	err = deploymentio.CreateDirectory(createdDir)
-	c.Assert(err, IsNil)
-
-	_, err = os.Stat(createdDir)
-	c.Assert(err, IsNil)
-}
-
-func (s *MySuite) TestCopyFromPathLocal(c *C) {
-	deploymentio := GetDeploymentioLocal()
-	testSrcFilename := filepath.Join(testDir, "testSrc")
-	str := []byte("TestCopyFromPathLocal")
-	if err := os.WriteFile(testSrcFilename, str, 0755); err != nil {
-		c.Fatalf("deploymentio_test: failed to create %s: %v", testSrcFilename, err)
+	{ // Try to create the exist directory
+		err := dio.CreateDirectory(dir)
+		c.Assert(err, ErrorMatches, "the directory already exists: .*")
 	}
 
-	testDstFilename := filepath.Join(testDir, "testDst")
-	deploymentio.CopyFromPath(testSrcFilename, testDstFilename)
+	{ // Ok
+		sub := filepath.Join(dir, "dog/cat")
+		c.Assert(dio.CreateDirectory(sub), IsNil)
+		stat, err := os.Stat(sub)
+		c.Assert(err, IsNil)
+		c.Check(stat.IsDir(), Equals, true)
+	}
+}
 
-	src, err := os.ReadFile(testSrcFilename)
+func (s *zeroSuite) TestCopyFromPathLocal(c *C) {
+	dio := GetDeploymentioLocal()
+	dir := c.MkDir()
+
+	src := filepath.Join(dir, "zebra")
+	if err := os.WriteFile(src, []byte("jupiter"), 0755); err != nil {
+		c.Fatal(err)
+	}
+
+	dst := filepath.Join(dir, "pony")
+	c.Assert(dio.CopyFromPath(src, dst), IsNil)
+
+	got, err := os.ReadFile(dst)
 	if err != nil {
-		c.Fatalf("deploymentio_test: failed to read %s: %v", testSrcFilename, err)
+		c.Fatal(err)
 	}
 
-	dst, err := os.ReadFile(testDstFilename)
-	if err != nil {
-		c.Fatalf("deploymentio_test: failed to read %s: %v", testDstFilename, err)
+	c.Assert("jupiter", Equals, string(got))
+}
+
+func (s *zeroSuite) TestMkdirWrapper(c *C) {
+	dir := c.MkDir()
+	{ // Success
+		dst := filepath.Join(dir, "piranha/barracuda")
+		c.Assert(mkdirWrapper(dst), IsNil)
 	}
 
-	c.Assert(string(src), Equals, string(dst))
+	{ // Failure: Path is not a directory
+		dst := filepath.Join(dir, "watermelon")
+		_, err := os.Create(dst)
+		c.Assert(err, IsNil)
+
+		c.Assert(mkdirWrapper(dst), ErrorMatches, "failed to create the directory .*")
+	}
 }
 
-func (s *MySuite) TestMkdirWrapper(c *C) {
-	// Success
-	testMkdirWrapperDir := filepath.Join(testDir, "testMkdirWrapperDir")
-	err := mkdirWrapper(testMkdirWrapperDir)
-	c.Assert(err, IsNil)
-
-	// Failure: Path is not a directory
-	badMkdirWrapperDir := filepath.Join(testDir, "NotADir")
-	_, err = os.Create(badMkdirWrapperDir)
-	c.Assert(err, IsNil)
-	err = mkdirWrapper(badMkdirWrapperDir)
-	expErr := "failed to create the directory .*"
-	c.Assert(err, ErrorMatches, expErr)
-}
-
-func (s *MySuite) TestCopyFromFS(c *C) {
-	// Success
-	deploymentio := GetDeploymentioLocal()
+func (s *zeroSuite) TestCopyFromFS(c *C) {
+	dio := GetDeploymentioLocal()
 	testFS := getTestFS()
-	testSrcGitignore := "pkg/modulewriter/deployment.gitignore.tmpl"
-	testDstGitignore := filepath.Join(testDir, ".gitignore")
-	err := deploymentio.CopyFromFS(testFS, testSrcGitignore, testDstGitignore)
+	dir := c.MkDir()
+
+	// Success
+	src := "pkg/modulewriter/deployment.gitignore.tmpl"
+	dst := filepath.Join(dir, ".gitignore")
+	err := dio.CopyFromFS(testFS, src, dst)
 	c.Assert(err, IsNil)
-	data, err := os.ReadFile(testDstGitignore)
+	data, err := os.ReadFile(dst)
 	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, testGitignoreTmpl)
 
 	// Success: This truncates the file if it already exists in the destination
-	testSrcNewGitignore := "pkg/modulewriter/deployment_new.gitignore.tmpl"
-	err = deploymentio.CopyFromFS(testFS, testSrcNewGitignore, testDstGitignore)
+	newSrc := "pkg/modulewriter/deployment_new.gitignore.tmpl"
+	err = dio.CopyFromFS(testFS, newSrc, dst)
 	c.Assert(err, IsNil)
-	newData, err := os.ReadFile(testDstGitignore)
+	newData, err := os.ReadFile(dst)
 	c.Assert(err, IsNil)
 	c.Assert(string(newData), Equals, testGitignoreNewTmpl)
 
 	// Failure: Invalid path
-	err = deploymentio.CopyFromFS(testFS, "not/valid", testDstGitignore)
+	err = dio.CopyFromFS(testFS, "not/valid", dst)
 	c.Assert(err, ErrorMatches, "*file does not exist")
 }


### PR DESCRIPTION
* Stop using `TestMain`, see `lib/google-golang/src/testing/testing.go` :

```go
// TestMain is a low-level primitive and should not be necessary for casual
// testing needs, where ordinary test functions suffice.
```

* Use `c.Fatal` instead of `log.Fatal`, see #1985 for motivation;
