### PR TITLE
Slurm6. Automagicaly set `nodeset.name` from module id.

### DIFF
--- a/community/examples/hpc-slurm6.yaml
+++ b/community/examples/hpc-slurm6.yaml
@@ -41,7 +41,6 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
-      name: ns1
       node_count_dynamic_max: 4
       machine_type: n2-standard-2
       enable_placement: false  # the default is: true

--- a/community/examples/hpc-slurm6.yaml
+++ b/community/examples/hpc-slurm6.yaml
@@ -37,7 +37,7 @@ deployment_groups:
     settings:
       local_mount: /home
 
-  - id: debug_nodeset
+  - id: dbugns
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
@@ -47,13 +47,13 @@ deployment_groups:
 
   - id: debug_partition
     source: community/modules/compute/schedmd-slurm-gcp-v6-partition
-    use: [debug_nodeset, homefs]
+    use: [dbugns, homefs]
     settings:
       partition_name: debug
       exclusive: false  # allows nodes to stay up after jobs are done
       is_default: true
 
-  - id: compute_nodeset
+  - id: compns
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
@@ -63,7 +63,7 @@ deployment_groups:
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v6-partition
-    use: [compute_nodeset, homefs]
+    use: [compns, homefs]
     settings:
       partition_name: compute
 

--- a/community/examples/hpc-slurm6.yaml
+++ b/community/examples/hpc-slurm6.yaml
@@ -37,7 +37,7 @@ deployment_groups:
     settings:
       local_mount: /home
 
-  - id: dbugns
+  - id: debug_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
@@ -47,13 +47,13 @@ deployment_groups:
 
   - id: debug_partition
     source: community/modules/compute/schedmd-slurm-gcp-v6-partition
-    use: [dbugns, homefs]
+    use: [debug_nodeset, homefs]
     settings:
       partition_name: debug
       exclusive: false  # allows nodes to stay up after jobs are done
       is_default: true
 
-  - id: compns
+  - id: compute_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
@@ -63,7 +63,7 @@ deployment_groups:
 
   - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v6-partition
-    use: [compns, homefs]
+    use: [compute_nodeset, homefs]
     settings:
       partition_name: compute
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -175,7 +175,7 @@ No modules.
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes. | `string` | `"c2-standard-60"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
 | <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the nodeset. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the nodeset. | `string` | n/a | yes |
 | <a name="input_node_conf"></a> [node\_conf](#input\_node\_conf) | Map of Slurm node line configuration. | `map(any)` | `{}` | no |
 | <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of dynamic nodes allowed in this partition. | `number` | `1` | no |
 | <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |
@@ -188,7 +188,6 @@ No modules.
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The project the subnetwork belongs to. | `string` | `""` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
-| <a name="input_toolkit_module_id"></a> [toolkit\_module\_id](#input\_toolkit\_module\_id) | DO NOT SET. This variable is set by the GHPC toolkit | `string` | `"unset"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Zone in which to create compute VMs. Additional zones in the same region can be specified in var.zones. | `string` | n/a | yes |
 | <a name="input_zone_target_shape"></a> [zone\_target\_shape](#input\_zone\_target\_shape) | Strategy for distributing VMs across zones in a region.<br>ANY<br>  GCE picks zones for creating VM instances to fulfill the requested number of VMs<br>  within present resource constraints and to maximize utilization of unused zonal<br>  reservations.<br>ANY\_SINGLE\_ZONE (default)<br>  GCE always selects a single zone for all the VMs, optimizing for resource quotas,<br>  available reservations and general capacity.<br>BALANCED<br>  GCE prioritizes acquisition of resources, scheduling VMs in zones where resources<br>  are available while distributing VMs as evenly as possible across allowed zones<br>  to minimize the impact of zonal failure. | `string` | `"ANY_SINGLE_ZONE"` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | Additional nodes in which to allow creation of partition nodes. Google Cloud<br>will find zone based on availability, quota and reservations. | `set(string)` | `[]` | no |

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -175,7 +175,7 @@ No modules.
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes. | `string` | `"c2-standard-60"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
 | <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the nodeset. | `string` | `"ghpc"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the nodeset. | `string` | `null` | no |
 | <a name="input_node_conf"></a> [node\_conf](#input\_node\_conf) | Map of Slurm node line configuration. | `map(any)` | `{}` | no |
 | <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of dynamic nodes allowed in this partition. | `number` | `1` | no |
 | <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |
@@ -188,6 +188,7 @@ No modules.
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The project the subnetwork belongs to. | `string` | `""` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
+| <a name="input_toolkit_module_id"></a> [toolkit\_module\_id](#input\_toolkit\_module\_id) | DO NOT SET. This variable is set by the GHPC toolkit | `string` | `"unset"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Zone in which to create compute VMs. Additional zones in the same region can be specified in var.zones. | `string` | n/a | yes |
 | <a name="input_zone_target_shape"></a> [zone\_target\_shape](#input\_zone\_target\_shape) | Strategy for distributing VMs across zones in a region.<br>ANY<br>  GCE picks zones for creating VM instances to fulfill the requested number of VMs<br>  within present resource constraints and to maximize utilization of unused zonal<br>  reservations.<br>ANY\_SINGLE\_ZONE (default)<br>  GCE always selects a single zone for all the VMs, optimizing for resource quotas,<br>  available reservations and general capacity.<br>BALANCED<br>  GCE prioritizes acquisition of resources, scheduling VMs in zones where resources<br>  are available while distributing VMs as evenly as possible across allowed zones<br>  to minimize the impact of zonal failure. | `string` | `"ANY_SINGLE_ZONE"` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | Additional nodes in which to allow creation of partition nodes. Google Cloud<br>will find zone based on availability, quota and reservations. | `set(string)` | `[]` | no |

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -175,7 +175,7 @@ No modules.
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes. | `string` | `"c2-standard-60"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
 | <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the nodeset. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the nodeset. Automatically populated by the module id if not set | `string` | n/a | yes |
 | <a name="input_node_conf"></a> [node\_conf](#input\_node\_conf) | Map of Slurm node line configuration. | `map(any)` | `{}` | no |
 | <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of dynamic nodes allowed in this partition. | `number` | `1` | no |
 | <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
@@ -18,9 +18,6 @@ locals {
 }
 
 locals {
-  auto_name = substr(replace(var.toolkit_module_id, "/[^a-z0-9]/", ""), 0, 6)
-  name      = try(coalesce(var.name, local.auto_name), "")
-
   additional_disks = [
     for ad in var.additional_disks : {
       disk_name    = ad.disk_name
@@ -37,7 +34,7 @@ locals {
     node_count_static      = var.node_count_static
     node_count_dynamic_max = var.node_count_dynamic_max
     node_conf              = var.node_conf
-    nodeset_name           = local.name
+    nodeset_name           = var.name
 
     disk_auto_delete = var.disk_auto_delete
     disk_labels      = merge(local.labels, var.disk_labels)

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
@@ -18,6 +18,8 @@ locals {
 }
 
 locals {
+  name = substr(replace(var.name, "/[^a-z0-9]/", ""), 0, 6)
+
   additional_disks = [
     for ad in var.additional_disks : {
       disk_name    = ad.disk_name
@@ -34,7 +36,7 @@ locals {
     node_count_static      = var.node_count_static
     node_count_dynamic_max = var.node_count_dynamic_max
     node_conf              = var.node_conf
-    nodeset_name           = var.name
+    nodeset_name           = local.name
 
     disk_auto_delete = var.disk_auto_delete
     disk_labels      = merge(local.labels, var.disk_labels)

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
@@ -18,6 +18,9 @@ locals {
 }
 
 locals {
+  auto_name = substr(replace(var.toolkit_module_id, "/[^a-z0-9]/", ""), 0, 6)
+  name      = try(coalesce(var.name, local.auto_name), "")
+
   additional_disks = [
     for ad in var.additional_disks : {
       disk_name    = ad.disk_name
@@ -34,7 +37,7 @@ locals {
     node_count_static      = var.node_count_static
     node_count_dynamic_max = var.node_count_dynamic_max
     node_conf              = var.node_conf
-    nodeset_name           = var.name
+    nodeset_name           = local.name
 
     disk_auto_delete = var.disk_auto_delete
     disk_labels      = merge(local.labels, var.disk_labels)

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/metadata.yaml
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/metadata.yaml
@@ -16,3 +16,5 @@
 spec:
   requirements:
     services: []
+ghpc:
+  inject_module_id: toolkit_module_id

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/metadata.yaml
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/metadata.yaml
@@ -17,4 +17,4 @@ spec:
   requirements:
     services: []
 ghpc:
-  inject_module_id: toolkit_module_id
+  inject_module_id: name

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -24,9 +24,4 @@ output "nodeset" {
     ], "${substr(var.machine_type, 0, 3)}:${var.disk_type}")
     error_message = "A disk_type=${var.disk_type} cannot be used with machine_type=${var.machine_type}."
   }
-
-  precondition {
-    condition     = can(regex("^[a-z](?:[a-z0-9]{0,5})$", local.name))
-    error_message = "Nodeset name (var.name) must begin with a letter, be fully alphanumeric and be 6 characters or less. Regexp: '^[a-z](?:[a-z0-9]{0,5})$'."
-  }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -24,4 +24,9 @@ output "nodeset" {
     ], "${substr(var.machine_type, 0, 3)}:${var.disk_type}")
     error_message = "A disk_type=${var.disk_type} cannot be used with machine_type=${var.machine_type}."
   }
+
+  precondition {
+    condition     = can(regex("^[a-z](?:[a-z0-9]{0,5})$", local.name))
+    error_message = "Nodeset name (var.name) must begin with a letter, be fully alphanumeric and be 6 characters or less. Regexp: '^[a-z](?:[a-z0-9]{0,5})$'."
+  }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf
@@ -15,12 +15,18 @@
 variable "name" {
   description = "Name of the nodeset."
   type        = string
-  default     = "ghpc"
+  default     = null
 
   validation {
-    condition     = can(regex("^[a-z](?:[a-z0-9]{0,5})$", var.name))
+    condition     = (var.name == null) || can(regex("^[a-z](?:[a-z0-9]{0,5})$", var.name))
     error_message = "Nodeset name (var.name) must begin with a letter, be fully alphanumeric and be 6 characters or less. Regexp: '^[a-z](?:[a-z0-9]{0,5})$'."
   }
+}
+
+variable "toolkit_module_id" {
+  description = "DO NOT SET. This variable is set by the GHPC toolkit"
+  type        = string
+  default     = "unset"
 }
 
 variable "node_conf" {

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf
@@ -15,18 +15,14 @@
 variable "name" {
   description = "Name of the nodeset."
   type        = string
-  default     = null
 
   validation {
-    condition     = (var.name == null) || can(regex("^[a-z](?:[a-z0-9]{0,5})$", var.name))
-    error_message = "Nodeset name (var.name) must begin with a letter, be fully alphanumeric and be 6 characters or less. Regexp: '^[a-z](?:[a-z0-9]{0,5})$'."
+    condition     = can(regex("^[a-z](?:[a-z0-9]{0,5})$", var.name))
+    error_message = <<EOT
+Nodeset name (var.name) must begin with a letter, be fully alphanumeric and be 6 characters or less.
+Got "${var.name}" (set to module id by default).
+EOT
   }
-}
-
-variable "toolkit_module_id" {
-  description = "DO NOT SET. This variable is set by the GHPC toolkit"
-  type        = string
-  default     = "unset"
 }
 
 variable "node_conf" {

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf
@@ -13,16 +13,8 @@
 # limitations under the License.
 
 variable "name" {
-  description = "Name of the nodeset."
+  description = "Name of the nodeset. Automatically populated by the module id if not set"
   type        = string
-
-  validation {
-    condition     = can(regex("^[a-z](?:[a-z0-9]{0,5})$", var.name))
-    error_message = <<EOT
-Nodeset name (var.name) must begin with a letter, be fully alphanumeric and be 6 characters or less.
-Got "${var.name}" (set to module id by default).
-EOT
-  }
 }
 
 variable "node_conf" {


### PR DESCRIPTION
```sh
Error: Invalid value for variable

  on main.tf line 41, in module "debug_nodeset":
  41:   name                   = "debug_nodeset"
    ├────────────────
    │ var.name is "debug_nodeset"

Nodeset name (var.name) must begin with a letter, be fully alphanumeric and
be 6 characters or less.
Got "debug_nodeset" (set to module id by default).
```