### PR TITLE
yamllint. Don't show warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
   rev: v1.32.0
   hooks:
   - id: yamllint
-    args: [-c=.yamllint]
+    args: [-c=.yamllint, --no-warnings]
 - repo: https://github.com/jackdewinter/pymarkdown
   rev: v0.9.12
   hooks:


### PR DESCRIPTION
Motivation: warnings doesn't cause lint to fail (only errors do), but they will be outputed along the errors (many lines), that makes it hard to see the actual error message

