### PR TITLE
Add "submit" option to batch-job-template module

### DIFF
--- a/examples/serverless-batch.yaml
+++ b/examples/serverless-batch.yaml
@@ -35,28 +35,22 @@ deployment_groups:
     use: [network1]
     settings: {local_mount: /sw}
 
-  - id: load-data-startup
-    source: modules/scripts/startup-script
-    settings:
-      runners:
-      - type: shell
-        destination: generate_hello.sh
-        content: |
-          #!/bin/sh
-          echo "Hello World" > /sw/hello.txt
-
   - id: batch-job
     source: modules/scheduler/batch-job-template
     use: [network1, appfs]
     settings:
-      runnable: "cat /sw/hello.txt"
+      runnable: |
+        mkdir -p /sw/$BATCH_JOB_UID
+        echo "Hello World from task $BATCH_TASK_INDEX" > /sw/$BATCH_JOB_UID/$BATCH_TASK_INDEX.txt
       machine_type: n2-standard-4
+      task_count: 8
+      task_count_per_node: 4
       instance_image:
         family: batch-centos-7-official
         project: batch-custom-image
+      submit: true
 
   - id: batch-login
     source: modules/scheduler/batch-login-node
     use: [batch-job]
-    settings: {startup_script: $(load-data-startup.startup_script)}
     outputs: [instructions]

--- a/examples/serverless-batch.yaml
+++ b/examples/serverless-batch.yaml
@@ -48,7 +48,6 @@ deployment_groups:
       instance_image:
         family: batch-centos-7-official
         project: batch-custom-image
-      submit: true
 
   - id: batch-login
     source: modules/scheduler/batch-login-node

--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -123,12 +123,14 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
 
@@ -142,6 +144,8 @@ limitations under the License.
 | Name | Type |
 |------|------|
 | [local_file.job_template](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [local_file.submit_script](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [null_resource.submit_job](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
 
@@ -167,6 +171,7 @@ limitations under the License.
 | <a name="input_runnable"></a> [runnable](#input\_runnable) | A string to be executed as the main workload of the Google Cloud Batch job. This will be used to populate the generated template. | `string` | `"## Add your workload here"` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the Google Cloud Batch compute node. Ignored if `instance_template` is provided. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | <pre>{<br>  "email": null,<br>  "scopes": [<br>    "https://www.googleapis.com/auth/devstorage.read_only",<br>    "https://www.googleapis.com/auth/logging.write",<br>    "https://www.googleapis.com/auth/monitoring.write",<br>    "https://www.googleapis.com/auth/servicecontrol",<br>    "https://www.googleapis.com/auth/service.management.readonly",<br>    "https://www.googleapis.com/auth/trace.append"<br>  ]<br>}</pre> | no |
 | <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script run before Google Cloud Batch job starts. Ignored if `instance_template` is provided. | `string` | `null` | no |
+| <a name="input_submit"></a> [submit](#input\_submit) | When set to true, the generated job file will be submitted automatically to Google Cloud as part of terraform apply. | `bool` | `false` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | The subnetwork that the Batch job should run on. Defaults to 'default' subnet. Ignored if `instance_template` is provided. | `any` | `null` | no |
 | <a name="input_task_count"></a> [task\_count](#input\_task\_count) | Number of parallel tasks | `number` | `1` | no |
 | <a name="input_task_count_per_node"></a> [task\_count\_per\_node](#input\_task\_count\_per\_node) | Max number of tasks that can be run on a VM at the same time. If not specified, Batch will decide a value. | `number` | `null` | no |

--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -46,9 +46,9 @@ locals {
   submit_script_contents = templatefile(
     "${path.module}/templates/batch-submit.sh.tftpl",
     {
-      project = var.project_id
+      project  = var.project_id
       location = var.region
-      config = local_file.job_template.filename
+      config   = local_file.job_template.filename
     }
   )
   submit_script_output_path = "${path.root}/submit-job.sh"
@@ -106,13 +106,13 @@ resource "local_file" "job_template" {
 }
 
 resource "local_file" "submit_script" {
-  content = local.submit_script_contents
+  content  = local.submit_script_contents
   filename = local.submit_script_output_path
 }
 
 resource "null_resource" "submit_job" {
-  depends_on = [ local_file.job_template ]
-  count = var.submit ? 1 : 0
+  depends_on = [local_file.job_template]
+  count      = var.submit ? 1 : 0
 
   # A new deployment should always submit a new job. Old finished jobs aren't persistent parts of
   # Cloud infrastructure.

--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -43,6 +43,16 @@ locals {
   job_filename             = var.job_filename != null ? var.job_filename : "cloud-batch-${local.job_id}.yaml"
   job_template_output_path = "${path.root}/${local.job_filename}"
 
+  submit_script_contents = templatefile(
+    "${path.module}/templates/batch-submit.sh.tftpl",
+    {
+      project = var.project_id
+      location = var.region
+      config = local_file.job_template.filename
+    }
+  )
+  submit_script_output_path = "${path.root}/submit-job.sh"
+
   subnetwork_name    = var.subnetwork != null ? var.subnetwork.name : "default"
   subnetwork_project = var.subnetwork != null ? var.subnetwork.project : var.project_id
 
@@ -93,4 +103,24 @@ module "instance_template" {
 resource "local_file" "job_template" {
   content  = local.job_template_contents
   filename = local.job_template_output_path
+}
+
+resource "local_file" "submit_script" {
+  content = local.submit_script_contents
+  filename = local.submit_script_output_path
+}
+
+resource "null_resource" "submit_job" {
+  depends_on = [ local_file.job_template ]
+  count = var.submit ? 1 : 0
+
+  # A new deployment should always submit a new job. Old finished jobs aren't persistent parts of
+  # Cloud infrastructure.
+  triggers = {
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = local.submit_script_output_path
+  }
 }

--- a/modules/scheduler/batch-job-template/templates/batch-submit.sh.tftpl
+++ b/modules/scheduler/batch-job-template/templates/batch-submit.sh.tftpl
@@ -1,0 +1,8 @@
+#!/bin/bash
+GCLOUD_MAJOR_VERSION=$(gcloud --version | head -n 1 | awk '{print $NF}' | cut -f1 --delimiter=.)
+if [ $((GCLOUD_MAJOR_VERSION >= 461)) ]; then
+    gcloud batch jobs submit --project=${project} --location=${location} --config=${config}
+else
+    echo "gcloud must be updated to version 461.0.0 or later."
+    exit 1
+fi

--- a/modules/scheduler/batch-job-template/variables.tf
+++ b/modules/scheduler/batch-job-template/variables.tf
@@ -217,6 +217,6 @@ variable "on_host_maintenance" {
 
 variable "submit" {
   description = "When set to true, the generated job file will be submitted automatically to Google Cloud as part of terraform apply."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/modules/scheduler/batch-job-template/variables.tf
+++ b/modules/scheduler/batch-job-template/variables.tf
@@ -214,3 +214,9 @@ variable "on_host_maintenance" {
     error_message = "When set, the on_host_maintenance must be set to MIGRATE or TERMINATE."
   }
 }
+
+variable "submit" {
+  description = "When set to true, the generated job file will be submitted automatically to Google Cloud as part of terraform apply."
+  type = bool
+  default = false
+}

--- a/modules/scheduler/batch-job-template/versions.tf
+++ b/modules/scheduler/batch-job-template/versions.tf
@@ -16,6 +16,10 @@
 
 terraform {
   required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
     local = {
       source  = "hashicorp/local"
       version = ">= 2.0.0"


### PR DESCRIPTION
Adds an option "submit" (default false) that causes the deployment to actually submit the job from the generated template, instead of merely creating the template file.

Also changes the serverless-batch hello world example to use submit: true and write a few files to the Filestore. The login node from that example no longer generates a file to read, but the user could log in to the login node and read the files generated by the Batch job.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
