### PR TITLE
Refactor `pkg/modulewriter` tests

### DIFF
--- a/pkg/modulereader/hcl_utils_test.go
+++ b/pkg/modulereader/hcl_utils_test.go
@@ -20,7 +20,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *MySuite) TestNormalizeType(c *C) {
+func (s *zeroSuite) TestNormalizeType(c *C) {
 	c.Check(
 		NormalizeType("object({count=number,kind=string})"),
 		Equals,
@@ -38,7 +38,7 @@ func (s *MySuite) TestNormalizeType(c *C) {
 
 // a full-loop test of ReadWrite is implemented in modulewriter package
 // focus on modes that should error
-func (s *MySuite) TestReadHclAtttributes(c *C) {
+func (s *zeroSuite) TestReadHclAtttributes(c *C) {
 	fn, err := os.CreateTemp("", "test-*")
 	if err != nil {
 		c.Fatal(err)


### PR DESCRIPTION
* Stop using `TestMain`, see `lib/google-golang/src/testing/testing.go` :

```go
// TestMain is a low-level primitive and should not be necessary for casual
// testing needs, where ordinary test functions suffice.
```

* Use `c.Fatal` instead of `log.Fatal`, see #1985 for motivation;
