### PR TITLE
Refactor `validate & expand` phase to perform it "layer by layer".

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -31,14 +31,6 @@ const (
 	deploymentLabel string = "ghpc_deployment"
 )
 
-func validateInputsAllModules(bp Blueprint) error {
-	errs := Errors{}
-	bp.WalkModulesSafe(func(p ModulePath, m *Module) {
-		errs.Add(validateModuleInputs(p, *m, bp))
-	})
-	return errs.OrNil()
-}
-
 func validateModuleInputs(mp ModulePath, m Module, bp Blueprint) error {
 	mi := m.InfoOrDie()
 	errs := Errors{}
@@ -103,31 +95,77 @@ func validateModulesAreUsed(bp Blueprint) error {
 	return errs.OrNil()
 }
 
-func (dc *DeploymentConfig) expandBackends() {
-	// 1. DEFAULT: use TerraformBackend configuration (if supplied) in each
-	//    resource group
+func (bp *Blueprint) expandVars() error {
+	var err error
+	if err = validateVars(bp.Vars); err != nil {
+		return err
+	}
+
+	bp.origVars = NewDict(bp.Vars.Items()) // copy
+	bp.expandGlobalLabels()
+	bp.Vars, err = bp.evalVars()
+	return err
+}
+
+func (bp *Blueprint) expandGroups() error {
+	bp.addKindToModules()
+
+	if err := checkModulesAndGroups(*bp); err != nil {
+		return err
+	}
+
+	var errs Errors
+	for ig := range bp.DeploymentGroups {
+		errs.Add(bp.expandGroup(Root.Groups.At(ig), &bp.DeploymentGroups[ig]))
+	}
+
+	if errs.Any() {
+		return errs
+	}
+
+	// Following actions depend on whole blueprint being expanded
+	// run it after all groups are expanded
+	if err := validateModulesAreUsed(*bp); err != nil {
+		return err
+	}
+	bp.populateOutputs()
+	return nil
+}
+
+func (bp Blueprint) expandGroup(gp groupPath, g *DeploymentGroup) error {
+	var errs Errors
+	bp.expandBackend(g)
+	for im := range g.Modules {
+		errs.Add(bp.expandModule(gp.Modules.At(im), &g.Modules[im]))
+	}
+	return errs.OrNil()
+}
+
+func (bp Blueprint) expandModule(mp ModulePath, m *Module) error {
+	bp.applyUseModules(m)
+	bp.applyGlobalVarsInModule(m)
+	return validateModuleInputs(mp, *m, bp)
+}
+
+func (bp Blueprint) expandBackend(grp *DeploymentGroup) {
+	// 1. DEFAULT: use TerraformBackend configuration (if supplied)
 	// 2. If top-level TerraformBackendDefaults is defined, insert that
 	//    backend into resource groups which have no explicit
 	//    TerraformBackend
 	// 3. In all cases, add a prefix for GCS backends if one is not defined
-	bp := &dc.Config
 	defaults := bp.TerraformBackendDefaults
-	if defaults.Type != "" {
-		for i := range bp.DeploymentGroups {
-			grp := &bp.DeploymentGroups[i]
-			be := &grp.TerraformBackend
-			if be.Type == "" {
-				be.Type = defaults.Type
-				be.Configuration = Dict{}
-				for k, v := range defaults.Configuration.Items() {
-					be.Configuration.Set(k, v)
-				}
-			}
-			if be.Type == "gcs" && !be.Configuration.Has("prefix") {
-				prefix := fmt.Sprintf("%s/%s/%s", bp.BlueprintName, bp.DeploymentName(), grp.Name)
-				be.Configuration.Set("prefix", cty.StringVal(prefix))
-			}
-		}
+	if defaults.Type == "" {
+		return
+	}
+
+	be := &grp.TerraformBackend
+	if be.Type == "" {
+		be.Type = defaults.Type
+		be.Configuration = NewDict(defaults.Configuration.Items())
+	}
+	if be.Type == "gcs" && !be.Configuration.Has("prefix") {
+		prefix := fmt.Sprintf("%s/%s/%s", bp.BlueprintName, bp.DeploymentName(), grp.Name)
+		be.Configuration.Set("prefix", cty.StringVal(prefix))
 	}
 }
 
@@ -177,7 +215,7 @@ func useModule(mod *Module, use Module) {
 
 		// Skip settings that do not have matching module inputs
 		inputType, ok := modInputsMap[setting]
-		if !ok {
+		if !ok || setting == "labels" { // also do not "use" module labels
 			continue
 		}
 
@@ -205,82 +243,54 @@ func useModule(mod *Module, use Module) {
 
 // applyUseModules applies variables from modules listed in the "use" field
 // when/if applicable
-func (dc *DeploymentConfig) applyUseModules() error {
-	return dc.Config.WalkModules(func(_ ModulePath, m *Module) error {
-		for _, u := range m.Use {
-			used, err := dc.Config.Module(u)
-			if err != nil { // should never happen
-				return err
-			}
-			useModule(m, *used)
+func (bp Blueprint) applyUseModules(m *Module) error {
+	for _, u := range m.Use {
+		used, err := bp.Module(u)
+		if err != nil { // should never happen
+			panic(err)
 		}
-		return nil
-	})
+		useModule(m, *used)
+	}
+	return nil
 }
 
-func moduleHasInput(m Module, n string) bool {
-	for _, input := range m.InfoOrDie().Inputs {
-		if input.Name == n {
-			return true
-		}
-	}
-	return false
-}
+// expandGlobalLabels sets defaults for labels based on other variables.
+func (bp *Blueprint) expandGlobalLabels() {
+	vars := &bp.Vars
+	defaults := cty.ObjectVal(map[string]cty.Value{
+		blueprintLabel:  cty.StringVal(bp.BlueprintName),
+		deploymentLabel: GlobalRef("deployment_name").AsValue()})
 
-// combineLabels sets defaults for labels based on other variables and merges
-// the global labels defined in Vars with module setting labels.
-func (dc *DeploymentConfig) combineLabels() {
-	vars := &dc.Config.Vars
-	defaults := map[string]cty.Value{
-		blueprintLabel:  cty.StringVal(dc.Config.BlueprintName),
-		deploymentLabel: vars.Get("deployment_name"),
-	}
 	labels := "labels"
-	if !vars.Has(labels) { // Shouldn't happen if blueprint was properly constructed
-		vars.Set(labels, cty.EmptyObjectVal)
+	var gl cty.Value
+	if !vars.Has(labels) {
+		gl = defaults
+	} else {
+		gl = FunctionCallExpression("merge", defaults, vars.Get(labels)).AsValue()
 	}
-	gl := mergeMaps(defaults, vars.Get(labels).AsValueMap())
-	vars.Set(labels, cty.ObjectVal(gl))
-
-	dc.Config.WalkModulesSafe(func(_ ModulePath, mod *Module) {
-		combineModuleLabels(mod, *dc)
-	})
+	vars.Set(labels, gl)
 }
 
-func combineModuleLabels(mod *Module, dc DeploymentConfig) {
-	labels := "labels"
-	if !moduleHasInput(*mod, labels) {
-		return // no op
-	}
-
-	ref := GlobalRef(labels).AsValue()
-	set := mod.Settings.Get(labels)
+func combineModuleLabels(mod Module) cty.Value {
+	ref := GlobalRef("labels").AsValue()
+	set := mod.Settings.Get("labels")
 
 	if !set.IsNull() {
-		merged := FunctionCallExpression("merge", ref, set).AsValue()
-		mod.Settings.Set(labels, merged) // = merge(vars.labels, {...labels_from_settings...})
-	} else {
-		mod.Settings.Set(labels, ref) // = vars.labels
-	}
-}
+		// = merge(vars.labels, {...labels_from_settings...})
+		return FunctionCallExpression("merge", ref, set).AsValue()
 
-// mergeMaps takes an arbitrary number of maps, and returns a single map that contains
-// a merged set of elements from all arguments.
-// If more than one given map defines the same key, then the one that is later in the argument sequence takes precedence.
-// See https://developer.hashicorp.com/terraform/language/functions/merge
-func mergeMaps(ms ...map[string]cty.Value) map[string]cty.Value {
-	r := map[string]cty.Value{}
-	for _, m := range ms {
-		for k, v := range m {
-			r[k] = v
-		}
 	}
-	return r
+	return ref // = vars.labels
 }
 
 func (bp Blueprint) applyGlobalVarsInModule(mod *Module) {
 	mi := mod.InfoOrDie()
 	for _, input := range mi.Inputs {
+		if input.Name == "labels" && bp.Vars.Has("labels") {
+			// labels are special case, always make use of global labels
+			mod.Settings.Set("labels", combineModuleLabels(*mod))
+		}
+
 		// Module setting exists? Nothing more needs to be done.
 		if mod.Settings.Has(input.Name) {
 			continue
@@ -296,14 +306,6 @@ func (bp Blueprint) applyGlobalVarsInModule(mod *Module) {
 			mod.Settings.Set(input.Name, cty.StringVal(string(mod.ID)))
 		}
 	}
-}
-
-// applyGlobalVariables takes any variables defined at the global level and
-// applies them to module settings if not already set.
-func (dc *DeploymentConfig) applyGlobalVariables() {
-	dc.Config.WalkModulesSafe(func(_ ModulePath, m *Module) {
-		dc.Config.applyGlobalVarsInModule(m)
-	})
 }
 
 // AutomaticOutputName generates unique deployment-group-level output names

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/modulereader"
 
@@ -23,31 +22,58 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *MySuite) TestExpandBackends(c *C) {
-	dc := s.getDeploymentConfigForTest()
-	deplName := dc.Config.Vars.Get("deployment_name").AsString()
+func (s *zeroSuite) TestExpandBackend(c *C) {
+	type BE = TerraformBackend // alias for brevity
+	noDefBe := Blueprint{BlueprintName: "tree",
+		Vars: NewDict(map[string]cty.Value{
+			"deployment_name": cty.StringVal("bush")})}
 
-	dc.Config.TerraformBackendDefaults = TerraformBackend{Type: "gcs"}
-	dc.expandBackends()
-
-	grp := dc.Config.DeploymentGroups[0]
-	c.Assert(grp.TerraformBackend.Type, Not(Equals), "")
-	gotPrefix := grp.TerraformBackend.Configuration.Get("prefix")
-	expPrefix := fmt.Sprintf("%s/%s/%s", dc.Config.BlueprintName, deplName, grp.Name)
-	c.Assert(gotPrefix, Equals, cty.StringVal(expPrefix))
-
-	// Add a new resource group, ensure each group name is included
-	newGroup := DeploymentGroup{
-		Name: "group2",
+	{ // no def BE, no group BE
+		g := DeploymentGroup{Name: "clown"}
+		noDefBe.expandBackend(&g)
+		c.Check(g.TerraformBackend, DeepEquals, BE{})
 	}
-	dc.Config.DeploymentGroups = append(dc.Config.DeploymentGroups, newGroup)
-	dc.expandBackends()
 
-	newGrp := dc.Config.DeploymentGroups[1]
-	c.Assert(newGrp.TerraformBackend.Type, Not(Equals), "")
-	gotPrefix = newGrp.TerraformBackend.Configuration.Get("prefix")
-	expPrefix = fmt.Sprintf("%s/%s/%s", dc.Config.BlueprintName, deplName, newGrp.Name)
-	c.Assert(gotPrefix, Equals, cty.StringVal(expPrefix))
+	{ // no def BE, group BE
+		g := DeploymentGroup{
+			Name:             "clown",
+			TerraformBackend: BE{Type: "gcs"}}
+		noDefBe.expandBackend(&g)
+		c.Check(g.TerraformBackend, DeepEquals, BE{Type: "gcs"})
+		// TODO: shall gcs.prefix be set to "tree/bush/clown"?
+	}
+
+	defBe := noDefBe
+	defBe.TerraformBackendDefaults = BE{
+		Type: "gcs",
+		Configuration: NewDict(map[string]cty.Value{
+			"leave": cty.StringVal("fall")})}
+
+	{ // def BE, no group BE
+		g := DeploymentGroup{Name: "clown"}
+		defBe.expandBackend(&g)
+
+		c.Check(g.TerraformBackend, DeepEquals, BE{ // no change
+			Type: "gcs",
+			Configuration: NewDict(map[string]cty.Value{
+				"prefix": cty.StringVal("tree/bush/clown"),
+				"leave":  cty.StringVal("fall")})})
+	}
+
+	{ // def BE, group BE non-gcs
+		g := DeploymentGroup{
+			Name: "clown",
+			TerraformBackend: BE{
+				Type: "pure_gold",
+				Configuration: NewDict(map[string]cty.Value{
+					"branch": cty.False})}}
+		defBe.expandBackend(&g)
+
+		c.Check(g.TerraformBackend, DeepEquals, BE{ // no change
+			Type: "pure_gold",
+			Configuration: NewDict(map[string]cty.Value{
+				"branch": cty.False})})
+	}
 }
 
 func (s *zeroSuite) TestAddListValue(c *C) {
@@ -191,146 +217,88 @@ func (s *zeroSuite) TestUseModule(c *C) {
 	}
 }
 
-func (s *MySuite) TestApplyUseModules(c *C) {
+func (s *zeroSuite) TestExpandModule(c *C) {
+	u := Module{ID: "potato", Source: c.TestName() + "/potato"}
+	setTestModuleInfo(u, modulereader.ModuleInfo{
+		Outputs: []modulereader.OutputInfo{
+			{Name: "az"},
+			{Name: "rose"},
+			{Name: "peony"}}})
 
-	{ // Simple Case
-		dc := s.getDeploymentConfigForTest()
-		c.Assert(dc.applyUseModules(), IsNil)
-	}
-	{ // Has Use Modules
-		dc := s.getDeploymentConfigForTest()
-		g := &dc.Config.DeploymentGroups[0]
-
-		using := Module{
-			ID:     "usingModule",
-			Source: "path/using",
-			Use:    ModuleIDs{"usedModule"},
-		}
-		used := Module{ID: "usedModule", Source: "path/used"}
-
-		g.Modules = append(g.Modules, using, used)
-
-		setTestModuleInfo(using, modulereader.ModuleInfo{
-			Inputs: []modulereader.VarInfo{{
-				Name: "potato", Type: cty.Number}}})
-		setTestModuleInfo(used, modulereader.ModuleInfo{
-			Outputs: []modulereader.OutputInfo{
-				{Name: "potato"}}})
-
-		c.Assert(dc.applyUseModules(), IsNil)
-
-		// Use ID doesn't exists (fail)
-		g.Modules[len(g.Modules)-1].ID = "wrongID"
-		err := dc.applyUseModules()
-		unkModErr := UnknownModuleError{used.ID}
-		c.Check(errors.Is(err, unkModErr), Equals, true)
-		c.Check(errors.Is(err, HintError{string(using.ID), unkModErr}), Equals, false)
-	}
-
-	{ // test multigroup deployment with config that has a known good match
-		dc := s.getMultiGroupDeploymentConfig()
-		m := &dc.Config.DeploymentGroups[1].Modules[0]
-		c.Assert(m.Settings, DeepEquals, Dict{})
-		c.Assert(dc.applyUseModules(), IsNil)
-		ref := ModuleRef("TestModule0", "test_inter_0").AsValue()
-		c.Assert(m.Settings.Items(), DeepEquals, map[string]cty.Value{
-			"test_inter_0": AsProductOfModuleUse(ref, "TestModule0")})
-	}
-
-	{ // Deliberately break the match and see that no settings are added
-		dc := s.getMultiGroupDeploymentConfig()
-		mod := &dc.Config.DeploymentGroups[1].Modules[0]
-		c.Assert(mod.Settings, DeepEquals, Dict{})
-
-		// this eliminates the matching output from the used module
-		setTestModuleInfo(*mod, modulereader.ModuleInfo{})
-
-		c.Assert(dc.applyUseModules(), IsNil)
-		c.Assert(mod.Settings, DeepEquals, Dict{})
-	}
-}
-
-func (s *zeroSuite) TestCombineLabels(c *C) {
-	infoWithLabels := modulereader.ModuleInfo{Inputs: []modulereader.VarInfo{{Name: "labels"}}}
-
-	coral := Module{
-		Source: "blue/salmon",
-		ID:     "coral",
+	m := Module{
+		ID:     "yarn",
+		Source: c.TestName() + "/yarn",
+		Use:    ModuleIDs{u.ID},
 		Settings: NewDict(map[string]cty.Value{
-			"labels": cty.ObjectVal(map[string]cty.Value{
-				"magenta": cty.StringVal("orchid"),
-			}),
-		}),
-	}
-	setTestModuleInfo(coral, infoWithLabels)
-
-	// has no labels set
-	khaki := Module{Source: "brown/oak", ID: "khaki"}
-	setTestModuleInfo(khaki, infoWithLabels)
-
-	// has no labels set, also module has no labels input
-	silver := Module{Source: "ivory/black", ID: "silver"}
-	setTestModuleInfo(silver, modulereader.ModuleInfo{Inputs: []modulereader.VarInfo{}})
-
-	dc := DeploymentConfig{
-		Config: Blueprint{
-			BlueprintName: "simple",
-			Vars: NewDict(map[string]cty.Value{
-				"deployment_name": cty.StringVal("golden"),
-			}),
-			DeploymentGroups: []DeploymentGroup{
-				{Name: "lime", Modules: []Module{coral, khaki, silver}},
-			},
+			"az": cty.StringVal("alpha"),
+		})}
+	setTestModuleInfo(m, modulereader.ModuleInfo{
+		Inputs: []modulereader.VarInfo{
+			{Name: "az"},     // set explicitly
+			{Name: "buki"},   // set as global var
+			{Name: "labels"}, // set as global var
+			{Name: "rose", Type: cty.List(cty.String)}, // used from `u`
+			{Name: "peony"},  // used from `u`, global var ignored
+			{Name: "orchid"}, // not present anywhere
 		},
-	}
-	dc.combineLabels()
-
-	// Were global labels created?
-	c.Check(dc.Config.Vars.Get("labels"), DeepEquals, cty.ObjectVal(map[string]cty.Value{
-		"ghpc_blueprint":  cty.StringVal("simple"),
-		"ghpc_deployment": cty.StringVal("golden"),
-	}))
-
-	labelsRef := GlobalRef("labels").AsValue()
-
-	lime := dc.Config.DeploymentGroups[0]
-	// Labels are set
-	coral = lime.Modules[0]
-	c.Check(coral.Settings.Get("labels"), DeepEquals, FunctionCallExpression(
-		"merge",
-		labelsRef,
-		cty.ObjectVal(map[string]cty.Value{"magenta": cty.StringVal("orchid")}),
-	).AsValue())
-
-	// Labels are not set
-	khaki = lime.Modules[1]
-	c.Check(khaki.Settings.Get("labels"), DeepEquals, labelsRef)
-
-	// No labels input
-	silver = lime.Modules[2]
-	c.Check(silver.Settings.Get("labels"), DeepEquals, cty.NilVal)
-}
-
-func (s *MySuite) TestApplyGlobalVariables(c *C) {
-	dc := s.getDeploymentConfigForTest()
-	mod := &dc.Config.DeploymentGroups[0].Modules[0]
-
-	// Test no inputs, one required, doesn't exist in globals
-	setTestModuleInfo(*mod, modulereader.ModuleInfo{
-		Inputs: []modulereader.VarInfo{{
-			Name:     "gold",
-			Type:     cty.String,
-			Required: true,
-		}},
 	})
 
-	// Test no input, one required, exists in globals
-	dc.Config.Vars.Set("gold", cty.StringVal("val"))
-	dc.applyGlobalVariables()
-	c.Assert(
-		mod.Settings.Get("gold"),
-		DeepEquals,
-		GlobalRef("gold").AsValue())
+	bp := Blueprint{
+		Vars: NewDict(map[string]cty.Value{
+			"labels": cty.EmptyObjectVal,
+			"az":     cty.StringVal("za"),   // will be ignored
+			"buki":   cty.StringVal("ikub"), // will be used
+			"vedi":   cty.StringVal("idav"), // not in module inputs
+			"peon":   cty.StringVal("noep"), // will be ignored
+		}),
+		DeploymentGroups: []DeploymentGroup{
+			{Modules: []Module{u, m}}},
+	}
+
+	mp := Root.Groups.At(0).Modules.At(1)
+	c.Assert(bp.expandModule(mp, &m), IsNil)
+	c.Check(m.Settings.Items(), DeepEquals, map[string]cty.Value{
+		"az":    cty.StringVal("alpha"),
+		"peony": AsProductOfModuleUse(ModuleRef(u.ID, "peony").AsValue(), u.ID),
+		"rose": AsProductOfModuleUse(MustParseExpression(
+			`flatten([module.potato.rose])`).AsValue(), u.ID),
+
+		"labels": GlobalRef("labels").AsValue(),
+		"buki":   GlobalRef("buki").AsValue(),
+	})
+}
+
+func (s *zeroSuite) TestApplyGlobalVarsInModule(c *C) {
+	mod := Module{
+		ID:     "carrot",
+		Source: c.TestName() + "/cabbage",
+		Kind:   TerraformKind,
+		Settings: NewDict(map[string]cty.Value{
+			"silver": cty.StringVal("glagol")})}
+
+	vars := NewDict(map[string]cty.Value{
+		"polonium": cty.StringVal("az"),
+		"pyrite":   cty.StringVal("buki"),
+		"silver":   cty.StringVal("vedi"),
+	})
+
+	setTestModuleInfo(mod, modulereader.ModuleInfo{
+		Inputs: []modulereader.VarInfo{
+			{Name: "gold"},   // doesn't exist in vars
+			{Name: "pyrite"}, // exists in vars, not set in module
+			{Name: "silver"}, // exists in vars, set in module
+			{Name: "helium"}, // to be set to ModuleID
+		},
+		Metadata: modulereader.Metadata{
+			Ghpc: modulereader.MetadataGhpc{
+				InjectModuleId: "helium"}}})
+
+	Blueprint{Vars: vars}.applyGlobalVarsInModule(&mod)
+
+	c.Check(mod.Settings.Items(), DeepEquals, map[string]cty.Value{
+		"silver": cty.StringVal("glagol"),
+		"helium": cty.StringVal("carrot"),
+		"pyrite": GlobalRef("pyrite").AsValue()})
 }
 
 func (s *zeroSuite) TestValidateModuleReference(c *C) {
@@ -393,8 +361,7 @@ func (s *zeroSuite) TestIntersection(c *C) {
 
 func (s *MySuite) TestOutputNamesByGroup(c *C) {
 	dc := s.getMultiGroupDeploymentConfig()
-	dc.applyGlobalVariables()
-	dc.applyUseModules()
+	c.Assert(dc.ExpandConfig(), IsNil)
 	bp := dc.Config
 
 	group0 := bp.DeploymentGroups[0]


### PR DESCRIPTION
To address errors caused by entity processing depending on other entity being processed first explictly split `expand` stage on layers: `BlueprintName  -> DefaultBackend -> Vars -> Groups`
