### PR TITLE
Update spack openfoam example to use /opt/apps directory

### DIFF
--- a/docs/tutorials/openfoam/spack-openfoam.md
+++ b/docs/tutorials/openfoam/spack-openfoam.md
@@ -75,7 +75,7 @@ which should be open in the Cloud Shell Editor (on the left).
 
 This file describes the cluster you will deploy. It defines:
 
-* the existing default network from your project
+* a vpc network
 * a monitoring dashboard with metrics on your cluster
 * a definition of a custom Spack installation
 * a startup script that
@@ -135,16 +135,16 @@ controller. This command can be used to view progress and check for completion
 of the startup script:
 
 ```bash
-gcloud compute instances get-serial-port-output --port 1 --zone us-central1-c --project <walkthrough-project-id/> slurm-spack-openfoam-controller | grep google_metadata_script_runner
+gcloud compute instances get-serial-port-output --port 1 --zone us-central1-c --project <walkthrough-project-id/> spackopenf-controller | grep google_metadata_script_runner
 ```
 
 When the startup script has finished running you will see the following line as
 the final output from the above command:
-> _`slurm-spack-openfoam-controller google_metadata_script_runner: Finished running startup scripts.`_
+> _`spackopenf-controller google_metadata_script_runner: Finished running startup scripts.`_
 
 Optionally while you wait, you can see your deployed VMs on Google Cloud
 Console. Open the link below in a new window. Look for
-`slurm-spack-openfoam-controller`. If you don't
+`spackopenf-controller`. If you don't
 see your VMs make sure you have the correct project selected (top left).
 
 ```text
@@ -204,7 +204,7 @@ OpenFOAM job.
 2. Submit the job to Slurm to be scheduled:
 
    ```bash
-   sbatch /apps/openfoam/submit_openfoam.sh
+   sbatch /opt/apps/openfoam/submit_openfoam.sh
    ```
 
 3. Once submitted, you can watch the job progress by repeatedly calling the
@@ -218,7 +218,7 @@ The `sbatch` command trigger Slurm to auto-scale up several nodes to run the job
 
 You can refresh the `Compute Engine` > `VM instances` page and see that
 additional VMs are being/have been created. These will be named something like
-`slurm-spack-openfoam-compute-0-0`.
+`spackopenf-comput-0`.
 
 When running `squeue`, observe the job status start as `CF` (configuring),
 change to `R` (running) once the compute VMs have been created, and finally `CG`
@@ -271,7 +271,7 @@ exit
 Run the following command in the cloud shell terminal to destroy the cluster:
 
 ```bash
-./ghpc deploy spack-openfoam
+./ghpc destroy spack-openfoam
 ```
 
 When complete you should see something like:

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -35,7 +35,7 @@ deployment_groups:
   - id: spack-setup
     source: community/modules/scripts/spack-setup
     settings:
-      install_dir: /apps/spack
+      install_dir: /opt/apps/spack
       spack_ref: v0.20.0
 
   - id: spack-execute
@@ -95,7 +95,7 @@ deployment_groups:
         # fi
         # spack buildcache keys --install --trust
 
-        spack config --scope defaults add config:build_stage:/apps/spack/spack-stage
+        spack config --scope defaults add config:build_stage:/opt/apps/spack/spack-stage
         spack config --scope defaults add -f /tmp/projections-config.yaml
         spack config --scope site add -f /tmp/slurm-external-config.yaml
 
@@ -124,17 +124,16 @@ deployment_groups:
         destination: setup_openfoam.sh
         content: |
           #!/bin/bash
-          source /apps/spack/share/spack/setup-env.sh
+          source /opt/apps/spack/share/spack/setup-env.sh
           spack env activate openfoam
-          chmod -R a+rwX /apps/spack/var/spack/environments/openfoam
       - type: data
-        destination: /apps/openfoam/submit_openfoam.sh
+        destination: /opt/apps/openfoam/submit_openfoam.sh
         content: |
           #!/bin/bash
           #SBATCH -N 2
           #SBATCH --ntasks-per-node 30
 
-          source /apps/spack/share/spack/setup-env.sh
+          source /opt/apps/spack/share/spack/setup-env.sh
           spack env activate openfoam
 
           cd $SLURM_SUBMIT_DIR


### PR DESCRIPTION
In V6, /opt/ is shared from controller node to all compute nodes. Previously we used /apps directory to install everything and share to compute nodes. This would install everything in /opt/apps. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
