### PR TITLE
Change subprocess signature to be python36 compatible

### DIFF
--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -55,8 +55,8 @@ VERSION_RES = """
 }
 """
 
-def subprocess_replace(cmd, shell, capture_output, text,
-                       check) -> subprocess.CompletedProcess:
+def subprocess_replace(cmd, shell, check, universal_newlines, stdout,
+                       stderr) -> subprocess.CompletedProcess:
     res = subprocess.CompletedProcess("", 0)
     res.stdout = ""
     if cmd == maintenance.VER_CMD:

--- a/tools/maintenance/maintenance.py
+++ b/tools/maintenance/maintenance.py
@@ -43,8 +43,8 @@ PRJ_CMD = "gcloud projects describe {}"
 SLURM_CMD = "sinfo --format=%n --noheader"
 
 def run_command(cmd: str, err_msg: str = None) -> subprocess.CompletedProcess:
-    res = subprocess.run(cmd, shell=True, capture_output=True, text=True,
-                         check=False)
+    res = subprocess.run(cmd, shell=True, universal_newlines=True, check=False,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if res.returncode != 0:
         raise subprocess.SubprocessError(f"{err_msg}:\n{res.stderr}")
 


### PR DESCRIPTION
`text` is just [alias](https://docs.python.org/3/library/subprocess.html#:~:text=Used%20Arguments.-,The%20universal_newlines%20argument%20is%20equivalent%20to%20text,-and%20is%20provided) for `universal_newlines` that was added in 3.7.

`stdout=subprocess.PIPE, stderr=subprocess.PIPE` [is equivalent to](https://github.com/python/cpython/blob/4b47a5b6ba66b02df9392feb97b8ead916f8c1fa/Lib/subprocess.py#L481-L486) `capture_output` (ref).

Ran manually to spot check.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
