### PR TITLE
Disable enable_devel in slurm-gcp v5 examples

### DIFF
--- a/community/examples/hpc-slurm-chromedesktop.yaml
+++ b/community/examples/hpc-slurm-chromedesktop.yaml
@@ -17,7 +17,6 @@
 blueprint_name: slurm-crd
 
 vars:
-  enable_devel: true
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: slurm-crd-01
   region: us-central1

--- a/community/examples/hpc-slurm-local-ssd.yaml
+++ b/community/examples/hpc-slurm-local-ssd.yaml
@@ -17,7 +17,6 @@
 blueprint_name: hpc-slurm-local-ssd
 
 vars:
-  enable_devel: true
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: hpc-localssd
   region: us-central1

--- a/community/examples/hpc-slurm-ramble-gromacs.yaml
+++ b/community/examples/hpc-slurm-ramble-gromacs.yaml
@@ -17,7 +17,6 @@
 blueprint_name: hpc-slurm-ramble-gromacs
 
 vars:
-  enable_devel: true
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: hpc-slurm-ramble-gromacs
   region: us-central1

--- a/community/examples/hpc-slurm-ubuntu2004.yaml
+++ b/community/examples/hpc-slurm-ubuntu2004.yaml
@@ -17,7 +17,6 @@
 blueprint_name: hpc-slurm-ubuntu2004
 
 vars:
-  enable_devel: true
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: slurm-gcp-v5
   region: us-west4

--- a/community/examples/htc-slurm.yaml
+++ b/community/examples/htc-slurm.yaml
@@ -23,7 +23,6 @@
 blueprint_name: htc-slurm
 
 vars:
-  enable_devel: true
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: htc-slurm
   region: us-west4

--- a/community/examples/tutorial-starccm-slurm.yaml
+++ b/community/examples/tutorial-starccm-slurm.yaml
@@ -17,7 +17,6 @@
 blueprint_name: starccm-on-slurm
 
 vars:
-  enable_devel: true
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: starccm-slurm
   region: us-central1

--- a/examples/cae/cae-slurm.yaml
+++ b/examples/cae/cae-slurm.yaml
@@ -28,7 +28,6 @@
 #
 blueprint_name: cae-slurm
 vars:
-  enable_devel: true
   project_id: ## Set GCP Project ID Here ##
   deployment_name: cae-slurm
   # check here for other regions with H3 deployments: https://cloud.google.com/compute/docs/regions-zones

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -17,7 +17,6 @@
 blueprint_name: hpc-enterprise-slurm
 
 vars:
-  enable_devel: true
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: hpc01
   region: us-central1

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -21,7 +21,6 @@
 blueprint_name: image-builder
 
 vars:
-  enable_devel: true
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: image-builder-001
   region: us-central1

--- a/examples/ml-slurm.yaml
+++ b/examples/ml-slurm.yaml
@@ -16,7 +16,6 @@
 blueprint_name: ml-slurm
 
 vars:
-  enable_devel: true
   project_id:  ## Set project id here
   deployment_name: ml-example
   region: asia-southeast1


### PR DESCRIPTION
#2189 unintentionally left enable_devel enabled in the final merge, although it was necessary in an early stage of review. This commit reverts that change now that an image based upon 5.10.2 has been published.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
