### PR TITLE
Make `config.Dict` immutable

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -178,7 +178,7 @@ func setCLIVariables(ds *config.DeploymentSettings, s []string) error {
 		if err := yaml.Unmarshal([]byte(arr[1]), &v); err != nil {
 			return fmt.Errorf("invalid input: unable to convert '%s' value '%s' to known type", key, arr[1])
 		}
-		ds.Vars.Set(key, v.Unwrap())
+		ds.Vars = ds.Vars.With(key, v.Unwrap())
 	}
 	return nil
 }
@@ -201,7 +201,7 @@ func setBackendConfig(ds *config.DeploymentSettings, s []string) error {
 		case "type":
 			be.Type = value
 		default:
-			be.Configuration.Set(key, cty.StringVal(value))
+			be.Configuration = be.Configuration.With(key, cty.StringVal(value))
 		}
 	}
 	ds.TerraformBackendDefaults = be
@@ -210,7 +210,7 @@ func setBackendConfig(ds *config.DeploymentSettings, s []string) error {
 
 func mergeDeploymentSettings(bp *config.Blueprint, ds config.DeploymentSettings) error {
 	for k, v := range ds.Vars.Items() {
-		bp.Vars.Set(k, v)
+		bp.Vars = bp.Vars.With(k, v)
 	}
 	if ds.TerraformBackendDefaults.Type != "" {
 		bp.TerraformBackendDefaults = ds.TerraformBackendDefaults

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -25,8 +25,9 @@ import (
 )
 
 func (s *MySuite) TestSetCLIVariables(c *C) {
-	ds := config.DeploymentSettings{}
-	ds.Vars.Set("deployment_name", cty.StringVal("bush"))
+	ds := config.DeploymentSettings{
+		Vars: config.Dict{}.
+			With("deployment_name", cty.StringVal("bush"))}
 
 	vars := []string{
 		"project_id=cli_test_project_id",
@@ -103,18 +104,14 @@ func (s *MySuite) TestSetBackendConfig(c *C) {
 
 func (s *MySuite) TestMergeDeploymentSettings(c *C) {
 	ds1 := config.DeploymentSettings{
-		Vars: config.NewDict(map[string]cty.Value{
-			"project_id":      cty.StringVal("ds_test_project_id"),
-			"deployment_name": cty.StringVal("ds_deployment_name"),
-		}),
-	}
+		Vars: config.Dict{}.
+			With("project_id", cty.StringVal("ds_test_project_id")).
+			With("deployment_name", cty.StringVal("ds_deployment_name"))}
 
 	bp1 := config.Blueprint{
-		Vars: config.NewDict(map[string]cty.Value{
-			"project_id":  cty.StringVal("bp_test_project_id"),
-			"example_var": cty.StringVal("bp_example_value"),
-		}),
-	}
+		Vars: config.Dict{}.
+			With("project_id", cty.StringVal("bp_test_project_id")).
+			With("example_var", cty.StringVal("bp_example_value"))}
 
 	// test priority-based merging of deployment variables
 	mergeDeploymentSettings(&bp1, ds1)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -687,10 +687,11 @@ func (s *zeroSuite) TestCheckBackend(c *C) {
 	}
 
 	{ // OK. No variables used
-		b := TerraformBackend{Type: "gcs"}
-		b.Configuration.
-			Set("bucket", cty.StringVal("trenta")).
-			Set("impersonate_service_account", cty.StringVal("who"))
+		b := TerraformBackend{
+			Type: "gcs",
+			Configuration: Dict{}.
+				With("bucket", cty.StringVal("trenta")).
+				With("impersonate_service_account", cty.StringVal("who"))}
 		c.Check(checkBackend(p, b), IsNil)
 	}
 
@@ -838,15 +839,21 @@ func (s *zeroSuite) TestValidateModuleSettingReference(c *C) {
 }
 
 func (s *zeroSuite) TestValidateModuleSettingReferences(c *C) {
-	m := Module{ID: "m"}
-	m.Settings.Set("white", GlobalRef("zebra").AsValue())
-	bp := Blueprint{}
+	m := Module{
+		ID: "m",
+		Settings: Dict{}.
+			With("white", GlobalRef("zebra").AsValue())}
 	p := Root.Groups.At(0).Modules.At(0)
 
-	c.Check(validateModuleSettingReferences(p, m, bp), NotNil)
+	{ // No zebra
+		c.Check(validateModuleSettingReferences(p, m, Blueprint{}), NotNil)
+	}
 
-	bp.Vars.Set("zebra", cty.StringVal("stripes"))
-	c.Check(validateModuleSettingReferences(p, m, bp), IsNil)
+	{ // Got zebra
+		bp := Blueprint{Vars: Dict{}.
+			With("zebra", cty.StringVal("stripes"))}
+		c.Check(validateModuleSettingReferences(p, m, bp), IsNil)
+	}
 }
 
 func (s *zeroSuite) TestGroupNameValidate(c *C) {

--- a/pkg/config/dict.go
+++ b/pkg/config/dict.go
@@ -27,11 +27,7 @@ type Dict struct {
 
 // NewDict constructor
 func NewDict(m map[string]cty.Value) Dict {
-	d := Dict{}
-	for k, v := range m {
-		d.Set(k, v)
-	}
-	return d
+	return Dict{m: maps.Clone(m)}
 }
 
 // Get returns stored value or cty.NilVal.
@@ -51,26 +47,19 @@ func (d *Dict) Has(k string) bool {
 	return ok
 }
 
-// Set adds/overrides value by key.
-// Returns reference to Dict-self.
-func (d *Dict) Set(k string, v cty.Value) *Dict {
-	if d.m == nil {
-		d.m = map[string]cty.Value{k: v}
-	} else {
-		d.m[k] = v
-	}
-	return d
+func (d Dict) With(k string, v cty.Value) Dict {
+	m := d.Items()
+	m[k] = v
+	return Dict{m: m}
 }
 
 // Items returns instance of map[string]cty.Value
 // will same set of key-value pairs as stored in Dict.
 // This map is a copy, changes to returned map have no effect on the Dict.
 func (d *Dict) Items() map[string]cty.Value {
-	m := map[string]cty.Value{}
-	if d.m != nil {
-		for k, v := range d.m {
-			m[k] = v
-		}
+	m := maps.Clone(d.m)
+	if m == nil { // never return nil
+		return map[string]cty.Value{}
 	}
 	return m
 }

--- a/pkg/config/dict_test.go
+++ b/pkg/config/dict_test.go
@@ -47,17 +47,11 @@ func TestZeroValueValid(t *testing.T) {
 			t.Errorf("diff (-want +got):\n%s", diff)
 		}
 	}
-
-	{ // Set
-		d := Dict{}
-		d.Set("lizard", cty.True) // no panic
-	}
 }
 
 func TestSetAndGet(t *testing.T) {
-	d := Dict{}
 	want := cty.StringVal("guava")
-	d.Set("hare", want)
+	d := Dict{}.With("hare", want)
 	got := d.Get("hare")
 	if diff := cmp.Diff(want, got, ctydebug.CmpOptions); diff != "" {
 		t.Errorf("diff (-want +got):\n%s", diff)
@@ -68,8 +62,7 @@ func TestSetAndGet(t *testing.T) {
 }
 
 func TestItemsAreCopy(t *testing.T) {
-	d := Dict{}
-	d.Set("apple", cty.StringVal("fuji"))
+	d := Dict{}.With("apple", cty.StringVal("fuji"))
 
 	items := d.Items()
 	items["apple"] = cty.StringVal("opal")

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -135,8 +135,10 @@ func (s *zeroSuite) TestUseModule(c *C) {
 	}
 
 	{ // Pass: Single Input/Output match - but setting was in blueprint so no-op
-		mod := Module{ID: "lime", Source: "limeTree"}
-		mod.Settings.Set("val1", ref)
+		mod := Module{
+			ID:       "lime",
+			Settings: Dict{}.With("val1", ref),
+			Source:   "limeTree"}
 		setTestModuleInfo(mod, modulereader.ModuleInfo{
 			Inputs: []modulereader.VarInfo{varInfoNumber},
 		})
@@ -150,8 +152,10 @@ func (s *zeroSuite) TestUseModule(c *C) {
 
 	{ // Pass: re-apply used modules, should be a no-op
 		// Assume no settings were in blueprint
-		mod := Module{ID: "lime", Source: "limeTree"}
-		mod.Settings.Set("val1", AsProductOfModuleUse(ref, "UsedModule"))
+		mod := Module{
+			ID:       "lime",
+			Settings: Dict{}.With("val1", AsProductOfModuleUse(ref, "UsedModule")),
+			Source:   "limeTree"}
 		setTestModuleInfo(mod, modulereader.ModuleInfo{
 			Inputs: []modulereader.VarInfo{varInfoNumber},
 		})
@@ -181,8 +185,11 @@ func (s *zeroSuite) TestUseModule(c *C) {
 
 	{ // Pass: Setting exists, Input is List, Output is not a list
 		// Assume setting was not set in blueprint
-		mod := Module{ID: "lime", Source: "limeTree"}
-		mod.Settings.Set("val1", AsProductOfModuleUse(cty.TupleVal([]cty.Value{ref}), "other"))
+		mod := Module{
+			ID:       "lime",
+			Settings: Dict{}.With("val1", AsProductOfModuleUse(cty.TupleVal([]cty.Value{ref}), "other")),
+			Source:   "limeTree"}
+
 		setTestModuleInfo(mod, modulereader.ModuleInfo{
 			Inputs: []modulereader.VarInfo{{Name: "val1", Type: cty.List(cty.Number)}},
 		})
@@ -199,8 +206,10 @@ func (s *zeroSuite) TestUseModule(c *C) {
 
 	{ // Pass: Setting exists, Input is List, Output is not a list
 		// Assume setting was set in blueprint
-		mod := Module{ID: "lime", Source: "limeTree"}
-		mod.Settings.Set("val1", cty.TupleVal([]cty.Value{ref}))
+		mod := Module{
+			ID:       "lime",
+			Settings: Dict{}.With("val1", cty.TupleVal([]cty.Value{ref})),
+			Source:   "limeTree"}
 		setTestModuleInfo(mod, modulereader.ModuleInfo{
 			Inputs: []modulereader.VarInfo{{Name: "val1", Type: cty.List(cty.Number)}},
 		})

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -22,37 +22,32 @@ import (
 )
 
 func (s *zeroSuite) TestValidateVars(c *C) {
-	base := map[string]cty.Value{
-		"deployment_name": cty.StringVal("serengeti"),
-	}
+	base := Dict{}.With("deployment_name", cty.StringVal("serengeti"))
 
 	{ // Success
-		vars := Dict{base}
+		vars := base
 		c.Check(validateVars(Blueprint{Vars: vars}), IsNil)
 	}
 
 	{ // Fail: Nil value
-		vars := Dict{base}
-		vars.Set("fork", cty.NilVal)
+		vars := base.With("fork", cty.NilVal)
 		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
 	}
 
 	{ // Fail: Null value
-		vars := Dict{base}
-		vars.Set("fork", cty.NullVal(cty.String))
+		vars := base.With("fork", cty.NullVal(cty.String))
 		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
 	}
 
 	{ // Fail: labels not a map
-		vars := Dict{base}
-		vars.Set("labels", cty.StringVal("a_string"))
+		vars := base.With("labels", cty.StringVal("a_string"))
 		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
 	}
 
 	{ // Fail: cyclic dependency
-		vars := Dict{base}
-		vars.Set("ar", GlobalRef("buz").AsValue())
-		vars.Set("buz", GlobalRef("ar").AsValue())
+		vars := base.
+			With("ar", GlobalRef("buz").AsValue()).
+			With("buz", GlobalRef("ar").AsValue())
 		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
 	}
 }

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -323,8 +323,12 @@ func (d *Dict) UnmarshalYAML(n *yaml.Node) error {
 	if !ty.IsObjectType() {
 		return nodeToPosErr(n, fmt.Errorf("must be a mapping, got %s", ty.FriendlyName()))
 	}
+
 	for k, w := range v.Unwrap().AsValueMap() {
-		d.Set(k, w)
+		if d.m == nil {
+			d.m = map[string]cty.Value{}
+		}
+		d.m[k] = w
 	}
 	return nil
 }

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -226,12 +226,11 @@ m2:
   mv: $(lime.bloom)
   hl: ((3 + 9))
 `
-	want := Dict{}
-	want.
-		Set("s1", cty.StringVal("red")).
-		Set("s2", cty.StringVal("pink")).
-		Set("m1", cty.EmptyObjectVal).
-		Set("m2", cty.ObjectVal(map[string]cty.Value{
+	want := Dict{}.
+		With("s1", cty.StringVal("red")).
+		With("s2", cty.StringVal("pink")).
+		With("m1", cty.EmptyObjectVal).
+		With("m2", cty.ObjectVal(map[string]cty.Value{
 			"m2f1": cty.StringVal("green"),
 			"m2f2": cty.TupleVal([]cty.Value{
 				cty.NumberIntVal(1),
@@ -266,11 +265,10 @@ func TestDictWrongTypeUnmarshalYAML(t *testing.T) {
 }
 
 func TestDictMarshalYAML(t *testing.T) {
-	d := Dict{}
-	d.
-		Set("s1", cty.StringVal("red")).
-		Set("m1", cty.EmptyObjectVal).
-		Set("m2", cty.ObjectVal(map[string]cty.Value{
+	d := Dict{}.
+		With("s1", cty.StringVal("red")).
+		With("m1", cty.EmptyObjectVal).
+		With("m2", cty.ObjectVal(map[string]cty.Value{
 			"m2f1": cty.StringVal("green"),
 			"m2f2": cty.TupleVal([]cty.Value{
 				cty.NumberIntVal(1),
@@ -298,8 +296,7 @@ func TestDictMarshalYAML(t *testing.T) {
 }
 
 func TestYAMLValueMarshalIntAsInt(t *testing.T) {
-	d := Dict{}
-	d.Set("zebra", cty.NumberIntVal(5))
+	d := Dict{}.With("zebra", cty.NumberIntVal(5))
 	want := "zebra: 5\n"
 	got, err := yaml.Marshal(d)
 	if err != nil {
@@ -317,10 +314,9 @@ pony: &passtime
 - sleep
 zebra: *passtime
 `
-	want := Dict{}
-	want.
-		Set("pony", cty.TupleVal([]cty.Value{cty.StringVal("eat"), cty.StringVal("sleep")})).
-		Set("zebra", cty.TupleVal([]cty.Value{cty.StringVal("eat"), cty.StringVal("sleep")}))
+	want := Dict{}.
+		With("pony", cty.TupleVal([]cty.Value{cty.StringVal("eat"), cty.StringVal("sleep")})).
+		With("zebra", cty.TupleVal([]cty.Value{cty.StringVal("eat"), cty.StringVal("sleep")}))
 	var got Dict
 	if err := yaml.Unmarshal([]byte(yml), &got); err != nil {
 		t.Fatalf("failed to decode: %v", err)

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -61,13 +61,13 @@ func (w PackerWriter) writeDeploymentGroup(
 	depGroup := bp.DeploymentGroups[grpIdx]
 
 	for _, mod := range depGroup.Modules {
-		pure := config.Dict{}
+		pure := map[string]cty.Value{}
 		for setting, v := range mod.Settings.Items() {
 			if len(config.FindIntergroupReferences(v, mod, bp)) == 0 {
-				pure.Set(setting, v)
+				pure[setting] = v
 			}
 		}
-		av, err := pure.Eval(bp)
+		av, err := config.NewDict(pure).Eval(bp)
 		if err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ func (w PackerWriter) writeDeploymentGroup(
 		if err = writePackerAutovars(av.Items(), modPath); err != nil {
 			return err
 		}
-		hasIgc := len(pure.Items()) < len(mod.Settings.Items())
+		hasIgc := len(pure) < len(mod.Settings.Items())
 		printPackerInstructions(instructionsFile, groupPath, ds, hasIgc)
 	}
 

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -200,7 +200,7 @@ func getProviders(bp config.Blueprint) []provider {
 		"region":  "region",
 		"zone":    "zone"} {
 		if bp.Vars.Has(v) {
-			gglConf.Set(s, config.GlobalRef(v).AsValue())
+			gglConf = gglConf.With(s, config.GlobalRef(v).AsValue())
 		}
 	}
 

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -403,16 +403,16 @@ func ImportInputs(deploymentGroupDir string, artifactsDir string, expandedBluepr
 
 		// evaluate Packer settings that contain intergroup references in the
 		// context of deployment variables and intergroup output values
-		intergroupSettings := config.Dict{}
+		intergroupSettings := map[string]cty.Value{}
 		for setting, value := range mod.Settings.Items() {
 			igcRefs := config.FindIntergroupReferences(value, mod, bp)
 			if len(igcRefs) > 0 {
-				intergroupSettings.Set(setting, value)
+				intergroupSettings[setting] = value
 			}
 		}
 
 		igcVars := modulewriter.FindIntergroupVariables(g, bp)
-		newModule, err := modulewriter.SubstituteIgcReferencesInModule(config.Module{Settings: intergroupSettings}, igcVars)
+		newModule, err := modulewriter.SubstituteIgcReferencesInModule(config.Module{Settings: config.NewDict(intergroupSettings)}, igcVars)
 		if err != nil {
 			return err
 		}

--- a/pkg/validators/quota_test.go
+++ b/pkg/validators/quota_test.go
@@ -210,11 +210,10 @@ requirements:
 	for _, tc := range tests {
 		t.Run(tc.yml, func(t *testing.T) {
 			var in config.Dict
-			bp := config.Blueprint{}
-			bp.Vars.
-				Set("project_id", cty.StringVal("apple")).
-				Set("region", cty.StringVal("narnia")).
-				Set("zone", cty.StringVal("narnia-51"))
+			bp := config.Blueprint{Vars: config.Dict{}.
+				With("project_id", cty.StringVal("apple")).
+				With("region", cty.StringVal("narnia")).
+				With("zone", cty.StringVal("narnia-51"))}
 			if err := yaml.Unmarshal([]byte(tc.yml), &in); err != nil {
 				t.Fatal("failed to unmarshal yaml")
 			}

--- a/pkg/validators/validators_test.go
+++ b/pkg/validators/validators_test.go
@@ -106,38 +106,35 @@ func (s *MySuite) TestDefaultValidators(c *C) {
 	}
 
 	{
-		bp := config.Blueprint{}
-		bp.Vars.Set("project_id", cty.StringVal("f00b"))
+		bp := config.Blueprint{Vars: config.Dict{}.
+			With("project_id", cty.StringVal("f00b"))}
 		c.Check(defaults(bp), DeepEquals, []config.Validator{
 			unusedMods, unusedVars, projectExists, apisEnabled})
 	}
 
 	{
-		bp := config.Blueprint{}
-		bp.Vars.
-			Set("project_id", cty.StringVal("f00b")).
-			Set("region", cty.StringVal("narnia"))
+		bp := config.Blueprint{Vars: config.Dict{}.
+			With("project_id", cty.StringVal("f00b")).
+			With("region", cty.StringVal("narnia"))}
 
 		c.Check(defaults(bp), DeepEquals, []config.Validator{
 			unusedMods, unusedVars, projectExists, apisEnabled, regionExists})
 	}
 
 	{
-		bp := config.Blueprint{}
-		bp.Vars.
-			Set("project_id", cty.StringVal("f00b")).
-			Set("zone", cty.StringVal("danger"))
+		bp := config.Blueprint{Vars: config.Dict{}.
+			With("project_id", cty.StringVal("f00b")).
+			With("zone", cty.StringVal("danger"))}
 
 		c.Check(defaults(bp), DeepEquals, []config.Validator{
 			unusedMods, unusedVars, projectExists, apisEnabled, zoneExists})
 	}
 
 	{
-		bp := config.Blueprint{}
-		bp.Vars.
-			Set("project_id", cty.StringVal("f00b")).
-			Set("region", cty.StringVal("narnia")).
-			Set("zone", cty.StringVal("danger"))
+		bp := config.Blueprint{Vars: config.Dict{}.
+			With("project_id", cty.StringVal("f00b")).
+			With("region", cty.StringVal("narnia")).
+			With("zone", cty.StringVal("danger"))}
 
 		c.Check(defaults(bp), DeepEquals, []config.Validator{
 			unusedMods, unusedVars, projectExists, apisEnabled, regionExists, zoneExists, zoneInRegion})


### PR DESCRIPTION
Replace mutator `Set` by builder `With`, see `pkg/config/dict.go`.

**Motivation:**
* Immutable structs are generally less  error-prone;
* Needed for easy `config.Blueprint.Clone()`;
* Stepping stone toward immutable `config.Blueprint`.