### PR TITLE
Hotfix wait for startup update

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -13,8 +13,13 @@
 // limitations under the License.
 plugin "google" {
   enabled = true
-  version = "0.23.0"
+  version = "0.26.0"
   source  = "github.com/terraform-linters/tflint-ruleset-google"
+}
+plugin "terraform" {
+  enabled = true
+  version = "0.5.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }
 rule "terraform_deprecated_index" {
   enabled = true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ HPC deployments on the Google Cloud Platform.`,
 				log.Fatalf("cmd.Help function failed: %s", err)
 			}
 		},
-		Version:     "v1.26.0",
+		Version:     "v1.26.1",
 		Annotations: annotation,
 	}
 )

--- a/community/modules/compute/gke-node-pool/variables.tf
+++ b/community/modules/compute/gke-node-pool/variables.tf
@@ -230,6 +230,7 @@ variable "timeout_update" {
 
 # Deprecated
 
+# tflint-ignore: terraform_unused_declarations
 variable "total_min_nodes" {
   description = "DEPRECATED: Use autoscaling_total_min_nodes."
   type        = number
@@ -240,6 +241,7 @@ variable "total_min_nodes" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "total_max_nodes" {
   description = "DEPRECATED: Use autoscaling_total_max_nodes."
   type        = number
@@ -250,6 +252,7 @@ variable "total_max_nodes" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "service_account" {
   description = "DEPRECATED: use service_account_email and scopes."
   type = object({

--- a/community/modules/compute/gke-node-pool/versions.tf
+++ b/community/modules/compute/gke-node-pool/versions.tf
@@ -26,6 +26,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.26.1"
   }
 }

--- a/community/modules/compute/htcondor-execute-point/versions.tf
+++ b/community/modules/compute/htcondor-execute-point/versions.tf
@@ -25,6 +25,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.26.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
@@ -126,6 +126,7 @@ variable "instance_image_custom" {
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_project" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -136,6 +137,7 @@ variable "source_image_project" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_family" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -146,6 +148,7 @@ variable "source_image_family" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -263,6 +266,7 @@ variable "on_host_maintenance" {
   default     = "TERMINATE"
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "gpu" {
   type = object({
     type  = string

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-node-group/v1.26.1"
   }
   required_version = ">= 1.1"
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-partition/v1.26.1"
   }
   required_version = ">= 0.13.0"
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 1.3"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.26.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset/v1.26.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 1.3"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.26.1"
   }
 }

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -30,10 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.26.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.26.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/file-system/DDN-EXAScaler/variables.tf
+++ b/community/modules/file-system/DDN-EXAScaler/variables.tf
@@ -202,6 +202,7 @@ variable "boot" {
 # project: project name
 # family: image family name
 # name: !!DEPRECATED!! - image name
+# tflint-ignore: terraform_unused_declarations
 variable "image" {
   description = "DEPRECATED: Source image properties"
   type        = any

--- a/community/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/community/modules/file-system/cloud-storage-bucket/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.26.1"
   }
   required_version = ">= 0.14.0"
 }

--- a/community/modules/file-system/gke-persistent-volume/versions.tf
+++ b/community/modules/file-system/gke-persistent-volume/versions.tf
@@ -29,6 +29,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-persistent-volume/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-persistent-volume/v1.26.1"
   }
 }

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/project/service-account/variables.tf
+++ b/community/modules/project/service-account/variables.tf
@@ -31,6 +31,7 @@ variable "description" {
   default     = "Service Account"
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "descriptions" {
   description = "Deprecated; create single service accounts using var.description."
   type        = list(string)
@@ -71,6 +72,7 @@ variable "name" {
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "names" {
   description = "Deprecated; create single service accounts using var.name."
   type        = list(string)
@@ -88,6 +90,7 @@ variable "org_id" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "prefix" {
   description = "Deprecated; prefix now set using var.deployment_name"
   type        = string

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-controller/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:SchedMD-slurm-on-gcp-login-node/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scheduler/gke-cluster/variables.tf
+++ b/community/modules/scheduler/gke-cluster/variables.tf
@@ -258,6 +258,7 @@ variable "timeout_update" {
 }
 
 # Deprecated
+# tflint-ignore: terraform_unused_declarations
 variable "service_account" {
   description = "DEPRECATED: use service_account_email and scopes."
   type = object({

--- a/community/modules/scheduler/gke-cluster/versions.tf
+++ b/community/modules/scheduler/gke-cluster/versions.tf
@@ -30,6 +30,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.26.1"
   }
 }

--- a/community/modules/scheduler/htcondor-access-point/versions.tf
+++ b/community/modules/scheduler/htcondor-access-point/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.26.1"
   }
 
   required_version = ">= 1.1"

--- a/community/modules/scheduler/htcondor-central-manager/versions.tf
+++ b/community/modules/scheduler/htcondor-central-manager/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.26.1"
   }
 
   required_version = ">= 1.1.0"

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.26.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scheduler/htcondor-setup/versions.tf
+++ b/community/modules/scheduler/htcondor-setup/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-setup/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-setup/v1.26.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
@@ -293,6 +293,7 @@ EOD
   default = []
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "gpu" {
   type = object({
     type  = string
@@ -349,6 +350,7 @@ EOD
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "network_ip" {
   type        = string
   description = "DEPRECATED: Use `static_ips` variable to assign an internal static ip address."
@@ -575,6 +577,7 @@ variable "instance_image_custom" {
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_project" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -585,6 +588,7 @@ variable "source_image_project" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_family" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -595,6 +599,7 @@ variable "source_image_family" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-controller/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-controller/v1.26.1"
   }
   required_version = ">= 1.1"
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
@@ -92,6 +92,7 @@ variable "region" {
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "network_ip" {
   type        = string
   description = "DEPRECATED: Use `static_ips` variable to assign an internal static ip address."
@@ -154,6 +155,7 @@ variable "min_cpu_platform" {
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "gpu" {
   type = object({
     type  = string
@@ -324,6 +326,7 @@ variable "instance_image_custom" {
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_project" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -334,6 +337,7 @@ variable "source_image_project" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image_family" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."
@@ -344,6 +348,7 @@ variable "source_image_family" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "source_image" {
   type        = string
   description = "DEPRECATED: Use `instance_image` instead."

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-login/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v5-login/v1.26.1"
   }
   required_version = ">= 1.1"
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-controller/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-controller/v1.26.1"
   }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.26.1"
   }
 }

--- a/community/modules/scripts/spack-setup/variables.tf
+++ b/community/modules/scripts/spack-setup/variables.tf
@@ -90,6 +90,7 @@ variable "labels" {
 
 # variables to be deprecated
 
+# tflint-ignore: terraform_unused_declarations
 variable "log_file" {
   description = <<-EOT
   DEPRECATED 
@@ -105,6 +106,7 @@ variable "log_file" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "spack_cache_url" {
   description = <<-EOT
   DEPRECATED
@@ -129,6 +131,7 @@ variable "spack_cache_url" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "configs" {
   description = <<-EOT
   DEPRECATED
@@ -151,6 +154,7 @@ variable "configs" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "compilers" {
   description = <<-EOT
   DEPRECATED
@@ -175,6 +179,7 @@ variable "compilers" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "licenses" {
   description = <<-EOT
   DEPRECATED
@@ -202,6 +207,7 @@ variable "licenses" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "packages" {
   description = <<-EOT
   DEPRECATED
@@ -222,6 +228,7 @@ variable "packages" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "install_flags" {
   description = "DEPRECATED - spack install is now performed using the [spack-execute](../spack-execute/) module `commands` variable."
   default     = null
@@ -232,6 +239,7 @@ variable "install_flags" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "concretize_flags" {
   description = "DEPRECATED - spack concretize is now performed using the [spack-execute](../spack-execute/) module `commands` variable."
   default     = null
@@ -242,6 +250,7 @@ variable "concretize_flags" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "gpg_keys" {
   description = <<EOT
   DEPRECATED
@@ -265,6 +274,7 @@ EOT
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "caches_to_populate" {
   description = <<-EOT
   DEPRECATED
@@ -295,6 +305,7 @@ EOT
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "environments" {
   description = <<-EOT
   DEPRECATED

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scripts/windows-startup-script/versions.tf
+++ b/community/modules/scripts/windows-startup-script/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -31,10 +31,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.26.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.26.1"
   }
 
   required_version = ">= 1.2.0"

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.26.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/network/vpc/variables.tf
+++ b/modules/network/vpc/variables.tf
@@ -31,6 +31,7 @@ variable "subnetwork_name" {
   default     = null
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "subnetwork_size" {
   description = "DEPRECATED: please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions"
   type        = number
@@ -117,6 +118,7 @@ variable "subnetworks" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "primary_subnetwork" {
   description = "DEPRECATED: please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions"
   type        = map(string)
@@ -127,6 +129,7 @@ variable "primary_subnetwork" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "additional_subnetworks" {
   description = "DEPRECATED: please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions"
   type        = list(map(string))

--- a/modules/scheduler/batch-login-node/variables.tf
+++ b/modules/scheduler/batch-login-node/variables.tf
@@ -85,6 +85,7 @@ variable "job_data" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "job_template_contents" {
   description = "Deprecated (use `job_data`): The contents of the Google Cloud Batch job template. Typically supplied by a batch-job-template module."
   type        = string
@@ -95,6 +96,7 @@ variable "job_template_contents" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "job_filename" {
   description = "Deprecated (use `job_data`): The filename of the generated job template file. Typically supplied by a batch-job-template module."
   type        = string
@@ -105,6 +107,7 @@ variable "job_filename" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "job_id" {
   description = "Deprecated (use `job_data`): The ID for the Google Cloud Batch job. Typically supplied by a batch-job-template module for use in the output instructions."
   type        = string

--- a/modules/scheduler/batch-login-node/versions.tf
+++ b/modules/scheduler/batch-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -136,6 +136,7 @@ variable "configure_ssh_host_patterns" {
   default     = []
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "prepend_ansible_installer" {
   description = <<EOT
   DEPRECATED. Use `install_ansible=false` to prevent ansible installation.

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.26.0"
+    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.26.1"
   }
 
   required_version = ">= 0.14.0"

--- a/tools/cloud-build/hpc-toolkit-builder.yaml
+++ b/tools/cloud-build/hpc-toolkit-builder.yaml
@@ -24,7 +24,7 @@ steps:
   - '--cache-from'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder:latest'
   - '--build-arg'
-  - 'TFLINT_VERSION=v0.46.0'
+  - 'TFLINT_VERSION=v0.49.0'
   - '--build-arg'
   - 'SHELLCHECK_VERSION=v0.9.0'
   - '-f'

--- a/tools/cloud-workstations/workstation-image.yaml
+++ b/tools/cloud-workstations/workstation-image.yaml
@@ -24,7 +24,7 @@ steps:
   - '--cache-from'
   - '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/hpc-toolkit-workstation:latest'
   - '--build-arg'
-  - 'TFLINT_VERSION=v0.46.0'
+  - 'TFLINT_VERSION=v0.49.0'
   - '-f'
   - 'tools/cloud-workstations/Dockerfile'
   - '.'


### PR DESCRIPTION
This PR is to fix the wait-for-startup script in the wake of the guest agent being updated.  We needed to add a new matching string to account for the new error message, which was introduced about a month ago.

Testing was run by creating a vm-instance with a startup script with various changes:

1. Script that just runs "exit 0"
2. Script that runs "exit 1"
3. Script that slept for longer than the timeout
4. Script that slept and ended before the timeout

Tested on:
Latest hpc-centos-7 image
Latest rocky-8 image
`hpc-centos-7-v20220214` - for old agent
`rocky-linux-9-v20221102` - for old agent

This issue was introduced by a commit to [guest-agent](https://github.com/GoogleCloudPlatform/guest-agent/commit/5c85572e7f2b36d14668bef2c53e3acf7347d798)