### PR TITLE
Don't persist evaluated `Blueprint.Vars`

### DIFF
--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -15,8 +15,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/exp/maps"
 )
@@ -95,13 +93,9 @@ func (d Dict) IsZero() bool {
 // Eval returns a copy of this Dict, where all Expressions
 // are evaluated and replaced by result of evaluation.
 func (d Dict) Eval(bp Blueprint) (Dict, error) {
-	var res Dict
-	for k, v := range d.Items() {
-		r, err := bp.Eval(v)
-		if err != nil {
-			return Dict{}, fmt.Errorf("error while trying to evaluate %#v: %w", k, err)
-		}
-		res.Set(k, r)
+	res, err := bp.Eval(d.AsObject())
+	if err != nil {
+		return Dict{}, err
 	}
-	return res, nil
+	return NewDict(res.AsValueMap()), nil
 }

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -96,15 +96,11 @@ func validateModulesAreUsed(bp Blueprint) error {
 }
 
 func (bp *Blueprint) expandVars() error {
-	var err error
-	if err = validateVars(bp.Vars); err != nil {
+	if err := validateVars(*bp); err != nil {
 		return err
 	}
-
-	bp.origVars = NewDict(bp.Vars.Items()) // copy
 	bp.expandGlobalLabels()
-	bp.Vars, err = bp.evalVars()
-	return err
+	return nil
 }
 
 func (bp *Blueprint) expandGroups() error {

--- a/pkg/config/expression.go
+++ b/pkg/config/expression.go
@@ -384,9 +384,12 @@ func valueReferences(v cty.Value) map[Reference]cty.Path {
 }
 
 func (bp *Blueprint) Eval(v cty.Value) (cty.Value, error) {
+	vars, err := bp.evalVars()
+	if err != nil {
+		return cty.NilVal, err
+	}
 	ctx := hcl.EvalContext{
-		Variables: map[string]cty.Value{
-			"var": bp.Vars.AsObject()},
+		Variables: map[string]cty.Value{"var": vars.AsObject()},
 		Functions: functions()}
 	return eval(v, &ctx)
 }

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -30,12 +30,16 @@ import (
 
 const maxLabels = 64
 
-func validateGlobalLabels(vars Dict) error {
-	if !vars.Has("labels") {
+func validateGlobalLabels(bp Blueprint) error {
+	if !bp.Vars.Has("labels") {
 		return nil
 	}
 	p := Root.Vars.Dot("labels")
-	labels := vars.Get("labels")
+
+	labels := bp.Vars.Get("labels")
+	if _, is := IsExpressionValue(labels); is {
+		return nil // do not inspect expressions
+	}
 	ty := labels.Type()
 
 	if !ty.IsObjectType() && !ty.IsMapType() {
@@ -49,18 +53,26 @@ func validateGlobalLabels(vars Dict) error {
 		// deployment failures.
 		errs.At(p, errors.New("vars.labels cannot have more than 64 labels"))
 	}
+
 	for k, v := range labels.AsValueMap() {
 		vp := p.Cty(cty.Path{}.IndexString(k))
+		// Check that label names are valid
+		if !isValidLabelName(k) {
+			errs.At(vp, HintError{
+				Err:  fmt.Errorf("invalid label name %q", k),
+				Hint: errMsgLabelNameReqs})
+		}
+
+		if _, is := IsExpressionValue(v); is {
+			continue // do not inspect expressions
+		}
+
 		if v.Type() != cty.String {
 			errs.At(vp, errors.New("vars.labels must be a map of strings"))
 			continue
 		}
 		s := v.AsString()
 
-		// Check that label names are valid
-		if !isValidLabelName(k) {
-			errs.At(vp, errors.Errorf("%s: '%s: %s'", errMsgLabelNameReqs, k, s))
-		}
 		// Check that label values are valid
 		if !isValidLabelValue(s) {
 			errs.At(vp, errors.Errorf("%s: '%s: %s'", errMsgLabelValueReqs, k, s))
@@ -70,12 +82,13 @@ func validateGlobalLabels(vars Dict) error {
 }
 
 // validateVars checks the global variables for viable types
-func validateVars(vars Dict) error {
+func validateVars(bp Blueprint) error {
 	errs := (&Errors{}).
-		Add(validateDeploymentName(vars)).
-		Add(validateGlobalLabels(vars))
+		Add(validateDeploymentName(bp)).
+		Add(validateGlobalLabels(bp))
 	// Check for any nil values
-	for key, val := range vars.Items() {
+	// Iterator over non evaluated variables, it's Ok if evaluated value is null
+	for key, val := range bp.Vars.Items() {
 		if val.IsNull() {
 			errs.At(Root.Vars.Dot(key), fmt.Errorf("deployment variable %q was not set", key))
 		}

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -28,25 +28,25 @@ func (s *zeroSuite) TestValidateVars(c *C) {
 
 	{ // Success
 		vars := Dict{base}
-		c.Check(validateVars(vars), IsNil)
+		c.Check(validateVars(Blueprint{Vars: vars}), IsNil)
 	}
 
 	{ // Fail: Nil value
 		vars := Dict{base}
 		vars.Set("fork", cty.NilVal)
-		c.Check(validateVars(vars), NotNil)
+		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
 	}
 
 	{ // Fail: Null value
 		vars := Dict{base}
 		vars.Set("fork", cty.NullVal(cty.String))
-		c.Check(validateVars(vars), NotNil)
+		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
 	}
 
 	{ // Fail: labels not a map
 		vars := Dict{base}
 		vars.Set("labels", cty.StringVal("a_string"))
-		c.Check(validateVars(vars), NotNil)
+		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
 	}
 }
 

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -47,9 +47,7 @@ func printPackerInstructions(w io.Writer, groupPath string, subPath string, prin
 }
 
 func writePackerAutovars(vars map[string]cty.Value, dst string) error {
-	packerAutovarsPath := filepath.Join(dst, packerAutoVarFilename)
-	err := WriteHclAttributes(vars, packerAutovarsPath)
-	return err
+	return WriteHclAttributes(vars, filepath.Join(dst, packerAutoVarFilename))
 }
 
 // writeDeploymentGroup writes any needed files to the top and module levels

--- a/pkg/validators/quota.go
+++ b/pkg/validators/quota.go
@@ -351,6 +351,8 @@ func parseResourceRequirementsInputs(bp config.Blueprint, inputs config.Dict) (r
 		return rrInputs{}, err
 	}
 
+	vars, _ := bp.Vars.Eval(bp)
+
 	// fill in default values
 	ignoreUsage := ifNull(clean.GetAttr("ignore_usage"), cty.False)
 	projectID, err := bp.ProjectID()
@@ -367,11 +369,11 @@ func parseResourceRequirementsInputs(bp config.Blueprint, inputs config.Dict) (r
 			return rrInputs{}, err
 		}
 		defDims := map[string]cty.Value{}
-		if bp.Vars.Has("region") {
-			defDims["region"] = bp.Vars.Get("region")
+		if vars.Has("region") {
+			defDims["region"] = vars.Get("region")
 		}
-		if bp.Vars.Has("zone") {
-			defDims["zone"] = bp.Vars.Get("zone")
+		if vars.Has("zone") {
+			defDims["zone"] = vars.Get("zone")
 		}
 		defDimsVal := cty.MapValEmpty(cty.String)
 		if len(defDims) > 0 {

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -29,7 +29,7 @@ vars:
   deployment_name: golden_copy_deployment
   labels:
     ghpc_blueprint: igc
-    ghpc_deployment: golden_copy_deployment
+    ghpc_deployment: ((var.deployment_name ))
   project_id: invalid-project
   region: us-east4
   zone: us-east4-c

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
@@ -29,10 +29,10 @@ vars:
   deployment_name: golden_copy_deployment
   labels:
     ghpc_blueprint: igc
-    ghpc_deployment: golden_copy_deployment
+    ghpc_deployment: ((var.deployment_name ))
   project_id: invalid-project
   region: us-east4
-  zone: us-east4-c
+  zone: (("${var.region}-c"))
 deployment_groups:
   - group: zero
     modules:

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
@@ -29,11 +29,11 @@ vars:
   deployment_name: golden_copy_deployment
   labels:
     ghpc_blueprint: merge_flatten
-    ghpc_deployment: golden_copy_deployment
+    ghpc_deployment: ((var.deployment_name ))
   project_id: invalid-project
-  region: us-east4
+  region: (("us-east${var.region_number}"))
   region_number: 4
-  zone: us-east4-c
+  zone: (("${var.region}-c"))
 deployment_groups:
   - group: zero
     modules:

--- a/tools/validate_configs/golden_copies/expectations/text_escape/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/.ghpc/artifacts/expanded_blueprint.yaml
@@ -27,10 +27,13 @@ validators:
     skip: true
 vars:
   deployment_name: golden_copy_deployment
-  labels:
-    ghpc_blueprint: text_escape
-    ghpc_deployment: golden_copy_deployment
-    ñred: ñblue
+  labels: |-
+    ((merge({
+      ghpc_blueprint  = "text_escape"
+      ghpc_deployment = var.deployment_name
+      }, {
+      ñred = "ñblue"
+    })))
   project_id: invalid-project
   zone: us-east4-c
 deployment_groups:


### PR DESCRIPTION
**Goal:** don't perform any evaluations during `expand` stage.
Only items left evaluated during expand stage are:
* `deployment_name` - to be considered in future designs.
* validators configs - TBD.

**Motivation**: Preparation to introduce "unknown" (during expand) values,  e.g. `deployment_name` or `ghpc_stage`.

Positive side effect: 
* expanded blueprint doesn't wipes out original expressions;
* no need to store "original vars" in state.