### PR TITLE
Initial implementation of deployment file flag

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -102,14 +102,14 @@ func (s *MySuite) TestSetBackendConfig(c *C) {
 }
 
 func (s *MySuite) TestMergeDeploymentSettings(c *C) {
-	ds := config.DeploymentSettings{
+	ds1 := config.DeploymentSettings{
 		Vars: config.NewDict(map[string]cty.Value{
 			"project_id":      cty.StringVal("ds_test_project_id"),
 			"deployment_name": cty.StringVal("ds_deployment_name"),
 		}),
 	}
 
-	bp := config.Blueprint{
+	bp1 := config.Blueprint{
 		Vars: config.NewDict(map[string]cty.Value{
 			"project_id":  cty.StringVal("bp_test_project_id"),
 			"example_var": cty.StringVal("bp_example_value"),
@@ -117,25 +117,25 @@ func (s *MySuite) TestMergeDeploymentSettings(c *C) {
 	}
 
 	// test priority-based merging of deployment variables
-	mergeDeploymentSettings(&bp, ds)
-	c.Check(bp.Vars.Items(), DeepEquals, map[string]cty.Value{
+	mergeDeploymentSettings(&bp1, ds1)
+	c.Check(bp1.Vars.Items(), DeepEquals, map[string]cty.Value{
 		"project_id":      cty.StringVal("ds_test_project_id"),
 		"deployment_name": cty.StringVal("ds_deployment_name"),
 		"example_var":     cty.StringVal("bp_example_value"),
 	})
 
 	// check merging zero-value backends
-	ds = config.DeploymentSettings{
+	ds2 := config.DeploymentSettings{
 		TerraformBackendDefaults: config.TerraformBackend{},
 	}
-	bp = config.Blueprint{
+	bp2 := config.Blueprint{
 		TerraformBackendDefaults: config.TerraformBackend{},
 	}
-	mergeDeploymentSettings(&bp, ds)
-	c.Check(bp.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{})
+	mergeDeploymentSettings(&bp2, ds2)
+	c.Check(bp2.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{})
 
 	// check keeping blueprint defined backend with no backend in deployment file
-	bp = config.Blueprint{
+	bp3 := config.Blueprint{
 		TerraformBackendDefaults: config.TerraformBackend{
 			Type: "gsc",
 			Configuration: config.NewDict(map[string]cty.Value{
@@ -143,8 +143,8 @@ func (s *MySuite) TestMergeDeploymentSettings(c *C) {
 			}),
 		},
 	}
-	mergeDeploymentSettings(&bp, ds)
-	c.Check(bp.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{
+	mergeDeploymentSettings(&bp3, ds2)
+	c.Check(bp3.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{
 		Type: "gsc",
 		Configuration: config.NewDict(map[string]cty.Value{
 			"bucket": cty.StringVal("bp_bucket"),
@@ -152,7 +152,7 @@ func (s *MySuite) TestMergeDeploymentSettings(c *C) {
 	})
 
 	// check overriding blueprint defined backend with deployment file
-	ds = config.DeploymentSettings{
+	ds3 := config.DeploymentSettings{
 		TerraformBackendDefaults: config.TerraformBackend{
 			Type: "gsc",
 			Configuration: config.NewDict(map[string]cty.Value{
@@ -160,8 +160,8 @@ func (s *MySuite) TestMergeDeploymentSettings(c *C) {
 			}),
 		},
 	}
-	mergeDeploymentSettings(&bp, ds)
-	c.Check(bp.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{
+	mergeDeploymentSettings(&bp3, ds3)
+	c.Check(bp3.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{
 		Type: "gsc",
 		Configuration: config.NewDict(map[string]cty.Value{
 			"bucket": cty.StringVal("ds_bucket"),

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -26,6 +26,10 @@ func init() {
 	cobra.CheckErr(expandCmd.Flags().MarkDeprecated("config",
 		"please see the command usage for more details."))
 
+	deploymentFileFlag := "deployment-file"
+	expandCmd.Flags().StringVarP(&deploymentFile, deploymentFileFlag, "d", "",
+		"Toolkit Deployment File.")
+	expandCmd.Flags().MarkHidden(deploymentFileFlag)
 	expandCmd.Flags().StringVarP(&outputFilename, "out", "o", "expanded.yaml",
 		"Output file for the expanded HPC Environment Definition.")
 	expandCmd.Flags().StringSliceVar(&cliVariables, "vars", nil, msgCLIVars)
@@ -48,7 +52,7 @@ var (
 )
 
 func runExpandCmd(cmd *cobra.Command, args []string) {
-	dc := expandOrDie(args[0])
+	dc := expandOrDie(args[0], deploymentFile)
 	checkErr(dc.ExportBlueprint(outputFilename))
 	logging.Info(boldGreen("Expanded Environment Definition created successfully, saved as %s."), outputFilename)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -252,6 +252,12 @@ type Blueprint struct {
 	origVars Dict
 }
 
+// DeploymentSettings are deployment-specific override settings
+type DeploymentSettings struct {
+	TerraformBackendDefaults TerraformBackend `yaml:"terraform_backend_defaults,omitempty"`
+	Vars                     Dict
+}
+
 // DeploymentConfig is a container for the imported YAML data and supporting data for
 // creating the blueprint from it
 type DeploymentConfig struct {
@@ -376,6 +382,14 @@ func NewDeploymentConfig(configFilename string) (DeploymentConfig, YamlCtx, erro
 		bp.ValidationLevel = ValidationError
 	}
 	return DeploymentConfig{Config: bp}, ctx, nil
+}
+
+func NewDeploymentSettings(deploymentFilename string) (DeploymentSettings, YamlCtx, error) {
+	depl, ctx, err := importDeploymentFile(deploymentFilename)
+	if err != nil {
+		return DeploymentSettings{}, ctx, err
+	}
+	return depl, ctx, nil
 }
 
 // ExportBlueprint exports the internal representation of a blueprint config

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -74,6 +74,26 @@ func importBlueprint(f string) (Blueprint, YamlCtx, error) {
 	return bp, yamlCtx, nil
 }
 
+func importDeploymentFile(f string) (DeploymentSettings, YamlCtx, error) {
+	data, err := os.ReadFile(f)
+	if err != nil {
+		return DeploymentSettings{}, YamlCtx{}, fmt.Errorf("%s, filename=%s: %v", errMsgFileLoadError, f, err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+
+	yamlCtx, err := NewYamlCtx(data)
+	if err != nil { // YAML parsing error
+		return DeploymentSettings{}, yamlCtx, err
+	}
+
+	var depl DeploymentSettings
+	if err = decoder.Decode(&depl); err != nil {
+		return DeploymentSettings{}, yamlCtx, parseYamlV3Error(err)
+	}
+	return depl, yamlCtx, nil
+}
+
 // YamlCtx is a contextual information to render errors.
 type YamlCtx struct {
 	pathToPos map[yPath]Pos

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -54,17 +54,25 @@ type Pos struct {
 	Column int
 }
 
-func importBlueprint(f string) (Blueprint, YamlCtx, error) {
+func readYaml(f string) (*yaml.Decoder, YamlCtx, error) {
 	data, err := os.ReadFile(f)
 	if err != nil {
-		return Blueprint{}, YamlCtx{}, fmt.Errorf("%s, filename=%s: %v", errMsgFileLoadError, f, err)
+		return &yaml.Decoder{}, YamlCtx{}, fmt.Errorf("%s, filename=%s: %v", errMsgFileLoadError, f, err)
 	}
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 
 	yamlCtx, err := NewYamlCtx(data)
 	if err != nil { // YAML parsing error
-		return Blueprint{}, yamlCtx, err
+		return &yaml.Decoder{}, yamlCtx, err
+	}
+	return decoder, yamlCtx, nil
+}
+
+func importBlueprint(f string) (Blueprint, YamlCtx, error) {
+	decoder, yamlCtx, err := readYaml(f)
+	if err != nil {
+		return Blueprint{}, YamlCtx{}, err
 	}
 
 	var bp Blueprint
@@ -75,16 +83,9 @@ func importBlueprint(f string) (Blueprint, YamlCtx, error) {
 }
 
 func importDeploymentFile(f string) (DeploymentSettings, YamlCtx, error) {
-	data, err := os.ReadFile(f)
+	decoder, yamlCtx, err := readYaml(f)
 	if err != nil {
-		return DeploymentSettings{}, YamlCtx{}, fmt.Errorf("%s, filename=%s: %v", errMsgFileLoadError, f, err)
-	}
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
-
-	yamlCtx, err := NewYamlCtx(data)
-	if err != nil { // YAML parsing error
-		return DeploymentSettings{}, yamlCtx, err
+		return DeploymentSettings{}, YamlCtx{}, err
 	}
 
 	var depl DeploymentSettings


### PR DESCRIPTION
From a secondary "deployment" file, implement

- merging deployment variables
- overriding Terraform backend defaults

Mark the flag hidden from the output of help menus. Does not yet implement validation level override or line/position error reporting.

To use, begin by defining a "deployment file":

```yaml
vars:
  project_id: a-project-that-exists

terraform_backend_defaults:
  type: gcs
  configuration:
    bucket: a-bucket-that-exists
```

And run

```shell
ghpc create -d deployment.yaml blueprint.yaml
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
