### PR TITLE
Ensure Windows VMs start HTCondor only after successful secret download

### DIFF
--- a/community/modules/compute/htcondor-execute-point/templates/download-condor-config.ps1.tftpl
+++ b/community/modules/compute/htcondor-execute-point/templates/download-condor-config.ps1.tftpl
@@ -18,3 +18,8 @@ if ($local_hash -cne $remote_hash) {
     gcloud storage cp ${config_object} $config_file
     Restart-Service condor
 }
+
+# ignored if service is already running; must be here to handle case where
+# machine is rebooted, but configuration has previously been downloaded
+# and service is disabled from automatic start
+Start-Service condor

--- a/community/modules/scheduler/htcondor-pool-secrets/templates/fetch-idtoken.ps1.tftpl
+++ b/community/modules/scheduler/htcondor-pool-secrets/templates/fetch-idtoken.ps1.tftpl
@@ -1,3 +1,6 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
 $config_dir = 'C:\Condor\config'
 if(!(test-path -PathType container -Path $config_dir)) {
       New-Item -ItemType Directory -Path $config_dir
@@ -15,3 +18,5 @@ Set-Content -Path "$config_file" -Value "$config_string"
 # obtain IDTOKEN for authentication by StartD to Central Manager
 gcloud secrets versions access latest --secret ${xp_idtoken_secret_id} `
     --out-file C:\condor\tokens.d\condor@${trust_domain}
+
+if ($LASTEXITCODE -ne 0) { throw "Could not download HTCondor IDTOKEN; exiting startup script" }

--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -29,12 +29,17 @@ $args=$args + ' INSTALLDIR="C:\Condor"'
 Start-Process "msiexec.exe" -Wait -ArgumentList "$args"
 Remove-Item "$htcondor_installer"
 
+# do not start HTCondor on boot by default. Allow startup script to download
+# configuration first and then start HTCondor
+Set-Service -StartupType Manual condor
+
 # remove settings from condor_config that we want to override in configuration step
 Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^CONDOR_HOST' -NotMatch)
 Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^INSTALL_USER' -NotMatch)
 Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^DAEMON_LIST' -NotMatch)
 Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor\condor_config" | Select-String -Pattern '^use SECURITY' -NotMatch)
 
+# install Python so that custom ClassAd hooks can execute
 $python_installer = 'C:\python-installer.exe'
 Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.11.4/python-3.11.4-amd64.exe" -OutFile "$python_installer"
 Start-Process -FilePath "$python_installer" -Wait -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_test=0'


### PR DESCRIPTION
This enables Managed Instance Group health checks to mark the node unhealthy for deletion. Additionally, this matches the behavior of HTCondor linux execute points ("compute nodes").

Manual testing (by deliberately deleting the secret token that allows the node to join the pool) shows the following in startup script logs:

```
2024/01/26 23:05:49 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1: ERROR: (gcloud.secrets.versions.access) PERMISSION_DENIED: Permission 'secretmanager.versions.access' denied for resource 'projects/toolkit-demo-zero-e913/secrets/renault-piscine-execute-point-idtoken/versions/latest' (or it may not exist).
2024/01/26 23:05:49 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1: Could not download HTCondor IDTOKEN; exiting startup script
2024/01/26 23:05:49 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1: At C:\Windows\TEMP\metadata-scripts461013486\windows-startup-script-ps1.ps1:22
2024/01/26 23:05:49 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1: char:28
2024/01/26 23:05:49 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1: + ... DE -ne 0) { throw "Could not download HTCondor IDTOKEN; exiting start ...
2024/01/26 23:05:50 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1: +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024/01/26 23:05:50 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1:     + CategoryInfo          : OperationStopped: (Could not downl... startup sc
2024/01/26 23:05:50 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1:    ript:String) [], RuntimeException
2024/01/26 23:05:50 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1:     + FullyQualifiedErrorId : Could not download HTCondor IDTOKEN; exiting sta
2024/01/26 23:05:50 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1:    rtup script
2024/01/26 23:05:50 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: windows-startup-script-ps1:
2024/01/26 23:05:50 C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe: Script "windows-startup-script-ps1" failed with error: exit status 1
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
