### PR TITLE
Don't run `destroy_resource_policies` before `destroy_nodes` is done

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -158,10 +158,15 @@ module "cleanup_compute_nodes" {
   project_id         = var.project_id
   when_destroy       = true
 
-  # Depend on controller network, as a best effort to avoid
-  # subnetwork resourceInUseByAnotherResource error
-  # NOTE: Can not use nodeset subnetworks as "A static list expression is required"
-  depends_on = [var.subnetwork_self_link]
+
+  depends_on = [
+    # Depend on controller network, as a best effort to avoid
+    # subnetwork resourceInUseByAnotherResource error
+    # NOTE: Can not use nodeset subnetworks as "A static list expression is required"
+    var.subnetwork_self_link,
+    # Ensure VMs are destroyed before resource policies
+    module.cleanup_resource_policies[0],
+  ]
 }
 
 


### PR DESCRIPTION
```sh
module.slurm_controller.module.cleanup_compute_nodes[0].null_resource.destroy_nodes_on_destroy[0]: Destruction complete after 2m52s
module.slurm_controller.module.cleanup_resource_policies[0].null_resource.destroy_resource_policies_on_destroy[0]: Destroying... [id=89627024760583747
65]
```

