### PR TITLE
DEMO. TF-native implementation of destroy-protection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,12 +213,13 @@ type ModuleIDs []ModuleID
 
 // Module stores YAML definition of an HPC cluster component defined in a blueprint
 type Module struct {
-	Source   string
-	Kind     ModuleKind
-	ID       ModuleID
-	Use      ModuleIDs                 `yaml:"use,omitempty"`
-	Outputs  []modulereader.OutputInfo `yaml:"outputs,omitempty"`
-	Settings Dict                      `yaml:"settings,omitempty"`
+	Source    string
+	Kind      ModuleKind
+	ID        ModuleID
+	Use       ModuleIDs                 `yaml:"use,omitempty"`
+	Outputs   []modulereader.OutputInfo `yaml:"outputs,omitempty"`
+	Settings  Dict                      `yaml:"settings,omitempty"`
+	Protected bool                      `yaml:"protected,omitempty"`
 	// DEPRECATED fields, keep in the struct for backwards compatibility
 	RequiredApis     interface{} `yaml:"required_apis,omitempty"`
 	WrapSettingsWith interface{} `yaml:"wrapsettingswith,omitempty"`


### PR DESCRIPTION
```yaml
# bp.yaml
blueprint_name: tst
vars:
  deployment_name: prot
deployment_groups:
- group: primary
  modules:
  - id: vpc
    source: modules/network/vpc
    protected: true
```

```hcl
// deployment::prot/primary/main.tf
module "vpc" {
  source          = "./modules/embedded/modules/network/vpc"
  deployment_name = var.deployment_name
  project_id      = var.project_id
  region          = var.region
}
resource "null_resource" "protection_vpc" {
  depends_on = ["module.vpc"]
  triggers = {
    deployment_name = var.deployment_name
    project_id      = var.project_id
    region          = var.region
  }
  lifecycle {
    prevent_destroy = true
  }
}
```

```sh
$ ./ghpc destroy prot $AA
Testing if deployment group prot/primary requires destroying cloud infrastructure
Error: terraform plan for deployment group prot/primary failed
exit status 1

Error: Instance cannot be destroyed

  on main.tf line 23:
  23: resource "null_resource" "protection_vpc" {

Resource null_resource.protection_vpc has lifecycle.prevent_destroy set, but
the plan calls for this resource to be destroyed. To avoid this error and
continue with the plan, either disable lifecycle.prevent_destroy or reduce
the scope of the plan using the -target flag.
```

Also changes to inputs  (e.g. `vars.region`) fill fail re-deployment as well:

```sh
$ ./ghpc deploy prot
Initializing deployment group prot/primary
Testing if deployment group prot/primary requires adding or changing cloud infrastructure
Error: terraform plan for deployment group prot/primary failed
exit status 1

Error: Instance cannot be destroyed

  on main.tf line 23:
  23: resource "null_resource" "protection_vpc" {
...
```

## Disabling protection
* Modify `bp.yaml`, remove `protected: true`
* `./ghpc reate bp.yaml -w`
* ` ./ghpc destroy prot $AA` - successfully destroys VPC