### PR TITLE
Refactor `Blueprint.WalkModules`

### DIFF
--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -320,9 +320,6 @@ func (s *MySuite) TestApplyGlobalVariables(c *C) {
 	dc := s.getDeploymentConfigForTest()
 	mod := &dc.Config.DeploymentGroups[0].Modules[0]
 
-	// Test no inputs, none required
-	c.Check(dc.applyGlobalVariables(), IsNil)
-
 	// Test no inputs, one required, doesn't exist in globals
 	setTestModuleInfo(*mod, modulereader.ModuleInfo{
 		Inputs: []modulereader.VarInfo{{
@@ -334,25 +331,11 @@ func (s *MySuite) TestApplyGlobalVariables(c *C) {
 
 	// Test no input, one required, exists in globals
 	dc.Config.Vars.Set("gold", cty.StringVal("val"))
-	c.Check(dc.applyGlobalVariables(), IsNil)
+	dc.applyGlobalVariables()
 	c.Assert(
 		mod.Settings.Get("gold"),
 		DeepEquals,
 		GlobalRef("gold").AsExpression().AsValue())
-
-	// Test one input, one required
-	mod.Settings.Set("reqVar", cty.StringVal("val"))
-	c.Assert(dc.applyGlobalVariables(), IsNil)
-
-	// Test one input, none required, exists in globals
-	setTestModuleInfo(*mod, modulereader.ModuleInfo{
-		Inputs: []modulereader.VarInfo{{
-			Name:     "gold",
-			Type:     cty.String,
-			Required: false,
-		}},
-	})
-	c.Assert(dc.applyGlobalVariables(), IsNil)
 }
 
 func (s *zeroSuite) TestIsSimpleVariable(c *C) {

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -156,10 +156,10 @@ type groupPath struct {
 	basePath
 	Name    basePath              `path:".group"`
 	Backend backendPath           `path:".terraform_backend"`
-	Modules arrayPath[modulePath] `path:".modules"`
+	Modules arrayPath[ModulePath] `path:".modules"`
 }
 
-type modulePath struct {
+type ModulePath struct {
 	basePath
 	Source   basePath              `path:".source"`
 	Kind     basePath              `path:".kind"`

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -82,7 +82,7 @@ func validateVars(vars Dict) error {
 	return errs.OrNil()
 }
 
-func validateModule(p modulePath, m Module, bp Blueprint) error {
+func validateModule(p ModulePath, m Module, bp Blueprint) error {
 	// Source/Kind validations are required to pass to perform other validations
 	if m.Source == "" {
 		return BpError{p.Source, EmptyModuleSource}
@@ -113,7 +113,7 @@ func validateModule(p modulePath, m Module, bp Blueprint) error {
 		OrNil()
 }
 
-func validateOutputs(p modulePath, mod Module, info modulereader.ModuleInfo) error {
+func validateOutputs(p ModulePath, mod Module, info modulereader.ModuleInfo) error {
 	errs := Errors{}
 	outputs := info.GetOutputsAsMap()
 
@@ -133,7 +133,7 @@ type moduleVariables struct {
 }
 
 func validateSettings(
-	p modulePath,
+	p ModulePath,
 	mod Module,
 	info modulereader.ModuleInfo) error {
 

--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -188,12 +188,11 @@ func testApisEnabled(bp config.Blueprint, inputs config.Dict) error {
 		return err
 	}
 	apis := map[string]bool{}
-	bp.WalkModules(func(m *config.Module) error {
+	bp.WalkModulesSafe(func(_ config.ModulePath, m *config.Module) {
 		services := m.InfoOrDie().Metadata.Spec.Requirements.Services
 		for _, api := range services {
 			apis[api] = true
 		}
-		return nil
 	})
 	return TestApisEnabled(p, maps.Keys(apis))
 }

--- a/pkg/validators/semantic.go
+++ b/pkg/validators/semantic.go
@@ -26,19 +26,14 @@ func testModuleNotUsed(bp config.Blueprint, inputs config.Dict) error {
 		return err
 	}
 	errs := config.Errors{}
-	for ig, g := range bp.DeploymentGroups {
-		for im, m := range g.Modules {
-			ums := m.ListUnusedModules()
-			p := config.Root.Groups.At(ig).Modules.At(im).Use
-
-			for iu, u := range m.Use {
-				if slices.Contains(ums, u) {
-					errs.At(p.At(iu), fmt.Errorf(unusedModuleMsg, m.ID, u))
-				}
+	bp.WalkModulesSafe(func(p config.ModulePath, m *config.Module) {
+		ums := m.ListUnusedModules()
+		for iu, u := range m.Use {
+			if slices.Contains(ums, u) {
+				errs.At(p.Use.At(iu), fmt.Errorf(unusedModuleMsg, m.ID, u))
 			}
 		}
-	}
-
+	})
 	return errs.OrNil()
 }
 


### PR DESCRIPTION
* Add safe-version to avoid useless `return nil`;
* Supply `ModulePath` to the "dangerous" version;
* Use `WalkModules` instead of nested for-loops in few cases.

