### PR TITLE
Refactor `pkg/sourcereader` tests.

### DIFF
--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -18,40 +18,24 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 )
 
 func (s *MySuite) TestIsDir(c *C) {
-	dir, err := os.MkdirTemp("", "test-*")
-	if err != nil {
-		c.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := c.MkDir()
+	c.Assert(checkDir(nil, []string{dir}), IsNil)
 
-	err = checkDir(nil, []string{dir})
+	p := filepath.Join(dir, "does-not-exist")
+	c.Assert(checkDir(nil, []string{p}), NotNil)
+
+	f, err := os.CreateTemp(dir, "test-*")
 	c.Assert(err, IsNil)
-
-	os.RemoveAll(dir)
-	err = checkDir(nil, []string{dir})
-	c.Assert(err, NotNil)
-
-	f, err := os.CreateTemp("", "test-*")
-	if err != nil {
-		c.Fatal(err)
-	}
-	defer os.Remove(f.Name())
-	err = checkDir(nil, []string{f.Name()})
-	c.Assert(err, NotNil)
+	c.Assert(checkDir(nil, []string{f.Name()}), NotNil)
 }
 
 func (s *MySuite) TestRunExport(c *C) {
-	dir, err := os.MkdirTemp("", "test-*")
-	if err != nil {
-		c.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	err = runExportCmd(nil, []string{dir})
-	c.Assert(err, NotNil)
+	dir := c.MkDir()
+	c.Assert(runExportCmd(nil, []string{dir}), NotNil)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,7 +48,7 @@ func Test(t *testing.T) {
 }
 
 func (s *MySuite) SetUpSuite(c *C) {
-	simpleYamlFile, err := os.CreateTemp("", "*.yaml")
+	simpleYamlFile, err := os.CreateTemp(c.MkDir(), "*.yaml")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -78,9 +78,7 @@ deployment_groups:
 	simpleYamlFile.Close()
 
 	// Create test directory with simple modules
-	if s.tmpTestDir, err = os.MkdirTemp("", "ghpc_config_tests_*"); err != nil {
-		c.Fatal(err)
-	}
+	s.tmpTestDir = c.MkDir()
 
 	moduleDir := filepath.Join(s.tmpTestDir, "module")
 	if err = os.Mkdir(moduleDir, 0755); err != nil {
@@ -96,15 +94,6 @@ deployment_groups:
         type        = string
     }`
 	if _, err = varFile.WriteString(testVariablesTF); err != nil {
-		c.Fatal(err)
-	}
-}
-
-func (s *MySuite) TearDownSuite(c *C) {
-	if err := os.Remove(s.simpleYamlFilename); err != nil {
-		c.Fatal(err)
-	}
-	if err := os.RemoveAll(s.tmpTestDir); err != nil {
 		c.Fatal(err)
 	}
 }

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -41,21 +41,11 @@ type MySuite struct {
 }
 
 func (s *MySuite) SetUpSuite(c *C) {
-	dir, err := os.MkdirTemp("", "ghpc_modulewriter_test_*")
-	if err != nil {
-		c.Fatal(err)
-	}
-	s.testDir = dir
+	s.testDir = c.MkDir()
 
 	// Create dummy module in testDir
 	s.terraformModuleDir = filepath.Join(s.testDir, "tfModule")
 	if err := os.Mkdir(s.terraformModuleDir, 0755); err != nil {
-		c.Fatal(err)
-	}
-}
-
-func (s *MySuite) TearDownSuite(c *C) {
-	if err := os.RemoveAll(s.testDir); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -244,10 +234,7 @@ func (s *MySuite) TestWriteDeployment(c *C) {
 
 func (s *MySuite) TestCreateGroupDirs(c *C) {
 	// Setup
-	testDeployDir := filepath.Join(s.testDir, "test_createGroupDirs")
-	if err := os.Mkdir(testDeployDir, 0755); err != nil {
-		c.Fatal("Failed to create test deployment directory for createGroupDirs")
-	}
+	testDeployDir := c.MkDir()
 	groupNames := []config.GroupName{"group0", "group1", "group2"}
 
 	// No deployment groups
@@ -580,11 +567,8 @@ func (s *MySuite) TestWriteVariables(c *C) {
 
 func (s *MySuite) TestWriteProviders(c *C) {
 	// Setup
-	testProvDir := filepath.Join(s.testDir, "TestWriteProviders")
+	testProvDir := c.MkDir()
 	provFilePath := filepath.Join(testProvDir, "providers.tf")
-	if err := os.Mkdir(testProvDir, 0755); err != nil {
-		c.Fatal("Failed to create test directory for creating providers.tf file")
-	}
 
 	// Simple success, empty vars
 	testVars := make(map[string]cty.Value)
@@ -681,11 +665,8 @@ func (s *MySuite) TestWritePackerAutoVars(c *C) {
 	expErr := fmt.Sprintf("error creating variables file %s:.*", packerAutoVarFilename)
 	c.Assert(err, ErrorMatches, expErr)
 
-	testPackerTemplateDir := filepath.Join(s.testDir, "TestWritePackerTemplate")
-	if err := os.Mkdir(testPackerTemplateDir, 0755); err != nil {
-		c.Fatalf("Failed to create test dir for creating %s file", packerAutoVarFilename)
-	}
-	err = writePackerAutovars(vars.Items(), testPackerTemplateDir)
+	// success
+	err = writePackerAutovars(vars.Items(), c.MkDir())
 	c.Assert(err, IsNil)
 
 }

--- a/pkg/sourcereader/goget_test.go
+++ b/pkg/sourcereader/goget_test.go
@@ -21,17 +21,17 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *MySuite) TestCopyGitModules(c *C) {
-	// Setup
-	destDir := filepath.Join(testDir, "TestCopyGitRepository")
-	if err := os.Mkdir(destDir, 0755); err != nil {
-		c.Fatal(err)
-	}
-	reader := GoGetterSourceReader{}
+type goGetSuite struct {
+	r GoGetterSourceReader
+}
 
+var _ = Suite(&goGetSuite{})
+
+func (s *goGetSuite) TestGetModule_GoGet(c *C) {
+	destDir := c.MkDir()
 	// Success via HTTPS
 	destDirForHTTPS := filepath.Join(destDir, "https")
-	err := reader.GetModule("github.com/terraform-google-modules/terraform-google-project-factory//helpers", destDirForHTTPS)
+	err := s.r.GetModule("github.com/terraform-google-modules/terraform-google-project-factory//helpers", destDirForHTTPS)
 	c.Assert(err, IsNil)
 	fInfo, err := os.Stat(filepath.Join(destDirForHTTPS, "terraform_validate"))
 	c.Assert(err, IsNil)
@@ -41,25 +41,19 @@ func (s *MySuite) TestCopyGitModules(c *C) {
 
 	// Success via HTTPS (Root directory)
 	destDirForHTTPSRootDir := filepath.Join(destDir, "https-rootdir")
-	err = reader.GetModule("github.com/terraform-google-modules/terraform-google-service-accounts.git?ref=v4.1.1", destDirForHTTPSRootDir)
+	err = s.r.GetModule("github.com/terraform-google-modules/terraform-google-service-accounts.git?ref=v4.1.1", destDirForHTTPSRootDir)
 	c.Assert(err, IsNil)
 	fInfo, err = os.Stat(filepath.Join(destDirForHTTPSRootDir, "main.tf"))
 	c.Assert(err, IsNil)
 	c.Assert(fInfo.Name(), Equals, "main.tf")
 	c.Assert(fInfo.Size() > 0, Equals, true)
 	c.Assert(fInfo.IsDir(), Equals, false)
-}
-
-func (s *MySuite) TestGetModule_Git(c *C) {
-	reader := GoGetterSourceReader{}
 
 	// Invalid git repository - path does not exists
 	badGitRepo := "github.com:not/exist.git"
-	err := reader.GetModule(badGitRepo, tfKindString)
-	c.Assert(err, NotNil)
+	c.Assert(s.r.GetModule(badGitRepo, tfKindString), NotNil)
 
 	// Invalid: Unsupported Module Source
 	badSource := "wut::https://www.googleapis.com/storage/v1/GoogleCloudPlatform/hpc-toolkit/modules"
-	err = reader.GetModule(badSource, tfKindString)
-	c.Assert(err, NotNil)
+	c.Assert(s.r.GetModule(badSource, tfKindString), NotNil)
 }

--- a/pkg/sourcereader/local_test.go
+++ b/pkg/sourcereader/local_test.go
@@ -15,94 +15,37 @@
 package sourcereader
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
 )
 
-// Util Functions
-func createTmpModule() {
-	var err error
-
-	// Create terraform module dir
-	terraformDir = filepath.Join(testDir, "terraformModule")
-	err = os.Mkdir(terraformDir, 0755)
-	if err != nil {
-		log.Fatalf("error creating test terraform module dir: %e", err)
-	}
-
-	// main.tf file
-	mainFile, err := os.Create(filepath.Join(terraformDir, "main.tf"))
-	if err != nil {
-		log.Fatalf("Failed to create main.tf: %v", err)
-	}
-	_, err = mainFile.WriteString(testMainTf)
-	if err != nil {
-		log.Fatalf("sourcereader_local_test: Failed to write main.tf test file. %v", err)
-	}
-
-	// variables.tf file
-	varFile, err := os.Create(filepath.Join(terraformDir, "variables.tf"))
-	if err != nil {
-		log.Fatalf("Failed to create variables.tf: %v", err)
-	}
-	_, err = varFile.WriteString(testVariablesTf)
-	if err != nil {
-		log.Fatalf(
-			"sourcereader_local_test: Failed to write variables.tf test file. %v", err)
-	}
-
-	// outputs.tf file
-	outFile, err := os.Create(filepath.Join(terraformDir, "outputs.tf"))
-	if err != nil {
-		log.Fatalf("Failed to create outputs.tf: %v", err)
-	}
-	_, err = outFile.WriteString(testOutputsTf)
-	if err != nil {
-		log.Fatalf("sourcereader_local_test: Failed to write outputs.tf test file. %v", err)
-	}
-
-	// Create packer module dir
-	packerDir = filepath.Join(testDir, "packerModule")
-	err = os.Mkdir(packerDir, 0755)
-	if err != nil {
-		log.Fatalf("error creating test packer module dir: %e", err)
-	}
-
-	// main.pkr.hcl file
-	mainFile, err = os.Create(filepath.Join(packerDir, "main.pkr.hcl"))
-	if err != nil {
-		log.Fatalf("Failed to create main.pkr.hcl: %v", err)
-	}
-	_, err = mainFile.WriteString(testMainTf)
-	if err != nil {
-		log.Fatalf("sourcereader_local_test: Failed to write main.pkr.hcl test file. %v", err)
-	}
-
-	// variables.pkr.hcl file
-	varFile, err = os.Create(filepath.Join(packerDir, "variables.pkr.hcl"))
-	if err != nil {
-		log.Fatalf("Failed to create variables.pkr.hcl: %v", err)
-	}
-	_, err = varFile.WriteString(testVariablesTf)
-	if err != nil {
-		log.Fatalf(
-			"sourcereader_local_test: Failed to write variables.pkr.hcl test file. %v", err)
-	}
+type localSuite struct {
+	r     LocalSourceReader
+	tfDir string
 }
 
-func (s *MySuite) TestGetModule_Local(c *C) {
-	reader := LocalSourceReader{}
+var _ = Suite(&localSuite{})
 
+func (s *localSuite) SetUpSuite(c *C) {
+	s.r = LocalSourceReader{}
+	d := c.MkDir()
+	// copy embedded modules to a temp directory
+	if err := copyDir(testEmbeddedFS, "modules", d); err != nil {
+		c.Fatal(err)
+	}
+	s.tfDir = filepath.Join(d, "network/vpc")
+}
+
+func (s *localSuite) TestGetModule(c *C) {
 	// Success
-	dest := filepath.Join(testDir, "TestGetModule_Local")
-	err := reader.GetModule(terraformDir, dest)
+	dest := filepath.Join(c.MkDir(), c.TestName())
+	err := s.r.GetModule(s.tfDir, dest)
 	c.Assert(err, IsNil)
 
 	// Invalid: Write to the same dest directory again
-	err = reader.GetModule(terraformDir, dest)
+	err = s.r.GetModule(s.tfDir, dest)
 	expectedErr := "the directory already exists: .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 
@@ -115,13 +58,36 @@ func (s *MySuite) TestGetModule_Local(c *C) {
 
 	// Invalid: No local module
 	badLocalMod := "./modules/does/not/exist"
-	err = reader.GetModule(badLocalMod, dest)
+	err = s.r.GetModule(badLocalMod, dest)
 	expectedErr = "local module doesn't exist at .*"
 	c.Assert(err, ErrorMatches, expectedErr)
 
 	// Invalid: Unsupported Module Source by LocalSourceReader
 	badSource := "gcs::https://www.googleapis.com/storage/v1/GoogleCloudPlatform/hpc-toolkit/modules"
-	err = reader.GetModule(badSource, dest)
+	err = s.r.GetModule(badSource, dest)
 	expectedErr = "source is not valid: .*"
 	c.Assert(err, ErrorMatches, expectedErr)
+}
+
+func (s *localSuite) TestCopyFromPath_Absent(c *C) {
+	src := filepath.Join(s.tfDir, "waldo")
+	dst := filepath.Join(c.MkDir(), c.TestName())
+
+	c.Assert(copyFromPath(src, dst), NotNil)
+}
+
+func (s *localSuite) TestCopyFromPath(c *C) {
+	dst := filepath.Join(c.MkDir(), c.TestName())
+
+	err := copyFromPath(s.tfDir, dst)
+	c.Assert(err, IsNil)
+	fInfo, err := os.Stat(filepath.Join(dst, "main.tf"))
+	c.Assert(err, IsNil)
+	c.Assert(fInfo.Name(), Equals, "main.tf")
+	c.Assert(fInfo.Size() > 0, Equals, true)
+	c.Assert(fInfo.IsDir(), Equals, false)
+
+	// Invalid: Specify the same destination path again
+	err = copyFromPath(s.tfDir, dst)
+	c.Assert(err, ErrorMatches, "the directory already exists: .*")
 }

--- a/pkg/sourcereader/modules/network/vpc/main.tf
+++ b/pkg/sourcereader/modules/network/vpc/main.tf
@@ -1,0 +1,21 @@
+# Copyright 2023 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 0.14.0"
+}
+
+locals {
+  name = "hello_${var.test_variable}"
+}

--- a/pkg/sourcereader/modules/network/vpc/output.tf
+++ b/pkg/sourcereader/modules/network/vpc/output.tf
@@ -1,0 +1,18 @@
+# Copyright 2023 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "test_output" {
+  description = "This is just a test"
+  value       = local.name
+}

--- a/pkg/sourcereader/modules/network/vpc/variables.tf
+++ b/pkg/sourcereader/modules/network/vpc/variables.tf
@@ -1,0 +1,18 @@
+# Copyright 2023 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "test_variable" {
+  description = "This is just a test"
+  type        = string
+}


### PR DESCRIPTION
* Don't hardcode creation of test dummy files, use embedded folder for this;
* Use `c.MkDir()` to one-line creation of test folders;
* Split `MySuite` into `local`, `embedded` and `goget` suites with different setup;