### PR TITLE
Prevent usage of placement with static and auto-scale nodes in same nodeset

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -32,4 +32,9 @@ output "nodeset" {
       If the specified reservation has a placement policy then it will be used automatically.
     EOD
   }
+
+  precondition {
+    condition     = !var.enable_placement || var.node_count_static == 0 || var.node_count_dynamic_max == 0
+    error_message = "Cannot use placement with static and auto-scaling nodes in the same node set."
+  }
 }


### PR DESCRIPTION
In theory this could work but currently does not work and is not something we have historically supported. Current behavior is that deployment succeeds but auto-scale nodes are not schedulable. 

I have confirmed that mixing static and auto-scale works when placement is off. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
