### PR TITLE
Adopt gcloud storage over gsutil by default

### DIFF
--- a/modules/scripts/startup-script/files/get_from_bucket.sh
+++ b/modules/scripts/startup-script/files/get_from_bucket.sh
@@ -13,15 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Given a url and filename, download an object to the vardir. This function uses
-# gsutil to fetch from the bucket.  Note, the service account for the instance
-# must be properly configured with a role having authorization to get objects
-# from the bucket.
+# Given a url and filename, download an object to the vardir. When the installed
+# version of gcloud is >=402.0.0 (Sept. 2022), then gcloud storage is used to
+# fetch from the bucket. Otherwise gsutil is used. Note, the service account for
+# the instance must be properly configured with a role having authorization to
+# get objects from the bucket.
 #
 # This function is intended for single file downloads and no attempt is made to
-# verify the checksum other than the default behavior of gsutil.
+# verify the checksum other than the default behavior of gcloud or gsutil.
 #
-# This function should have no other platform dependencies other than gsutil.
+# This function has no other platform dependencies other than gcloud / gsutil.
 
 # This code originated from: https://github.com/terraform-google-modules/terraform-google-startup-scripts?ref=v1.0.0
 stdlib::get_from_bucket() {
@@ -50,16 +51,22 @@ stdlib::get_from_bucket() {
 	[[ -d ${dir} ]] || mkdir "${dir}"
 	local attempt=0
 	local max_retries=7
+	# store gcs command as array and then split when called by stdlib::cmd
+	if stdlib::cmd gcloud help storage cp &>/dev/null; then
+		gcs_command=(gcloud storage cp --no-user-output-enabled)
+	else
+		gcs_command=(gsutil -q cp)
+	fi
 	while [[ $attempt -le $max_retries ]]; do
 		if [[ $attempt -gt 0 ]]; then
 			local wait=$((2 ** attempt))
 			stdlib::error "Retry attempt ${attempt} of ${max_retries} with exponential backoff: ${wait} seconds."
 			sleep $wait
 		fi
-		if stdlib::cmd gsutil -q cp "${url}" "${dir}/${fname}"; then
+		if stdlib::cmd "${gcs_command[@]}" "${url}" "${dir}/${fname}"; then
 			break
 		else
-			stdlib::error "gsutil reported non-zero exit code fetching ${url}."
+			stdlib::error "${gcs_command[*]} reported non-zero exit code fetching ${url}."
 			((attempt++))
 		fi
 	done


### PR DESCRIPTION
All versions of gcloud >= 402.0.0 (Sept. 2022) support the "storage cp" command. This PR adopts that functionality when it is available. This works around some observed issues with gsutil in HTTPS proxy environments while adopting the forward looking solution.

Tested with this blueprint. Troubleshooting it made clear that each was adopting gsutil or gcloud appropriately. In each case, `/etc/i_was_here` is created without generating any spurious messages in `/var/log/messages` (or syslog) or in the `journalctl -b 0 -u google-startup-scripts.service` output.

```yaml
---
blueprint_name: test-gcs

vars:
  project_id:  ## Set project id here
  deployment_name: testfix
  region: us-east4
  zone: us-east4-c

deployment_groups:
- group: first
  modules:
  - id: network1
    source: modules/network/vpc
  - id: script
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: shell
        destination: test_gcs.sh
        content: |
          #!/bin/bash
          touch /etc/i_was_here
  - id: vm0
    source: modules/compute/vm-instance
    use:
    - network1
    - script
    settings:
      name_prefix: vm0
      machine_type: n1-standard-2
  - id: vm1
    source: modules/compute/vm-instance
    use:
    - network1
    - script
    settings:
      name_prefix: vm1
      machine_type: n1-standard-2
      instance_image:
        project: debian-cloud
        name: debian-11-bullseye-v20220822
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
