### PR TITLE
Add spelling hints for global vars and outputs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,25 +101,19 @@ func (bp *Blueprint) Module(id ModuleID) (*Module, error) {
 	return mod, nil
 }
 
-// SuggestModuleIDHint return a correct spelling of given ModuleID id if one
-// is close enough (based on maxHintDist)
-func (bp Blueprint) SuggestModuleIDHint(id ModuleID) (string, bool) {
-	clMod := ""
-	minDist := -1
-	bp.WalkModules(func(m *Module) error {
-		dist := levenshtein.Distance(string(m.ID), string(id), nil)
-		if minDist == -1.0 || dist < minDist {
-			minDist = dist
-			clMod = string(m.ID)
+func hintSpelling(s string, dict []string, err error) error {
+	best, minDist := "", maxHintDist+1
+	for _, w := range dict {
+		d := levenshtein.Distance(s, w, nil)
+		if d < minDist {
+			best, minDist = w, d
 		}
-		return nil
-	})
-
-	if clMod != "" && minDist <= maxHintDist {
-		return clMod, true
 	}
+	if minDist <= maxHintDist {
+		return HintError{fmt.Sprintf("did you mean %q?", best), err}
+	}
+	return err
 
-	return "", false
 }
 
 // ModuleGroup returns the group containing the module

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -842,17 +842,17 @@ func (s *zeroSuite) TestValidateModuleSettingReference(c *C) {
 	// FAIL. get global hint
 	mod := ModuleID("var")
 	unkModErr := UnknownModuleError{mod}
-	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{"Did you mean \"vars\"?", unkModErr}), Equals, true)
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{`did you mean "vars"?`, unkModErr}), Equals, true)
 
 	// FAIL. get module ID hint
 	mod = ModuleID("pkp")
 	unkModErr = UnknownModuleError{mod}
-	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{fmt.Sprintf("Did you mean \"%s\"?", string(pkr.ID)), unkModErr}), Equals, true)
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{fmt.Sprintf("did you mean %q?", string(pkr.ID)), unkModErr}), Equals, true)
 
 	// FAIL. get no hint
 	mod = ModuleID("test")
 	unkModErr = UnknownModuleError{mod}
-	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{fmt.Sprintf("Did you mean \"%s\"?", string(pkr.ID)), unkModErr}), Equals, false)
+	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), HintError{fmt.Sprintf("did you mean %q?", string(pkr.ID)), unkModErr}), Equals, false)
 	c.Check(errors.Is(vld(bp, mod11, ModuleRef(mod, "kale")), unkModErr), Equals, true)
 }
 

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -153,7 +153,6 @@ const (
 	errMsgInvalidVar       = string("invalid variable definition in")
 	errMsgVarNotFound      = string("could not find source of variable")
 	errMsgIntergroupOrder  = string("references to outputs from other groups must be to earlier groups")
-	errMsgNoOutput         = string("output not found for a variable")
 	errMsgCannotUsePacker  = string("Packer modules cannot be used by other modules")
 	errMsgDuplicateGroup   = string("group names must be unique")
 	errMsgDuplicateID      = string("module IDs must be unique")


### PR DESCRIPTION
```yaml
...
  - id: other
    source: modules/scripts/startup-script
          
  - id: this
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: $(vars.project)
        region: $(other.startup_skript)
        destination: $(var.region)
        content: $(otter.thing)
```

```sh
Error: invalid module id: "otter" - did you mean "other"?
37:         content: $(otter.thing)
            ^
Error: invalid module id: "var" - did you mean "vars"?
36:         destination: $(var.region)
            ^
Error: module "other" does not have output "startup_skript" - did you mean "startup_script"?
35:         region: $(other.startup_skript)
            ^
Error: module "this" references unknown global variable "project" - did you mean "project_id"?
34:       - type: $(vars.project)
            ^
```