### PR TITLE
Refactor `cmd`

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -33,65 +33,46 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const msgCLIVars = "Comma-separated list of name=value variables to override YAML configuration. Can be used multiple times."
-const msgCLIBackendConfig = "Comma-separated list of name=value variables to set Terraform backend configuration. Can be used multiple times."
-
-func init() {
-	createCmd.Flags().StringVarP(&bpFilenameDeprecated, "config", "c", "", "")
-	cobra.CheckErr(createCmd.Flags().MarkDeprecated("config",
-		"please see the command usage for more details."))
-
-	deploymentFileFlag := "deployment-file"
-	createCmd.Flags().StringVarP(&deploymentFile, deploymentFileFlag, "d", "",
-		"Toolkit Deployment File.")
-	createCmd.Flags().MarkHidden(deploymentFileFlag)
-	createCmd.MarkFlagFilename(deploymentFileFlag, "yaml", "yml")
-	createCmd.Flags().StringVarP(&outputDir, "out", "o", "",
+func addCreateFlags(c *cobra.Command) *cobra.Command {
+	c.Flags().StringVarP(&createFlags.outputDir, "out", "o", "",
 		"Sets the output directory where the HPC deployment directory will be created.")
-	createCmd.Flags().StringSliceVar(&cliVariables, "vars", nil, msgCLIVars)
-	createCmd.Flags().StringSliceVar(&cliBEConfigVars, "backend-config", nil, msgCLIBackendConfig)
-	createCmd.Flags().StringVarP(&validationLevel, "validation-level", "l", "WARNING", validationLevelDesc)
-	createCmd.Flags().StringSliceVar(&validatorsToSkip, "skip-validators", nil, skipValidatorsDesc)
-	createCmd.Flags().BoolVarP(&overwriteDeployment, "overwrite-deployment", "w", false,
+	c.Flags().BoolVarP(&createFlags.overwriteDeployment, "overwrite-deployment", "w", false,
 		"If specified, an existing deployment directory is overwritten by the new deployment. \n"+
 			"Note: Terraform state IS preserved. \n"+
 			"Note: Terraform workspaces are NOT supported (behavior undefined). \n"+
 			"Note: Packer is NOT supported.")
-	createCmd.Flags().BoolVar(&forceOverwrite, "force", false,
+	c.Flags().BoolVar(&createFlags.forceOverwrite, "force", false,
 		"Forces overwrite of existing deployment directory. \n"+
 			"If set, --overwrite-deployment is implied. \n"+
 			"No validation is performed on the existing deployment directory.")
+	return addExpandFlags(c, false /*addOutFlag to avoid clash with "create" `out` flag*/)
+}
+
+func init() {
 	rootCmd.AddCommand(createCmd)
 }
 
 var (
-	bpFilenameDeprecated string
-	deploymentFile       string
-	outputDir            string
-	cliVariables         []string
+	createFlags = struct {
+		outputDir           string
+		overwriteDeployment bool
+		forceOverwrite      bool
+	}{}
 
-	cliBEConfigVars     []string
-	overwriteDeployment bool
-	forceOverwrite      bool
-	validationLevel     string
-	validationLevelDesc = "Set validation level to one of (\"ERROR\", \"WARNING\", \"IGNORE\")"
-	validatorsToSkip    []string
-	skipValidatorsDesc  = "Validators to skip"
-
-	createCmd = &cobra.Command{
-		Use:               "create BLUEPRINT_NAME",
+	createCmd = addCreateFlags(&cobra.Command{
+		Use:               "create <BLUEPRINT_FILE>",
 		Short:             "Create a new deployment.",
 		Long:              "Create a new deployment based on a provided blueprint.",
 		Run:               runCreateCmd,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: filterYaml,
-	}
+	})
 )
 
 func runCreateCmd(cmd *cobra.Command, args []string) {
-	bp := expandOrDie(args[0], deploymentFile)
-	deplDir := filepath.Join(outputDir, bp.DeploymentName())
-	checkErr(checkOverwriteAllowed(deplDir, bp, overwriteDeployment, forceOverwrite))
+	bp := expandOrDie(args[0])
+	deplDir := filepath.Join(createFlags.outputDir, bp.DeploymentName())
+	checkErr(checkOverwriteAllowed(deplDir, bp, createFlags.overwriteDeployment, createFlags.forceOverwrite))
 	checkErr(modulewriter.WriteDeployment(bp, deplDir))
 
 	logging.Info("To deploy your infrastructure please run:")
@@ -108,7 +89,8 @@ func printAdvancedInstructionsMessage(deplDir string) {
 	logging.Info(modulewriter.InstructionsPath(deplDir))
 }
 
-func expandOrDie(path string, dPath string) config.Blueprint {
+// TODO: move to expand.go
+func expandOrDie(path string) config.Blueprint {
 	bp, ctx, err := config.NewBlueprint(path)
 	if err != nil {
 		logging.Fatal(renderError(err, ctx))
@@ -116,22 +98,22 @@ func expandOrDie(path string, dPath string) config.Blueprint {
 
 	var ds config.DeploymentSettings
 	var dCtx config.YamlCtx
-	if dPath != "" {
-		ds, dCtx, err = config.NewDeploymentSettings(dPath)
+	if expandFlags.deploymentFile != "" {
+		ds, dCtx, err = config.NewDeploymentSettings(expandFlags.deploymentFile)
 		if err != nil {
 			logging.Fatal(renderError(err, dCtx))
 		}
 	}
-	if err := setCLIVariables(&ds, cliVariables); err != nil {
+	if err := setCLIVariables(&ds, expandFlags.cliVariables); err != nil {
 		logging.Fatal("Failed to set the variables at CLI: %v", err)
 	}
-	if err := setBackendConfig(&ds, cliBEConfigVars); err != nil {
+	if err := setBackendConfig(&ds, expandFlags.cliBEConfigVars); err != nil {
 		logging.Fatal("Failed to set the backend config at CLI: %v", err)
 	}
 
 	mergeDeploymentSettings(&bp, ds)
 
-	checkErr(setValidationLevel(&bp, validationLevel))
+	checkErr(setValidationLevel(&bp, expandFlags.validationLevel))
 	skipValidators(&bp)
 
 	if bp.GhpcVersion != "" {
@@ -148,6 +130,7 @@ func expandOrDie(path string, dPath string) config.Blueprint {
 	return bp
 }
 
+// TODO: move to expand.go
 func validateMaybeDie(bp config.Blueprint, ctx config.YamlCtx) {
 	err := validators.Execute(bp)
 	if err == nil {
@@ -181,6 +164,7 @@ func validateMaybeDie(bp config.Blueprint, ctx config.YamlCtx) {
 
 }
 
+// TODO: move to expand.go
 func setCLIVariables(ds *config.DeploymentSettings, s []string) error {
 	for _, cliVar := range s {
 		arr := strings.SplitN(cliVar, "=", 2)
@@ -199,6 +183,7 @@ func setCLIVariables(ds *config.DeploymentSettings, s []string) error {
 	return nil
 }
 
+// TODO: move to expand.go
 func setBackendConfig(ds *config.DeploymentSettings, s []string) error {
 	if len(s) == 0 {
 		return nil // no op
@@ -234,6 +219,7 @@ func mergeDeploymentSettings(bp *config.Blueprint, ds config.DeploymentSettings)
 }
 
 // SetValidationLevel allows command-line tools to set the validation level
+// TODO: move to expand.go
 func setValidationLevel(bp *config.Blueprint, s string) error {
 	switch s {
 	case "ERROR":
@@ -248,17 +234,11 @@ func setValidationLevel(bp *config.Blueprint, s string) error {
 	return nil
 }
 
+// TODO: move to expand.go
 func skipValidators(bp *config.Blueprint) {
-	for _, v := range validatorsToSkip {
+	for _, v := range expandFlags.validatorsToSkip {
 		bp.SkipValidator(v)
 	}
-}
-
-func filterYaml(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) != 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
 }
 
 func forceErr(err error) error {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -26,64 +26,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func addDeployFlags(c *cobra.Command) *cobra.Command {
+	return addAutoApproveFlag(
+		addArtifactsDirFlag(c))
+}
+
 func init() {
-	artifactsFlag := "artifacts"
-
-	deployCmd.Flags().StringVarP(&artifactsDir, artifactsFlag, "a", "", "Artifacts output directory (automatically configured if unset)")
-	deployCmd.MarkFlagDirname(artifactsFlag)
-
-	autoApproveFlag := "auto-approve"
-	deployCmd.Flags().BoolVarP(&autoApprove, autoApproveFlag, "", false, "Automatically approve proposed changes")
-
 	rootCmd.AddCommand(deployCmd)
 }
 
 var (
-	deploymentRoot string
-	autoApprove    bool
-	applyBehavior  shell.ApplyBehavior
-	deployCmd      = &cobra.Command{
-		Use:               "deploy DEPLOYMENT_DIRECTORY",
+	deployCmd = addDeployFlags(&cobra.Command{
+		Use:               "deploy <DEPLOYMENT_DIRECTORY>",
 		Short:             "deploy all resources in a Toolkit deployment directory.",
 		Long:              "deploy all resources in a Toolkit deployment directory.",
 		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkDir),
 		ValidArgsFunction: matchDirs,
-		PreRunE:           parseDeployArgs,
 		Run:               runDeployCmd,
 		SilenceUsage:      true,
-	}
+	})
 )
 
-func parseDeployArgs(cmd *cobra.Command, args []string) error {
-	applyBehavior = getApplyBehavior(autoApprove)
-
-	deploymentRoot = args[0]
-	artifactsDir = getArtifactsDir(deploymentRoot)
-	if err := shell.CheckWritableDir(artifactsDir); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func getApplyBehavior(autoApprove bool) shell.ApplyBehavior {
-	if autoApprove {
-		return shell.AutomaticApply
-	}
-	return shell.PromptBeforeApply
-}
-
 func runDeployCmd(cmd *cobra.Command, args []string) {
-	expandedBlueprintFile := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
+	deplRoot := args[0]
+	artDir := getArtifactsDir(deplRoot)
+	checkErr(shell.CheckWritableDir(artDir))
+
+	expandedBlueprintFile := filepath.Join(artDir, modulewriter.ExpandedBlueprintName)
 	bp, _, err := config.NewBlueprint(expandedBlueprintFile)
 	checkErr(err)
 	groups := bp.DeploymentGroups
-	checkErr(validateRuntimeDependencies(groups))
-	checkErr(shell.ValidateDeploymentDirectory(groups, deploymentRoot))
+	checkErr(validateRuntimeDependencies(deplRoot, groups))
+	checkErr(shell.ValidateDeploymentDirectory(groups, deplRoot))
 
 	for _, group := range groups {
-		groupDir := filepath.Join(deploymentRoot, string(group.Name))
-		checkErr(shell.ImportInputs(groupDir, artifactsDir, expandedBlueprintFile))
+		groupDir := filepath.Join(deplRoot, string(group.Name))
+		checkErr(shell.ImportInputs(groupDir, artDir, expandedBlueprintFile))
 
 		switch group.Kind() {
 		case config.PackerKind:
@@ -91,25 +69,25 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 			subPath, e := modulewriter.DeploymentSource(group.Modules[0])
 			checkErr(e)
 			moduleDir := filepath.Join(groupDir, subPath)
-			checkErr(deployPackerGroup(moduleDir))
+			checkErr(deployPackerGroup(moduleDir, getApplyBehavior()))
 		case config.TerraformKind:
-			checkErr(deployTerraformGroup(groupDir))
+			checkErr(deployTerraformGroup(groupDir, artDir, getApplyBehavior()))
 		default:
 			checkErr(fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind().String()))
 		}
 	}
 	logging.Info("\n###############################")
-	printAdvancedInstructionsMessage(deploymentRoot)
+	printAdvancedInstructionsMessage(deplRoot)
 }
 
-func validateRuntimeDependencies(groups []config.DeploymentGroup) error {
+func validateRuntimeDependencies(deplDir string, groups []config.DeploymentGroup) error {
 	for _, group := range groups {
 		var err error
 		switch group.Kind() {
 		case config.PackerKind:
 			err = shell.ConfigurePacker()
 		case config.TerraformKind:
-			groupDir := filepath.Join(deploymentRoot, string(group.Name))
+			groupDir := filepath.Join(deplDir, string(group.Name))
 			_, err = shell.ConfigureTerraform(groupDir)
 		default:
 			err = fmt.Errorf("group %s is an unsupported kind %q", group.Name, group.Kind().String())
@@ -121,7 +99,7 @@ func validateRuntimeDependencies(groups []config.DeploymentGroup) error {
 	return nil
 }
 
-func deployPackerGroup(moduleDir string) error {
+func deployPackerGroup(moduleDir string, applyBehavior shell.ApplyBehavior) error {
 	if err := shell.ConfigurePacker(); err != nil {
 		return err
 	}
@@ -147,7 +125,7 @@ func deployPackerGroup(moduleDir string) error {
 	return nil
 }
 
-func deployTerraformGroup(groupDir string) error {
+func deployTerraformGroup(groupDir string, artifactsDir string, applyBehavior shell.ApplyBehavior) error {
 	tf, err := shell.ConfigureTerraform(groupDir)
 	if err != nil {
 		return err

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -24,13 +24,15 @@ import (
 )
 
 func (s *MySuite) TestDeployGroups(c *C) {
-	applyBehavior = shell.NeverApply
 	var err error
 	pathEnv := os.Getenv("PATH")
 	os.Setenv("PATH", "")
-	err = deployTerraformGroup(".")
-	c.Assert(err, NotNil)
-	err = deployPackerGroup(".")
-	c.Assert(err, NotNil)
+
+	err = deployTerraformGroup(".", getArtifactsDir("."), shell.NeverApply)
+	c.Check(err, NotNil)
+
+	err = deployPackerGroup(".", shell.NeverApply)
+	c.Check(err, NotNil)
+
 	os.Setenv("PATH", pathEnv)
 }

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -27,13 +27,9 @@ import (
 )
 
 func init() {
-	artifactsFlag := "artifacts"
-	destroyCmd.Flags().StringVarP(&artifactsDir, artifactsFlag, "a", "", "Artifacts output directory (automatically configured if unset)")
-	destroyCmd.MarkFlagDirname(artifactsFlag)
-
-	destroyCmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Automatically approve proposed changes")
-
-	rootCmd.AddCommand(destroyCmd)
+	rootCmd.AddCommand(
+		addAutoApproveFlag(
+			addArtifactsDirFlag(destroyCmd)))
 }
 
 var (
@@ -43,41 +39,30 @@ var (
 		Long:              "destroy all resources in a Toolkit deployment directory.",
 		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkDir),
 		ValidArgsFunction: matchDirs,
-		PreRunE:           parseDestroyArgs,
-		RunE:              runDestroyCmd,
+		Run:               runDestroyCmd,
 		SilenceUsage:      true,
 	}
 )
 
-func parseDestroyArgs(cmd *cobra.Command, args []string) error {
-	applyBehavior = getApplyBehavior(autoApprove)
-
-	deploymentRoot = args[0]
-	artifactsDir = getArtifactsDir(deploymentRoot)
+func runDestroyCmd(cmd *cobra.Command, args []string) {
+	deplRoot := args[0]
+	artifactsDir := getArtifactsDir(deplRoot)
 
 	if isDir, _ := shell.DirInfo(artifactsDir); !isDir {
-		return fmt.Errorf("artifacts path %s is not a directory", artifactsDir)
+		checkErr(fmt.Errorf("artifacts path %s is not a directory", artifactsDir))
 	}
 
-	return nil
-}
-
-func runDestroyCmd(cmd *cobra.Command, args []string) error {
 	expandedBlueprintFile := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
 	bp, _, err := config.NewBlueprint(expandedBlueprintFile)
-	if err != nil {
-		return err
-	}
+	checkErr(err)
 
-	if err := shell.ValidateDeploymentDirectory(bp.DeploymentGroups, deploymentRoot); err != nil {
-		return err
-	}
+	checkErr(shell.ValidateDeploymentDirectory(bp.DeploymentGroups, deplRoot))
 
 	// destroy in reverse order of creation!
 	packerManifests := []string{}
 	for i := len(bp.DeploymentGroups) - 1; i >= 0; i-- {
 		group := bp.DeploymentGroups[i]
-		groupDir := filepath.Join(deploymentRoot, string(group.Name))
+		groupDir := filepath.Join(deplRoot, string(group.Name))
 
 		var err error
 		switch group.Kind() {
@@ -91,13 +76,10 @@ func runDestroyCmd(cmd *cobra.Command, args []string) error {
 		default:
 			err = fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind().String())
 		}
-		if err != nil {
-			return err
-		}
+		checkErr(err)
 	}
 
 	modulewriter.WritePackerDestroyInstructions(os.Stdout, packerManifests)
-	return nil
 }
 
 func destroyTerraformGroup(groupDir string) error {
@@ -106,5 +88,5 @@ func destroyTerraformGroup(groupDir string) error {
 		return err
 	}
 
-	return shell.Destroy(tf, applyBehavior)
+	return shell.Destroy(tf, getApplyBehavior())
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -16,7 +16,7 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/modulewriter"
 	"hpc-toolkit/pkg/shell"
@@ -26,89 +26,52 @@ import (
 )
 
 func init() {
-	artifactsFlag := "artifacts"
-	exportCmd.Flags().StringVarP(&artifactsDir, artifactsFlag, "a", "", "Artifacts output directory (automatically configured if unset)")
-	exportCmd.MarkFlagDirname(artifactsFlag)
 	rootCmd.AddCommand(exportCmd)
 }
 
 var (
-	artifactsDir string
-	exportCmd    = &cobra.Command{
+	exportCmd = addArtifactsDirFlag(&cobra.Command{
 		Use:               "export-outputs DEPLOYMENT_GROUP_DIRECTORY",
 		Short:             "Export outputs from deployment group.",
 		Long:              "Export output values from deployment group to other deployment groups that depend upon them.",
 		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkDir),
 		ValidArgsFunction: matchDirs,
-		PreRun:            parseExportImportArgs,
-		RunE:              runExportCmd,
+		Run:               runExportCmd,
 		SilenceUsage:      true,
-	}
+	})
 )
 
-func checkDir(cmd *cobra.Command, args []string) error {
-	path := args[0]
-	if path == "" {
-		return nil
-	}
-	if isDir, _ := shell.DirInfo(path); !(isDir) {
-		return fmt.Errorf("%s must be a directory", path)
-	}
-
-	return nil
+func parseExportImportArgs(args []string) (string, string) {
+	gd := filepath.Clean(args[0])
+	return filepath.Join(gd, ".."), gd
 }
 
-func matchDirs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return nil, cobra.ShellCompDirectiveFilterDirs | cobra.ShellCompDirectiveNoFileComp
-}
+func runExportCmd(cmd *cobra.Command, args []string) {
+	deplRoot, groupDir := parseExportImportArgs(args)
 
-func parseExportImportArgs(cmd *cobra.Command, args []string) {
-	deploymentRoot = filepath.Join(filepath.Clean(args[0]), "..")
-	artifactsDir = getArtifactsDir(deploymentRoot)
-}
+	artifactsDir := getArtifactsDir(deplRoot)
+	deploymentGroup := config.GroupName(filepath.Base(groupDir))
 
-func getArtifactsDir(deploymentRoot string) string {
-	if artifactsDir == "" {
-		return modulewriter.ArtifactsDir(deploymentRoot)
-	}
-	return artifactsDir
-}
-
-func runExportCmd(cmd *cobra.Command, args []string) error {
-	groupDir := filepath.Clean(args[0])
-	deploymentGroup := config.GroupName(filepath.Base(args[0]))
-
-	if err := shell.CheckWritableDir(artifactsDir); err != nil {
-		return err
-	}
+	checkErr(shell.CheckWritableDir(artifactsDir))
 
 	expandedBlueprintFile := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
 	bp, _, err := config.NewBlueprint(expandedBlueprintFile)
-	if err != nil {
-		return err
-	}
+	checkErr(err)
 
-	if err := shell.ValidateDeploymentDirectory(bp.DeploymentGroups, deploymentRoot); err != nil {
-		return err
-	}
+	checkErr(shell.ValidateDeploymentDirectory(bp.DeploymentGroups, deplRoot))
 
 	group, err := bp.Group(deploymentGroup)
-	if err != nil {
-		return err
-	}
+	checkErr(err)
+
 	if group.Kind() == config.PackerKind {
-		return fmt.Errorf("export command is unsupported on Packer modules because they do not have outputs")
+		checkErr(errors.New("export command is unsupported on Packer modules because they do not have outputs"))
 	}
 	if group.Kind() != config.TerraformKind {
-		return fmt.Errorf("export command is supported for Terraform modules only")
+		checkErr(errors.New("export command is supported for Terraform modules only"))
 	}
 
 	tf, err := shell.ConfigureTerraform(groupDir)
-	if err != nil {
-		return err
-	}
-	if err = shell.ExportOutputs(tf, artifactsDir, shell.NeverApply); err != nil {
-		return err
-	}
-	return nil
+	checkErr(err)
+
+	checkErr(shell.ExportOutputs(tf, artifactsDir, shell.NeverApply))
 }

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -34,8 +34,3 @@ func (s *MySuite) TestIsDir(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(checkDir(nil, []string{f.Name()}), NotNil)
 }
-
-func (s *MySuite) TestRunExport(c *C) {
-	dir := c.MkDir()
-	c.Assert(runExportCmd(nil, []string{dir}), NotNil)
-}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -25,45 +25,31 @@ import (
 )
 
 func init() {
-	artifactsFlag := "artifacts"
-	importCmd.Flags().StringVarP(&artifactsDir, artifactsFlag, "a", "", "Artifacts directory (automatically configured if unset)")
-	importCmd.MarkFlagDirname(artifactsFlag)
 	rootCmd.AddCommand(importCmd)
 }
 
 var (
-	importCmd = &cobra.Command{
+	importCmd = addArtifactsDirFlag(&cobra.Command{
 		Use:               "import-inputs DEPLOYMENT_GROUP_DIRECTORY",
 		Short:             "Import input values from previous deployment groups.",
 		Long:              "Import input values from previous deployment groups upon which this group depends.",
 		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkDir),
 		ValidArgsFunction: matchDirs,
-		PreRun:            parseExportImportArgs,
-		RunE:              runImportCmd,
+		Run:               runImportCmd,
 		SilenceUsage:      true,
-	}
+	})
 )
 
-func runImportCmd(cmd *cobra.Command, args []string) error {
-	groupDir := filepath.Clean(args[0])
+func runImportCmd(cmd *cobra.Command, args []string) {
+	deplRoot, groupDir := parseExportImportArgs(args)
+	artifactsDir := getArtifactsDir(deplRoot)
 
-	if err := shell.CheckWritableDir(groupDir); err != nil {
-		return err
-	}
+	checkErr(shell.CheckWritableDir(groupDir))
 
 	expandedBlueprintFile := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
 	bp, _, err := config.NewBlueprint(expandedBlueprintFile)
-	if err != nil {
-		return err
-	}
+	checkErr(err)
 
-	if err := shell.ValidateDeploymentDirectory(bp.DeploymentGroups, deploymentRoot); err != nil {
-		return err
-	}
-
-	if err := shell.ImportInputs(groupDir, artifactsDir, expandedBlueprintFile); err != nil {
-		return err
-	}
-
-	return nil
+	checkErr(shell.ValidateDeploymentDirectory(bp.DeploymentGroups, deplRoot))
+	checkErr(shell.ImportInputs(groupDir, artifactsDir, expandedBlueprintFile))
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,75 @@
+// Copyright 2024 "Google LLC"
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"hpc-toolkit/pkg/modulewriter"
+	"hpc-toolkit/pkg/shell"
+
+	"github.com/spf13/cobra"
+)
+
+var flagArtifactsDir string
+
+func addArtifactsDirFlag(c *cobra.Command) *cobra.Command {
+	c.Flags().StringVarP(&flagArtifactsDir, "artifacts", "a", "", "Artifacts directory (automatically configured if unset)")
+	c.MarkFlagDirname("artifacts")
+	return c
+}
+
+func getArtifactsDir(deploymentRoot string) string {
+	if flagArtifactsDir == "" {
+		return modulewriter.ArtifactsDir(deploymentRoot)
+	}
+	return flagArtifactsDir
+}
+
+var flagAutoApprove bool
+
+func getApplyBehavior() shell.ApplyBehavior {
+	if flagAutoApprove {
+		return shell.AutomaticApply
+	}
+	return shell.PromptBeforeApply
+}
+
+func addAutoApproveFlag(c *cobra.Command) *cobra.Command {
+	c.Flags().BoolVar(&flagAutoApprove, "auto-approve", false, "Automatically approve proposed changes")
+	return c
+}
+
+func checkDir(cmd *cobra.Command, args []string) error {
+	path := args[0]
+	if path == "" {
+		return nil
+	}
+	if isDir, _ := shell.DirInfo(path); !(isDir) {
+		return fmt.Errorf("%s must be a directory", path)
+	}
+
+	return nil
+}
+
+func matchDirs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return nil, cobra.ShellCompDirectiveFilterDirs | cobra.ShellCompDirectiveNoFileComp
+}
+
+func filterYaml(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
+}


### PR DESCRIPTION
* Do not duplicate shared flags logic:
  * `artifactsDir` -> to reusable `addArtifactsDirFlag`;
  *  `addCreateFlags` calls `addExpandFlags` instead of copy-pasting flag setters from `expand.go`.
* Name all global flag variables explicitly to reduce namespace pollution, e.g. `forceOverwrite -> createFlags.forceOverwrite`;
* Use `Run` over `RunE` to make use of `checkErr` and unify rendering (not default to `cobra` rendering);
* Don't use `PreRun`, merge with `Run` to avoid usage of global vars for communication.

**Motivation:** preparation to upcoming changes (`deploy` does `create`) that would make fixed problems worse (copy all flags of `create` to `deploy`)