### PR TITLE
Batch MPI pool example

### DIFF
--- a/examples/batch-mpi-pool.yaml
+++ b/examples/batch-mpi-pool.yaml
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: batch-mpi-pool
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: batch-mpi-pool-small
+  region: us-central1
+  nfs_share:
+    server_ip: 10.120.149.122
+    remote_path: /share
+    mount_path: /mnt/disks/share
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: batch-create-mpi-pool
+    source: modules/scheduler/batch-mpi-pool
+    settings:
+      pool_size: 4
+      pool_duration: 1h
+      boot_image: batch-hpc-centos
+      machine_type: c2-standard-60

--- a/modules/scheduler/batch-mpi-pool/README.md
+++ b/modules/scheduler/batch-mpi-pool/README.md
@@ -1,0 +1,83 @@
+# Description
+
+This module creates a Batch Node Pool configured for running HPC workloads with
+Intel MPI. The number of VMs in the pool, the machine type of those VMs, the
+boot image used, and the maximum allowed idle time of the pool (before it is automatically
+deleted) can all be customized. An NFS share can also be specified, which will be mounted
+automatically by each node in the pool.
+
+After the pool is created subsequent Batch jobs can be execute on the pool's nodes. Batch
+automatically divides the nodes of the pool amongst the jobs targetting it and manages the
+queue of jobs targetting a pool when the pool is not large enough to run all its jobs at
+the same time.
+
+## Example
+
+```yaml
+- id: batch-mpi-pool
+  source: modules/scheduler/batch-mpi-pool
+  ...
+```
+
+## Authentication
+
+The module submits a Batch job to create a node pool using the gcloud CLI on the
+workstation deploying the workspace. Google Cloud credentials for an account with
+the `Batch Job Administrator` role must be available on the workstation.
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+## Resources
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment, also used for the job\_id | `string` | n/a | yes |
+| <a name="project_id"></a> [project\_id](#input\_project\_id) | The project to create the node pool | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_zone) | The region in which to create the node pool | `string` | n/a | yes |
+| <a name="pool_size"></a> [pool\_size](#input\_pool\_size) | The number of nodes to place in the pool | `number` | n/a | yes |
+| <a name="pool_duration"></a> [pool\_duration](#input\_pool\_duration) | The allowed idle lifetime of the node pool | `string` | `1h` | no |
+| <a name="machine_type"></a> [machine\_type](#input\_machine\_type) | The type of VM to add to the pool | `string` | `c2-standard-60` | no |
+| <a name="boot_image"></a> [boot\_image](#input\_boot\_image) | The boot image to use for VMs added to the pool | `string` | `batch-hpc-centos` | no |
+| <a name="nfs_share.server\_ip"></a> [nfs\_share.server_ip](#input\_nfs\_share.server_ip) | The IP address of an NFS server for the pool VMs to mount | `string` | n/a | no |
+| <a name="nfs_share.remote\_path"></a> [nfs\_share.remote_path](#input\_nfs\_share.remote_path) | The remote path of the NFS server to mount (e.g. /share) | `string` | n/a | no |
+| <a name="nfs_share.mount\_path"></a> [nfs\_share.mount_path](#input\_nfs\_share.mount_path) | The path on each VM in the pool to mount the NFS share | `string` | n/a | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions for submitting Batch jobs to the node pool |
+| <a name="output_batch_run_mpi_workload"></a> [batch_run_mpi_workload](#output\_batch_run_mpi_workload) | Sample job configuration for an MPI job to run in the node pool |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/scheduler/batch-mpi-pool/main.tf
+++ b/modules/scheduler/batch-mpi-pool/main.tf
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  pool_name = "${var.deployment_name}-pool"
+  pool_duration = var.pool_duration != null ? var.pool_duration : "1h"
+  machine_type = var.machine_type != null ? var.machine_type : "c2-standard-60"
+  boot_image = var.boot_image != null ? var.boot_image : "batch-hpc-centos"
+  make_mpi_pool_job_config_contents = templatefile(
+    "${path.module}/templates/batch-make-mpi-pool-job-config.json.tftpl",
+    {
+      pool_name     = local.pool_name
+      pool_size     = var.pool_size
+      pool_duration = local.pool_duration
+      machine_type  = local.machine_type
+      boot_image    = local.boot_image
+      nfs_share     = var.nfs_share
+    }
+  )
+  run_mpi_workload_config_contents = templatefile(
+    "${path.module}/templates/batch-run-mpi-workload.json.tftpl",
+    {
+      pool_name = local.pool_name
+      pool_size = var.pool_size    
+      nfs_share = var.nfs_share
+    }
+  )
+
+  run_mpi_workload_config_path = "${path.root}/run-mpi-batch-job.json"
+  make_pool_job_id = "${var.deployment_name}-make-pool"
+  readme_contents = templatefile(
+    "${path.module}/templates/readme.md.tftpl",
+    {
+      project = var.project_id
+      location = var.region
+      job_id = local.make_pool_job_id
+      run_mpi_config_path = local.run_mpi_workload_config_path
+    }
+  )
+
+  make_mpi_pool_job_config_path = "${path.root}/make-pool.json"
+  make_pool_script_contents = templatefile(
+    "${path.module}/templates/make-pool.sh.tftpl",
+    {
+      project = var.project_id
+      location = var.region
+      job_id = local.make_pool_job_id
+      config = local.make_mpi_pool_job_config_path
+    }
+  )
+}
+
+resource "local_file" "make_mpi_pool_job_config" {
+  content  = local.make_mpi_pool_job_config_contents
+  filename = local.make_mpi_pool_job_config_path
+}
+
+resource "local_file" "run_mpi_workload_job_config" {
+  content = local.run_mpi_workload_config_contents
+  filename = local.run_mpi_workload_config_path
+}
+
+resource "local_file" "make_pool_script" {
+  content = local.make_pool_script_contents
+  filename = "make-pool.sh"
+}
+
+resource "local_file" "readme" {
+  content = local.readme_contents
+  filename = "README.md"
+}
+
+resource "null_resource" "run_make_pool" {
+ depends_on = [ local_file.make_pool_script ]
+ provisioner "local-exec" {
+    command = "${path.root}/make-pool.sh"
+  }
+}

--- a/modules/scheduler/batch-mpi-pool/metadata.yaml
+++ b/modules/scheduler/batch-mpi-pool/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - batch.googleapis.com
+    - compute.googleapis.com

--- a/modules/scheduler/batch-mpi-pool/templates/batch-make-mpi-pool-job-config.json.tftpl
+++ b/modules/scheduler/batch-mpi-pool/templates/batch-make-mpi-pool-job-config.json.tftpl
@@ -1,0 +1,43 @@
+{
+  "taskGroups": [{
+    "taskSpec": {
+      "runnables": [
+        {
+          "script": {
+            "text": "google_mpi_tuning --nosmt; google_install_mpi --intel_mpi; echo ready"
+          }
+        }
+      ]
+      %{ if nfs_share != null },"volumes":[
+        {
+          "nfs":{
+            "server": "${nfs_share.server_ip}",
+            "remote_path": "${nfs_share.remote_path}"
+          },
+          "mount_path": "${nfs_share.mount_path}"
+        }
+      ]%{ endif }
+    },
+    "taskCount":${pool_size},
+    "taskCountPerNode": 1,
+    "requireHostsFile": true,
+    "permissiveSsh": true
+  }],
+  "allocationPolicy":{
+    "instances":{
+      "policy":{
+        "machineType": %{ if machine_type != "" }"${machine_type}"%{ else }"c2-standard-60"%{ endif },
+        "bootDisk": {
+          "image": %{ if boot_image != "" }"${boot_image}"%{ else }"batch-hpc-centos"%{ endif }
+        }
+      }
+    }
+  },
+  "logsPolicy": {
+    "destination": "CLOUD_LOGGING"
+  },
+  "labels": {
+    "goog-batch-job-group": "${pool_name}",
+    "goog-batch-node-pool-max-idle-time": "${pool_duration}"
+  }
+}

--- a/modules/scheduler/batch-mpi-pool/templates/batch-run-mpi-workload.json.tftpl
+++ b/modules/scheduler/batch-mpi-pool/templates/batch-run-mpi-workload.json.tftpl
@@ -1,0 +1,28 @@
+{
+  "taskGroups": [{
+    "taskSpec": {
+      "runnables": [
+        {
+          "script": {
+            "text": "mpirun --hostfile=/etc/cloudbatch-taskgroup-hosts -np ${pool_size} -ppn 1 hostname"
+          }
+        }
+      ]%{ if nfs_share != null },
+      "volumes":[
+        {
+          "nfs":{
+            "server": "${nfs_share.server_ip}",
+            "remote_path": "${nfs_share.remote_path}"
+          },
+          "mount_path": "${nfs_share.mount_path}"
+        }
+      ]%{ endif }
+    }
+  }],
+  "logsPolicy": {
+    "destination": "CLOUD_LOGGING"
+  },
+  "labels": {
+    "goog-batch-job-group": "${pool_name}"
+  }
+}

--- a/modules/scheduler/batch-mpi-pool/templates/make-pool.sh.tftpl
+++ b/modules/scheduler/batch-mpi-pool/templates/make-pool.sh.tftpl
@@ -1,0 +1,2 @@
+#!/bin/bash
+gcloud batch jobs submit ${job_id} --project=${project} --location=${location} --config=${config}

--- a/modules/scheduler/batch-mpi-pool/templates/readme.md.tftpl
+++ b/modules/scheduler/batch-mpi-pool/templates/readme.md.tftpl
@@ -1,0 +1,7 @@
+  This deployment has created a Batch Node Pool via the Batch Job projects/${project}/locations/${location}/jobs/${job_id}.
+  After this initial pool-configuration job has completed, you can submit additional jobs to Batch to be executed on the pool.
+
+  A configuration for a simple MPI job that runs "hostname" once on each node of the pool is included in batch-run-mpi-workload.json.
+  You can submit a job with this configuration with gcloud.
+
+      gcloud batch jobs submit --project=${project} --location=${location} --config=${run_mpi_config_path}

--- a/modules/scheduler/batch-mpi-pool/variables.tf
+++ b/modules/scheduler/batch-mpi-pool/variables.tf
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project in which the HPC deployment will be created"
+  type        = string
+}
+
+variable "region" {
+  description = "The region in which to create the node pool"
+  type        = string
+}
+
+variable "pool_size" {
+  description = "Number of VMs to add to the node pool"
+  type        = number
+  default     = 4
+}
+
+variable "pool_duration" {
+  description = "Maximum idle time for the pool, after which it will be automatically deprovisioned"
+  type        = string
+  default     = "1h"
+}
+
+variable "machine_type" {
+  description = "Machine type for VMs in the pool"
+  type        = string
+  default     = "c2-standard-60"
+}
+
+variable "boot_image" {
+  description = "Boot image for the VMs in the pool"
+  type        = string
+  default     = "batch-hpc-centos"
+}
+
+variable "nfs_share" {
+  description = "An NFS share (optional) to be mounted by each node in the pool"
+  type = object({
+    server_ip            = string
+    remote_path          = string
+    mount_path           = string
+  })
+}
+
+variable "deployment_name" {
+  description = "Name of the deployment, used for the pool name"
+  type        = string
+}
+
+variable "gcloud_version" {
+  description = "The version of the gcloud cli being used. Used for output instructions. Valid inputs are `\"alpha\"`, `\"beta\"` and \"\" (empty string for default version)"
+  type        = string
+  default     = "alpha"
+
+  validation {
+    condition     = contains(["alpha", "beta", ""], var.gcloud_version)
+    error_message = "Allowed values for gcloud_version are 'alpha', 'beta', or '' (empty string)."
+  }
+}

--- a/modules/scheduler/batch-mpi-pool/versions.tf
+++ b/modules/scheduler/batch-mpi-pool/versions.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}


### PR DESCRIPTION
Adds a module to create a Batch Node Pool with VMs configured to run MPI workloads with Intel MPI and (optionally) with an NFS share pre-mounted on each VM.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
