### PR TITLE
Fix for wait-for-startup.yml ansible task

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
@@ -22,7 +22,7 @@
   become: true
   ansible.builtin.wait_for:
     path: /var/log/messages
-    search_regex: '.*{{ vm_name }}.*startup-script exit status ([0-9]+)'
+    search_regex: '.+startup-script exit status ([0-9]+)'
     timeout: "{{ timeout_seconds }}"
   register: startup_status
 - name: Fail if startup script exited with a non-zero return code

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
@@ -19,12 +19,13 @@
 
 - name: Wait for startup script to complete
   become: true
-  ansible.builtin.wait_for:
-    path: /var/log/messages
-    search_regex: '.+startup-script exit status ([0-9]+)'
-    timeout: "{{ timeout_seconds }}"
-  register: startup_status
+  ansible.builtin.shell: journalctl -u google-startup-scripts.service -b | grep -oP "startup-script exit status \K\d+"
+  register: result
+  until: result.rc == 0
+  retries: "{{ (timeout_seconds/5)|int }}"
+  delay: 5
+
 - name: Fail if startup script exited with a non-zero return code
   ansible.builtin.fail:
     msg: There was a failure in the startup script
-  when: startup_status['match_groups'][0] != "0"
+  when: result.stdout != "0"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
@@ -15,7 +15,6 @@
 - name: Assert variables are defined
   ansible.builtin.assert:
     that:
-    - vm_name is defined
     - timeout_seconds is defined
 
 - name: Wait for startup script to complete

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-batch-submission.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-batch-submission.yml
@@ -20,7 +20,6 @@
 - name: Include wait for startup script
   ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
   vars:
-    vm_name: "{{ remote_node }}"
     timeout_seconds: 600
 
 - name: Batch Job Block

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-monitoring.yml
@@ -17,7 +17,6 @@
 - name: Include wait for startup script
   ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
   vars:
-    vm_name: "{{ remote_node }}"
     timeout_seconds: 600
 
 - name: Gather service facts

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-spack.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-spack.yml
@@ -17,7 +17,6 @@
 - name: Include wait for startup script
   ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
   vars:
-    vm_name: "{{ image_name }}"
     timeout_seconds: 10800  # 3 hrs, should be less than integration test timeout
 - name: Ensure spack is installed
   ansible.builtin.command: spack --version

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-spack.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-spack.yml
@@ -17,7 +17,7 @@
 - name: Include wait for startup script
   ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
   vars:
-    timeout_seconds: 10800  # 3 hrs, should be less than integration test timeout
+    timeout_seconds: 10800  # 3 hrs
 - name: Ensure spack is installed
   ansible.builtin.command: spack --version
   changed_when: False

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-spack.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-spack.yml
@@ -18,7 +18,7 @@
   ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
   vars:
     vm_name: "{{ image_name }}"
-    timeout_seconds: 21600
+    timeout_seconds: 10800  # 3 hrs, should be less than integration test timeout
 - name: Ensure spack is installed
   ansible.builtin.command: spack --version
   changed_when: False


### PR DESCRIPTION
The spack-gromacs test has failed the last few times it's been run.  This is due to an issue with the HPC-Rocky-8 image and the new Slurm-GCP-6.4 image.  In both images the hostname in /var/log/messages does not match the VM hostname, which causes the wait-for-startup.yml playbook to wait until the timeout.  At this point the test fails.

Two fixes have been added:
1. The `{vm_image}` has been removed from the task and the tasks that called it.  We will just rely on the `startup-script exit status` portion of the line, and now its taken from `journalctl` so that we know it's from this boot instead of potentially looking at the leftover data in `/var/log/messages`.  This also required switching to using an until loop instead of wait_for.  One side effect is that the number of failed attempts is printed out, which can be a number of lines for longer running startup-scripts.
2. The timeout has been reduced to 3 hours.  It was originally 6 hours which is longer than the timeout of the integration test that was calling the task.  This meant the integration test was timing out so the error was not as clear.

This has been tested by running the spack-gromacs and monitoring integration tests, which use this task.