### PR TITLE
Add `has_to_be_used` behaviour to some of modules

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/metadata.yaml
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/metadata.yaml
@@ -16,3 +16,5 @@
 spec:
   requirements:
     services: []
+ghpc:
+  has_to_be_used: true

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/metadata.yaml
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/metadata.yaml
@@ -18,3 +18,4 @@ spec:
     services: []
 ghpc:
   inject_module_id: name
+  has_to_be_used: true

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/metadata.yaml
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/metadata.yaml
@@ -16,3 +16,5 @@
 spec:
   requirements:
     services: []
+ghpc:
+  has_to_be_used: true

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/metadata.yaml
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/metadata.yaml
@@ -16,3 +16,5 @@
 spec:
   requirements:
     services: []
+ghpc:
+  has_to_be_used: true

--- a/docs/module-guidelines.md
+++ b/docs/module-guidelines.md
@@ -201,5 +201,8 @@ spec:
 ghpc:  # [optional]
   # [optional] `inject_module_id`, if set, will inject blueprint 
   # module id as a value for the module variable `var_name`.
-  inject_module_id: var_name 
+  inject_module_id: var_name
+  # [optional] `has_to_be_used` is a boolean flag, if set to true,
+  # the creation will fail if the module is not used.
+  has_to_be_used: true 
 ```

--- a/pkg/modulereader/metadata.go
+++ b/pkg/modulereader/metadata.go
@@ -47,6 +47,8 @@ type MetadataGhpc struct {
 	// Optional, set to the string-typed module variable name.
 	// If set, the blueprint module id will be set as a value of this variable.
 	InjectModuleId string `yaml:"inject_module_id"`
+	// If set to true, the creation will fail if the module is not used.
+	HasToBeUsed bool `yaml:"has_to_be_used"`
 }
 
 // GetMetadata reads and parses `metadata.yaml` from module root.


### PR DESCRIPTION
```sh
Error: module "debug_nodeset" was not used - you need to add it to the `use`-block of downstream modules
40:   - id: debug_nodeset
        ^
```