### PR TITLE
Align local provider usage in startup-script with rest of Toolkit

### DIFF
--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -255,7 +255,7 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0, < 2.2.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
@@ -263,7 +263,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
-| <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0, < 2.2.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.0.0, < 2.2.0"
+      version = ">= 2.0.0"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
This commit effectively reverts 824a2397b8a5f4bfe64d70df6b1c339fec353115 whose underlying issue was long ago resolved. This ensures that the startup-script module uses the latest release of the local provider (like the rest of the Toolkit modules)

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
