### PR TITLE
Fix HTCondow Windows URI for latest 23.0 LTS release

### DIFF
--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -15,7 +15,7 @@ Remove-Item "$runtime_installer"
 
 # download HTCondor installer
 $htcondor_installer = 'C:\htcondor.msi'
-%{ if condor_version == "10.*" }
+%{ if condor_version == "23.*" }
 Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/23.0/current/condor-Windows-x64.msi -OutFile "$htcondor_installer"
 %{ else ~}
 Invoke-WebRequest https://research.cs.wisc.edu/htcondor/tarball/23.0/${condor_version}/release/condor-${condor_version}-Windows-x64.msi -OutFile "$htcondor_installer"


### PR DESCRIPTION
This fixes the behavior of HTCondor installation module to download the latest 23.0.x **Windows** release if the user does not specify a specific version (by defaulting to `23.*`. This matches the behavior of the Linux installation implementation.

This can be manually tested by `curl -O` the following URIs and comparing checksums.

- https://research.cs.wisc.edu/htcondor/tarball/23.0/current/condor-Windows-x64.msi
- https://research.cs.wisc.edu/htcondor/tarball/23.0/23.0.3/release/condor-23.0.3-Windows-x64.msi

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
