### PR TITLE
Refactor `WriteDeployment`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
   - id: go-vet
   - id: go-imports
   - id: go-cyclo
-    args: [-over=15]
+    args: [-over=13]
   - id: go-unit-tests
   - id: go-build
   - id: go-mod-tidy

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -57,11 +57,10 @@ func writePackerAutovars(vars map[string]cty.Value, dst string) error {
 func (w PackerWriter) writeDeploymentGroup(
 	dc config.DeploymentConfig,
 	grpIdx int,
-	deployDir string,
+	groupPath string,
 	instructionsFile io.Writer,
 ) error {
 	depGroup := dc.Config.DeploymentGroups[grpIdx]
-	groupPath := filepath.Join(deployDir, string(depGroup.Name))
 	igcInputs := map[string]bool{}
 
 	for _, mod := range depGroup.Modules {

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -294,77 +294,57 @@ func writeTerraformInstructions(w io.Writer, grpPath string, n config.GroupName,
 	}
 }
 
-// writeDeploymentGroup creates and sets up the provided terraform deployment
-// group in the provided deployment directory
-// depGroup: The deployment group that is being written
-// globalVars: The top-level variables, needed for writing terraform.tfvars and
-// variables.tf
-// groupDir: The path to the directory the resource group will be created in
+// writeDeploymentGroup creates and sets up the terraform deployment group
 func (w TFWriter) writeDeploymentGroup(
 	dc config.DeploymentConfig,
 	groupIndex int,
-	deploymentDir string,
-	instructionsFile io.Writer,
+	groupPath string,
+	instructions io.Writer,
 ) error {
-	depGroup := dc.Config.DeploymentGroups[groupIndex]
-	deploymentVars := getUsedDeploymentVars(depGroup, dc.Config)
-	intergroupVars := FindIntergroupVariables(depGroup, dc.Config)
+	g := dc.Config.DeploymentGroups[groupIndex]
+	deploymentVars := getUsedDeploymentVars(g, dc.Config)
+	intergroupVars := FindIntergroupVariables(g, dc.Config)
 	intergroupInputs := make(map[string]bool)
 	for _, igVar := range intergroupVars {
 		intergroupInputs[igVar.Name] = true
 	}
 
-	groupPath := filepath.Join(deploymentDir, string(depGroup.Name))
-
 	// Write main.tf file
-	doctoredModules := substituteIgcReferences(depGroup.Modules, intergroupVars)
-	if err := writeMain(
-		doctoredModules, depGroup.TerraformBackend, groupPath,
-	); err != nil {
-		return fmt.Errorf("error writing main.tf file for deployment group %s: %v",
-			depGroup.Name, err)
+	doctoredModules := substituteIgcReferences(g.Modules, intergroupVars)
+	if err := writeMain(doctoredModules, g.TerraformBackend, groupPath); err != nil {
+		return fmt.Errorf("error writing main.tf file for deployment group %s: %w", g.Name, err)
 	}
 
 	// Write variables.tf file
 	if err := writeVariables(deploymentVars, maps.Values(intergroupVars), groupPath); err != nil {
-		return fmt.Errorf(
-			"error writing variables.tf file for deployment group %s: %v",
-			depGroup.Name, err)
+		return fmt.Errorf("error writing variables.tf file for deployment group %s: %w", g.Name, err)
 	}
 
 	// Write outputs.tf file
-	if err := writeOutputs(depGroup.Modules, groupPath); err != nil {
-		return fmt.Errorf(
-			"error writing outputs.tf file for deployment group %s: %v",
-			depGroup.Name, err)
+	if err := writeOutputs(g.Modules, groupPath); err != nil {
+		return fmt.Errorf("error writing outputs.tf file for deployment group %s: %w", g.Name, err)
 	}
 
 	// Write terraform.tfvars file
 	if err := writeTfvars(deploymentVars, groupPath); err != nil {
-		return fmt.Errorf(
-			"error writing terraform.tfvars file for deployment group %s: %v",
-			depGroup.Name, err)
+		return fmt.Errorf("error writing terraform.tfvars file for deployment group %s: %w", g.Name, err)
 	}
 
 	// Write providers.tf file
 	if err := writeProviders(deploymentVars, groupPath); err != nil {
-		return fmt.Errorf(
-			"error writing providers.tf file for deployment group %s: %v",
-			depGroup.Name, err)
+		return fmt.Errorf("error writing providers.tf file for deployment group %s: %w", g.Name, err)
 	}
 
 	// Write versions.tf file
 	if err := writeVersions(groupPath); err != nil {
-		return fmt.Errorf(
-			"error writing versions.tf file for deployment group %s: %v",
-			depGroup.Name, err)
+		return fmt.Errorf("error writing versions.tf file for deployment group %s: %v", g.Name, err)
 	}
 
 	multiGroupDeployment := len(dc.Config.DeploymentGroups) > 1
 	printImportInputs := multiGroupDeployment && groupIndex > 0
 	printExportOutputs := multiGroupDeployment && groupIndex < len(dc.Config.DeploymentGroups)-1
 
-	writeTerraformInstructions(instructionsFile, groupPath, depGroup.Name, printExportOutputs, printImportInputs)
+	writeTerraformInstructions(instructions, groupPath, g.Name, printExportOutputs, printImportInputs)
 
 	return nil
 }


### PR DESCRIPTION
* Move group-related logic from `WriteDeployment` into separate function;
* Reduced number of places where group dir path is decided;
* Set appropriate order between `createGroupDir` and `copyGroupSources`;
* Use error-wrapping;
* Reduce `gocyclo` threhsold `15 -> 13`;

