### PR TITLE
Add zone finding for cpu partitions in hpc-enterprise-slurm test

### DIFF
--- a/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
@@ -22,6 +22,7 @@ zone: europe-west1-d
 cli_deployment_vars:
   region: europe-west1
   zone: "{{ zone }}"
+  zones: "[europe-west1-b,europe-west1-c,europe-west1-d]"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-enterprise-slurm.yaml"
 network: "default"


### PR DESCRIPTION
Test will look for capacity across multiple zones to avoid stockout. Did not put in public blueprint as this may impact egress costs.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
