### PR TITLE
`ghpc import-inputs`. Fix panic; refactor to meet `gocyclo` requirements

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -444,22 +444,23 @@ func (dg DeploymentGroup) OutputNames() []string {
 
 // OutputNamesByGroup returns the outputs from prior groups that match input
 // names for this group as a map
-func OutputNamesByGroup(g DeploymentGroup, dc DeploymentConfig) (map[GroupName][]string, error) {
-	refs := g.FindAllIntergroupReferences(dc.Config)
-	inputNames := make([]string, len(refs))
+func OutputNamesByGroup(g DeploymentGroup, bp Blueprint) (map[GroupName][]string, error) {
+	refs := g.FindAllIntergroupReferences(bp)
+	inputs := make([]string, len(refs))
 	for i, ref := range refs {
-		inputNames[i] = AutomaticOutputName(ref.Name, ref.Module)
+		inputs[i] = AutomaticOutputName(ref.Name, ref.Module)
 	}
 
-	i := dc.Config.GroupIndex(g.Name)
+	i := bp.GroupIndex(g.Name)
 	if i == -1 {
 		return nil, fmt.Errorf("group %s not found in blueprint", g.Name)
 	}
-	outputNamesByGroup := make(map[GroupName][]string)
-	for _, g := range dc.Config.DeploymentGroups[:i] {
-		outputNamesByGroup[g.Name] = intersection(inputNames, g.OutputNames())
+
+	res := make(map[GroupName][]string)
+	for _, pg := range bp.DeploymentGroups[:i] {
+		res[pg.Name] = intersection(inputs, pg.OutputNames())
 	}
-	return outputNamesByGroup, nil
+	return res, nil
 }
 
 // return sorted list of elements common to s1 and s2

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -476,16 +476,17 @@ func (s *MySuite) TestOutputNamesByGroup(c *C) {
 	dc := s.getMultiGroupDeploymentConfig()
 	dc.applyGlobalVariables()
 	dc.applyUseModules()
+	bp := dc.Config
 
-	group0 := dc.Config.DeploymentGroups[0]
+	group0 := bp.DeploymentGroups[0]
 	mod0 := group0.Modules[0]
-	group1 := dc.Config.DeploymentGroups[1]
+	group1 := bp.DeploymentGroups[1]
 
-	outputNamesGroup0, err := OutputNamesByGroup(group0, dc)
+	outputNamesGroup0, err := OutputNamesByGroup(group0, bp)
 	c.Assert(err, IsNil)
 	c.Assert(outputNamesGroup0, DeepEquals, map[GroupName][]string{})
 
-	outputNamesGroup1, err := OutputNamesByGroup(group1, dc)
+	outputNamesGroup1, err := OutputNamesByGroup(group1, bp)
 	c.Assert(err, IsNil)
 	c.Assert(outputNamesGroup1, DeepEquals, map[GroupName][]string{
 		group0.Name: {AutomaticOutputName("test_inter_0", mod0.ID)},

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/sys/unix"
 )
 
@@ -58,12 +57,14 @@ func intersectMapKeys[K comparable, T any](s []K, m map[K]T) map[K]T {
 	return intersection
 }
 
-func mergeMapsWithoutLoss[K comparable, V any](m1 map[K]V, m2 map[K]V) {
-	expectedLength := len(m1) + len(m2)
-	maps.Copy(m1, m2)
-	if len(m1) != expectedLength {
-		panic(fmt.Errorf("unexpected key collision in maps"))
+func mergeMapsWithoutLoss[K comparable, V any](to map[K]V, from map[K]V) error {
+	for k, v := range from {
+		if _, ok := to[k]; ok {
+			return fmt.Errorf("duplicate key %v", k)
+		}
+		to[k] = v
 	}
+	return nil
 }
 
 // DirInfo reports if path is a directory and new files can be written in it

--- a/pkg/shell/common_test.go
+++ b/pkg/shell/common_test.go
@@ -85,12 +85,14 @@ func (s *MySuite) TestCheckWritableDir(c *C) {
 }
 
 func (s *MySuite) TestMergeMapsWithoutLoss(c *C) {
-	m1 := map[string]int{"foo": 0}
-	m2 := map[string]int{"bar": 1}
+	t := map[string]int{"foo": 0}
+	f := map[string]int{"bar": 1}
 
-	mergeMapsWithoutLoss(m1, m2)
+	c.Check(mergeMapsWithoutLoss(t, f), IsNil)
+	c.Check(f, DeepEquals, map[string]int{"bar": 1})
+	c.Check(t, DeepEquals, map[string]int{"foo": 0, "bar": 1})
 
-	c.Assert(func() { mergeMapsWithoutLoss(m1, m1) }, PanicMatches, "unexpected key collision in maps")
+	c.Check(mergeMapsWithoutLoss(t, f), ErrorMatches, "duplicate key bar")
 }
 
 func (s *MySuite) TestValidateDeploymentDirectory(c *C) {


### PR DESCRIPTION
```sh ./ghpc deploy clues
$ 
./ghpc deploy clues

...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

subnetwork_name_network = "default"
Collecting terraform outputs from clues/zero
Writing outputs artifact from deployment group zero to file clues/.ghpc/artifacts/zero_outputs.tfvars
collecting outputs for group one from group zero
Error: duplicate key subnetwork_name_network
```