### PR TITLE
OFE: Spack upgrade to v0.21.0

### DIFF
--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/spack_install/tasks/main.yaml
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/spack_install/tasks/main.yaml
@@ -25,7 +25,7 @@
   ansible.builtin.git:
     repo: https://github.com/spack/spack.git
     dest: "{{ spack_dir }}"
-    version: v0.19.1
+    version: v0.21.0
     depth: 1
 
 - name: Apply Global Spack configurations

--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
@@ -173,7 +173,7 @@ sudo su - gcluster -c /bin/bash <<EOF
   printf "\nDownloading Frontend dependencies...\n"
   mkdir dependencies
   pushd dependencies
-  git clone -b v0.17.1 --depth 1 https://github.com/spack/spack.git
+  git clone -b v0.21.0 --depth 1 https://github.com/spack/spack.git
   printf "\npre-generating Spack package list\n"
   ./spack/bin/spack list > /dev/null
   popd

--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -63,7 +63,6 @@ platformdirs==3.8.0
 pre-commit==3.3.3
 proto-plus==1.22.3
 protobuf==4.23.3
-py==1.11.0
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21

--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -1,7 +1,9 @@
+altgraph==0.17.4
 archspec==0.2.1
 argcomplete==3.1.1
 asgiref==3.7.2
 astroid==2.15.5
+attrs==23.1.0
 # This should be supported by zoneinfo in Python 3.9+
 backports.zoneinfo==0.2.1;python_version<"3.9"
 cachetools==5.3.1
@@ -42,17 +44,26 @@ h11==0.14.0
 httplib2==0.22.0
 identify==2.5.24
 idna==3.4
+importlib-resources==6.1.1
 isort==5.12.0
+Jinja2==3.1.2
+jsonschema==4.20.0
+jsonschema-specifications==2023.11.1
 lazy-object-proxy==1.9.0
 libcst==1.0.1
+macholib==1.16.3
+MarkupSafe==2.1.3
 mccabe==0.7.0
 mypy-extensions==1.0.0
 nodeenv==1.8.0
 oauthlib==3.2.2
+path==16.7.1
+pkgutil_resolve_name==1.3.10
 platformdirs==3.8.0
 pre-commit==3.3.3
 proto-plus==1.22.3
 protobuf==4.23.3
+py==1.11.0
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21
@@ -64,10 +75,14 @@ pyparsing==3.1.0
 python3-openid==3.2.0
 pytz==2023.3
 PyYAML==6.0
+referencing==0.31.0
 requests==2.31.0
 requests-oauthlib==1.3.1
 retry==0.9.2
+rpds-py==0.13.1
 rsa==4.9
+ruamel.yaml==0.18.5
+ruamel.yaml.clib==0.2.8
 semantic-version==2.10.0
 setuptools-rust==1.6.0
 six==1.16.0
@@ -84,3 +99,4 @@ virtualenv==20.23.1
 wrapt==1.15.0
 xmltodict==0.13.0
 yq==3.2.2
+zipp==3.17.0

--- a/community/front-end/ofe/website/ghpcfe/cluster_manager/spack.py
+++ b/community/front-end/ofe/website/ghpcfe/cluster_manager/spack.py
@@ -36,7 +36,7 @@ def get_package_list():
 
 
 def get_package_info(names):
-    pkgs = [spack.repo.get(name) for name in names]
+    pkgs = [spack.repo.PATH.get_pkg_class(name) for name in names]
     return (
         {
             "name": pkg.name,


### PR DESCRIPTION
Upgrading OFE Spack to version v0.21.0 to support the latest versions of the applications.
For example:
![image](https://github.com/GoogleCloudPlatform/hpc-toolkit/assets/117852832/9ccb17d8-863b-457d-a5e2-0597c7a6ea20)
