### PR TITLE
Simplify rendering of errors with Position instead of Path

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -40,6 +40,8 @@ func renderError(err error, ctx config.YamlCtx) string {
 		return renderHintError(te, ctx)
 	case config.BpError:
 		return renderBpError(te, ctx)
+	case config.PosError:
+		return renderPosError(te, ctx)
 	default:
 		return fmt.Sprintf("%s: %s", boldRed("Error"), err)
 	}
@@ -65,12 +67,14 @@ func renderHintError(err config.HintError, ctx config.YamlCtx) string {
 
 func renderBpError(err config.BpError, ctx config.YamlCtx) string {
 	if pos, ok := findPos(err.Path, ctx); ok {
-		return renderPosError(err.Err, pos, ctx)
+		posErr := config.PosError{Pos: pos, Err: err.Err}
+		return renderPosError(posErr, ctx)
 	}
 	return renderError(err.Err, ctx)
 }
 
-func renderPosError(err error, pos config.Pos, ctx config.YamlCtx) string {
+func renderPosError(err config.PosError, ctx config.YamlCtx) string {
+	pos := err.Pos
 	line := pos.Line - 1
 	if line < 0 || line >= len(ctx.Lines) {
 		return renderError(err, ctx)
@@ -83,5 +87,5 @@ func renderPosError(err error, pos config.Pos, ctx config.YamlCtx) string {
 		arrow = spaces + "^"
 	}
 
-	return fmt.Sprintf("%s\n%s%s\n%s", renderError(err, ctx), pref, ctx.Lines[line], arrow)
+	return fmt.Sprintf("%s\n%s%s\n%s", renderError(err.Err, ctx), pref, ctx.Lines[line], arrow)
 }

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -35,6 +35,20 @@ func (e BpError) Unwrap() error {
 	return e.Err
 }
 
+// PosError is an error wrapper to augment Position
+type PosError struct {
+	Pos Pos
+	Err error
+}
+
+func (e PosError) Error() string {
+	return fmt.Sprintf("line %d column %d: %s", e.Pos.Line, e.Pos.Column, e.Err)
+}
+
+func (e PosError) Unwrap() error {
+	return e.Err
+}
+
 // HintError wraps another error to suggest other values
 type HintError struct {
 	Hint string

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -179,9 +179,6 @@ type outputPath struct {
 // Root is a starting point for creating a Blueprint Path
 var Root rootPath
 
-// internalPath is to be used to report problems outside of Blueprint schema (e.g. YAML parsing error position)
-var internalPath = mapPath[basePath]{basePath{nil, "__internal_path__"}}
-
 func init() {
 	initPath(&Root, nil, "")
 }

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -72,9 +72,6 @@ func TestPath(t *testing.T) {
 		{r.Backend.Type, "terraform_backend_defaults.type"},
 		{r.Backend.Configuration, "terraform_backend_defaults.configuration"},
 		{r.Backend.Configuration.Dot("goo"), "terraform_backend_defaults.configuration.goo"},
-
-		{internalPath, "__internal_path__"},
-		{internalPath.Dot("a"), "__internal_path__.a"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.want, func(t *testing.T) {
@@ -103,8 +100,6 @@ func TestPathParent(t *testing.T) {
 		{r.Vars.Dot("red").Cty(cp.IndexInt(6)), r.Vars.Dot("red")},
 		{r.Vars.Dot("red").Cty(cp.IndexInt(6).IndexString("gg")), r.Vars.Dot("red").Cty(cp.IndexInt(6))},
 		{r.Vars.Dot("red").Cty(cp.IndexInt(6).IndexString("gg").Index(cty.True)), r.Vars.Dot("red").Cty(cp.IndexInt(6))},
-		{internalPath, nil},
-		{internalPath.Dot("gold"), internalPath},
 	}
 	for _, tc := range tests {
 		t.Run(tc.p.String(), func(t *testing.T) {

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -260,7 +260,7 @@ func TestDictWrongTypeUnmarshalYAML(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
-	if diff := cmp.Diff(err.Error(), "line 2: must be a mapping, got number"); diff != "" {
+	if diff := cmp.Diff(err.Error(), "line 2 column 1: must be a mapping, got number"); diff != "" {
 		t.Errorf("diff (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/modulereader/resreader.go
+++ b/pkg/modulereader/resreader.go
@@ -48,6 +48,7 @@ type OutputInfo struct {
 
 // UnmarshalYAML supports parsing YAML OutputInfo fields as a simple list of
 // strings or as a list of maps directly into OutputInfo struct
+// TODO: unmarshal logic shouldn't be defined in this package, move to pkg/config
 func (mo *OutputInfo) UnmarshalYAML(value *yaml.Node) error {
 	var name string
 	const yamlErrorMsg string = "block beginning at line %d: %s"


### PR DESCRIPTION
* Remove `internalPath`;
* Add `PosError` wrapper, render it specifically.