### PR TITLE
Fail `terraform_docs` hook if any error occurs.

### DIFF
--- a/tools/autodoc/terraform_docs.sh
+++ b/tools/autodoc/terraform_docs.sh
@@ -23,5 +23,8 @@ done
 uniq_paths=$(echo "${paths[@]}" | tr ' ' '\n' | sort -u)
 
 for path in $uniq_paths; do
-	terraform-docs markdown --config .tfdocs-markdown.yaml "${path}"
+	terraform-docs markdown --config .tfdocs-markdown.yaml "${path}" || {
+		echo "Error generating docs for ${path}"
+		exit 1
+	}
 done


### PR DESCRIPTION
Before that change the check was resilient to failures, e.g.
```
Error: begin comment is missing
```

