### PR TITLE
Remove `setGlobalLabels` as it's not needed

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -31,30 +31,6 @@ const (
 	deploymentLabel string = "ghpc_deployment"
 )
 
-// expand expands variables and strings in the yaml config. Used directly by
-// ExpandConfig for the create and expand commands.
-func (dc *DeploymentConfig) expand() error {
-	dc.expandBackends()
-	dc.combineLabels()
-
-	if err := dc.applyUseModules(); err != nil {
-		return err
-	}
-
-	dc.applyGlobalVariables()
-
-	if err := validateInputsAllModules(dc.Config); err != nil {
-		return err
-	}
-
-	if err := validateModulesAreUsed(dc.Config); err != nil {
-		return err
-	}
-
-	dc.Config.populateOutputs()
-	return nil
-}
-
 func validateInputsAllModules(bp Blueprint) error {
 	errs := Errors{}
 	bp.WalkModulesSafe(func(p ModulePath, m *Module) {

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -23,11 +23,6 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *MySuite) TestExpand(c *C) {
-	dc := s.getDeploymentConfigForTest()
-	c.Check(dc.expand(), IsNil)
-}
-
 func (s *MySuite) TestExpandBackends(c *C) {
 	dc := s.getDeploymentConfigForTest()
 	deplName := dc.Config.Vars.Get("deployment_name").AsString()


### PR DESCRIPTION
The `combineLabels` will do it.

Unfold  `dc.expand()` within `ExpandConfig()`


