### PR TITLE
Perform explicit cyclic dependencies check in `validateVars`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -673,15 +673,14 @@ func varsTopologicalOrder(vars Dict) ([]string, error) {
 		used[n] = 1 // put on stack
 		v := vars.Get(n)
 		for ref, rp := range valueReferences(v) {
-			// TODO: instead of ref.Name render as a full reference
-			repr, p := ref.Name, Root.Vars.Dot(n).Cty(rp)
+			p := Root.Vars.Dot(n).Cty(rp)
 
 			if !ref.GlobalVar {
-				return BpError{p, fmt.Errorf("non-global variable %q referenced in expression", repr)}
+				return BpError{p, fmt.Errorf("non-global variable %q referenced in expression", ref.Name)}
 			}
 
 			if used[ref.Name] == 1 {
-				return BpError{p, fmt.Errorf("cyclic dependency detected: %q -> %q", n, repr)}
+				return BpError{p, fmt.Errorf("cyclic dependency detected: %q -> %q", n, ref.Name)}
 			}
 
 			if used[ref.Name] == 0 {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -83,6 +83,10 @@ func validateGlobalLabels(bp Blueprint) error {
 
 // validateVars checks the global variables for viable types
 func validateVars(bp Blueprint) error {
+	if _, err := varsTopologicalOrder(bp.Vars); err != nil {
+		return err
+	}
+
 	errs := (&Errors{}).
 		Add(validateDeploymentName(bp)).
 		Add(validateGlobalLabels(bp))

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -48,6 +48,13 @@ func (s *zeroSuite) TestValidateVars(c *C) {
 		vars.Set("labels", cty.StringVal("a_string"))
 		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
 	}
+
+	{ // Fail: cyclic dependency
+		vars := Dict{base}
+		vars.Set("ar", GlobalRef("buz").AsValue())
+		vars.Set("buz", GlobalRef("ar").AsValue())
+		c.Check(validateVars(Blueprint{Vars: vars}), NotNil)
+	}
 }
 
 func (s *zeroSuite) TestValidateSettings(c *C) {


### PR DESCRIPTION
Currently it's done implicitly by calling `validateDeploymentName -> evalVars`, but that can change in the future.
