### PR TITLE
Show hint message if unsupported function is used

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -949,7 +949,7 @@ func (s *zeroSuite) TestEvalVars(c *C) {
 		_, err := (&Blueprint{Vars: vars}).evalVars()
 		var berr BpError
 		if errors.As(err, &berr) {
-			c.Check(berr.Error(), Matches, ".*no function.*DoesHalt.*")
+			c.Check(berr.Error(), Matches, ".*unsupported function.*DoesHalt.*")
 			c.Check(berr.Path.String(), Equals, "vars.uro")
 		} else {
 			c.Error(err, " should be BpError")


### PR DESCRIPTION

![Screenshot 2024-02-06 at 4 51 35 PM](https://github.com/GoogleCloudPlatform/hpc-toolkit/assets/1387442/50b72d6a-ca3e-4dca-8699-f51ad155c184)

**Context:**
Currently we have a few contexts that got evaluated by ghpc:
* `vars`;
* `module.settings` in packer groups;
* `validators.input` Our evaluation context only supports 2 functions: `merge` and `flatten`.

The rest of expressions (`module.settings` in TF groups) are not evaluated by ghpc => can use any valid HCL-syntax.
