### PR TITLE
Copies python binaries instead of symlink for more isolated venv

### DIFF
--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -186,7 +186,7 @@ main() {
 	fi
 
 	# Create pip virtual environment for HPC Toolkit
-	${python_path} -m venv "${venv_path}"
+	${python_path} -m venv "${venv_path}" --copies
 	venv_python_path=${venv_path}/bin/python3
 
 	# Upgrade pip if necessary


### PR DESCRIPTION
This prevents changes to the system python from affecting our virtual environment.

Tested: 
- Built image using this pr and ran ansible using the built image.
- I also observed under some conditions this avoided the venv from being corrupted when system python changed.

Note: This did not resolve the issue I have observed with the selinux python library when building Slurm on Rocky8.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
