### PR TITLE
Startup stackdriver option

### DIFF
--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -141,6 +141,26 @@ better performance under some HPC workloads. While official documentation
 recommends using the _Cloud Ops Agent_, it is recommended to use
 `install_stackdriver_agent` when performance is important.
 
+If an image or machine already has Cloud Ops Agent installed and you would like
+to instead use the Stackdrier Agent, the following script will remove the Cloud
+Ops Agent and install the Stackdriver Agent.
+
+```bash
+# Remove Cloud Ops Agent
+sudo systemctl stop google-cloud-ops-agent.service
+sudo systemctl disable google-cloud-ops-agent.service
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+sudo bash add-google-cloud-ops-agent-repo.sh --uninstall
+sudo bash add-google-cloud-ops-agent-repo.sh --remove-repo
+
+# Install Stackdriver Agent
+curl -sSO https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
+sudo bash add-monitoring-agent-repo.sh --also-install
+curl -sSO https://dl.google.com/cloudagents/add-logging-agent-repo.sh
+sudo bash add-logging-agent-repo.sh --also-install
+sudo service stackdriver-agent start
+```
+
 ### Example
 
 ```yaml

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -130,6 +130,17 @@ To view outputs from a Linux startup script, run:
 sudo journalctl -u google-startup-scripts.service
 ```
 
+### Monitoring Agent Installation
+
+This `startup-script` module has several options for installing a Google
+monitoring agent. There are two relevant settings: `install_stackdriver_agent`
+and `install_cloud_ops_agent`.
+
+The _Stackdriver Agent_ also called the _Legacy Cloud Monitoring Agent_ provides
+better performance under some HPC workloads. While official documentation
+recommends using the _Cloud Ops Agent_, it is recommended to use
+`install_stackdriver_agent` when performance is important.
+
 ### Example
 
 ```yaml
@@ -171,7 +182,7 @@ they are able to do so by using the `gcs_bucket_path` as shown in the below exam
   source: ./modules/scripts/startup-script
   settings:
     gcs_bucket_path: gs://user-test-bucket/folder1/folder2
-    install_cloud_ops_agent: true
+    install_stackdriver_agent: true
 
 - id: compute-cluster
   source: ./modules/compute/vm-instance
@@ -238,7 +249,8 @@ No modules.
 | <a name="input_gcs_bucket_path"></a> [gcs\_bucket\_path](#input\_gcs\_bucket\_path) | The GCS path for storage bucket and the object, starting with `gs://`. | `string` | `null` | no |
 | <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy) | Web (http and https) proxy configuration for pip, apt, and yum/dnf | `string` | `""` | no |
 | <a name="input_install_ansible"></a> [install\_ansible](#input\_install\_ansible) | Run Ansible installation script if either set to true or unset and runner of type 'ansible-local' are used. | `bool` | `null` | no |
-| <a name="input_install_cloud_ops_agent"></a> [install\_cloud\_ops\_agent](#input\_install\_cloud\_ops\_agent) | Run Google Ops Agent installation script if set to true. | `bool` | `false` | no |
+| <a name="input_install_cloud_ops_agent"></a> [install\_cloud\_ops\_agent](#input\_install\_cloud\_ops\_agent) | Warning: Consider using `install_stackdriver_agent` for better performance. Run Google Ops Agent installation script if set to true. | `bool` | `false` | no |
+| <a name="input_install_stackdriver_agent"></a> [install\_stackdriver\_agent](#input\_install\_stackdriver\_agent) | Run Google Stackdriver Agent installation script if set to true. Preferred over ops agent for performance. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels for the created GCS bucket. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_prepend_ansible_installer"></a> [prepend\_ansible\_installer](#input\_prepend\_ansible\_installer) | DEPRECATED. Use `install_ansible=false` to prevent ansible installation. | `bool` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |

--- a/modules/scripts/startup-script/files/install_monitoring_agent.sh
+++ b/modules/scripts/startup-script/files/install_monitoring_agent.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,14 @@
 # limitations under the License.
 
 LEGACY_MONITORING_PACKAGE='stackdriver-agent'
+LEGACY_MONITORING_SCRIPT_URL='https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh'
 LEGACY_LOGGING_PACKAGE='google-fluentd'
+LEGACY_LOGGING_SCRIPT_URL='https://dl.google.com/cloudagents/add-logging-agent-repo.sh'
+
 OPSAGENT_PACKAGE='google-cloud-ops-agent'
 OPSAGENT_SCRIPT_URL='https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh'
+
+install_legacy="${1:-true}"
 
 fail() {
 	echo >&2 "[$(date +'%Y-%m-%dT%H:%M:%S%z')] $*"
@@ -43,18 +48,28 @@ handle_debian() {
 			grep "${OPSAGENT_PACKAGE} is installed"
 	}
 
-	install_opsagent() {
+	install_with_retry() {
 		MAX_RETRY=50
 		RETRY=0
-		until [ ${RETRY} -eq ${MAX_RETRY} ] || curl -s "${OPSAGENT_SCRIPT_URL}" | bash -s -- --also-install; do
+		until [ ${RETRY} -eq ${MAX_RETRY} ] || curl -s "${1}" | bash -s -- --also-install; do
 			RETRY=$((RETRY + 1))
-			echo "WARNING: Cloud ops installation failed on try ${RETRY} of ${MAX_RETRY}"
+			echo "WARNING: Installation of ${1} failed on try ${RETRY} of ${MAX_RETRY}"
 			sleep 5
 		done
 		if [ $RETRY -eq $MAX_RETRY ]; then
-			echo "ERROR: Cloud ops installation was not successful after ${MAX_RETRY} attempts."
+			echo "ERROR: Installation of ${1} was not successful after ${MAX_RETRY} attempts."
 			exit 1
 		fi
+	}
+
+	install_opsagent() {
+		install_with_retry "${OPSAGENT_SCRIPT_URL}"
+	}
+
+	install_stackdriver_agent() {
+		install_with_retry "${LEGACY_MONITORING_SCRIPT_URL}"
+		install_with_retry "${LEGACY_LOGGING_SCRIPT_URL}"
+		service stackdriver-agent start
 	}
 }
 
@@ -79,7 +94,13 @@ handle_redhat() {
 	}
 
 	install_opsagent() {
-		curl -s https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh | bash -s -- --also-install
+		curl -s "${OPSAGENT_SCRIPT_URL}" | bash -s -- --also-install
+	}
+
+	install_stackdriver_agent() {
+		curl -sS "${LEGACY_MONITORING_SCRIPT_URL}" | bash -s -- --also-install
+		curl -sS "${LEGACY_LOGGING_SCRIPT_URL}" | bash -s -- --also-install
+		service stackdriver-agent start
 	}
 }
 
@@ -93,10 +114,17 @@ main() {
 	fi
 
 	if is_legacy_installed || is_opsagent_installed; then
-		fail "Legacy or Ops Agent is already installed."
+		fail "Legacy (stackdriver) or Ops Agent is already installed."
 	fi
 
-	install_opsagent
+	if [[ "${install_legacy}" == true ]]; then
+		echo "Installing legacy monitoring agent (stackdriver)"
+		install_stackdriver_agent
+	else
+		echo "Installing cloud ops agent"
+		echo "WARNING: cloud ops agent may have a performance impact. Consider using legacy monitoring agent (stackdriver)."
+		install_opsagent
+	fi
 }
 
 main

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -26,7 +26,7 @@ locals {
       type        = "shell"
       source      = "${path.module}/files/install_monitoring_agent.sh"
       destination = "install_monitoring_agent_automatic.sh"
-      args        = var.install_cloud_ops_agent ? "false" : "true" # install legacy (stackdriver)
+      args        = var.install_cloud_ops_agent ? "ops" : "legacy" # install legacy (stackdriver)
     }] :
     []
   )
@@ -175,7 +175,7 @@ resource "google_storage_bucket_object" "scripts" {
 
   lifecycle {
     precondition {
-      condition     = !var.install_cloud_ops_agent || !var.install_stackdriver_agent
+      condition     = !(var.install_cloud_ops_agent && var.install_stackdriver_agent)
       error_message = "Only one of var.install_stackdriver_agent or var.install_cloud_ops_agent can be set. Stackdriver is recommended for best performance."
     }
   }

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -20,11 +20,16 @@ locals {
 }
 
 locals {
-  ops_agent_installer = var.install_cloud_ops_agent ? [{
-    type        = "shell"
-    source      = "${path.module}/files/install_cloud_ops_agent.sh"
-    destination = "install_cloud_ops_agent_automatic.sh"
-  }] : []
+  monitoring_agent_installer = (
+    var.install_cloud_ops_agent || var.install_stackdriver_agent ?
+    [{
+      type        = "shell"
+      source      = "${path.module}/files/install_monitoring_agent.sh"
+      destination = "install_monitoring_agent_automatic.sh"
+      args        = var.install_cloud_ops_agent ? "false" : "true" # install legacy (stackdriver)
+    }] :
+    []
+  )
 
   warnings = [
     {
@@ -84,7 +89,7 @@ locals {
   runners = concat(
     local.warnings,
     local.proxy_runner,
-    local.ops_agent_installer,
+    local.monitoring_agent_installer,
     local.ansible_installer,
     local.configure_ssh_runners,
     var.runners
@@ -166,6 +171,13 @@ resource "google_storage_bucket_object" "scripts" {
   timeouts {
     create = "10m"
     update = "10m"
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !var.install_cloud_ops_agent || !var.install_stackdriver_agent
+      error_message = "Only one of var.install_stackdriver_agent or var.install_cloud_ops_agent can be set. Stackdriver is recommended for best performance."
+    }
   }
 }
 

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -113,7 +113,13 @@ EOT
 }
 
 variable "install_cloud_ops_agent" {
-  description = "Run Google Ops Agent installation script if set to true."
+  description = "Warning: Consider using `install_stackdriver_agent` for better performance. Run Google Ops Agent installation script if set to true."
+  type        = bool
+  default     = false
+}
+
+variable "install_stackdriver_agent" {
+  description = "Run Google Stackdriver Agent installation script if set to true. Preferred over ops agent for performance."
   type        = bool
   default     = false
 }

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-monitoring.yml
@@ -19,24 +19,28 @@
   vars:
     vm_name: "{{ remote_node }}"
     timeout_seconds: 600
+
 - name: Gather service facts
   become: true
   ansible.builtin.service_facts:
-- name: Fail if ops agent is not running
+
+- name: Fail if stackdriver agent is not running
   ansible.builtin.assert:
     that:
-    - ansible_facts.services["google-cloud-ops-agent.service"].status == "enabled"
-    - ansible_facts.services["google-cloud-ops-agent-fluent-bit.service"].state == "running"
-    - ansible_facts.services["google-cloud-ops-agent-opentelemetry-collector.service"].state == "running"
+    - ansible_facts.services["stackdriver-agent"].status == "enabled"
+    - ansible_facts.services["stackdriver-agent"].state == "running"
+
 - name: Check that monitoring dashboard has been created
   changed_when: false
   ansible.builtin.command: gcloud monitoring dashboards list --format="get(displayName)"
   run_once: true
   delegate_to: localhost
   register: dashboards
+
 - name: Print dashboard information
   ansible.builtin.debug:
     var: dashboards
+
 - name: Fail if the HPC Dashboard hasn't been created
   ansible.builtin.fail:
     msg: Failed to create dashboard

--- a/tools/cloud-build/daily-tests/blueprints/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/monitoring.yaml
@@ -21,6 +21,8 @@ vars:
   deployment_name: monitoring
   region: us-central1
   zone: us-central1-c
+  add_deployment_name_before_prefix: true
+  machine_type: c2-standard-4
 
 deployment_groups:
 - group: primary
@@ -38,24 +40,47 @@ deployment_groups:
   - id: bucket-for-startup-script
     source: community/modules/file-system/cloud-storage-bucket
 
-  - id: startup
+  - id: startup-ops
     source: modules/scripts/startup-script
     use: [bucket-for-startup-script]
     settings:
       install_cloud_ops_agent: true
 
-  - id: workstation
-    source: ./modules/compute/vm-instance
+  - id: workstation-ops
+    source: modules/compute/vm-instance
     use:
     - network
     - homefs
-    - startup
+    - startup-ops
     settings:
-      machine_type: c2-standard-4
-      metadata:
-        enable-oslogin: true
+      name_prefix: workstation-ops
+
+  - id: startup-stack
+    source: modules/scripts/startup-script
+    use: [bucket-for-startup-script]
+    settings:
+      install_stackdriver_agent: true
+
+  - id: workstation-stack
+    source: modules/compute/vm-instance
+    use:
+    - network
+    - homefs
+    - startup-stack
+    settings:
+      name_prefix: workstation-stackdriver
+
+  - id: wait0
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: $(workstation-ops.name[0])
+
+  - id: wait1
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_name: $(workstation-stack.name[0])
 
   - id: hpc-dash
-    source: ./modules/monitoring/dashboard
+    source: modules/monitoring/dashboard
     settings:
       title: $(vars.deployment_name)

--- a/tools/cloud-build/daily-tests/tests/monitoring.yml
+++ b/tools/cloud-build/daily-tests/tests/monitoring.yml
@@ -20,6 +20,6 @@ zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/monitoring.yaml"
 network: "{{ deployment_name }}-net"
-remote_node: "{{ deployment_name }}-0"
+remote_node: "{{ deployment_name }}-workstation-stackdriver-0"
 post_deploy_tests:
 - test-validation/test-monitoring.yml

--- a/tools/validate_configs/test_configs/apt-collision.yaml
+++ b/tools/validate_configs/test_configs/apt-collision.yaml
@@ -42,7 +42,7 @@ deployment_groups:
     kind: terraform
     id: startup
     settings:
-      install_cloud_ops_agent: true
+      install_stackdriver_agent: true
       install_ansible: true
 
   - source: modules/compute/vm-instance

--- a/tools/validate_configs/test_configs/ubuntu-ss.yaml
+++ b/tools/validate_configs/test_configs/ubuntu-ss.yaml
@@ -63,7 +63,7 @@ deployment_groups:
   - id: startup
     source: ./modules/scripts/startup-script
     settings:
-      install_cloud_ops_agent: true
+      install_stackdriver_agent: true
       runners:
       - type: data
         source: /tmp/foo.tgz


### PR DESCRIPTION
Under some HPC workloads the Cloud Ops Agent has been observed to cause reduced performance. The old Stackdriver agent show the same performance regression. The recommendation is to use the legacy agent for HPC applications.

The integration test ensures that the neither agent causes a failure during installation. Since we are recommending Stackdriver I have switched the test to actually confirming that Stackdriver is running. 

Testing: Manually deployed both stackdriver and ops agent across the following images and confirmed the service was running:
- hpc-rocky-linux-8
- hpc-centos-7
- ubuntu-2004-lts
- debian-11

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
