### PR TITLE
Allow usage of expression for `vars.deployment_name`

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -79,9 +79,7 @@ var (
 
 func runCreateCmd(cmd *cobra.Command, args []string) {
 	dc := expandOrDie(args[0])
-	deplName, err := dc.Config.DeploymentName()
-	checkErr(err)
-	deplDir := filepath.Join(outputDir, deplName)
+	deplDir := filepath.Join(outputDir, dc.Config.DeploymentName())
 	checkErr(checkOverwriteAllowed(deplDir, dc.Config, overwriteDeployment))
 	checkErr(modulewriter.WriteDeployment(dc, deplDir))
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -408,51 +408,46 @@ func (s *zeroSuite) TestGetModule(c *C) {
 	}
 }
 
-func (s *zeroSuite) TestDeploymentName(c *C) {
-	bp := Blueprint{}
+func (s *zeroSuite) TestValidateDeploymentName(c *C) {
 	var e InputValueError
 
+	h := func(val cty.Value) error {
+		vars := NewDict(map[string]cty.Value{"deployment_name": val})
+		return validateDeploymentName(vars)
+	}
+
 	// Is deployment_name a valid string?
-	bp.Vars.Set("deployment_name", cty.StringVal("yellow"))
-	dn, err := bp.DeploymentName()
-	c.Assert(dn, Equals, "yellow")
-	c.Assert(err, IsNil)
+	c.Check(h(cty.StringVal("yellow")), IsNil)
 
-	// Is deployment_name an empty string?
-	bp.Vars.Set("deployment_name", cty.StringVal(""))
-	dn, err = bp.DeploymentName()
-	c.Assert(dn, Equals, "")
-	c.Check(errors.As(err, &e), Equals, true)
+	{ // Is deployment_name an empty string?
+		err := h(cty.StringVal(""))
+		c.Check(errors.As(err, &e), Equals, true)
+	}
 
-	// Is deployment_name not a string?
-	bp.Vars.Set("deployment_name", cty.NumberIntVal(100))
-	dn, err = bp.DeploymentName()
-	c.Assert(dn, Equals, "")
-	c.Check(errors.As(err, &e), Equals, true)
+	{ // Is deployment_name not a string?
+		err := h(cty.NumberIntVal(100))
+		c.Check(errors.As(err, &e), Equals, true)
+	}
 
-	// Is deployment_names longer than 63 characters?
-	bp.Vars.Set("deployment_name", cty.StringVal("deployment_name-deployment_name-deployment_name-deployment_name-0123"))
-	dn, err = bp.DeploymentName()
-	c.Assert(dn, Equals, "")
-	c.Check(errors.As(err, &e), Equals, true)
+	{ // Is deployment_names longer than 63 characters?
+		err := h(cty.StringVal("deployment_name-deployment_name-deployment_name-deployment_name-0123"))
+		c.Check(errors.As(err, &e), Equals, true)
+	}
 
-	// Does deployment_name contain special characters other than dashes or underscores?
-	bp.Vars.Set("deployment_name", cty.StringVal("deployment.name"))
-	dn, err = bp.DeploymentName()
-	c.Assert(dn, Equals, "")
-	c.Check(errors.As(err, &e), Equals, true)
+	{ // Does deployment_name contain special characters other than dashes or underscores?
+		err := h(cty.StringVal("deployment.name"))
+		c.Check(errors.As(err, &e), Equals, true)
+	}
 
-	// Does deployment_name contain capital letters?
-	bp.Vars.Set("deployment_name", cty.StringVal("Deployment_name"))
-	dn, err = bp.DeploymentName()
-	c.Assert(dn, Equals, "")
-	c.Check(errors.As(err, &e), Equals, true)
+	{ // Does deployment_name contain capital letters?
+		err := h(cty.StringVal("Deployment_name"))
+		c.Check(errors.As(err, &e), Equals, true)
+	}
 
-	// Is deployment_name not set?
-	bp.Vars = Dict{}
-	dn, err = bp.DeploymentName()
-	c.Assert(dn, Equals, "")
-	c.Check(errors.As(err, &e), Equals, true)
+	{ // Is deployment_name not set?
+		err := validateDeploymentName(Dict{})
+		c.Check(errors.As(err, &e), Equals, true)
+	}
 }
 
 func (s *zeroSuite) TestCheckBlueprintName(c *C) {
@@ -902,12 +897,19 @@ func (s *zeroSuite) TestEvalVars(c *C) {
 			"bc": MustParseExpression(`"${var.b}|${var.c}"`).AsValue(),
 		})
 		bp := Blueprint{Vars: vars}
-		c.Check(bp.evalVars(), IsNil)
-		c.Check(bp.Vars.Items(), DeepEquals, map[string]cty.Value{
+		got, err := bp.evalVars()
+		c.Check(err, IsNil)
+		c.Check(got.Items(), DeepEquals, map[string]cty.Value{
 			"a":  cty.StringVal("A"),
 			"b":  cty.StringVal("A_B"),
 			"c":  cty.StringVal("A_B_C"),
 			"bc": cty.StringVal("A_B|A_B_C"),
+		})
+		c.Check(bp.Vars.Items(), DeepEquals, map[string]cty.Value{ // no change
+			"a":  cty.StringVal("A"),
+			"b":  MustParseExpression(`"${var.a}_B"`).AsValue(),
+			"c":  MustParseExpression(`"${var.b}_C"`).AsValue(),
+			"bc": MustParseExpression(`"${var.b}|${var.c}"`).AsValue(),
 		})
 	}
 	{ // Non global ref
@@ -915,8 +917,7 @@ func (s *zeroSuite) TestEvalVars(c *C) {
 			"a": cty.StringVal("A"),
 			"b": MustParseExpression(`"${var.a}_${module.foo.ko}"`).AsValue(),
 		})
-		bp := Blueprint{Vars: vars}
-		err := bp.evalVars()
+		_, err := (&Blueprint{Vars: vars}).evalVars()
 		var berr BpError
 		if errors.As(err, &berr) {
 			c.Check(berr.Path.String(), Equals, "vars.b")
@@ -931,8 +932,7 @@ func (s *zeroSuite) TestEvalVars(c *C) {
 			"bo":  cty.StringVal("===="),
 			"ros": MustParseExpression(`"${var.uro}_${var.bo}_ros"`).AsValue(),
 		})
-		bp := Blueprint{Vars: vars}
-		err := bp.evalVars()
+		_, err := (&Blueprint{Vars: vars}).evalVars()
 		var berr BpError
 		if errors.As(err, &berr) {
 			if berr.Path.String() != "vars.uro" && berr.Path.String() != "vars.ros" {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -70,12 +70,13 @@ func validateGlobalLabels(vars Dict) error {
 
 // validateVars checks the global variables for viable types
 func validateVars(vars Dict) error {
-	errs := Errors{}
-	errs.Add(validateGlobalLabels(vars))
+	errs := (&Errors{}).
+		Add(validateDeploymentName(vars)).
+		Add(validateGlobalLabels(vars))
 	// Check for any nil values
 	for key, val := range vars.Items() {
 		if val.IsNull() {
-			errs.At(Root.Vars.Dot(key), fmt.Errorf("deployment variable %s was not set", key))
+			errs.At(Root.Vars.Dot(key), fmt.Errorf("deployment variable %q was not set", key))
 		}
 	}
 	return errs.OrNil()

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -22,19 +22,23 @@ import (
 )
 
 func (s *zeroSuite) TestValidateVars(c *C) {
+	base := map[string]cty.Value{
+		"deployment_name": cty.StringVal("serengeti"),
+	}
+
 	{ // Success
-		vars := Dict{}
+		vars := Dict{base}
 		c.Check(validateVars(vars), IsNil)
 	}
 
 	{ // Fail: Nil value
-		vars := Dict{}
+		vars := Dict{base}
 		vars.Set("fork", cty.NilVal)
 		c.Check(validateVars(vars), NotNil)
 	}
 
 	{ // Fail: labels not a map
-		vars := Dict{}
+		vars := Dict{base}
 		vars.Set("labels", cty.StringVal("a_string"))
 		c.Check(validateVars(vars), NotNil)
 	}


### PR DESCRIPTION
* Perform deployment_name  validation after evaluation;
* Make `evalVars` to return new vars instead of mutating;
* Make `DeploymentName` to not return error.
