### PR TITLE
Eliminate startup-script hasn't started message

### DIFF
--- a/modules/scripts/startup-script/files/running-script-warning.sh
+++ b/modules/scripts/startup-script/files/running-script-warning.sh
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 SCRIPT_COMPLETE_FILE="/run/startup_script_msg"
-WARNING_MESSAGE="** WARNING **: HPC Toolkit startup scripts have not started yet."
 
 # Ensure we're in an interactive terminal and not root
 if [ -t 1 ] && [ "$(id -u)" -ne 0 ]; then
@@ -22,10 +21,6 @@ if [ -t 1 ] && [ "$(id -u)" -ne 0 ]; then
 	if [ -s "$SCRIPT_COMPLETE_FILE" ]; then
 		echo
 		cat "$SCRIPT_COMPLETE_FILE"
-		echo
-	elif [ ! -f "$SCRIPT_COMPLETE_FILE" ]; then
-		echo
-		echo "$WARNING_MESSAGE"
 		echo
 	fi
 fi


### PR DESCRIPTION
The /etc/profile.d login prompt informational message makes the assumption that the VM is running a startup-script that uses our startup-script module. This assumption is broken when an image is built using our startup-script module and then a VM is booted with that image that does not execute our startup-script module. This assumption is also broken upon reboots of Slurm VMs because our script is wrapped inside a startup script solution developed by SchedMD that exits early when Slurm has previously started successfully. We can reconsider enabling this message more robustly as part of future work.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
