### PR TITLE
DEMO. Deploy-time quota validation without metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/terraform-exec v0.19.0
+	github.com/hashicorp/terraform-json v0.17.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 	google.golang.org/api v0.152.0
@@ -36,7 +37,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
-	github.com/hashicorp/terraform-json v0.17.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -25,6 +25,7 @@ import (
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/modulereader"
 	"hpc-toolkit/pkg/modulewriter"
+	"hpc-toolkit/pkg/validators"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -197,7 +198,13 @@ func planModule(tf *tfexec.Terraform, path string, destroy bool) (bool, error) {
 		}
 		return false, &TfError{msg, plainError}
 	}
-
+	plan, err := tf.ShowPlanFile(context.Background(), path)
+	if err != nil {
+		return false, err
+	}
+	if err := validators.QuotaCheckPlan(plan); err != nil {
+		return false, err
+	}
 	return wantsChange, nil
 }
 


### PR DESCRIPTION
DO_NOT_SUBMIT

Get information about resources directly from Terraform plan

```yaml
  ...
  modules:
  - id: network
    source: modules/network/vpc
  - id: workstation
    source: modules/compute/vm-instance
    use: [network]
    settings:
      instance_count: 2
      name_prefix: workstation
      machine_type: n2-standard-16
      disk_size_gb: 2500
```

```sh
$ ./ghpc deploy q
Testing if deployment group q/primary requires adding or changing cloud infrastructure
Error: 
not enough quota "Total persistent disk reserved (GB)" as "1/{project}/{region}", limit=4096 < requested=5000
not enough quota "N2 CPUs" as "1/{project}/{region}", limit=24 < requested=32
```
