### PR TITLE
Initialize tflint with GitHub authentication token to avoid rate limiting

### DIFF
--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -44,6 +44,10 @@ jobs:
     - uses: terraform-linters/setup-tflint@v4
       with:
         tflint_version: v0.49.0
+    - run: tflint --init
+      env:
+        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
     - uses: pre-commit/action@v3.0.1
     - uses: pre-commit-ci/lite-action@v1.0.2
       # this if statement looks funny but it ensures that this step runs


### PR DESCRIPTION
This job failed:

- https://github.com/GoogleCloudPlatform/hpc-toolkit/actions/runs/7870801057/job/21472762538?pr=2229

Which led me to this recommended usage in the documentation:

- https://github.com/terraform-linters/setup-tflint/tree/2520cd5f9ca0476e1d33a08f9e13cadce84a6ea5?tab=readme-ov-file#usage

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
