### PR TITLE
Portability fixes for Slurm v6 image building example

### DIFF
--- a/community/examples/hpc-build-slurm-image.yaml
+++ b/community/examples/hpc-build-slurm-image.yaml
@@ -15,7 +15,7 @@
 blueprint_name: hpc-build-slurm-image
 
 vars:
-  project_id: ns-playground-2023-01-19  ## Set GCP Project ID Here ##
+  project_id:  ## Set GCP Project ID Here ##
   deployment_name: build-slurm-1
   region: us-central1
   zone: us-central1-a

--- a/community/examples/hpc-build-slurm-image.yaml
+++ b/community/examples/hpc-build-slurm-image.yaml
@@ -20,7 +20,7 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-  image_build_machine_type: n2d-standard-32
+  image_build_machine_type: n2d-standard-16
   build_from_image_family: hpc-rocky-linux-8
   build_from_image_project: cloud-hpc-image-public
   built_image_family: my-custom-slurm


### PR DESCRIPTION
- development project_id should not be in public-facing example
- reduce size of image builder to be more likely to fit within a starting project quota (my development project begins with 24 N2D CPUs)

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
