### PR TITLE
Add login node in spack wrfv3 tutorial example

### DIFF
--- a/docs/tutorials/wrfv3/spack-wrfv3.md
+++ b/docs/tutorials/wrfv3/spack-wrfv3.md
@@ -84,6 +84,7 @@ This file describes the cluster you will deploy. It defines:
   * sets up a Spack environment including downloading an example input deck
   * places a submission script on a shared drive
 * a Slurm cluster
+  * a Slurm login node
   * a Slurm controller
   * An auto-scaling Slurm partition
 
@@ -146,21 +147,21 @@ the final output from the above command:
 
 Optionally while you wait, you can see your deployed VMs on Google Cloud
 Console. Open the link below in a new window. Look for
-`spackwrfv3-controller`. If you don't
+`spackwrfv3-controller` and `spackwrfv3-login-login-001`. If you don't
 see your VMs make sure you have the correct project selected (top left).
 
 ```text
 https://console.cloud.google.com/compute?project=<walkthrough-project-id/>
 ```
 
-## Connecting to the controller node
+## Connecting to the login node
 
-Once the startup script has completed, connect to the controller node.
+Once the startup script has completed, connect to the login node.
 
-Use the following command to ssh into the controller node from cloud shell:
+Use the following command to ssh into the login node from cloud shell:
 
 ```bash
-gcloud compute ssh spackwrfv3-controller --zone us-central1-c --project <walkthrough-project-id/>
+gcloud compute ssh spackwrfv3-login-login-001 --zone us-central1-c --project <walkthrough-project-id/>
 ```
 
 You may be prompted to set up SSH. If so follow the prompts and if asked for a
@@ -184,15 +185,15 @@ following instructions:
    https://console.cloud.google.com/compute?project=<walkthrough-project-id/>
    ```
 
-1. Click on the `SSH` button associated with the `spackwrfv3-controller`
+1. Click on the `SSH` button associated with the `spackwrfv3-login-login-001`
    instance.
 
    This will open a separate pop up window with a terminal into our newly
-   created Slurm controller VM.
+   created Slurm login VM.
 
 ## Run a Job on the Cluster
 
-   **The commands below should be run on the Slurm controller node.**
+   **The commands below should be run on the Slurm login node.**
 
 We will use the submission script (see line 122 of the blueprint) to submit a
 Weather Research and Forecasting (WRF) Model job.
@@ -240,7 +241,7 @@ about 5 minutes to run.
 Several files will have been generated in the `test_run/` folder you created.
 
 The `rsl.out.0000` file has information on the run. You can view this file by
-running the following command on the controller node:
+running the following command on the login node:
 
 ```bash
 cat rsl.out.0000
@@ -261,9 +262,9 @@ https://console.cloud.google.com/monitoring/dashboards?project=<walkthrough-proj
 To avoid incurring ongoing charges we will want to destroy our cluster.
 
 For this we need to return to our cloud shell terminal. Run `exit` in the
-terminal to close the SSH connection to the controller node:
+terminal to close the SSH connection to the login node:
 
-> **_NOTE:_** If you are accessing the controller node terminal via a separate pop-up
+> **_NOTE:_** If you are accessing the login node terminal via a separate pop-up
 > then make sure to call `exit` in the pop-up window.
 
 ```bash

--- a/docs/tutorials/wrfv3/spack-wrfv3.yaml
+++ b/docs/tutorials/wrfv3/spack-wrfv3.yaml
@@ -103,7 +103,7 @@ deployment_groups:
           spack install
         fi
 
-  - id: controller-setup
+  - id: login-setup
     source: modules/scripts/startup-script
     settings:
       runners:
@@ -156,13 +156,21 @@ deployment_groups:
     use: [compute_nodeset]
     settings:
       partition_name: compute
+      is_default: true
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network1]
+    settings:
+      name_prefix: login
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
     - network1
     - compute_partition
+    - slurm_login
     settings:
       disable_controller_public_ips: false
-      controller_startup_scripts_timeout: 21600
-      controller_startup_script: $(controller-setup.startup_script)
+      login_startup_scripts_timeout: 21600
+      login_startup_script: $(login-setup.startup_script)


### PR DESCRIPTION
This PR updates the spack wrfv3 example to include a login node.
When manually testing `sbatch /opt/apps/wrfv3/submit_wrfv3.sh` on the login node, the job successfully completes and the following is in the directory. 
```
[spackwrfv3-login-login-001 test_run]$ ls
aerosol.formatted                 co2_trans                                  ozone.formatted        rsl.error.0005  rsl.error.0029  rsl.error.0053  rsl.out.0017  rsl.out.0041  tr49t67
aerosol_lat.formatted             coeff_p.asc                                ozone_lat.formatted    rsl.error.0006  rsl.error.0030  rsl.error.0054  rsl.out.0018  rsl.out.0042  tr49t85
aerosol_lon.formatted             coeff_q.asc                                ozone_plev.formatted   rsl.error.0007  rsl.error.0031  rsl.error.0055  rsl.out.0019  rsl.out.0043  tr67t85
aerosol_plev.formatted            constants.asc                              p3_lookup_table_1.dat  rsl.error.0008  rsl.error.0032  rsl.error.0056  rsl.out.0020  rsl.out.0044  TSK.png
bulkdens.asc_s_0_03_0_9           create_p3_lookupTable_1.f90                PH.png                 rsl.error.0009  rsl.error.0033  rsl.error.0057  rsl.out.0021  rsl.out.0045  TSLB.png
bulkradii.asc_s_0_03_0_9          diffwrf.py                                 QVAPOR.png             rsl.error.0010  rsl.error.0034  rsl.error.0058  rsl.out.0022  rsl.out.0046  U.png
CAM_ABS_DATA                      ETAMPNEW_DATA                              RAINC.png              rsl.error.0011  rsl.error.0035  rsl.error.0059  rsl.out.0023  rsl.out.0047  URBPARM.TBL
CAM_AEROPT_DATA                   ETAMPNEW_DATA_DBL                          RAINNC.png             rsl.error.0012  rsl.error.0036  rsl.out.0000    rsl.out.0024  rsl.out.0048  URBPARM_UZE.TBL
CAMtr_volume_mixing_ratio.A1B     ETAMPNEW_DATA.expanded_rain                README.namelist        rsl.error.0013  rsl.error.0037  rsl.out.0001    rsl.out.0025  rsl.out.0049  VEGPARM.TBL
CAMtr_volume_mixing_ratio.A2      ETAMPNEW_DATA.expanded_rain_DBL            README.rasm_diag       rsl.error.0014  rsl.error.0038  rsl.out.0002    rsl.out.0026  rsl.out.0050  V.png
CAMtr_volume_mixing_ratio.RCP4.5  GENPARM.TBL                                README.tslist          rsl.error.0015  rsl.error.0039  rsl.out.0003    rsl.out.0027  rsl.out.0051  wind-turbine-1.tbl
CAMtr_volume_mixing_ratio.RCP6    grib2map.tbl                               README.txt             rsl.error.0016  rsl.error.0040  rsl.out.0004    rsl.out.0028  rsl.out.0052  W.png
CAMtr_volume_mixing_ratio.RCP8.5  gribmap.txt                                real.exe               rsl.error.0017  rsl.error.0041  rsl.out.0005    rsl.out.0029  rsl.out.0053  wrfbdy_d01
capacity.asc                      hostfile                                   RRTM_DATA              rsl.error.0018  rsl.error.0042  rsl.out.0006    rsl.out.0030  rsl.out.0054  wrf.exe
CCN_ACTIVATE.BIN                  kernels.asc_s_0_03_0_9                     RRTM_DATA_DBL          rsl.error.0019  rsl.error.0043  rsl.out.0007    rsl.out.0031  rsl.out.0055  wrfout_d01_2001-10-24_12:00:00
CLM_ALB_ICE_DFS_DATA              kernels_z.asc                              RRTMG_LW_DATA          rsl.error.0020  rsl.error.0044  rsl.out.0008    rsl.out.0032  rsl.out.0056  wrfout_d01_2001-10-24_12:00:00-ORIG
CLM_ALB_ICE_DRC_DATA              LANDUSE.TBL                                RRTMG_LW_DATA_DBL      rsl.error.0021  rsl.error.0045  rsl.out.0009    rsl.out.0033  rsl.out.0057  wrfrst_d01_2001-10-24_09:00:00
CLM_ASM_ICE_DFS_DATA              masses.asc                                 RRTMG_SW_DATA          rsl.error.0022  rsl.error.0046  rsl.out.0010    rsl.out.0034  rsl.out.0058
CLM_ASM_ICE_DRC_DATA              MPTABLE.TBL                                RRTMG_SW_DATA_DBL      rsl.error.0023  rsl.error.0047  rsl.out.0011    rsl.out.0035  rsl.out.0059
CLM_DRDSDT0_DATA                  MU.png                                     rsl.error.0000         rsl.error.0024  rsl.error.0048  rsl.out.0012    rsl.out.0036  slurm-1.out
CLM_EXT_ICE_DFS_DATA              namelist.input                             rsl.error.0001         rsl.error.0025  rsl.error.0049  rsl.out.0013    rsl.out.0037  SOILPARM.TBL
CLM_EXT_ICE_DRC_DATA              namelist.input.backup.2024-02-14_02_49_07  rsl.error.0002         rsl.error.0026  rsl.error.0050  rsl.out.0014    rsl.out.0038  tc.exe
CLM_KAPPA_DATA                    namelist.output                            rsl.error.0003         rsl.error.0027  rsl.error.0051  rsl.out.0015    rsl.out.0039  termvels.asc
CLM_TAU_DATA                      ndown.exe                                  rsl.error.0004         rsl.error.0028  rsl.error.0052  rsl.out.0016    rsl.out.0040  T.png
```
