### PR TITLE
Support use of http/https proxy for pip/apt/yum package managers

### DIFF
--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -236,6 +236,7 @@ No modules.
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |
 | <a name="input_gcs_bucket_path"></a> [gcs\_bucket\_path](#input\_gcs\_bucket\_path) | The GCS path for storage bucket and the object, starting with `gs://`. | `string` | `null` | no |
+| <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy) | Web (http and https) proxy configuration for pip, apt, and yum/dnf | `string` | `""` | no |
 | <a name="input_install_ansible"></a> [install\_ansible](#input\_install\_ansible) | Run Ansible installation script if either set to true or unset and runner of type 'ansible-local' are used. | `bool` | `null` | no |
 | <a name="input_install_cloud_ops_agent"></a> [install\_cloud\_ops\_agent](#input\_install\_cloud\_ops\_agent) | Run Google Ops Agent installation script if set to true. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels for the created GCS bucket. Key-value pairs. | `map(string)` | n/a | yes |

--- a/modules/scripts/startup-script/files/configure_proxy.sh
+++ b/modules/scripts/startup-script/files/configure_proxy.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -o pipefail
+
+web_proxy="${1:-}"
+if [ -z "$web_proxy" ]; then
+	echo "Error: must provide 1 argument identifying http/https proxy"
+	exit 1
+fi
+
+# configure pip to use proxy
+PIP_CONF=/etc/pip.conf
+if [ ! -f "$PIP_CONF" ]; then
+	cat <<-EOF >"$PIP_CONF"
+		[global]
+		proxy=$web_proxy
+	EOF
+fi
+
+# configure yum or dnf to use proxy
+if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] ||
+	[ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
+	YUM_CONF="/etc/yum.conf"
+	if ! grep -q '^proxy=.*' "$YUM_CONF"; then
+		sed --follow-symlinks -i.bak "/^\[main]/a proxy=$web_proxy" "$YUM_CONF"
+	else
+		sed --follow-symlinks -i.bak "s,proxy=.*,proxy=$web_proxy," "$YUM_CONF"
+	fi
+fi
+
+# configure apt to use proxy
+if [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release 2>/dev/null ||
+	grep -qi ubuntu /etc/os-release 2>/dev/null; then
+	APT_CONF_PROXY="/etc/apt/apt.conf.d/99proxy.conf"
+	if [ ! -f "$APT_CONF_PROXY" ]; then
+		cat <<-EOF >"$APT_CONF_PROXY"
+			Acquire::http::Proxy "$web_proxy";
+			Acquire::https::Proxy "$web_proxy";
+		EOF
+	fi
+fi

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -158,3 +158,10 @@ variable "ansible_virtualenv_path" {
     error_message = "var.ansible_virtualenv_path must be an absolute path to a directory without spaces or special characters"
   }
 }
+
+variable "http_proxy" {
+  description = "Web (http and https) proxy configuration for pip, apt, and yum/dnf"
+  type        = string
+  default     = ""
+  nullable    = false
+}


### PR DESCRIPTION
There is a customer request for package managers to function with http proxies. This PR configures pip and yum or apt (depending on OS) to use a configured proxy for both http and https traffic. It is outside of the scope of the Toolkit to provision the proxy. If no proxy is specified, then no proxy configuration is made. The configuration must occur before the installation of Ansible which depends upon pip/yum/apt.

Alternative of using HTTP_PROXY environment variables in Ansible installation was considered but rejected because it would also impact gcloud/gsutil and would be a temporary configuration. This configures all subsequent attempts to use pip/yum/apt.

I have tested with this blueprint (vm00 does not use proxy at all, and the other are 4 different OSes) and verified that each package manager attempts to use the configured proxy (and fails):

```yaml
---
blueprint_name: test-proxy

vars:
  project_id:  ## Set project id here
  deployment_name: proxy
  region: us-east4
  zone: us-east4-c

deployment_groups:
- group: first
  modules:
  - id: network1
    source: modules/network/vpc
  - id: script
    source: modules/scripts/startup-script
    settings:
      http_proxy: http://my.proxy:80
      runners:
      - type: shell
        destination: test_proxy.sh
        content: |
          #!/bin/bash
          touch /etc/i_was_here
  - id: script00
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: shell
        destination: test_proxy2.sh
        content: |
          #!/bin/bash
          touch /etc/i_was_here
  - id: vm00
    source: modules/compute/vm-instance
    use:
    - network1
    - script00
    settings:
      name_prefix: vm00
      machine_type: n1-standard-2
  - id: vm0
    source: modules/compute/vm-instance
    use:
    - network1
    - script
    settings:
      name_prefix: vm0
      machine_type: n1-standard-2
  - id: vm1
    source: modules/compute/vm-instance
    use:
    - network1
    - script
    settings:
      name_prefix: vm1
      machine_type: n1-standard-2
      instance_image:
        project: debian-cloud
        family: debian-12
  - id: vm2
    source: modules/compute/vm-instance
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
