### PR TITLE
Point ref errors to a location within nested object

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -308,7 +308,7 @@ func (m Module) ListUnusedModules() ModuleIDs {
 // GetUsedDeploymentVars returns a list of deployment vars used in the given value
 func GetUsedDeploymentVars(val cty.Value) []string {
 	res := []string{}
-	for _, ref := range valueReferences(val) {
+	for ref := range valueReferences(val) {
 		if ref.GlobalVar {
 			res = append(res, ref.Name)
 		}
@@ -653,9 +653,10 @@ func (bp *Blueprint) WalkModules(walker func(*Module) error) error {
 func validateModuleSettingReferences(p modulePath, m Module, bp Blueprint) error {
 	errs := Errors{}
 	for k, v := range m.Settings.Items() {
-		for _, r := range valueReferences(v) {
-			// TODO: add a cty.Path suffix to the errors path for better location
-			errs.At(p.Settings.Dot(k), validateModuleSettingReference(bp, m, r))
+		for r, rp := range valueReferences(v) {
+			errs.At(
+				p.Settings.Dot(k).Cty(rp),
+				validateModuleSettingReference(bp, m, r))
 		}
 	}
 	return errs.OrNil()
@@ -684,18 +685,13 @@ func (bp *Blueprint) evalVars() (Dict, error) {
 	dfs = func(n string) error {
 		used[n] = 1 // put on stack
 		v := bp.Vars.Get(n)
-		for _, ref := range valueReferences(v) {
+		for ref, rp := range valueReferences(v) {
+			p := Root.Vars.Dot(n).Cty(rp)
 			if !ref.GlobalVar {
-				return BpError{
-					Root.Vars.Dot(n),
-					fmt.Errorf("non-global variable %q referenced in expression", ref.Name),
-				}
+				return BpError{p, fmt.Errorf("non-global variable %q referenced in expression", ref.Name)}
 			}
 			if used[ref.Name] == 1 {
-				return BpError{
-					Root.Vars.Dot(n),
-					fmt.Errorf("cyclic dependency detected: %q -> %q", n, ref.Name),
-				}
+				return BpError{p, fmt.Errorf("cyclic dependency detected: %q -> %q", n, ref.Name)}
 			}
 			if used[ref.Name] == 0 {
 				if err := dfs(ref.Name); err != nil {

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -390,7 +390,7 @@ func (dg DeploymentGroup) FindAllIntergroupReferences(bp Blueprint) []Reference 
 func FindIntergroupReferences(v cty.Value, mod Module, bp Blueprint) []Reference {
 	g := bp.ModuleGroupOrDie(mod.ID)
 	res := []Reference{}
-	for _, r := range valueReferences(v) {
+	for r := range valueReferences(v) {
 		if !r.GlobalVar && bp.ModuleGroupOrDie(r.Module).Name != g.Name {
 			res = append(res, r)
 		}

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -25,7 +25,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
-	"golang.org/x/exp/maps"
 )
 
 // Reference is data struct that represents a reference to a variable.
@@ -422,17 +421,17 @@ func functions() map[string]function.Function {
 	}
 }
 
-func valueReferences(v cty.Value) []Reference {
-	r := map[Reference]bool{}
-	cty.Walk(v, func(_ cty.Path, v cty.Value) (bool, error) {
+func valueReferences(v cty.Value) map[Reference]cty.Path {
+	r := map[Reference]cty.Path{}
+	cty.Walk(v, func(p cty.Path, v cty.Value) (bool, error) {
 		if e, is := IsExpressionValue(v); is {
 			for _, ref := range e.References() {
-				r[ref] = true
+				r[ref] = p
 			}
 		}
 		return true, nil
 	})
-	return maps.Keys(r)
+	return r
 }
 
 func evalValue(v cty.Value, bp Blueprint) (cty.Value, error) {


### PR DESCRIPTION
```yaml
...
  modules:
  - id: tst
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: data
        destination: $(vars.hi)
```

```sh
# BEFORE
Error: module "tst" references unknown global variable "hi"
30:       runners:
          ^
# AFTER
Error: module "tst" references unknown global variable "hi"
32:         destination: $(vars.hi)
            ^
```