### PR TITLE
Improve readability of "required setting is missing" error

### DIFF
--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -163,7 +163,6 @@ const (
 	errMsgFileLoadError    = string("failed to read the input yaml")
 	errMsgYamlMarshalError = string("failed to export the configuration to a blueprint yaml file")
 	errMsgYamlSaveError    = string("failed to write the expanded yaml")
-	errMsgMissingSetting   = string("a required setting is missing from a module")
 	errMsgInvalidVar       = string("invalid variable definition in")
 	errMsgVarNotFound      = string("could not find source of variable")
 	errMsgIntergroupOrder  = string("references to outputs from other groups must be to earlier groups")

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -80,8 +80,7 @@ func validateModuleInputs(mp ModulePath, m Module, bp Blueprint) error {
 
 		if !m.Settings.Has(input.Name) {
 			if input.Required {
-				errs.At(ip, fmt.Errorf("%s: Module ID: %s Setting: %s",
-					errMsgMissingSetting, m.ID, input.Name))
+				errs.At(ip, fmt.Errorf("a required setting %q is missing from a module %q", input.Name, m.ID))
 			}
 			continue
 		}


### PR DESCRIPTION
```sh
# BEFORE
$ ./ghpc create tst.yaml -w
Error: a required setting is missing from a module: Module ID: vm Setting: zone
33:   - id: vm
        ^

# AFTER
$ ./ghpc create tst.yaml -w
Error: a required setting "zone" is missing from a module "vm"
33:   - id: vm
        ^
```