### PR TITLE
Use `cty.Type` instead of `string` to represent type of vars.

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -179,14 +179,8 @@ func (s *MySuite) getMultiGroupDeploymentConfig() DeploymentConfig {
 
 	testModuleInfo0 := modulereader.ModuleInfo{
 		Inputs: []modulereader.VarInfo{
-			{
-				Name: "deployment_name",
-				Type: "string",
-			},
-			{
-				Name: altProjectIDSetting,
-				Type: "string",
-			},
+			{Name: "deployment_name", Type: cty.String},
+			{Name: altProjectIDSetting, Type: cty.String},
 		},
 		Outputs: []modulereader.OutputInfo{
 			{
@@ -220,13 +214,8 @@ func (s *MySuite) getMultiGroupDeploymentConfig() DeploymentConfig {
 
 	testModuleInfo2 := modulereader.ModuleInfo{
 		Inputs: []modulereader.VarInfo{
-			{
-				Name: "deployment_name",
-				Type: "string",
-			},
-			{
-				Name: matchingIntergroupName,
-			},
+			{Name: "deployment_name", Type: cty.String},
+			{Name: matchingIntergroupName},
 		},
 		Outputs: []modulereader.OutputInfo{},
 	}

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"hpc-toolkit/pkg/modulereader"
 
@@ -121,8 +120,8 @@ func (dc *DeploymentConfig) expandBackends() {
 	}
 }
 
-func getModuleInputMap(inputs []modulereader.VarInfo) map[string]string {
-	modInputs := make(map[string]string)
+func getModuleInputMap(inputs []modulereader.VarInfo) map[string]cty.Type {
+	modInputs := make(map[string]cty.Type)
 	for _, input := range inputs {
 		modInputs[input.Name] = input.Type
 	}
@@ -178,7 +177,7 @@ func useModule(mod *Module, use Module) {
 
 		// skip settings that are not of list type, but already have a value
 		// these were probably added by a previous call to this function
-		isList := strings.HasPrefix(inputType, "list")
+		isList := inputType.IsListType()
 		if alreadySet && !isList {
 			continue
 		}

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -77,10 +77,7 @@ func (s *zeroSuite) TestUseModule(c *C) {
 		ID:     "UsedModule",
 		Source: "usedSource",
 	}
-	varInfoNumber := modulereader.VarInfo{
-		Name: "val1",
-		Type: "number",
-	}
+	varInfoNumber := modulereader.VarInfo{Name: "val1", Type: cty.Number}
 	ref := ModuleRef("UsedModule", "val1").AsExpression().AsValue()
 
 	{ // Pass: No Inputs, No Outputs
@@ -152,7 +149,7 @@ func (s *zeroSuite) TestUseModule(c *C) {
 	{ // Pass: Single Input/Output match, input is list, not already set
 		mod := Module{ID: "lime", Source: "limeTree"}
 		setTestModuleInfo(mod, modulereader.ModuleInfo{
-			Inputs: []modulereader.VarInfo{{Name: "val1", Type: "list"}},
+			Inputs: []modulereader.VarInfo{{Name: "val1", Type: cty.List(cty.Number)}},
 		})
 		setTestModuleInfo(used, modulereader.ModuleInfo{
 			Outputs: []modulereader.OutputInfo{{Name: "val1"}},
@@ -169,7 +166,7 @@ func (s *zeroSuite) TestUseModule(c *C) {
 		mod := Module{ID: "lime", Source: "limeTree"}
 		mod.Settings.Set("val1", AsProductOfModuleUse(cty.TupleVal([]cty.Value{ref}), "other"))
 		setTestModuleInfo(mod, modulereader.ModuleInfo{
-			Inputs: []modulereader.VarInfo{{Name: "val1", Type: "list"}},
+			Inputs: []modulereader.VarInfo{{Name: "val1", Type: cty.List(cty.Number)}},
 		})
 		setTestModuleInfo(used, modulereader.ModuleInfo{
 			Outputs: []modulereader.OutputInfo{{Name: "val1"}},
@@ -187,7 +184,7 @@ func (s *zeroSuite) TestUseModule(c *C) {
 		mod := Module{ID: "lime", Source: "limeTree"}
 		mod.Settings.Set("val1", cty.TupleVal([]cty.Value{ref}))
 		setTestModuleInfo(mod, modulereader.ModuleInfo{
-			Inputs: []modulereader.VarInfo{{Name: "val1", Type: "list"}},
+			Inputs: []modulereader.VarInfo{{Name: "val1", Type: cty.List(cty.Number)}},
 		})
 		setTestModuleInfo(used, modulereader.ModuleInfo{
 			Outputs: []modulereader.OutputInfo{{Name: "val1"}},
@@ -220,9 +217,7 @@ func (s *MySuite) TestApplyUseModules(c *C) {
 
 		setTestModuleInfo(using, modulereader.ModuleInfo{
 			Inputs: []modulereader.VarInfo{{
-				Name: "potato",
-				Type: "number",
-			}}})
+				Name: "potato", Type: cty.Number}}})
 		setTestModuleInfo(used, modulereader.ModuleInfo{
 			Outputs: []modulereader.OutputInfo{
 				{Name: "potato"}}})
@@ -332,7 +327,7 @@ func (s *MySuite) TestApplyGlobalVariables(c *C) {
 	setTestModuleInfo(*mod, modulereader.ModuleInfo{
 		Inputs: []modulereader.VarInfo{{
 			Name:     "gold",
-			Type:     "string",
+			Type:     cty.String,
 			Required: true,
 		}},
 	})
@@ -353,7 +348,7 @@ func (s *MySuite) TestApplyGlobalVariables(c *C) {
 	setTestModuleInfo(*mod, modulereader.ModuleInfo{
 		Inputs: []modulereader.VarInfo{{
 			Name:     "gold",
-			Type:     "string",
+			Type:     cty.String,
 			Required: false,
 		}},
 	})

--- a/pkg/inspect/modules_test.go
+++ b/pkg/inspect/modules_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/exp/slices"
 )
 
@@ -121,7 +123,7 @@ func checkInputType(t *testing.T, mod modInfo, input string, expected string) {
 		t.Errorf("%s does not have input %s", mod.Source, input)
 	}
 	expected = modulereader.NormalizeType(expected)
-	got := modulereader.NormalizeType(i.Type)
+	got := typeexpr.TypeString(i.Type)
 	if expected != got {
 		t.Errorf("%s %s has unexpected type expected:\n%#v\ngot:\n%#v",
 			mod.Source, input, expected, got)
@@ -148,7 +150,7 @@ func TestNetworkStorage(t *testing.T) {
 
 	for _, mod := range notEmpty(query(hasInput("network_storage")), t) {
 		i, _ := mod.Input("network_storage")
-		got := modulereader.NormalizeType(i.Type)
+		got := typeexpr.TypeString(i.Type)
 		if got != obj && got != lst {
 			t.Errorf("%s `network_storage` has unexpected type expected:\n%#v\nor\n%#v\ngot:\n%#v",
 				mod.Source, obj, lst, got)
@@ -189,7 +191,7 @@ func TestMetadataInjectModuleId(t *testing.T) {
 			if !ok {
 				t.Fatalf("has no input %q", gm.InjectModuleId)
 			}
-			if in.Type != "string" {
+			if in.Type != cty.String {
 				t.Errorf("%q type is not a string, but %q", gm.InjectModuleId, in.Type)
 			}
 		})

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -61,9 +61,13 @@ func getHCLInfo(source string) (ModuleInfo, error) {
 	var vars []VarInfo
 	var outs []OutputInfo
 	for _, v := range module.Variables {
+		ty, err := GetCtyType(v.Type)
+		if err != nil {
+			return ModuleInfo{}, fmt.Errorf("failed to parse type of variable %q: %w", v.Name, err)
+		}
 		vInfo := VarInfo{
 			Name:        v.Name,
-			Type:        v.Type,
+			Type:        ty,
 			Description: v.Description,
 			Default:     v.Default,
 			Required:    v.Required,
@@ -82,15 +86,27 @@ func getHCLInfo(source string) (ModuleInfo, error) {
 	return ret, nil
 }
 
-// Transforms HCL type string into cty.Type
-func getCtyType(hclType string) (cty.Type, error) {
+// Transforms Terraform type string into cty.Type
+func GetCtyType(hclType string) (cty.Type, error) {
+	if hclType == "" { // treat empty type as `any`
+		// see https://developer.hashicorp.com/terraform/language/values/variables#type-constraints
+		return cty.DynamicPseudoType, nil
+	}
 	expr, diags := hclsyntax.ParseExpression([]byte(hclType), "", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return cty.Type{}, diags
+		return cty.NilType, diags
 	}
-	typ, diags := typeexpr.TypeConstraint(expr)
+
+	switch hcl.ExprAsKeyword(expr) {
+	case "list":
+		return cty.List(cty.DynamicPseudoType), nil
+	case "map":
+		return cty.Map(cty.DynamicPseudoType), nil
+	}
+
+	typ, _, diags := typeexpr.TypeConstraintWithDefaults(expr)
 	if diags.HasErrors() {
-		return cty.Type{}, diags
+		return cty.NilType, diags
 	}
 	return typ, nil
 }
@@ -104,7 +120,7 @@ func getCtyType(hclType string) (cty.Type, error) {
 //
 // This method is fail-safe, if error arises passed type will be returned without changes.
 func NormalizeType(hclType string) string {
-	ctyType, err := getCtyType(hclType)
+	ctyType, err := GetCtyType(hclType)
 	if err != nil {
 		logging.Error("Failed to parse HCL type='%s', got %v", hclType, err)
 		return hclType

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -25,13 +25,14 @@ import (
 	"path"
 
 	"github.com/hashicorp/go-getter"
+	"github.com/zclconf/go-cty/cty"
 	"gopkg.in/yaml.v3"
 )
 
 // VarInfo stores information about a module input variables
 type VarInfo struct {
 	Name        string
-	Type        string
+	Type        cty.Type
 	Description string
 	Default     interface{}
 	Required    bool

--- a/pkg/modulereader/resreader_test.go
+++ b/pkg/modulereader/resreader_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
 )
@@ -88,7 +89,7 @@ func (s *MySuite) TestGetModuleInfo_Embedded(c *C) {
 		c.Check(mi, DeepEquals, ModuleInfo{
 			Inputs: []VarInfo{{
 				Name:        "test_variable",
-				Type:        "string",
+				Type:        cty.String,
 				Description: "This is just a test",
 				Required:    true}},
 			Outputs: []OutputInfo{{
@@ -136,7 +137,7 @@ func (s *MySuite) TestGetModuleInfo_Local(c *C) {
 		c.Check(mi, DeepEquals, ModuleInfo{
 			Inputs: []VarInfo{{
 				Name:        "test_variable",
-				Type:        "string",
+				Type:        cty.String,
 				Description: "This is just a test",
 				Required:    true}},
 			Outputs: []OutputInfo{{
@@ -190,7 +191,7 @@ func (s *MySuite) TestGetInfo_TFReder(c *C) {
 	info, err := reader.GetInfo(s.terraformDir)
 	c.Assert(err, IsNil)
 	c.Check(info, DeepEquals, ModuleInfo{
-		Inputs:  []VarInfo{{Name: "test_variable", Type: "string", Description: "This is just a test", Required: true}},
+		Inputs:  []VarInfo{{Name: "test_variable", Type: cty.String, Description: "This is just a test", Required: true}},
 		Outputs: []OutputInfo{{Name: "test_output", Description: "This is just a test"}},
 	})
 
@@ -201,7 +202,7 @@ func (s *MySuite) TestGetInfo_PackerReader(c *C) {
 	exp := ModuleInfo{
 		Inputs: []VarInfo{{
 			Name:        "test_variable",
-			Type:        "string",
+			Type:        cty.String,
 			Description: "This is just a test",
 			Required:    true}}}
 

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
@@ -234,81 +236,31 @@ func (s *MySuite) TestRestoreTfState(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (s *zeroSuite) TestGetTypeTokens(c *C) {
-	// Success Integer
-	tok := getTypeTokens(cty.NumberIntVal(-1))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("number")))
-
-	tok = getTypeTokens(cty.NumberIntVal(0))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("number")))
-
-	tok = getTypeTokens(cty.NumberIntVal(1))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("number")))
-
-	// Success Float
-	tok = getTypeTokens(cty.NumberFloatVal(-99.9))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("number")))
-
-	tok = getTypeTokens(cty.NumberFloatVal(99.9))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("number")))
-
-	// Success String
-	tok = getTypeTokens(cty.StringVal("Lorum"))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("string")))
-
-	tok = getTypeTokens(cty.StringVal(""))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("string")))
-
-	// Success Bool
-	tok = getTypeTokens(cty.BoolVal(true))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("bool")))
-
-	tok = getTypeTokens(cty.BoolVal(false))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("bool")))
-
-	// Success tuple
-	tok = getTypeTokens(cty.TupleVal([]cty.Value{}))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("list")))
-
-	tok = getTypeTokens(cty.TupleVal([]cty.Value{cty.StringVal("Lorum")}))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("list")))
-
-	// Success list
-	tok = getTypeTokens(cty.ListVal([]cty.Value{cty.StringVal("Lorum")}))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("list")))
-
-	// Success object
-	tok = getTypeTokens(cty.ObjectVal(map[string]cty.Value{}))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("any")))
-
-	val := cty.ObjectVal(map[string]cty.Value{"Lorum": cty.StringVal("Ipsum")})
-	tok = getTypeTokens(val)
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("any")))
-
-	// Success Map
-	val = cty.MapVal(map[string]cty.Value{"Lorum": cty.StringVal("Ipsum")})
-	tok = getTypeTokens(val)
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("any")))
-
-	// Success any
-	tok = getTypeTokens(cty.NullVal(cty.DynamicPseudoType))
-	c.Assert(tok, HasLen, 1)
-	c.Assert(string(tok[0].Bytes), Equals, string([]byte("any")))
+func TestGetTypeTokensRelaxed(t *testing.T) {
+	type test struct {
+		input cty.Type
+		want  string
+	}
+	tests := []test{
+		{cty.Number, "number"},
+		{cty.String, "string"},
+		{cty.Bool, "bool"},
+		{cty.Tuple([]cty.Type{}), "list(any)"},
+		{cty.Tuple([]cty.Type{cty.String}), "list(any)"},
+		{cty.List(cty.String), "list(any)"},
+		{cty.Object(map[string]cty.Type{}), "any"},
+		{cty.Object(map[string]cty.Type{"Lorum": cty.String}), "any"},
+		{cty.Map(cty.String), "any"},
+		{cty.DynamicPseudoType, "any"},
+	}
+	for _, tc := range tests {
+		t.Run(typeexpr.TypeString(tc.input), func(t *testing.T) {
+			got := string(getTypeTokens(relaxVarType(tc.input)).Bytes())
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("diff (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func (s *MySuite) TestCreateBaseFile(c *C) {


### PR DESCRIPTION
NOTE: after this change instead of `list` the `list(any)` will be written into `variables.tf`.
