### PR TITLE
Improve logging for expressions errors

### DIFF
--- a/pkg/config/expression_test.go
+++ b/pkg/config/expression_test.go
@@ -106,6 +106,9 @@ was here`, `"5gold\nwas here"`, false},
 
 		{`#!/bin/bash
 echo "Hello $(vars.project_id) from $(vars.region)"`, `"#!/bin/bash\necho \"Hello ${var.project_id} from ${var.region}\""`, false},
+		{`#!/bin/bash
+echo "Hello $(vars.project_id)"
+`, `"#!/bin/bash\necho \"Hello ${var.project_id}\"\n"`, false},
 		{"", `""`, false},
 		{`$(try(vars.this) + one(vars.time))`, "try(var.this)+one(var.time)", false},
 

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -388,7 +388,7 @@ func parseYamlV3Error(err error) error {
 // If no position can be extracted, returns error without position.
 // Else returns PosError{Pos{Line: line_number}, error_message}.
 func parseYamlV3ErrorString(s string) error {
-	match := regexp.MustCompile(`^(yaml: )?(line (\d+): )?(.*)$`).FindStringSubmatch(s)
+	match := regexp.MustCompile(`^(yaml: )?(line (\d+): )?((.|\n)*)$`).FindStringSubmatch(s)
 	if match == nil {
 		return errors.New(s)
 	}


### PR DESCRIPTION
* One can't translate HCL diagnostics position to the global YAML position,
due to lack of information about YAML string-style (e.g. double quoted, plain, folded etc),
therefore start position of the string in YAML document and indentation.
Render error in a scope of a single line of the string instead.

```sh
# BEFORE
Error: :0,21-22: Invalid character; This character is not used within the language., and 1 other diagnostic(s)
34:         content: |

# AFTER
Error: Invalid character; This character is not used within the language.
  echo "Hello $(vars.project_id from $(vars.region)"
                                     ^
34:         content: |
```

* Prevent line-breaks within expressions.
This constraint existed before, but was accidentally relaxed by recent PR.