### PR TITLE
Reduce duplication of yaml-parsing code

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,10 +195,6 @@ const (
 	ValidationIgnore
 )
 
-func isValidValidationLevel(level int) bool {
-	return !(level > ValidationIgnore || level < ValidationError)
-}
-
 // Validator defines a validation step to be run on a blueprint
 type Validator struct {
 	Validator string
@@ -345,25 +341,12 @@ func checkMovedModule(source string) error {
 }
 
 // NewBlueprint is a constructor for Blueprint
-func NewBlueprint(configFilename string) (Blueprint, YamlCtx, error) {
-	bp, ctx, err := importBlueprint(configFilename)
-	if err != nil {
-		return Blueprint{}, ctx, err
-	}
-	// if the validation level has been explicitly set to an invalid value
-	// in YAML blueprint then silently default to validationError
-	if !isValidValidationLevel(bp.ValidationLevel) {
-		bp.ValidationLevel = ValidationError
-	}
-	return bp, ctx, nil
+func NewBlueprint(path string) (Blueprint, YamlCtx, error) {
+	return parseYamlFile[Blueprint](path)
 }
 
 func NewDeploymentSettings(deploymentFilename string) (DeploymentSettings, YamlCtx, error) {
-	depl, ctx, err := importDeploymentFile(deploymentFilename)
-	if err != nil {
-		return DeploymentSettings{}, ctx, err
-	}
-	return depl, ctx, nil
+	return parseYamlFile[DeploymentSettings](deploymentFilename)
 }
 
 // Export exports the internal representation of a blueprint config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -520,19 +520,6 @@ func (s *MySuite) TestNewBlueprint(c *C) {
 	c.Assert(bp, DeepEquals, newBp)
 }
 
-func (s *MySuite) TestImportBlueprint(c *C) {
-	bp, _, err := importBlueprint(s.simpleYamlFilename)
-	c.Assert(err, IsNil)
-	c.Check(bp.BlueprintName, Equals, "simple")
-	c.Check(bp.DeploymentGroups[0].Modules[0].ID, Equals, ModuleID("vpc"))
-
-	_, _, emptyErr := importBlueprint(s.emptyFilename)
-	c.Assert(emptyErr, NotNil)
-
-	_, _, unsupportedErr := importBlueprint(s.unsupportedFilename)
-	c.Assert(unsupportedErr, NotNil)
-}
-
 func (s *MySuite) TestNewDeploymentSettings(c *C) {
 	ds, _, err := NewDeploymentSettings(s.deploymentFilename)
 	c.Assert(err, IsNil)
@@ -660,18 +647,12 @@ func (s *zeroSuite) TestValidateGlobalLabels(c *C) {
 	}
 }
 
-func (s *zeroSuite) TestImportBlueprint_ExtraField_ThrowsError(c *C) {
-	yaml := []byte(`
+func (s *zeroSuite) TestParseBlueprint_ExtraField_ThrowsError(c *C) {
+	// should fail on strict unmarshal as field does not match schema
+	_, _, err := parseYaml[Blueprint]([]byte(`
 blueprint_name: hpc-cluster-high-io
 # line below is not in our schema
-dragon: "Lews Therin Telamon"`)
-	file, _ := os.CreateTemp("", "*.yaml")
-	file.Write(yaml)
-	filename := file.Name()
-	file.Close()
-
-	// should fail on strict unmarshal as field does not match schema
-	_, _, err := importBlueprint(filename)
+dragon: "Lews Therin Telamon"`))
 	c.Check(err, NotNil)
 }
 
@@ -685,15 +666,6 @@ func (s *MySuite) TestExportBlueprint(c *C) {
 	c.Assert(fileInfo.Name(), Equals, outFilename)
 	c.Assert(fileInfo.Size() > 0, Equals, true)
 	c.Assert(fileInfo.IsDir(), Equals, false)
-}
-
-func (s *zeroSuite) TestValidationLevels(c *C) {
-	c.Check(isValidValidationLevel(0), Equals, true)
-	c.Check(isValidValidationLevel(1), Equals, true)
-	c.Check(isValidValidationLevel(2), Equals, true)
-
-	c.Check(isValidValidationLevel(-1), Equals, false)
-	c.Check(isValidValidationLevel(3), Equals, false)
 }
 
 func (s *zeroSuite) TestCheckMovedModules(c *C) {

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -160,7 +160,6 @@ var EmptyGroupName = errors.New("group name must be set for each deployment grou
 
 // Error messages
 const (
-	errMsgFileLoadError    = string("failed to read the input yaml")
 	errMsgYamlMarshalError = string("failed to export the configuration to a blueprint yaml file")
 	errMsgYamlSaveError    = string("failed to write the expanded yaml")
 	errMsgInvalidVar       = string("invalid variable definition in")

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -54,45 +54,29 @@ type Pos struct {
 	Column int
 }
 
-func readYaml(f string) (*yaml.Decoder, YamlCtx, error) {
-	data, err := os.ReadFile(f)
-	if err != nil {
-		return &yaml.Decoder{}, YamlCtx{}, fmt.Errorf("%s, filename=%s: %v", errMsgFileLoadError, f, err)
-	}
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
+func parseYaml[T any](y []byte) (T, YamlCtx, error) {
+	var s T
 
-	yamlCtx, err := NewYamlCtx(data)
+	yamlCtx, err := NewYamlCtx(y)
 	if err != nil { // YAML parsing error
-		return &yaml.Decoder{}, yamlCtx, err
+		return s, yamlCtx, err
 	}
-	return decoder, yamlCtx, nil
+
+	decoder := yaml.NewDecoder(bytes.NewReader(y))
+	decoder.KnownFields(true)
+	if err = decoder.Decode(&s); err != nil {
+		return s, yamlCtx, parseYamlV3Error(err)
+	}
+	return s, yamlCtx, nil
 }
 
-func importBlueprint(f string) (Blueprint, YamlCtx, error) {
-	decoder, yamlCtx, err := readYaml(f)
+func parseYamlFile[T any](path string) (T, YamlCtx, error) {
+	y, err := os.ReadFile(path)
 	if err != nil {
-		return Blueprint{}, YamlCtx{}, err
+		var s T
+		return s, YamlCtx{}, fmt.Errorf("failed to read the input yaml, filename=%s: %v", path, err)
 	}
-
-	var bp Blueprint
-	if err = decoder.Decode(&bp); err != nil {
-		return Blueprint{}, yamlCtx, parseYamlV3Error(err)
-	}
-	return bp, yamlCtx, nil
-}
-
-func importDeploymentFile(f string) (DeploymentSettings, YamlCtx, error) {
-	decoder, yamlCtx, err := readYaml(f)
-	if err != nil {
-		return DeploymentSettings{}, YamlCtx{}, err
-	}
-
-	var depl DeploymentSettings
-	if err = decoder.Decode(&depl); err != nil {
-		return DeploymentSettings{}, yamlCtx, parseYamlV3Error(err)
-	}
-	return depl, yamlCtx, nil
+	return parseYaml[T](y)
 }
 
 // YamlCtx is a contextual information to render errors.


### PR DESCRIPTION
* Reduce duplication of yaml-parsing code;
* Remove unused `isValidValidationLevel`, validation level is always overwritten from CLI vars.

