### PR TITLE
Check if supplied value matches expected module variable type

### DIFF
--- a/pkg/config/expression_test.go
+++ b/pkg/config/expression_test.go
@@ -154,6 +154,7 @@ func TestTokensForValueNoLiteral(t *testing.T) {
 				"ba": cty.NumberIntVal(56),
 			})}),
 		"pony.zebra": cty.NilVal,
+		"zanzibar":   cty.NullVal(cty.DynamicPseudoType),
 	})
 	want := hclwrite.NewEmptyFile()
 	want.Body().AppendUnstructuredTokens(hclwrite.TokensForValue(val))

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -37,6 +37,12 @@ func (s *zeroSuite) TestValidateVars(c *C) {
 		c.Check(validateVars(vars), NotNil)
 	}
 
+	{ // Fail: Null value
+		vars := Dict{base}
+		vars.Set("fork", cty.NullVal(cty.String))
+		c.Check(validateVars(vars), NotNil)
+	}
+
 	{ // Fail: labels not a map
 		vars := Dict{base}
 		vars.Set("labels", cty.StringVal("a_string"))

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -337,10 +337,11 @@ b: null
 c: ~
 d: "null"
 `
+	anyNull := cty.NullVal(cty.DynamicPseudoType)
 	want := cty.ObjectVal(map[string]cty.Value{
-		"a": cty.NilVal,
-		"b": cty.NilVal,
-		"c": cty.NilVal,
+		"a": anyNull,
+		"b": anyNull,
+		"c": anyNull,
 		"d": cty.StringVal("null"),
 	})
 

--- a/pkg/modulereader/metadata.go
+++ b/pkg/modulereader/metadata.go
@@ -54,7 +54,6 @@ type MetadataGhpc struct {
 func GetMetadata(source string) (Metadata, error) {
 	var err error
 	var data []byte
-	// TODO: use bpmetadata.UnmarshalMetadata, it performs some additional checks
 	filePath := filepath.Join(source, "metadata.yaml")
 
 	switch {

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -58,8 +58,8 @@ func (s *MySuite) getDeploymentConfigForTest() config.DeploymentConfig {
 		Kind:   config.TerraformKind,
 		ID:     "testModule",
 		Settings: config.NewDict(map[string]cty.Value{
-			"deployment_name": cty.NilVal,
-			"project_id":      cty.NilVal,
+			"deployment_name": cty.NullVal(cty.String),
+			"project_id":      cty.NullVal(cty.String),
 		}),
 		Outputs: []modulereader.OutputInfo{
 			{

--- a/pkg/validators/validators_test.go
+++ b/pkg/validators/validators_test.go
@@ -32,37 +32,39 @@ func Test(t *testing.T) {
 }
 
 func (s *MySuite) TestCheckInputs(c *C) {
+	dummy := cty.NullVal(cty.String)
+
 	{ // OK: Inputs is equal to required inputs without regard to ordering
 		i := config.NewDict(map[string]cty.Value{
-			"in0": cty.NilVal,
-			"in1": cty.NilVal})
+			"in0": dummy,
+			"in1": dummy})
 		c.Check(checkInputs(i, []string{"in0", "in1"}), IsNil)
 		c.Check(checkInputs(i, []string{"in1", "in0"}), IsNil)
 	}
 
 	{ // FAIL: inputs are a proper subset of required inputs
 		i := config.NewDict(map[string]cty.Value{
-			"in0": cty.NilVal,
-			"in1": cty.NilVal})
+			"in0": dummy,
+			"in1": dummy})
 		err := checkInputs(i, []string{"in0", "in1", "in2"})
 		c.Check(err, NotNil)
 	}
 
 	{ // FAIL: inputs intersect with required inputs but are not a proper subset
 		i := config.NewDict(map[string]cty.Value{
-			"in0": cty.NilVal,
-			"in1": cty.NilVal,
-			"in3": cty.NilVal})
+			"in0": dummy,
+			"in1": dummy,
+			"in3": dummy})
 		err := checkInputs(i, []string{"in0", "in1", "in2"})
 		c.Check(err, NotNil)
 	}
 
 	{ // FAIL inputs are a proper superset of required inputs
 		i := config.NewDict(map[string]cty.Value{
-			"in0": cty.NilVal,
-			"in1": cty.NilVal,
-			"in2": cty.NilVal,
-			"in3": cty.NilVal})
+			"in0": dummy,
+			"in1": dummy,
+			"in2": dummy,
+			"in3": dummy})
 		err := checkInputs(i, []string{"in0", "in1", "in2"})
 		c.Check(err, ErrorMatches, "only 3 inputs \\[in0 in1 in2\\] should be provided")
 	}


### PR DESCRIPTION
* Check if supplied value matches expected module variable type;
* Do not use `cty.NilVal` as a representation of `null`, use `cty.NullVal(any)` instead;

**Example:**
```yaml
vars:
  ...
  mtu: JUMBO

deployment_groups:
- group: primary
  modules:
  - id: network
    source: modules/network/vpc
    settings:
      mtu: $(vars.mtu)
```

```sh
Error: unsuitable value for "mtu": a number is required
32:       mtu: $(vars.mtu)
```