### PR TITLE
Slurm6. more validations around `static/exclusive/placement/reservation`

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -24,4 +24,12 @@ output "nodeset" {
     ], "${substr(var.machine_type, 0, 3)}:${var.disk_type}")
     error_message = "A disk_type=${var.disk_type} cannot be used with machine_type=${var.machine_type}."
   }
+
+  precondition {
+    condition     = (var.reservation_name == null) || !var.enable_placement
+    error_message = <<-EOD
+      If reservation is specified, `var.enable_placement` must be `false`.
+      If the specified reservation has a placement policy then it will be used automatically.
+    EOD
+  }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/main.tf
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 locals {
-
-  use_placement = [for ns in var.nodeset : ns.nodeset_name if ns.enable_placement]
+  non_static_ns_with_placement = [for ns in var.nodeset : ns.nodeset_name if ns.enable_placement && ns.node_count_static == 0]
+  use_static                   = [for ns in concat(var.nodeset, var.nodeset_tpu) : ns.nodeset_name if ns.node_count_static > 0]
 
   partition = {
     default               = var.is_default

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/outputs.tf
@@ -18,18 +18,16 @@ output "partitions" {
   value = [local.partition]
 
   precondition {
-    condition     = (length(local.use_placement) == 0) || var.exclusive
-    error_message = "If any nodeset `enable_placement`, `var.exclusive` must be set true"
+    condition     = (length(local.non_static_ns_with_placement) == 0) || var.exclusive
+    error_message = "If any non-static nodesets has `enable_placement`, `var.exclusive` must be set true"
   }
 
   precondition {
-    condition     = (length(local.use_placement) == 0) || contains(["NO", "Exclusive"], lookup(var.partition_conf, "Oversubscribe", "NO"))
-    error_message = "If any nodeset `enable_placement`, var.partition_conf[\"Oversubscribe\"] should be either undefined, \"NO\", or \"Exclusive\"."
-  }
-
-  precondition {
-    condition     = (length(local.use_placement) == 0) || (lookup(var.partition_conf, "SuspendTime", null) == null)
-    error_message = "If any nodeset `enable_placement`, var.partition_conf[\"SuspendTime\"] should be undefined."
+    condition     = (length(local.use_static) == 0) || !var.exclusive
+    error_message = <<-EOD
+    Can't use static nodes within partition with `var.exclusive` set to `true`.
+    NOTE: Partition's `var.exclusive` is set to `true` by default. Set it to `false` explicitly to use static nodes.
+    EOD
   }
 }
 


### PR DESCRIPTION
* Prevent usage of `static_nodes` and `exclusive` together
* Validate `enable_placement -> exclusive`
* Validate `reservation -> !enable_placement`

