### PR TITLE
Add login node in the spack openfoam tutorial example

### DIFF
--- a/docs/tutorials/openfoam/spack-openfoam.md
+++ b/docs/tutorials/openfoam/spack-openfoam.md
@@ -84,6 +84,7 @@ This file describes the cluster you will deploy. It defines:
   * sets up a Spack environment including downloading an example input deck
   * places a submission script on a shared drive
 * a Slurm cluster
+  * a Slurm login node
   * a Slurm controller
   * An auto-scaling Slurm partition
 
@@ -144,21 +145,21 @@ the final output from the above command:
 
 Optionally while you wait, you can see your deployed VMs on Google Cloud
 Console. Open the link below in a new window. Look for
-`spackopenf-controller`. If you don't
+`spackopenf-controller` and `spackopenf-login-login-001`. If you don't
 see your VMs make sure you have the correct project selected (top left).
 
 ```text
 https://console.cloud.google.com/compute?project=<walkthrough-project-id/>
 ```
 
-## Connecting to the controller node
+## Connecting to the login node
 
-Once the startup script has completed, connect to the controller node.
+Once the startup script has completed, connect to the login node.
 
-Use the following command to ssh into the controller node from cloud shell:
+Use the following command to ssh into the login node from cloud shell:
 
 ```bash
-gcloud compute ssh spackopenf-controller --zone us-central1-c --project <walkthrough-project-id/>
+gcloud compute ssh spackopenf-login-login-001 --zone us-central1-c --project <walkthrough-project-id/>
 ```
 
 You may be prompted to set up SSH. If so follow the prompts and if asked for a
@@ -182,15 +183,15 @@ following instructions:
    https://console.cloud.google.com/compute?project=<walkthrough-project-id/>
    ```
 
-1. Click on the `SSH` button associated with the `spackopenf-controller`
+1. Click on the `SSH` button associated with the `spackopenf-login-login-001`
    instance.
 
    This will open a separate pop up window with a terminal into our newly
-   created Slurm controller VM.
+   created Slurm login VM.
 
 ## Run a Job on the Cluster
 
-   **The commands below should be run on the Slurm controller node.**
+   **The commands below should be run on the Slurm login node.**
 
 We will use the submission script (see line 122 of the blueprint) to submit a
 OpenFOAM job.
@@ -238,7 +239,7 @@ about 5 minutes to run.
 Several files will have been generated in the `test_run/` folder you created.
 
 The `slurm-1.out` file has information on the run such as performance. You can
-view this file by running the following command on the controller node:
+view this file by running the following command on the login node:
 
 ```bash
 cat slurm-*.out
@@ -259,9 +260,9 @@ https://console.cloud.google.com/monitoring/dashboards?project=<walkthrough-proj
 To avoid incurring ongoing charges we will want to destroy our cluster.
 
 For this we need to return to our cloud shell terminal. Run `exit` in the
-terminal to close the SSH connection to the controller node:
+terminal to close the SSH connection to the login node:
 
-> **_NOTE:_** If you are accessing the controller node terminal via a separate pop-up
+> **_NOTE:_** If you are accessing the login node terminal via a separate pop-up
 > then make sure to call `exit` in the pop-up window.
 
 ```bash

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -110,7 +110,7 @@ deployment_groups:
           spack install
         fi
 
-  - id: controller-setup
+  - id: login-setup
     source: modules/scripts/startup-script
     settings:
       runners:
@@ -170,12 +170,21 @@ deployment_groups:
       partition_name: compute
       is_default: true
 
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network1]
+    settings:
+      name_prefix: login
+      machine_type: n2-standard-4
+      disable_login_public_ips: false
+
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
     - network1
     - compute_partition
+    - slurm_login
     settings:
-      controller_startup_script: $(controller-setup.startup_script)
-      controller_startup_scripts_timeout: 21600
+      login_startup_script: $(login-setup.startup_script)
+      login_startup_scripts_timeout: 21600
       disable_controller_public_ips: false


### PR DESCRIPTION
This PR adds login node in spack-openfoam tutorial example. 
Manual Test on login node `sbatch /opt/apps/openfoam/submit_openfoam.sh`
```
[ext_harshthakkar_google_com@spackopenf-login-login-001 test_run]$ ls
0         hostfile     processor12  processor17  processor21  processor26  processor30  processor35  processor4   processor44  processor49  processor53  processor58  processor9
0.orig    processor0   processor13  processor18  processor22  processor27  processor31  processor36  processor40  processor45  processor5   processor54  processor59  slurm-1.out
Allclean  processor1   processor14  processor19  processor23  processor28  processor32  processor37  processor41  processor46  processor50  processor55  processor6   system
Allrun    processor10  processor15  processor2   processor24  processor29  processor33  processor38  processor42  processor47  processor51  processor56  processor7
constant  processor11  processor16  processor20  processor25  processor3   processor34  processor39  processor43  processor48  processor52  processor57  processor8
[ext_harshthakkar_google_com@spackopenf-login-login-001 test_run]$
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
