### PR TITLE
Update `checkOverwriteAllowed`

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -303,7 +303,7 @@ func checkOverwriteAllowed(depDir string, bp config.Blueprint, overwriteFlag boo
 	// try to get previous deployment
 	expPath := filepath.Join(modulewriter.ArtifactsDir(depDir), modulewriter.ExpandedBlueprintName)
 	if _, err := os.Stat(expPath); os.IsNotExist(err) {
-		return fmt.Errorf("expanded blueprint file %q is missing, maybe your previous GHPC version is too old", expPath)
+		return fmt.Errorf("expanded blueprint file %q is missing, this could be a result of changing GHPC version between consecutive deployments", expPath)
 	}
 	prev, _, err := config.NewDeploymentConfig(expPath)
 	if err != nil {
@@ -311,7 +311,7 @@ func checkOverwriteAllowed(depDir string, bp config.Blueprint, overwriteFlag boo
 	}
 
 	if prev.Config.GhpcVersion != bp.GhpcVersion {
-		logging.Info("WARNING: ghpc_version has changed from %q to %q", prev.Config.GhpcVersion, bp.GhpcVersion)
+		logging.Info("WARNING: ghpc_version has changed from %q to %q, using different versions of GHPC to update a live deployment is not officially supported. Proceed at your own risk", prev.Config.GhpcVersion, bp.GhpcVersion)
 	}
 
 	if !overwriteFlag {

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -17,6 +17,9 @@ package cmd
 import (
 	"errors"
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/modulewriter"
+	"os"
+	"path/filepath"
 
 	"github.com/zclconf/go-cty/cty"
 	. "gopkg.in/check.v1"
@@ -163,4 +166,50 @@ func (s *MySuite) TestValidateMaybeDie(c *C) {
 	}
 	ctx, _ := config.NewYamlCtx([]byte{})
 	validateMaybeDie(bp, ctx) // smoke test
+}
+
+func (s *MySuite) TestIsOverwriteAllowed_Absent(c *C) {
+	testDir := c.MkDir()
+	depDir := filepath.Join(testDir, "casper")
+
+	bp := config.Blueprint{}
+	c.Check(checkOverwriteAllowed(depDir, bp, false /*overwriteFlag*/), IsNil)
+	c.Check(checkOverwriteAllowed(depDir, bp, true /*overwriteFlag*/), IsNil)
+}
+
+func (s *MySuite) TestIsOverwriteAllowed_Malformed(c *C) {
+	depDir := c.MkDir() // empty deployment folder considered malformed
+
+	bp := config.Blueprint{}
+	c.Check(checkOverwriteAllowed(depDir, bp, false /*overwriteFlag*/), ErrorMatches, ".* already exists, use -w to overwrite")
+	c.Check(checkOverwriteAllowed(depDir, bp, true /*overwriteFlag*/), IsNil)
+}
+
+func (s *MySuite) TestIsOverwriteAllowed_Present(c *C) {
+	depDir := c.MkDir()
+	artDir := modulewriter.ArtifactsDir(depDir)
+	if err := os.MkdirAll(artDir, 0755); err != nil {
+		c.Fatal(err)
+	}
+
+	prev := config.DeploymentConfig{
+		Config: config.Blueprint{
+			DeploymentGroups: []config.DeploymentGroup{
+				{Name: "isildur"}}}}
+	if err := prev.ExportBlueprint(filepath.Join(artDir, "expanded_blueprint.yaml")); err != nil {
+		c.Fatal(err)
+	}
+
+	super := config.Blueprint{
+		DeploymentGroups: []config.DeploymentGroup{
+			{Name: "isildur"},
+			{Name: "elendil"}}}
+	c.Check(checkOverwriteAllowed(depDir, super, false /*overwriteFlag*/), ErrorMatches, ".* already exists, use -w to overwrite")
+	c.Check(checkOverwriteAllowed(depDir, super, true /*overwriteFlag*/), IsNil)
+
+	sub := config.Blueprint{
+		DeploymentGroups: []config.DeploymentGroup{
+			{Name: "aragorn"}}}
+	c.Check(checkOverwriteAllowed(depDir, sub, false /*overwriteFlag*/), ErrorMatches, `.*remove a deployment group "isildur".*`)
+	c.Check(checkOverwriteAllowed(depDir, sub, true /*overwriteFlag*/), ErrorMatches, `.*remove a deployment group "isildur".*`)
 }

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -192,8 +192,8 @@ func (s *MySuite) TestIsOverwriteAllowed_NoExpanded(c *C) {
 	}
 
 	bp := config.Blueprint{}
-	c.Check(checkOverwriteAllowed(depDir, bp, false /*overwriteFlag*/), ErrorMatches, ".* previous GHPC version is too old")
-	c.Check(checkOverwriteAllowed(depDir, bp, true /*overwriteFlag*/), ErrorMatches, ".* previous GHPC version is too old")
+	c.Check(checkOverwriteAllowed(depDir, bp, false /*overwriteFlag*/), ErrorMatches, ".* changing GHPC version.*")
+	c.Check(checkOverwriteAllowed(depDir, bp, true /*overwriteFlag*/), ErrorMatches, ".* changing GHPC version.*")
 }
 
 func (s *MySuite) TestIsOverwriteAllowed_Malformed(c *C) {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -74,7 +74,7 @@ func getApplyBehavior(autoApprove bool) shell.ApplyBehavior {
 }
 
 func runDeployCmd(cmd *cobra.Command, args []string) {
-	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
+	expandedBlueprintFile := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
 	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	checkErr(err)
 	groups := dc.Config.DeploymentGroups

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -63,7 +63,7 @@ func parseDestroyArgs(cmd *cobra.Command, args []string) error {
 }
 
 func runDestroyCmd(cmd *cobra.Command, args []string) error {
-	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
+	expandedBlueprintFile := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
 	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	if err != nil {
 		return err

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -32,10 +32,6 @@ func init() {
 	rootCmd.AddCommand(exportCmd)
 }
 
-var defaultArtifactsDir = filepath.Join(modulewriter.HiddenGhpcDirName, modulewriter.ArtifactsDirName)
-
-const expandedBlueprintFilename string = "expanded_blueprint.yaml"
-
 var (
 	artifactsDir string
 	exportCmd    = &cobra.Command{
@@ -73,7 +69,7 @@ func parseExportImportArgs(cmd *cobra.Command, args []string) {
 
 func getArtifactsDir(deploymentRoot string) string {
 	if artifactsDir == "" {
-		return filepath.Clean(filepath.Join(deploymentRoot, defaultArtifactsDir))
+		return modulewriter.ArtifactsDir(deploymentRoot)
 	}
 	return artifactsDir
 }
@@ -86,7 +82,7 @@ func runExportCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
+	expandedBlueprintFile := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
 	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	if err != nil {
 		return err

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/modulewriter"
 	"hpc-toolkit/pkg/shell"
 	"path/filepath"
 
@@ -50,7 +51,7 @@ func runImportCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	expandedBlueprintFile := filepath.Join(artifactsDir, expandedBlueprintFilename)
+	expandedBlueprintFile := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
 	dc, _, err := config.NewDeploymentConfig(expandedBlueprintFile)
 	if err != nil {
 		return err

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -371,12 +371,11 @@ func (w TFWriter) writeDeploymentGroup(
 
 // Transfers state files from previous resource groups (in .ghpc/) to a newly written blueprint
 func (w TFWriter) restoreState(deploymentDir string) error {
-	prevDeploymentGroupPath := filepath.Join(
-		deploymentDir, HiddenGhpcDirName, prevDeploymentGroupDirName)
+	prevDeploymentGroupPath := filepath.Join(HiddenGhpcDir(deploymentDir), prevDeploymentGroupDirName)
 	files, err := os.ReadDir(prevDeploymentGroupPath)
 	if err != nil {
 		return fmt.Errorf(
-			"Error trying to read previous modules in %s, %w",
+			"error trying to read previous modules in %s, %w",
 			prevDeploymentGroupPath, err)
 	}
 


### PR DESCRIPTION
**BREAKING CHANGE:**
Use `expanded_blueprint.yaml` to get list of groups instead of listing deployment dir. 

This will render old deployments (created by GHPC version 7 months old, before #1193 ) as "malformed" from POV of overwriting logic => user will not be able to overwrite
Other changes:
* Move it from `modulewriter` to `cmd`;
* Make it to return detailed error;
```sh
...
Error: you are attempting to remove a deployment group "one", which is not supported
```

```sh
...
Error: deployment folder "clues" already exists, use -w to overwrite
```


* Make `modulewriter` unaware of overwriting logic;
* Compare baked `ghpc_versions`, warn if mismatch.

```sh
...
WARNING: ghpc_version has changed from "v1.25.0-156-gd198216a" to "v1.25.0-155-g136bc46a"
To deploy your infrastructure please run:
...
```


