### PR TITLE
Add support for string interpolation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1260,6 +1260,18 @@ Whenever possible, blueprint variables are preferred over literal variables.
 `ghpc` will perform basic validation making sure all blueprint variables are
 defined before creating a deployment, making debugging quicker and easier.
 
+### String Interpolation
+
+The `$(...)` expressions can be used within strings, see:
+
+```yaml
+settings:
+  title: Magnificent $(vars.name)
+  script: |
+    #!/bin/bash
+    echo "Hello $(vars.project_id) from $(vars.region)"
+```
+
 ### Escape Variables
 
 Under circumstances where the variable notation conflicts with the content of a setting or string, for instance when defining a startup-script runner that uses a subshell like in the example below, a non-quoted backslash (`\`) can be used as an escape character. It preserves the literal value of the next character that follows:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1237,8 +1237,6 @@ The variable is referred to by the source, either vars for deploment variables
 or the module ID for module variables, followed by the name of the value being
 referenced. The entire variable is then wrapped in “$()”.
 
-Currently, string interpolation with variables is not supported.
-
 ### Literal Variables
 
 Literal variables should only be used by those familiar

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -672,22 +672,22 @@ func (s *zeroSuite) TestCheckBackends(c *C) {
 
 	{ // FAIL. Variable in defaults type
 		b := TerraformBackend{Type: "$(vartype)"}
-		c.Check(check(b), ErrorMatches, ".*type.*vartype.*")
+		c.Check(check(b), NotNil)
 	}
 
 	{ // FAIL. Variable in group backend type
 		b := TerraformBackend{Type: "$(vartype)"}
-		c.Check(check(dummy, b), ErrorMatches, ".*type.*vartype.*")
+		c.Check(check(dummy, b), NotNil)
 	}
 
 	{ // FAIL. Deployment variable in defaults type
 		b := TerraformBackend{Type: "$(vars.type)"}
-		c.Check(check(b), ErrorMatches, ".*type.*vars\\.type.*")
+		c.Check(check(b), NotNil)
 	}
 
 	{ // FAIL. HCL literal
 		b := TerraformBackend{Type: "((var.zen))"}
-		c.Check(check(b), ErrorMatches, ".*type.*zen.*")
+		c.Check(check(b), NotNil)
 	}
 
 	{ // OK. Not a variable
@@ -697,13 +697,13 @@ func (s *zeroSuite) TestCheckBackends(c *C) {
 
 	{ // FAIL. Mid-string variable in defaults type
 		b := TerraformBackend{Type: "hugs_$(vartype)_hugs"}
-		c.Check(check(b), ErrorMatches, ".*type.*vartype.*")
+		c.Check(check(b), NotNil)
 	}
 
 	{ // FAIL. Variable in defaults configuration
 		b := TerraformBackend{Type: "gcs"}
 		b.Configuration.Set("bucket", GlobalRef("trenta").AsExpression().AsValue())
-		c.Check(check(b), ErrorMatches, ".*can not use variables.*")
+		c.Check(check(b), NotNil)
 	}
 
 	{ // OK. handles nested configuration
@@ -714,7 +714,7 @@ func (s *zeroSuite) TestCheckBackends(c *C) {
 				"alpha": cty.StringVal("a"),
 				"beta":  GlobalRef("boba").AsExpression().AsValue(),
 			}))
-		c.Check(check(b), ErrorMatches, ".*can not use variables.*")
+		c.Check(check(b), NotNil)
 	}
 }
 

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -17,7 +17,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"regexp"
 
 	"hpc-toolkit/pkg/modulereader"
 
@@ -30,14 +29,6 @@ import (
 const (
 	blueprintLabel  string = "ghpc_blueprint"
 	deploymentLabel string = "ghpc_deployment"
-)
-
-var (
-	// Checks if a variable exists only as a substring, ex:
-	// Matches: "a$(vars.example)", "word $(vars.example)", "word$(vars.example)", "$(vars.example)"
-	// Doesn't match: "\$(vars.example)", "no variable in this string"
-	anyVariableExp    *regexp.Regexp = regexp.MustCompile(`(^|[^\\])\$\((.*?)\)`)
-	simpleVariableExp *regexp.Regexp = regexp.MustCompile(`^\$\((.*)\)$`)
 )
 
 // expand expands variables and strings in the yaml config. Used directly by
@@ -418,16 +409,6 @@ func validateModuleSettingReference(bp Blueprint, mod Module, r Reference) error
 		return hintSpelling(r.Name, outputs, err)
 	}
 	return nil
-}
-
-// isSimpleVariable checks if the entire string is just a single variable
-func isSimpleVariable(str string) bool {
-	return simpleVariableExp.MatchString(str)
-}
-
-// hasVariable checks to see if any variable exists in a string
-func hasVariable(str string) bool {
-	return anyVariableExp.MatchString(str)
 }
 
 // FindAllIntergroupReferences finds all intergroup references within the group

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -338,60 +338,6 @@ func (s *MySuite) TestApplyGlobalVariables(c *C) {
 		GlobalRef("gold").AsExpression().AsValue())
 }
 
-func (s *zeroSuite) TestIsSimpleVariable(c *C) {
-	// True: Correct simple variable
-	got := isSimpleVariable("$(some_text)")
-	c.Assert(got, Equals, true)
-	// False: Missing $
-	got = isSimpleVariable("(some_text)")
-	c.Assert(got, Equals, false)
-	// False: Missing (
-	got = isSimpleVariable("$some_text)")
-	c.Assert(got, Equals, false)
-	// False: Missing )
-	got = isSimpleVariable("$(some_text")
-	c.Assert(got, Equals, false)
-	// False: Contains Prefix
-	got = isSimpleVariable("prefix-$(some_text)")
-	c.Assert(got, Equals, false)
-	// False: Contains Suffix
-	got = isSimpleVariable("$(some_text)-suffix")
-	c.Assert(got, Equals, false)
-	// False: Contains prefix and suffix
-	got = isSimpleVariable("prefix-$(some_text)-suffix")
-	c.Assert(got, Equals, false)
-	// False: empty string
-	got = isSimpleVariable("")
-	c.Assert(got, Equals, false)
-}
-
-func (s *zeroSuite) TestHasVariable(c *C) {
-	// True: simple variable
-	got := hasVariable("$(some_text)")
-	c.Assert(got, Equals, true)
-	// True: has prefix
-	got = hasVariable("prefix-$(some_text)")
-	c.Assert(got, Equals, true)
-	// True: has suffix
-	got = hasVariable("$(some_text)-suffix")
-	c.Assert(got, Equals, true)
-	// True: Two variables
-	got = hasVariable("$(some_text)$(some_more)")
-	c.Assert(got, Equals, true)
-	// True: two variable with other text
-	got = hasVariable("prefix-$(some_text)-$(some_more)-suffix")
-	c.Assert(got, Equals, true)
-	// False: missing $
-	got = hasVariable("(some_text)")
-	c.Assert(got, Equals, false)
-	// False: missing (
-	got = hasVariable("$some_text)")
-	c.Assert(got, Equals, false)
-	// False: missing )
-	got = hasVariable("$(some_text")
-	c.Assert(got, Equals, false)
-}
-
 func (s *zeroSuite) TestValidateModuleReference(c *C) {
 	a := Module{ID: "moduleA"}
 	b := Module{ID: "moduleB"}

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -254,14 +254,13 @@ func (y *YamlValue) unmarshalScalar(n *yaml.Node) error {
 	if err != nil {
 		return err
 	}
-	y.Wrap(v)
 
-	if y.Unwrap().Type() == cty.String {
-		if y.v, err = parseYamlString(y.v.AsString()); err != nil {
+	if v.Type() == cty.String {
+		if v, err = parseYamlString(v.AsString()); err != nil {
 			return fmt.Errorf("line %d: %w", n.Line, err)
 		}
 	}
-
+	y.Wrap(v)
 	return nil
 }
 

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -529,27 +529,6 @@ func (s *MySuite) TestWritePackerAutoVars(c *C) {
 
 }
 
-func (s *zeroSuite) TestStringEscape(c *C) {
-	f := func(s string) string {
-		toks := config.TokensForValue(cty.StringVal(s))
-		return string(toks.Bytes())
-	}
-	// LiteralVariables
-	c.Check(f(`\((not.var))`), Equals, `"((not.var))"`)
-	c.Check(f(`abc\((not.var))abc`), Equals, `"abc((not.var))abc"`)
-	c.Check(f(`abc \((not.var)) abc`), Equals, `"abc ((not.var)) abc"`)
-	c.Check(f(`abc \((not.var1)) abc \((not.var2)) abc`), Equals, `"abc ((not.var1)) abc ((not.var2)) abc"`)
-	c.Check(f(`abc \\((escape.backslash))`), Equals, `"abc \\((escape.backslash))"`)
-
-	// BlueprintVariables
-	c.Check(f(`\$(not.var)`), Equals, `"$(not.var)"`)
-	c.Check(f(`abc\$(not.var)abc`), Equals, `"abc$(not.var)abc"`)
-	c.Check(f(`abc \$(not.var) abc`), Equals, `"abc $(not.var) abc"`)
-	c.Check(f(`abc \$(not.var1) abc \$(not.var2) abc`), Equals, `"abc $(not.var1) abc $(not.var2) abc"`)
-	c.Check(f(`abc \\$(escape.backslash)`), Equals, `"abc \\$(escape.backslash)"`)
-
-}
-
 func (s *zeroSuite) TestDeploymentSource(c *C) {
 	{ // git
 		m := config.Module{Kind: config.TerraformKind, Source: "github.com/x/y.git"}


### PR DESCRIPTION
Example:
```yaml
  - id: bahcha
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: data
        destination: /tmp/$(vars.path)/arbuz
        content: |
          #!/bin/bash
          echo "Hello $(vars.project_id) from $(vars.region)"
```

### Refactor escaping logic:
* Don't persist escape backslashes in `cty.Value` representation;
* Don't "escape-back" during HCL-write;
* Keep all escape logic & info to the YAML-unmarshal/marshall code.

### Treat every non-HCL-literal YAML string as an expression

* Split string on plain-string and BP-expression by tokenizing it (see `tokenizeBpString`)
* If it is one plain-string piece, return `cty.StringVal`;
* If it is one expression piece, return expression without string interpolation;
* return HCL string interpolation expression combining all parts.

