### PR TITLE
Fix typo in lustre-slurm integration test blueprint

### DIFF
--- a/tools/cloud-build/daily-tests/blueprints/lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-slurm.yaml
@@ -26,6 +26,9 @@ vars:
   # enable_placement: false
   # on_host_maintenance: MIGRATE
   num_nodes: 1
+  centos_image:
+    family: slurm-gcp-5-10-hpc-centos-7
+    project: schedmd-slurm-public
   rocky_image:
     family: slurm-gcp-5-10-hpc-rocky-linux-8
     project: schedmd-slurm-public
@@ -87,7 +90,6 @@ deployment_groups:
   #     instance_image:
   #       family: slurm-gcp-5-10-ubuntu-2004-lts
   #       project: schedmd-slurm-public
-  #     instance_image_custom: true
 
   # - id: ubuntu_partition
   #   source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -104,7 +106,6 @@ deployment_groups:
     settings:
       node_count_dynamic_max: $(vars.num_nodes)
       instance_image: $(vars.rocky_image)
-      instance_image_custom: true
 
   - id: rocky_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition
@@ -120,8 +121,7 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: $(vars.num_nodes)
-      instance_image: $(vars.rocky_image)
-      instance_image_custom: true
+      instance_image: $(vars.centos_image)
 
   - id: centos_partition
     source: community/modules/compute/schedmd-slurm-gcp-v5-partition


### PR DESCRIPTION
Fixing 2 errors in the lustre-slurm integration test:

- no need to set instance_image_custom
- CentOS partition accidentally testing Rocky 8

Marking do not merge since base branch of PR is release-candidate. Should discuss and agree before merging. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
