### PR TITLE
Updating spack and ramble buckets to use 8 digits of hex

### DIFF
--- a/community/modules/scripts/ramble-setup/main.tf
+++ b/community/modules/scripts/ramble-setup/main.tf
@@ -72,7 +72,7 @@ locals {
     "destination" = "install_ramble.yml"
   }
 
-  bucket_md5  = substr(md5("${var.project_id}.${var.deployment_name}"), 0, 4)
+  bucket_md5  = substr(md5("${var.project_id}.${var.deployment_name}"), 0, 8)
   bucket_name = "ramble-scripts-${local.bucket_md5}"
   runners     = [local.install_ramble_deps_runner, local.install_ramble_runner, local.python_reqs_runner]
 

--- a/community/modules/scripts/spack-setup/main.tf
+++ b/community/modules/scripts/spack-setup/main.tf
@@ -79,7 +79,7 @@ locals {
     "destination" = "install_spack.yml"
   }
 
-  bucket_md5  = substr(md5("${var.project_id}.${var.deployment_name}.${local.script_content}"), 0, 4)
+  bucket_md5  = substr(md5("${var.project_id}.${var.deployment_name}.${local.script_content}"), 0, 8)
   bucket_name = "spack-scripts-${local.bucket_md5}"
   runners     = [local.install_spack_deps_runner, local.install_spack_runner]
 


### PR DESCRIPTION
Description in title.

Can't use b64 because of naming restrictions (no uppercase)

This was tested with the hpc-slurm-ramble-gromacs example with no errors.