### PR TITLE
Fix broken golang, add tests to meet coverage threshold

### DIFF
--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -272,8 +272,7 @@ func prepDepDir(depDir string) error {
 	if err := deploymentio.CreateDirectory(depDir); err != nil {
 		// Confirm we have a previously written deployment dir before overwriting.
 		if _, err := os.Stat(ghpcDir); os.IsNotExist(err) {
-			return fmt.Errorf(
-				"while trying to update the deployment directory at %s, the '.ghpc/' dir could not be found", depDir)
+			return fmt.Errorf("while trying to update the deployment directory at %s, the '.ghpc/' dir could not be found", depDir)
 		}
 	} else {
 		if err := deploymentio.CreateDirectory(ghpcDir); err != nil {

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package modulewriter
 
 import (
-	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/deploymentio"
@@ -674,4 +673,18 @@ func (s *zeroSuite) TestSubstituteIgcReferencesInModule(c *C) {
 		config.MustParseExpression(`var.pink + 6 + var.lime`).AsValue(),
 		config.MustParseExpression(`module.tennis.brown`).AsValue(),
 	})})
+}
+
+func (s *zeroSuite) TestWritePackerDestroyInstructions(c *C) {
+	{ // no manifest
+		b := new(strings.Builder)
+		WritePackerDestroyInstructions(b, nil)
+		c.Check(b.String(), Equals, "")
+	}
+	{ // with manifest
+		b := new(strings.Builder)
+		WritePackerDestroyInstructions(b, []string{"Aldebaran", "Betelgeuse"})
+		got := strings.ReplaceAll(b.String(), "\n", "") // one-line to simplify matcher
+		c.Check(got, Matches, ".*Aldebaran.*Betelgeuse.*")
+	}
 }

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -354,9 +354,7 @@ func (w TFWriter) restoreState(deploymentDir string) error {
 	prevDeploymentGroupPath := filepath.Join(HiddenGhpcDir(deploymentDir), prevDeploymentGroupDirName)
 	files, err := os.ReadDir(prevDeploymentGroupPath)
 	if err != nil {
-		return fmt.Errorf(
-			"error trying to read previous modules in %s, %w",
-			prevDeploymentGroupPath, err)
+		return fmt.Errorf("error trying to read previous modules in %s, %w", prevDeploymentGroupPath, err)
 	}
 
 	for _, f := range files {


### PR DESCRIPTION
Two PRs touched this file:
#2007 
#2013 
Merged without rebase the rendered `import errors` unused => failed `go build`
