### PR TITLE
Adopt empty string as default value for maintenance_interval

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
@@ -141,7 +141,7 @@ No modules.
 | <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Self link to a custom instance template. If set, other VM definition<br>variables such as machine\_type and instance\_image will be ignored in favor<br>of the provided instance template.<br><br>For more information on creating custom images for the instance template<br>that comply with Slurm on GCP see the "Slurm on GCP Custom Images" section<br>in docs/vm-images.md. | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to partition compute instances. Key-value pairs. | `map(string)` | `{}` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes. | `string` | `"c2-standard-60"` | no |
-| <a name="input_maintenance_interval"></a> [maintenance\_interval](#input\_maintenance\_interval) | Specifies the frequency of planned maintenance events. Must be unset (null) or "PERIODIC". | `string` | `null` | no |
+| <a name="input_maintenance_interval"></a> [maintenance\_interval](#input\_maintenance\_interval) | Specifies the frequency of planned maintenance events. Must be "PERIODIC" or empty string to not use this feature. | `string` | `""` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
 | <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the node group. | `string` | `"ghpc"` | no |

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
@@ -414,14 +414,14 @@ variable "additional_networks" {
 }
 
 variable "maintenance_interval" {
-  description = "Specifies the frequency of planned maintenance events. Must be unset (null) or \"PERIODIC\"."
-  default     = null
+  description = "Specifies the frequency of planned maintenance events. Must be \"PERIODIC\" or empty string to not use this feature."
+  default     = ""
   type        = string
-  nullable    = true
+  nullable    = false
 
   validation {
-    condition     = var.maintenance_interval == null || var.maintenance_interval == "PERIODIC"
-    error_message = "var.maintenance_interval must be unset (null) or set to \"PERIODIC\""
+    condition     = contains(["", "PERIODIC"], var.maintenance_interval)
+    error_message = "var.maintenance_interval must be the empty string or \"PERIODIC\""
   }
 }
 

--- a/tools/validate_configs/test_configs/node-groups.yaml
+++ b/tools/validate_configs/test_configs/node-groups.yaml
@@ -139,7 +139,7 @@ deployment_groups:
         instance_template: null
         labels: $(vars.labels)
         machine_type: n2-standard-16
-        maintenance_interval: null
+        maintenance_interval: ""
         metadata: {}
         min_cpu_platform: null
         on_host_maintenance: TERMINATE


### PR DESCRIPTION
The default value of null cannot be set as a deployment variable; this
will allow the value to be set at the top of a blueprint with a comment to the
user to modify to "PERIODIC" as necessary.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
