### PR TITLE
Slurm6. Fix bug that prevents specifying `partition_conf`

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/main.tf
@@ -14,7 +14,7 @@
 
 locals {
 
-  use_placement = [for ns in var.partition_conf : ns.nodeset_name if ns.enable_placement]
+  use_placement = [for ns in var.nodeset : ns.nodeset_name if ns.enable_placement]
 
   partition = {
     default               = var.is_default


### PR DESCRIPTION
Referenced variable had moved from partition_conf to nodeset from v5 to v6.