### PR TITLE
Start legacy monitoring agent after installing

### DIFF
--- a/modules/scripts/startup-script/files/install_monitoring_agent.sh
+++ b/modules/scripts/startup-script/files/install_monitoring_agent.sh
@@ -71,6 +71,7 @@ handle_debian() {
 		install_with_retry "${LEGACY_MONITORING_SCRIPT_URL}"
 		install_with_retry "${LEGACY_LOGGING_SCRIPT_URL}"
 		service stackdriver-agent start
+		service google-fluentd start
 	}
 }
 
@@ -102,6 +103,7 @@ handle_redhat() {
 		curl -sS "${LEGACY_MONITORING_SCRIPT_URL}" | bash -s -- --also-install
 		curl -sS "${LEGACY_LOGGING_SCRIPT_URL}" | bash -s -- --also-install
 		service stackdriver-agent start
+		service google-fluentd start
 	}
 }
 


### PR DESCRIPTION
Documentation says logging agent is started automatically but it was observed that the agent was not started. 

Tested: Ran with this changed and observed that `sudo service google-fluentd status` is running.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
