### PR TITLE
Make TPU non-preemptible in blueprint and add retries in JAX verification integration test

### DIFF
--- a/community/examples/hpc-slurm6-tpu.yaml
+++ b/community/examples/hpc-slurm6-tpu.yaml
@@ -36,10 +36,10 @@ deployment_groups:
       node_type: v2-8
       tf_version: 2.10.0
       disable_public_ips: false
-      # To specify if TPU nodes are preemptible. The nodes will be shut down if
-      # it requires additional resources.
+      # Preemptible TPUs cost much less than non-preemptible TPUs.
+      # The Cloud TPU service might preempt (shut down) these TPUs at any time.
       # https://cloud.google.com/tpu/docs/preemptible
-      preemptible: true
+      preemptible: false
       # Specify whether to preserve TPU on suspend.
       # If set to true, suspended VM will be stopped.
       # If set to false, suspended VM will be deleted.

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-slurm-v6-tpu.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-slurm-v6-tpu.yml
@@ -44,6 +44,8 @@
 - name: Run JAX verification
   register: jax_status
   failed_when: jax_status.rc != 0
+  retries: 3
+  delay: 100
   ansible.builtin.command: |
     srun -N 1 -p tpu bash -c '
     pip install --upgrade 'jax[tpu]>0.3.0' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html


### PR DESCRIPTION
This PR makes TPU non-preemptible and also adds retries in jax verification integration test to avoid stock outs and catch real issues. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
