### PR TITLE
Support explicit reserved_ip_range for Filestore instances

### DIFF
--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -185,6 +185,7 @@ No modules.
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is connected given in the format:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Filestore instance will be created. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Location for Filestore instances at Enterprise tier. | `string` | n/a | yes |
+| <a name="input_reserved_ip_range"></a> [reserved\_ip\_range](#input\_reserved\_ip\_range) | Reserved IP range for Filestore instance (set to null to enable automatic selection) | `string` | `null` | no |
 | <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `1024` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Location for Filestore instances below Enterprise tier. | `string` | n/a | yes |
 

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -64,9 +64,10 @@ resource "google_filestore_instance" "filestore_instance" {
   labels = local.labels
 
   networks {
-    network      = local.shared_vpc ? var.network_id : local.network_name
-    connect_mode = var.connect_mode
-    modes        = ["MODE_IPV4"]
+    network           = local.shared_vpc ? var.network_id : local.network_name
+    connect_mode      = var.connect_mode
+    modes             = ["MODE_IPV4"]
+    reserved_ip_range = var.reserved_ip_range
   }
 
   dynamic "timeouts" {

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -109,6 +109,18 @@ variable "connect_mode" {
   default     = "DIRECT_PEERING"
 }
 
+variable "reserved_ip_range" {
+  description = "Reserved IP range for Filestore instance (set to null to enable automatic selection)"
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.reserved_ip_range == null || can(cidrhost(var.reserved_ip_range, 0))
+    error_message = "IP address range must be in CIDR format."
+  }
+}
+
 variable "mount_options" {
   description = "NFS mount options to mount file system."
   type        = string


### PR DESCRIPTION
This PR allows a user to set an explicit IP range in which to create Filestore instances by direct peering. The default remains automatic selection. Tested with:

```yaml
  - id: homefs
    source: modules/file-system/filestore
    use:
    - sysnet
    settings:
      filestore_tier: HIGH_SCALE_SSD
      size_gb: 10240
      local_mount: /home
      reserved_ip_range: 192.168.0.0/26
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
