### PR TITLE
Validation added to Slurm v5 login_startup_scripts_timeout

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
@@ -128,6 +128,11 @@ variable "login_startup_scripts_timeout" {
     EOD
   type        = number
   default     = 300
+
+  validation {
+    condition     = var.login_startup_scripts_timeout == 300
+    error_message = "Changes to login_startup_scripts_timeout (default: 300s) are not respected, this will be fixed in a later release"
+  }
 }
 
 variable "cgroup_conf_tpl" {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
@@ -131,7 +131,7 @@ variable "login_startup_scripts_timeout" {
 
   validation {
     condition     = var.login_startup_scripts_timeout == 300
-    error_message = "Changes to login_startup_scripts_timeout (default: 300s) are not respected, this will be fixed in a later release"
+    error_message = "Changes to login_startup_scripts_timeout (default: 300s) are not respected, this is a known issue that will be fixed in a later release"
   }
 }
 


### PR DESCRIPTION
The login startup scripts timeout value is not being respected in `setup.py`.  This is because Slurm v5 adds a suffix to the login node, which causes the timeout look up to default to 300s.  This is currently being fixed in slurm-gcp, and once a new image is released, this validation can be removed.

This meant to be more of a warning for users who try to use this variable.  This value would go to the correct location, it just isn't used correctly.
