### PR TITLE
Update hpc-slurm-legacy-sharedvpc example and references to use Slurm V6

### DIFF
--- a/community/examples/hpc-slurm-legacy-sharedvpc.yaml
+++ b/community/examples/hpc-slurm-legacy-sharedvpc.yaml
@@ -55,46 +55,50 @@ deployment_groups:
       local_mount: /home
       connect_mode: PRIVATE_SERVICE_ACCESS
 
-  # This debug_partition will work out of the box without requesting additional GCP quota.
+  - id: debug_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network1]
+    settings:
+      node_count_dynamic_max: 4
+      machine_type: n2-standard-2
+      enable_placement: false  # the default is: true
+
   - id: debug_partition
-    source: community/modules/compute/SchedMD-slurm-on-gcp-partition
-    use:
-    - network1
-    - homefs
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [debug_nodeset, homefs]
     settings:
       partition_name: debug
-      max_node_count: 4
-      enable_placement: false
-      exclusive: false
-      machine_type: n2-standard-2
+      exclusive: false  # allows nodes to stay up after jobs are done
+      is_default: true
 
-  # This compute_partition is far more performant than debug_partition but may require requesting GCP quotas first.
-  - id: compute_partition
-    source: community/modules/compute/SchedMD-slurm-on-gcp-partition
-    use:
-    - network1
-    - homefs
+  - id: compute_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network1]
     settings:
-      partition_name: compute
-      max_node_count: 20
+      node_count_dynamic_max: 20
       bandwidth_tier: gvnic_enabled
 
-  - id: slurm_controller
-    source: community/modules/scheduler/SchedMD-slurm-on-gcp-controller
-    use:
-    - network1
-    - homefs
-    - debug_partition  # debug partition will be default as it is listed first
-    - compute_partition
+  - id: compute_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [compute_nodeset, homefs]
     settings:
-      login_node_count: 1
-      shared_vpc_host_project: $(vars.host_project_id)
+      partition_name: compute
 
   - id: slurm_login
-    source: community/modules/scheduler/SchedMD-slurm-on-gcp-login-node
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network1]
+    settings:
+      name_prefix: login
+      machine_type: n2-standard-4
+      disable_login_public_ips: false
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
     - network1
+    - debug_partition
+    - compute_partition
+    - slurm_login
     - homefs
-    - slurm_controller
     settings:
-      shared_vpc_host_project: $(vars.host_project_id)
+      disable_controller_public_ips: false

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [pfs-daos.yaml](#pfs-daosyaml-) ![community-badge]
   * [hpc-slurm-daos.yaml](#hpc-slurm-daosyaml-) ![community-badge]
   * [hpc-amd-slurm.yaml](#hpc-amd-slurmyaml-) ![community-badge]
+  * [hpc-slurm-legacy-sharedvpc.yaml](#hpc-slurm-legacy-sharedvpcyaml-) ![community-badge]
   * [client-google-cloud-storage.yaml](#client-google-cloud-storageyaml--) ![community-badge] ![experimental-badge]
   * [hpc-slurm-gromacs.yaml](#hpc-slurm-gromacsyaml--) ![community-badge] ![experimental-badge]
   * [omnia-cluster.yaml](#omnia-clusteryaml--) ![community-badge] ![experimental-badge]
@@ -41,7 +42,6 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [hpc-slurm-chromedesktop.yaml](#hpc-slurm-chromedesktopyaml--) ![community-badge] ![experimental-badge]
   * [flux-cluster](#flux-clusteryaml--) ![community-badge] ![experimental-badge]
   * [tutorial-fluent.yaml](#tutorial-fluentyaml--) ![community-badge] ![experimental-badge]
-  * [hpc-slurm-legacy-sharedvpc.yaml](#hpc-slurm-legacy-sharedvpcyaml--) ![community-badge] ![deprecated-badge]
 * [Blueprint Schema](#blueprint-schema)
 * [Writing an HPC Blueprint](#writing-an-hpc-blueprint)
   * [Blueprint Boilerplate](#blueprint-boilerplate)
@@ -977,12 +977,17 @@ See [README](../community/examples/flux-framework/README.md)
 
 [flux-cluster.yaml]: ../community/examples/flux-framework/flux-cluster.yaml
 
-### [hpc-slurm-legacy-sharedvpc.yaml] ![community-badge] ![deprecated-badge]
+### [hpc-slurm-legacy-sharedvpc.yaml] ![community-badge]
 
 This blueprint demonstrates the use of the Slurm and Filestore modules in
-the service project of an existing Shared VPC.  Before attempting to deploy the
+the service project of an existing Shared VPC. Before attempting to deploy the
 blueprint, one must first complete [initial setup for provisioning Filestore in
-a Shared VPC service project][fs-shared-vpc].
+a Shared VPC service project][fs-shared-vpc]. Depending on how the shared VPC
+was created one may have to perform a few additional manual steps to configure
+the VPC. One may need to create firewall rules allowing SSH to be able to access
+the controller and login nodes. Also since this blueprint doesn't use external
+IPs for compute nodes, one must needs to [set up cloud nat][cloudnat] and
+[set up iap][iap].
 
 [hpc-slurm-legacy-sharedvpc.yaml]: ../community/examples/hpc-slurm-legacy-sharedvpc.yaml
 [fs-shared-vpc]: https://cloud.google.com/filestore/docs/shared-vpc


### PR DESCRIPTION
In this PR, I used 1 host project 1 service project and then set up shared VPC in host project. Also, set up firewall rule to allow access (ssh) to this shared VPC network. Below are the result on the login, controller, compute node.

* Login node https://screenshot.googleplex.com/3c8LzgwraF8soir
```
Last login: Wed Jan 24 18:58:43 2024 from 35.235.240.0
[ext_harshthakkar_google_com@hpcsmallsh-login-login-001 ~]$ df -h
Filesystem                       Size  Used Avail Use% Mounted on
devtmpfs                         7.9G     0  7.9G   0% /dev
tmpfs                            7.9G     0  7.9G   0% /dev/shm
tmpfs                            7.9G  8.6M  7.9G   1% /run
tmpfs                            7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sda2                         50G   16G   35G  32% /
/dev/sda1                        200M  5.8M  195M   3% /boot/efi
tmpfs                            1.6G     0  1.6G   0% /run/user/0
10.43.128.2:/nfsshare           1007G     0  956G   0% /home
hpcsmallsh-controller:/opt/apps   50G   16G   35G  32% /opt/apps
tmpfs                            1.6G     0  1.6G   0% /run/user/3672659445
[ext_harshthakkar_google_com@hpcsmallsh-login-login-001 ~]$ 
```

* Controller Node
```
Last login: Wed Jan 24 18:58:06 2024 from 35.235.240.3
[ext_harshthakkar_google_com@hpcsmallsh-controller ~]$ df -h
Filesystem             Size  Used Avail Use% Mounted on
devtmpfs               7.9G     0  7.9G   0% /dev
tmpfs                  7.9G     0  7.9G   0% /dev/shm
tmpfs                  7.9G  8.6M  7.9G   1% /run
tmpfs                  7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sda2               50G   16G   35G  32% /
/dev/sda1              200M  5.8M  195M   3% /boot/efi
tmpfs                  1.6G     0  1.6G   0% /run/user/0
10.43.128.2:/nfsshare 1007G     0  956G   0% /home
tmpfs                  1.6G     0  1.6G   0% /run/user/3672659445
[ext_harshthakkar_google_com@hpcsmallsh-controller ~]$
```


* Compute node after running slurm job.
```
ext_harshthakkar_google_com@hpcsmallsh-comput-0 ~]$ 
[ext_harshthakkar_google_com@hpcsmallsh-comput-0 ~]$ df -h
Filesystem                       Size  Used Avail Use% Mounted on
devtmpfs                         119G     0  119G   0% /dev
tmpfs                            119G     0  119G   0% /dev/shm
tmpfs                            119G  8.7M  119G   1% /run
tmpfs                            119G     0  119G   0% /sys/fs/cgroup
/dev/sda2                         50G   17G   34G  34% /
/dev/sda1                        200M  5.8M  195M   3% /boot/efi
tmpfs                             24G     0   24G   0% /run/user/0
tmpfs                             24G     0   24G   0% /run/user/3672659445
hpcsmallsh-controller:/opt/apps   50G   16G   35G  32% /opt/apps
10.43.128.2:/nfsshare           1007G     0  956G   0% /home
[ext_harshthakkar_google_com@hpcsmallsh-comput-0 ~]$ 
```


### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
