### PR TITLE
Restrict GitHub actions to operate on upstream

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: github.repository == 'GoogleCloudPlatform/hpc-toolkit'
     runs-on: ubuntu-latest
     steps:
     - name: 'Checkout Repository'

--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -32,6 +32,7 @@ on:
 
 jobs:
   pr-label-validation:
+    if: github.repository == 'GoogleCloudPlatform/hpc-toolkit'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
The dependency license and PR label actions only need to run on the GoogleCloudPlatform copy of the HPC Toolkit. I have observed regular failures when I test pull requests in a fork. e.g.

https://github.com/tpdownes/hpc-toolkit/actions/runs/7818840918/job/21329927774

The above is not an "expected" failure of the check, but a permissions/configuration problem. I believe best approach is simply to not run the action unless it's aimed at our repository.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
