### PR TITLE
Refactor `eval` functions

### DIFF
--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -97,7 +97,7 @@ func (d Dict) IsZero() bool {
 func (d Dict) Eval(bp Blueprint) (Dict, error) {
 	var res Dict
 	for k, v := range d.Items() {
-		r, err := evalValue(v, bp)
+		r, err := bp.Eval(v)
 		if err != nil {
 			return Dict{}, fmt.Errorf("error while trying to evaluate %#v: %w", k, err)
 		}

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -82,7 +82,7 @@ func validateModuleInputs(mp ModulePath, m Module, bp Blueprint) error {
 }
 
 func attemptEvalModuleInput(val cty.Value, bp Blueprint) (cty.Value, bool) {
-	v, err := evalValue(val, bp)
+	v, err := bp.Eval(val)
 	// there could be a legitimate reasons for it.
 	// e.g. use of modules output or unsupported (by ghpc) functions
 	// TODO:

--- a/pkg/config/expression_test.go
+++ b/pkg/config/expression_test.go
@@ -198,7 +198,7 @@ func TestFlattenFunctionCallExpression(t *testing.T) {
 		cty.NumberIntVal(2),
 		cty.NumberIntVal(3)})
 
-	got, err := expr.Eval(bp)
+	got, err := bp.Eval(expr.AsValue())
 	if err != nil {
 		t.Errorf("got unexpected error: %s", err)
 	}
@@ -226,7 +226,7 @@ func TestMergeFunctionCallExpression(t *testing.T) {
 		"two": cty.NumberIntVal(2),
 	})
 
-	got, err := expr.Eval(bp)
+	got, err := bp.Eval(expr.AsValue())
 	if err != nil {
 		t.Errorf("got unexpected error: %s", err)
 	}


### PR DESCRIPTION
Make `Blueprint.Eval` the only place where blueprint context is created and avoid recursive context creation.
