### PR TITLE
Version constrain Flux module for improved reliability

### DIFF
--- a/community/examples/flux-framework/flux-cluster.yaml
+++ b/community/examples/flux-framework/flux-cluster.yaml
@@ -34,7 +34,7 @@ deployment_groups:
     settings:
       local_mount: /home
   - id: fluxfw-gcp
-    source: github.com/GoogleCloudPlatform/scientific-computing-examples.git/fluxfw-gcp/tf
+    source: github.com/GoogleCloudPlatform/scientific-computing-examples//fluxfw-gcp/tf?ref=867e558
     settings:
       compute_node_specs:
       - name_prefix: gfluxfw-compute


### PR DESCRIPTION
The Flux cluster module recently began failing to pass our validation tests because it began requiring the Terraform `google` provider 5.5+ and we do not yet support the 5.x series. https://github.com/GoogleCloudPlatform/scientific-computing-examples/pull/69 should address this issue already. This PR further increases reliability by pinning to a specific commit within the Flux module repo itself.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
