### PR TITLE
Modify cloud-storage-bucket to include ability to set bucket viewers

### DIFF
--- a/community/modules/file-system/cloud-storage-bucket/README.md
+++ b/community/modules/file-system/cloud-storage-bucket/README.md
@@ -127,6 +127,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_storage_bucket.bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_binding.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
@@ -143,6 +144,7 @@ No modules.
 | <a name="input_random_suffix"></a> [random\_suffix](#input\_random\_suffix) | If true, a random id will be appended to the suffix of the bucket name. | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region to deploy to | `string` | n/a | yes |
 | <a name="input_use_deployment_name_in_bucket_name"></a> [use\_deployment\_name\_in\_bucket\_name](#input\_use\_deployment\_name\_in\_bucket\_name) | If true, the deployment name will be included as part of the bucket name. This helps prevent naming clashes across multiple deployments. | `bool` | `true` | no |
+| <a name="input_viewers"></a> [viewers](#input\_viewers) | A list of additional accounts that can read packages from this bucket | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/community/modules/file-system/cloud-storage-bucket/main.tf
+++ b/community/modules/file-system/cloud-storage-bucket/main.tf
@@ -42,3 +42,9 @@ resource "google_storage_bucket" "bucket" {
   labels                      = local.labels
   force_destroy               = var.force_destroy
 }
+
+resource "google_storage_bucket_iam_binding" "viewers" {
+  bucket  = google_storage_bucket.bucket.name
+  role    = "roles/storage.objectViewer"
+  members = var.viewers
+}

--- a/community/modules/file-system/cloud-storage-bucket/variables.tf
+++ b/community/modules/file-system/cloud-storage-bucket/variables.tf
@@ -69,3 +69,16 @@ variable "force_destroy" {
   type        = bool
   default     = false
 }
+
+variable "viewers" {
+  description = "A list of additional accounts that can read packages from this bucket"
+  type        = set(string)
+  default     = []
+
+  validation {
+    error_message = "All bucket viewers must be in IAM style: user:user@example.com, serviceAccount:sa@example.com, or group:group@example.com."
+    condition = alltrue([
+      for viewer in var.viewers : length(regexall("^(user|serviceAccount|group):", viewer)) > 0
+    ])
+  }
+}


### PR DESCRIPTION
Creation of a bucket without any viewers implies project-wide assignment of roles, which is often seen as a security risk in enterprise environments. This adds the ability to grant viewer ("read") access to a service account (or user, group) to the specific bucket being created.


### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
