### PR TITLE
Updates to HTCondor autoscaler

### DIFF
--- a/community/modules/compute/htcondor-execute-point/templates/download-condor-config.ps1.tftpl
+++ b/community/modules/compute/htcondor-execute-point/templates/download-condor-config.ps1.tftpl
@@ -16,6 +16,10 @@ $remote_hash = gcloud --format="value(md5_hash)" storage hash ${config_object}
 if ($local_hash -cne $remote_hash) {
     Write-Output "Updating condor configuration"
     gcloud storage cp ${config_object} $config_file
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "Could not download HTCondor configuration; exiting startup script"
+    }
     Restart-Service condor
 }
 

--- a/community/modules/compute/htcondor-execute-point/templates/download-condor-config.ps1.tftpl
+++ b/community/modules/compute/htcondor-execute-point/templates/download-condor-config.ps1.tftpl
@@ -1,19 +1,24 @@
 # create directory for local condor_config customizations
 $config_dir = 'C:\Condor\config'
-if(!(test-path -PathType container -Path $config_dir)) {
+if(!(test-path -PathType container -Path $config_dir))
+{
       New-Item -ItemType Directory -Path $config_dir
 }
 
 # update local condor_config if blueprint has changed
 $config_file = "$config_dir\50-ghpc-managed"
-if (Test-Path -Path $config_file -PathType Leaf) {
+if (Test-Path -Path $config_file -PathType Leaf)
+{
     $local_hash = gcloud --format="value(md5_hash)" storage hash $config_file
-} else {
+}
+else
+{
     $local_hash = "INVALID-HASH"
 }
 
 $remote_hash = gcloud --format="value(md5_hash)" storage hash ${config_object}
-if ($local_hash -cne $remote_hash) {
+if ($local_hash -cne $remote_hash)
+{
     Write-Output "Updating condor configuration"
     gcloud storage cp ${config_object} $config_file
     if ($LASTEXITCODE -ne 0)

--- a/community/modules/scheduler/htcondor-central-manager/templates/condor_config.tftpl
+++ b/community/modules/scheduler/htcondor-central-manager/templates/condor_config.tftpl
@@ -20,6 +20,11 @@ use role:get_htcondor_central_manager
 CONDOR_HOST = $(IPV4_ADDRESS)
 
 # Central Manager configuration settings
+# https://htcondor.readthedocs.io/en/23.0/admin-manual/configuration-macros.html#condor-collector-configuration-file-entries
+# https://htcondor.readthedocs.io/en/23.0/admin-manual/configuration-macros.html#condor-negotiator-configuration-file-entries
+# set classad lifetime (expiration) to ~5x the update interval for all daemons
+# defaults to 900s
+CLASSAD_LIFETIME = 180
 COLLECTOR_UPDATE_INTERVAL = 30
 NEGOTIATOR_UPDATE_INTERVAL = 30
 NEGOTIATOR_DEPTH_FIRST = True

--- a/community/modules/scheduler/htcondor-pool-secrets/templates/fetch-idtoken.ps1.tftpl
+++ b/community/modules/scheduler/htcondor-pool-secrets/templates/fetch-idtoken.ps1.tftpl
@@ -2,8 +2,9 @@ Set-StrictMode -Version latest
 $ErrorActionPreference = 'Stop'
 
 $config_dir = 'C:\Condor\config'
-if(!(test-path -PathType container -Path $config_dir)) {
-      New-Item -ItemType Directory -Path $config_dir
+if(!(test-path -PathType container -Path $config_dir))
+{
+    New-Item -ItemType Directory -Path $config_dir
 }
 $config_file = "$config_dir\51-ghpc-trust-domain"
 
@@ -19,4 +20,7 @@ Set-Content -Path "$config_file" -Value "$config_string"
 gcloud secrets versions access latest --secret ${xp_idtoken_secret_id} `
     --out-file C:\condor\tokens.d\condor@${trust_domain}
 
-if ($LASTEXITCODE -ne 0) { throw "Could not download HTCondor IDTOKEN; exiting startup script" }
+if ($LASTEXITCODE -ne 0)
+{
+    throw "Could not download HTCondor IDTOKEN; exiting startup script"
+}

--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -253,6 +253,9 @@ class AutoScaler:
         current_target = responseGroupInfo["targetSize"]
         print(f"Current MIG target size: {current_target}")
 
+        # Find instances that are being modified by the MIG (currentAction is
+        # any value other than "NONE"). A common reason an instance is modified
+        # is it because it has failed a health check.
         reqModifyingInstances = self.instanceGroupManagers.listManagedInstances(
             project=self.project,
             **self.zoneargs,

--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -253,17 +253,14 @@ class AutoScaler:
         current_target = responseGroupInfo["targetSize"]
         print(f"Current MIG target size: {current_target}")
 
-        being_born_states = ["CREATING", "RECREATING", "VERIFYING"]
-        being_born_filters = [ f"currentAction = \"{state}\"" for state in being_born_states ]
-        being_born_combined_filter = ' OR '.join(being_born_filters)
-        reqCreatingInstances = self.instanceGroupManagers.listManagedInstances(
+        reqModifyingInstances = self.instanceGroupManagers.listManagedInstances(
             project=self.project,
             **self.zoneargs,
             instanceGroupManager=self.instance_group_manager,
-            filter=being_born_combined_filter,
+            filter="currentAction != \"NONE\"",
             orderBy="creationTimestamp desc"
         )
-        respCreatingInstances = reqCreatingInstances.execute()
+        respModifyingInstances = reqModifyingInstances.execute()
 
         # Find VMs that are idle (no dynamic slots created from partitionable
         # slots) in the MIG handled by this autoscaler
@@ -287,17 +284,19 @@ class AutoScaler:
         # their readiness to join pool (creating, unhealthy, healthy+idle)
         idle_nodes = OrderedDict()
         try:
-            creatingInstances = respCreatingInstances["managedInstances"]
+            modifyingInstances = respModifyingInstances["managedInstances"]
         except KeyError:
-            creatingInstances = []
+            modifyingInstances = []
+
+        print(f"There are {len(modifyingInstances)} VMs being modified by the managed instance group")
 
         # there is potential for nodes in MIG health check "VERIFYING" state
         # to have already joined the pool and be running jobs
-        for instance in creatingInstances:
+        for instance in modifyingInstances:
             self_link = instance["instance"]
             node_name = self_link.rsplit("/", 1)[-1]
             if node_name not in claimed_nodes:
-                idle_nodes[self_link] = "creating"
+                idle_nodes[self_link] = "modifying"
 
         for ad in idle_node_ads:
             node = ad["Machine"].split(".")[0]
@@ -311,7 +310,7 @@ class AutoScaler:
             idle_nodes[self_link] = "idle"
         n_idle = len(idle_nodes)
 
-        print(f"There are {n_idle} VMs being created or idle in the pool")
+        print(f"There are {n_idle} VMs being modified or idle in the pool")
         if self.debug > 1:
             print("Listing idle nodes:")
             pprint(idle_nodes)


### PR DESCRIPTION
The primary feature of this PR is to adopt a more conservative approach in the autoscaler. It will now treat nodes in any state that reflects automated MIG modification as an "idle" node for the purposes of autoscaling. This helps prevent autoscaling runaway when VMs are unable to enter the healthy state (which reflects
as "NONE" for currentAction in the MIG).

- [Expire ClassAds more rapidly](https://github.com/GoogleCloudPlatform/hpc-toolkit/commit/23af765dd49f03ed731a2f5990cd3995fa1c3425)
- [ensure Windows nodes are detected as unhealthy](https://github.com/GoogleCloudPlatform/hpc-toolkit/commit/b1de00ac94a740f0ec331af14f993f0274712604)
- [Align formatting choices with recent commits](https://github.com/GoogleCloudPlatform/hpc-toolkit/commit/729b0c47c97898e7aea93aaa8fe4a83c3489f900)

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
