### PR TITLE
Update to Slurm-GCP 5.10.4

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/variables.tf
@@ -15,7 +15,7 @@
  */
 
 # Most variables have been sourced and modified from the SchedMD/slurm-gcp
-# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 
 variable "project_id" {
   description = "Project in which the HPC deployment will be created."

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition-dynamic/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition-dynamic/README.md
@@ -69,7 +69,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_slurm_partition"></a> [slurm\_partition](#module\_slurm\_partition) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition | 5.10.2 |
+| <a name="module_slurm_partition"></a> [slurm\_partition](#module\_slurm\_partition) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition | 5.10.4 |
 
 ## Resources
 

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition-dynamic/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition-dynamic/main.tf
@@ -29,7 +29,7 @@ locals {
 }
 
 module "slurm_partition" {
-  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition?ref=5.10.2"
+  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition?ref=5.10.4"
 
   slurm_cluster_name   = local.slurm_cluster_name
   enable_job_exclusive = var.exclusive

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition-dynamic/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition-dynamic/variables.tf
@@ -15,7 +15,7 @@
  */
 
 # Most variables have been sourced and modified from the SchedMD/slurm-gcp
-# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 
 variable "deployment_name" {
   description = "Name of the deployment."

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
@@ -146,7 +146,7 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_slurm_partition"></a> [slurm\_partition](#module\_slurm\_partition) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition | 5.10.2 |
+| <a name="module_slurm_partition"></a> [slurm\_partition](#module\_slurm\_partition) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition | 5.10.4 |
 
 ## Resources
 

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
@@ -38,7 +38,7 @@ data "google_compute_zones" "available" {
 }
 
 module "slurm_partition" {
-  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition?ref=5.10.2"
+  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_partition?ref=5.10.4"
 
   slurm_cluster_name                = local.slurm_cluster_name
   partition_nodes                   = var.node_groups

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/variables.tf
@@ -15,7 +15,7 @@
  */
 
 # Most variables have been sourced and modified from the SchedMD/slurm-gcp
-# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 
 variable "deployment_name" {
   description = "Name of the deployment."

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
@@ -17,14 +17,14 @@ controller for optimal performance at different scales.
 >
 > ```shell
 > # Install Python3 and run
-> pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.10.2/scripts/requirements.txt
+> pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.10.4/scripts/requirements.txt
 > ```
 
-[SchedMD/slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
-[slurm\_controller\_instance]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/terraform/slurm_cluster/modules/slurm_controller_instance
-[slurm\_instance\_template]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/terraform/slurm_cluster/modules/slurm_instance_template
+[SchedMD/slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
+[slurm\_controller\_instance]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/terraform/slurm_cluster/modules/slurm_controller_instance
+[slurm\_instance\_template]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/terraform/slurm_cluster/modules/slurm_instance_template
 [slurm-ug]: https://goo.gle/slurm-gcp-user-guide.
-[requirements.txt]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/scripts/requirements.txt
+[requirements.txt]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/scripts/requirements.txt
 [enable\_cleanup\_compute]: #input\_enable\_cleanup\_compute
 [enable\_cleanup\_subscriptions]: #input\_enable\_cleanup\_subscriptions
 [enable\_reconfigure]: #input\_enable\_reconfigure
@@ -94,12 +94,12 @@ This option has some additional requirements:
   development environment deploying the cluster. One can use following commands:
 
   ```bash
-  pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.10.2/scripts/requirements.txt
+  pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.10.4/scripts/requirements.txt
   ```
 
   For more information, see the [description][optdeps] of this module.
 
-[optdeps]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/terraform/slurm_cluster#optional
+[optdeps]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/terraform/slurm_cluster#optional
 
 ## Custom Images
 
@@ -215,8 +215,8 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_slurm_controller_instance"></a> [slurm\_controller\_instance](#module\_slurm\_controller\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_instance | 5.10.2 |
-| <a name="module_slurm_controller_template"></a> [slurm\_controller\_template](#module\_slurm\_controller\_template) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template | 5.10.2 |
+| <a name="module_slurm_controller_instance"></a> [slurm\_controller\_instance](#module\_slurm\_controller\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_instance | 5.10.4 |
+| <a name="module_slurm_controller_template"></a> [slurm\_controller\_template](#module\_slurm\_controller\_template) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template | 5.10.4 |
 
 ## Resources
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/main.tf
@@ -55,7 +55,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 module "slurm_controller_instance" {
-  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_instance?ref=5.10.2"
+  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_instance?ref=5.10.4"
 
   access_config                      = local.access_config
   slurm_cluster_name                 = local.slurm_cluster_name
@@ -92,7 +92,7 @@ module "slurm_controller_instance" {
 }
 
 module "slurm_controller_template" {
-  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=5.10.2"
+  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=5.10.4"
 
   additional_disks         = local.additional_disks
   can_ip_forward           = var.can_ip_forward

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/variables.tf
@@ -15,7 +15,7 @@
  */
 
 # Most variables have been sourced and modified from the SchedMD/slurm-gcp
-# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 
 variable "access_config" {
   description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
@@ -38,7 +38,7 @@ manually. This will require addition configuration and verification of
 permissions. For more information see the [hybrid.md] documentation on
 [slurm-gcp].
 
-[slurm-controller-hybrid]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/terraform/slurm_cluster/modules/slurm_controller_hybrid
+[slurm-controller-hybrid]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/terraform/slurm_cluster/modules/slurm_controller_hybrid
 
 > **_NOTE:_** The hybrid module requires the following dependencies to be
 > installed on the system deploying the module:
@@ -58,15 +58,15 @@ permissions. For more information see the [hybrid.md] documentation on
 [pyyaml]: https://pypi.org/project/PyYAML/
 [google-api-python-client]: https://pypi.org/project/google-api-python-client/
 [google-cloud-pubsub]: https://pypi.org/project/google-cloud-pubsub/
-[requirements.txt]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/scripts/requirements.txt
+[requirements.txt]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/scripts/requirements.txt
 
 ### Manual Configuration
 This module *does not* complete the installation of hybrid partitions on your
 slurm cluster. After deploying, you must follow the steps listed out in the
 [hybrid.md] documentation under [manual steps].
 
-[hybrid.md]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/docs/hybrid.md
-[manual steps]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/docs/hybrid.md#manual-configurations
+[hybrid.md]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/docs/hybrid.md
+[manual steps]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/docs/hybrid.md#manual-configurations
 
 ### Example Usage
 The hybrid module can be added to a blueprint as follows:
@@ -146,10 +146,10 @@ strongly advise only using versions 21 or 22 when using this module. Attempting
 to use this module with any version older than 21 may lead to unexpected
 results.
 
-[slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+[slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 [pre-existing-network-storage]: ../../../../modules/file-system/pre-existing-network-storage/
 [schedmd-slurm-gcp-v5-partition]: ../../compute/schedmd-slurm-gcp-v5-partition/
-[packer templates]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/packer
+[packer templates]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/packer
 
 ## License
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -181,7 +181,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_slurm_controller_instance"></a> [slurm\_controller\_instance](#module\_slurm\_controller\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_hybrid | 5.10.2 |
+| <a name="module_slurm_controller_instance"></a> [slurm\_controller\_instance](#module\_slurm\_controller\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_hybrid | 5.10.4 |
 
 ## Resources
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/main.tf
@@ -28,7 +28,7 @@ locals {
 }
 
 module "slurm_controller_instance" {
-  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_hybrid?ref=5.10.2"
+  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_controller_hybrid?ref=5.10.4"
 
   project_id                      = var.project_id
   slurm_cluster_name              = local.slurm_cluster_name

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
@@ -5,9 +5,9 @@ This module creates a login node for a Slurm cluster based on the
 terraform modules. The login node is used in conjunction with the
 [Slurm controller](../schedmd-slurm-gcp-v5-controller/README.md).
 
-[SchedMD/slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
-[slurm\_login\_instance]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/terraform/slurm_cluster/modules/slurm_login_instance
-[slurm\_instance\_template]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/terraform/slurm_cluster/modules/slurm_instance_template
+[SchedMD/slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
+[slurm\_login\_instance]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/terraform/slurm_cluster/modules/slurm_login_instance
+[slurm\_instance\_template]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/terraform/slurm_cluster/modules/slurm_instance_template
 
 ### Example
 
@@ -46,8 +46,8 @@ The HPC Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
 modules. For support with the underlying modules, see the instructions in the
 [slurm-gcp README][slurm-gcp-readme].
 
-[slurm-on-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
-[slurm-gcp-readme]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2#slurm-on-google-cloud-platform
+[slurm-on-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
+[slurm-gcp-readme]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4#slurm-on-google-cloud-platform
 
 ## License
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -82,8 +82,8 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_slurm_login_instance"></a> [slurm\_login\_instance](#module\_slurm\_login\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_login_instance | 5.10.2 |
-| <a name="module_slurm_login_template"></a> [slurm\_login\_template](#module\_slurm\_login\_template) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template | 5.10.2 |
+| <a name="module_slurm_login_instance"></a> [slurm\_login\_instance](#module\_slurm\_login\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_login_instance | 5.10.4 |
+| <a name="module_slurm_login_template"></a> [slurm\_login\_template](#module\_slurm\_login\_template) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template | 5.10.4 |
 
 ## Resources
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/main.tf
@@ -50,7 +50,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 module "slurm_login_template" {
-  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=5.10.2"
+  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=5.10.4"
 
   additional_disks         = local.additional_disks
   can_ip_forward           = var.can_ip_forward
@@ -88,7 +88,7 @@ module "slurm_login_template" {
 }
 
 module "slurm_login_instance" {
-  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_login_instance?ref=5.10.2"
+  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_login_instance?ref=5.10.4"
 
   access_config         = local.access_config
   slurm_cluster_name    = local.slurm_cluster_name

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/variables.tf
@@ -15,7 +15,7 @@
  */
 
 # Most variables have been sourced and modified from the SchedMD/slurm-gcp
-# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+# github repository: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 
 variable "project_id" {
   type        = string

--- a/docs/hybrid-slurm-cluster/demo-with-cloud-controller-instructions.md
+++ b/docs/hybrid-slurm-cluster/demo-with-cloud-controller-instructions.md
@@ -22,7 +22,7 @@ for use with an on-premise slurm-cluster.
 > further testing is done, documentation on applying the hybrid module to
 > on-premise slurm clusters will be added and expanded.
 
-[slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+[slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 
 ## Definitions
 

--- a/docs/hybrid-slurm-cluster/deploy-instructions.md
+++ b/docs/hybrid-slurm-cluster/deploy-instructions.md
@@ -264,8 +264,8 @@ sudo systemctl restart slurmctld
 If the restart did not succeed, the logs at `/var/log/slurm/slurmctld.log`
 should point you in the right direction.
 
-[slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
-[slurm-gcp-hybrid]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/docs/hybrid.md
+[slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
+[slurm-gcp-hybrid]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/docs/hybrid.md
 [demo-with-cloud-controller-instructions.md]: ./demo-with-cloud-controller-instructions.md
 
 ## Validate the Hybrid Cluster

--- a/docs/hybrid-slurm-cluster/on-prem-instructions.md
+++ b/docs/hybrid-slurm-cluster/on-prem-instructions.md
@@ -39,9 +39,9 @@ detail, as well as how to customize many of these assumptions to fit your needs.
 deployments in their [hybrid.md] documentation.
 
 [hybridmodule]: ../../community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
-[slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+[slurm-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 [slurm\_controller\_hybrid]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/master/terraform/slurm_cluster/modules/slurm_controller_hybrid
-[hybrid.md]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/docs/hybrid.md
+[hybrid.md]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/docs/hybrid.md
 
 ### NFS Mounts
 
@@ -235,12 +235,12 @@ image created with slurm 21.08.8:
     partition_name: compute
 ```
 
-[slurmgcppacker]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/packer
-[example.pkrvars.hcl]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2/packer/example.pkrvars.hcl
-[slurmversion]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/packer/variables.pkr.hcl#L97
-[`service_account_scopes`]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/packer/variables.pkr.hcl#L166
-[`munge_user`]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/ansible/roles/munge/defaults/main.yml#L17
-[`slurm_user`]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.2/ansible/roles/slurm/defaults/main.yml#L31
+[slurmgcppacker]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/packer
+[example.pkrvars.hcl]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4/packer/example.pkrvars.hcl
+[slurmversion]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/packer/variables.pkr.hcl#L97
+[`service_account_scopes`]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/packer/variables.pkr.hcl#L166
+[`munge_user`]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/ansible/roles/munge/defaults/main.yml#L17
+[`slurm_user`]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5.10.4/ansible/roles/slurm/defaults/main.yml#L31
 
 ## On Premise Setup
 

--- a/docs/image-building.md
+++ b/docs/image-building.md
@@ -168,7 +168,7 @@ deployment_groups:
 - group: packer
   modules:
   - id: custom-image
-    source: github.com/GoogleCloudPlatform/slurm-gcp//packer?ref=5.10.2&depth=1
+    source: github.com/GoogleCloudPlatform/slurm-gcp//packer?ref=5.10.4&depth=1
     kind: packer
     settings:
       use_iap: true

--- a/examples/README.md
+++ b/examples/README.md
@@ -605,7 +605,7 @@ The blueprint contains 3 groups:
 >
 > ```shell
 > # Install Python3 and run
-> pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.10.2/scripts/requirements.txt
+> pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.10.4/scripts/requirements.txt
 > ```
 
 Similar to the [hpc-slurm.yaml] example, but using Ubuntu 20.04 instead of CentOS 7.

--- a/modules/README.md
+++ b/modules/README.md
@@ -212,7 +212,7 @@ Pub/Sub subscription. Primarily used for [FSI - MonteCarlo Tutorial][fsi-monteca
 [schedmd-slurm-gcp-v5-controller]: ../community/modules/scheduler/schedmd-slurm-gcp-v5-controller/README.md
 [schedmd-slurm-gcp-v5-login]: ../community/modules/scheduler/schedmd-slurm-gcp-v5-login/README.md
 [schedmd-slurm-gcp-v5-hybrid]: ../community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
-[slurm-gcp-version-5]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.2
+[slurm-gcp-version-5]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/5.10.4
 [slurm-gcp-version-6]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/6.2.0
 [pbspro-client]: ../community/modules/scheduler/pbspro-client/README.md
 [pbspro-server]: ../community/modules/scheduler/pbspro-server/README.md


### PR DESCRIPTION
Update Slurm-GCP v5 modules to tagged release 5.10.4. This should include no changes in the Terraform behavior but the latest images are based upon this release and, for good practices, we should align.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
