### PR TITLE
update TFLint to 0.49 & latest plugin in precommit

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -14,12 +14,12 @@
 
 plugin "google" {
   enabled = true
-  version = "0.23.0"
+  version = "0.26.0"
   source  = "github.com/terraform-linters/tflint-ruleset-google"
 }
 plugin "terraform" {
   enabled = true
-  version = "0.4.0"
+  version = "0.5.0"
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }
 rule "terraform_deprecated_index" {

--- a/community/modules/compute/gke-node-pool/variables.tf
+++ b/community/modules/compute/gke-node-pool/variables.tf
@@ -230,6 +230,7 @@ variable "timeout_update" {
 
 # Deprecated
 
+# tflint-ignore: terraform_unused_declarations
 variable "total_min_nodes" {
   description = "DEPRECATED: Use autoscaling_total_min_nodes."
   type        = number
@@ -240,6 +241,7 @@ variable "total_min_nodes" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "total_max_nodes" {
   description = "DEPRECATED: Use autoscaling_total_max_nodes."
   type        = number
@@ -250,6 +252,7 @@ variable "total_max_nodes" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "service_account" {
   description = "DEPRECATED: use service_account_email and scopes."
   type = object({

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
@@ -126,6 +126,7 @@ variable "instance_image_custom" {
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_project" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -136,6 +137,7 @@ variable "source_image_project" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_family" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -146,6 +148,7 @@ variable "source_image_family" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -263,6 +266,7 @@ variable "on_host_maintenance" {
   default     = "TERMINATE"
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "gpu" {
   type = object({
     type  = string

--- a/community/modules/file-system/DDN-EXAScaler/variables.tf
+++ b/community/modules/file-system/DDN-EXAScaler/variables.tf
@@ -202,6 +202,7 @@ variable "boot" {
 # project: project name
 # family: image family name
 # name: !!DEPRECATED!! - image name
+# tflint-ignore: terraform_unused_declarations
 variable "image" {
   description = "DEPRECATED: Source image properties"
   type        = any

--- a/community/modules/project/service-account/variables.tf
+++ b/community/modules/project/service-account/variables.tf
@@ -31,6 +31,7 @@ variable "description" {
   default     = "Service Account"
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "descriptions" {
   description = "Deprecated; create single service accounts using var.description."
   type        = list(string)
@@ -71,6 +72,7 @@ variable "name" {
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "names" {
   description = "Deprecated; create single service accounts using var.name."
   type        = list(string)
@@ -88,6 +90,7 @@ variable "org_id" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "prefix" {
   description = "Deprecated; prefix now set using var.deployment_name"
   type        = string

--- a/community/modules/scheduler/gke-cluster/variables.tf
+++ b/community/modules/scheduler/gke-cluster/variables.tf
@@ -258,6 +258,7 @@ variable "timeout_update" {
 }
 
 # Deprecated
+# tflint-ignore: terraform_unused_declarations
 variable "service_account" {
   description = "DEPRECATED: use service_account_email and scopes."
   type = object({

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
@@ -293,6 +293,7 @@ EOD
   default = []
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "gpu" {
   type = object({
     type  = string
@@ -349,6 +350,7 @@ EOD
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "network_ip" {
   type        = string
   description = "DEPRECATED: Use `static_ips` variable to assign an internal static ip address."
@@ -575,6 +577,7 @@ variable "instance_image_custom" {
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_project" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -585,6 +588,7 @@ variable "source_image_project" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_family" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -595,6 +599,7 @@ variable "source_image_family" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
@@ -92,6 +92,7 @@ variable "region" {
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "network_ip" {
   type        = string
   description = "DEPRECATED: Use `static_ips` variable to assign an internal static ip address."
@@ -154,6 +155,7 @@ variable "min_cpu_platform" {
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "gpu" {
   type = object({
     type  = string
@@ -324,6 +326,7 @@ variable "instance_image_custom" {
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_project" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -334,6 +337,7 @@ variable "source_image_project" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_family" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -344,6 +348,7 @@ variable "source_image_family" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."

--- a/community/modules/scripts/spack-setup/variables.tf
+++ b/community/modules/scripts/spack-setup/variables.tf
@@ -90,6 +90,7 @@ variable "labels" {
 
 # variables to be deprecated
 
+# tflint-ignore: terraform_unused_declarations
 variable "log_file" {
   description = <<-EOT
   DEPRECATED 
@@ -105,6 +106,7 @@ variable "log_file" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "spack_cache_url" {
   description = <<-EOT
   DEPRECATED
@@ -129,6 +131,7 @@ variable "spack_cache_url" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "configs" {
   description = <<-EOT
   DEPRECATED
@@ -151,6 +154,7 @@ variable "configs" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "compilers" {
   description = <<-EOT
   DEPRECATED
@@ -175,6 +179,7 @@ variable "compilers" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "licenses" {
   description = <<-EOT
   DEPRECATED
@@ -202,6 +207,7 @@ variable "licenses" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "packages" {
   description = <<-EOT
   DEPRECATED
@@ -222,6 +228,7 @@ variable "packages" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "install_flags" {
   description = "DEPRECATED - spack install is now performed using the [spack-execute](../spack-execute/) module `commands` variable."
   default     = null
@@ -232,6 +239,7 @@ variable "install_flags" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "concretize_flags" {
   description = "DEPRECATED - spack concretize is now performed using the [spack-execute](../spack-execute/) module `commands` variable."
   default     = null
@@ -242,6 +250,7 @@ variable "concretize_flags" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "gpg_keys" {
   description = <<EOT
   DEPRECATED
@@ -265,6 +274,7 @@ EOT
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "caches_to_populate" {
   description = <<-EOT
   DEPRECATED
@@ -295,6 +305,7 @@ EOT
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "environments" {
   description = <<-EOT
   DEPRECATED

--- a/modules/network/vpc/variables.tf
+++ b/modules/network/vpc/variables.tf
@@ -31,6 +31,7 @@ variable "subnetwork_name" {
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "subnetwork_size" {
   description = "DEPRECATED: please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions"
   type        = number
@@ -117,6 +118,7 @@ variable "subnetworks" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "primary_subnetwork" {
   description = "DEPRECATED: please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions"
   type        = map(string)
@@ -127,6 +129,7 @@ variable "primary_subnetwork" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "additional_subnetworks" {
   description = "DEPRECATED: please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions"
   type        = list(map(string))

--- a/modules/scheduler/batch-login-node/variables.tf
+++ b/modules/scheduler/batch-login-node/variables.tf
@@ -85,6 +85,7 @@ variable "job_data" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "job_template_contents" {
   description = "Deprecated (use `job_data`): The contents of the Google Cloud Batch job template. Typically supplied by a batch-job-template module."
   type        = string
@@ -95,6 +96,7 @@ variable "job_template_contents" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "job_filename" {
   description = "Deprecated (use `job_data`): The filename of the generated job template file. Typically supplied by a batch-job-template module."
   type        = string
@@ -105,6 +107,7 @@ variable "job_filename" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "job_id" {
   description = "Deprecated (use `job_data`): The ID for the Google Cloud Batch job. Typically supplied by a batch-job-template module for use in the output instructions."
   type        = string

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -136,6 +136,7 @@ variable "configure_ssh_host_patterns" {
   default     = []
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "prepend_ansible_installer" {
   description = <<EOT
   DEPRECATED. Use `install_ansible=false` to prevent ansible installation.

--- a/tools/cloud-build/hpc-toolkit-builder.yaml
+++ b/tools/cloud-build/hpc-toolkit-builder.yaml
@@ -24,7 +24,7 @@ steps:
   - '--cache-from'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder:latest'
   - '--build-arg'
-  - 'TFLINT_VERSION=v0.46.0'
+  - 'TFLINT_VERSION=v0.49.0'
   - '--build-arg'
   - 'SHELLCHECK_VERSION=v0.9.0'
   - '-f'

--- a/tools/cloud-workstations/workstation-image.yaml
+++ b/tools/cloud-workstations/workstation-image.yaml
@@ -24,7 +24,7 @@ steps:
   - '--cache-from'
   - '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/hpc-toolkit-workstation:latest'
   - '--build-arg'
-  - 'TFLINT_VERSION=v0.46.0'
+  - 'TFLINT_VERSION=v0.49.0'
   - '-f'
   - 'tools/cloud-workstations/Dockerfile'
   - '.'


### PR DESCRIPTION
This change fixes the unused variable warning so that validation blocks are not counted as a use of the input variables. i.e. it eliminate false negatives.

TFLint 0.49.0 includes a bundled generic ruleset (v0.5.0) for the terraform language itself. v0.5.0 includes a [change](https://github.com/terraform-linters/tflint-ruleset-terraform/pull/133) made in response to an [issue](https://github.com/terraform-linters/tflint-ruleset-terraform/issues/94).

TFLINT_VERSION is updated to `v0.49.0`
version of terraform plugin is updated to  `0.5.0`
all warnings are decorated by `# tflint-ignore: terraform_unused_declarations` 

a local run is passing:
```
➜  hpc-toolkit git:(tflint-update) ✗ pre-commit run -a terraform_tflint
Terraform validate with tflint...........................................Passed
```
as well as `make tests`