### PR TITLE
`tools/enforce_coverage.pl`, fix for gLinux & improve output

### DIFF
--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -16,27 +16,29 @@
 use strict;
 use warnings;
 
-# TODO: raise ./cmd min coverage to 80% after tests are written
-my $min = 80;
-my $cmdmin = 40;
-my $shellmin = 0;
-my $validatorsmin = 25;
-my $failed_coverage = 0;
-
+my @failed;
 while (<>){
   print $_;
-  if ( $_ =~ /hpc-toolkit\/cmd.*coverage: (\d+\.\d)%/) {
-    $failed_coverage++ if ($1 < $cmdmin);
-  } elsif ( $_ =~ /hpc-toolkit\/pkg\/shell.*coverage: (\d+\.\d)%/) {
-    $failed_coverage++ if ($1 < $shellmin);
-  } elsif ( $_ =~ /hpc-toolkit\/pkg\/validators.*coverage: (\d+\.\d)%/) {
-    $failed_coverage++ if ($1 < $validatorsmin);  
-  } elsif ( $_ =~ /coverage: (\d+\.\d)%/ ) {
-    $failed_coverage++ if ($1 < $min);
+
+  my @thresholds = qw(
+    cmd 40
+    pkg/shell 0
+    pkg/logging 0
+    pkg/validators 25
+    pkg/inspect 60
+    pkg 80
+  );
+
+  while (@thresholds) {
+    my ($path, $threshold) = splice(@thresholds, 0, 2);
+    if ( $_ =~ /hpc-toolkit\/$path.*coverage: (\d+\.\d)%/) {
+      chomp, push @failed, "$_ <= $threshold%\n" if ($1 < $threshold);
+      last;
+    }
   }
 }
 
-if ($failed_coverage > 0) {
-   print STDERR "Coverage must be above $cmdmin% for ./cmd and $min% for other packages, $failed_coverage packages were below that.\n";
+if (@failed) {
+   print STDERR "\nFAILED:\n@failed";
    exit 1
 }


### PR DESCRIPTION
* Set new thresholds, to prevent failures on gLinux
  * `pkg/logging: 0` - previously ignored, because was reported as 
  ```sh
  ?   	hpc-toolkit/pkg/logging	[no test files]
  ```
  * `pkg/inspect: 60` - suddenly dropped `83% -> 70%`, TODO
* Output package that failed;

```sh
# BEFORE
$ make test-engine
**************** vetting go code **********************
**************** running ghpc unit tests **************
go vet ./cmd/... ./pkg/...
go test -cover ./cmd/... ./pkg/... 2>&1 |  perl tools/enforce_coverage.pl
ok      hpc-toolkit/cmd (cached)        coverage: 47.2% of statements
ok      hpc-toolkit/pkg/config  (cached)        coverage: 89.7% of statements
ok      hpc-toolkit/pkg/deploymentio    (cached)        coverage: 88.2% of statements
ok      hpc-toolkit/pkg/inspect (cached)        coverage: 70.6% of statements
        hpc-toolkit/pkg/logging         coverage: 0.0% of statements
ok      hpc-toolkit/pkg/modulereader    (cached)        coverage: 85.6% of statements
ok      hpc-toolkit/pkg/modulewriter    (cached)        coverage: 82.4% of statements
ok      hpc-toolkit/pkg/shell   (cached)        coverage: 24.9% of statements
ok      hpc-toolkit/pkg/sourcereader    (cached)        coverage: 89.4% of statements
ok      hpc-toolkit/pkg/validators      (cached)        coverage: 31.1% of statements
Coverage must be above 40% for ./cmd and 80% for other packages, 2 packages were below that.
make: *** [Makefile:74: test-engine] Error 1

# AFTER
$ make test-engine
**************** vetting go code **********************
**************** running ghpc unit tests **************
go vet ./cmd/... ./pkg/...
go test -cover ./cmd/... ./pkg/... 2>&1 |  perl tools/enforce_coverage.pl
ok      hpc-toolkit/cmd (cached)        coverage: 47.2% of statements
ok      hpc-toolkit/pkg/config  (cached)        coverage: 89.7% of statements
ok      hpc-toolkit/pkg/deploymentio    (cached)        coverage: 88.2% of statements
ok      hpc-toolkit/pkg/inspect (cached)        coverage: 70.6% of statements
        hpc-toolkit/pkg/logging         coverage: 0.0% of statements
ok      hpc-toolkit/pkg/modulereader    (cached)        coverage: 85.6% of statements
ok      hpc-toolkit/pkg/modulewriter    (cached)        coverage: 82.4% of statements
ok      hpc-toolkit/pkg/shell   (cached)        coverage: 24.9% of statements
ok      hpc-toolkit/pkg/sourcereader    (cached)        coverage: 89.4% of statements
ok      hpc-toolkit/pkg/validators      (cached)        coverage: 31.1% of statements

FAILED:
ok      hpc-toolkit/pkg/inspect (cached)        coverage: 70.6% of statements <= 80%
        hpc-toolkit/pkg/logging         coverage: 0.0% of statements <= 80%
make: *** [Makefile:74: test-engine] Error 1
```
