### PR TITLE
Add TPU v4 blueprint and tutorial to demonstrate running TPU workload

### DIFF
--- a/community/examples/hpc-slurm6-tpu-v4.md
+++ b/community/examples/hpc-slurm6-tpu-v4.md
@@ -1,0 +1,90 @@
+# Run TPU jobs in Slurm Cluster with TPU Partition
+
+This page demonstrates how to run TPU job like [maxtest](https://github.com/google/maxtext)
+performance benchmark test in Slurm Cluster with TPU partition using [hpc-slurm6-tpu-v4.yaml](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/community/examples/hpc-slurm6-tpu-v4.yaml)
+blueprint.
+
+## Generate the deployment and deploy the cluster
+
+In order to deploy and run this blueprint, you need to download dataset in your
+cloud storage bucket. You need follow steps mentioned in [download dataset](https://github.com/google/maxtext?tab=readme-ov-file#getting-started-download-dataset-and-configure) to download
+the dataset in your GCS. After that you can update the blueprint to use the
+dataset from GCS bucket in training script.
+
+```bash
+./ghpc create community/examples/hpc-slurm6-tpu-v4.yaml -l ERROR --vars project_id=<project-id>;
+./ghpc deploy slurm6-tpu --auto-approve
+```
+
+This would deploy slurm cluster with TPU partition, dynamic compute partition. Maxtest benchmark test script
+will be stored in `/opt/apps/scripts/tpu-test` directory.
+
+## Connect to the login node
+Once the startup script has completed, connect to the login node.
+
+Use the following command to ssh into the login node from cloud shell:
+
+```bash
+gcloud compute ssh slurm6tpu-login-v6tpu-001 --zone us-central2-b --project <project-id>
+```
+
+You may be prompted to set up SSH. If so follow the prompts and if asked for a
+password, just hit `[enter]` leaving the input blank.
+
+## Run maxtest script
+
+```bash
+cd /opt/apps/scripts/tpu-test/
+sbatch -ptpu --mem=50000 run_maxtest.sh
+```
+
+The `sbatch` command trigger Slurm to auto-scale up nodes to run the job.
+
+You can refresh the TPU instances page and see that TPU is being/has been created.
+These will be named something like `slurm6tpu-v4x8-0`.
+
+When running `squeue`, observe the job status start as `CF` (configuring), change to
+`R` (running) once the compute VMs have been created, and finally `CG` (completing)
+when job has finished and nodes are spooling down.
+
+## Review the output
+
+The `/opt/apps/scripts/tpu-test` directory will have several files and directories generated.
+`slurm-<job-id>.out` file contains standard output for the TPU job.
+
+```bash
+cat slurm-1.out
+```
+
+This should have something like
+
+```bash
+completed step: 23, seconds: 4.911, TFLOP/s/device: 34.760, loss: 12.192
+completed step: 24, seconds: 4.908, TFLOP/s/device: 34.781, loss: 12.173
+```
+
+This would run for the number of steps that have been provided.
+
+## Destroy the Cluster
+
+To avoid incurring ongoing charges we will want to destroy our cluster.
+
+For this we need to return to our cloud shell terminal. Run exit in the terminal to close the SSH connection to the login node.
+
+Run the following command in the cloud shell terminal to destroy the cluster:
+
+```bash
+./ghpc destroy slurm6-tpu --auto-approve
+```
+
+When complete you should see something like:
+
+```bash
+Destroy complete! Resources: xx destroyed.
+```
+
+> **_NOTE:_** If destroy is run before Slurm shut down the auto-scale nodes then
+> they will be left behind and destroy may fail. In this case you can delete the
+> VMs manually and rerun the destroy command above.
+
+## Tutorial Complete

--- a/community/examples/hpc-slurm6-tpu-v4.yaml
+++ b/community/examples/hpc-slurm6-tpu-v4.yaml
@@ -1,0 +1,120 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: slurm6-tpu
+
+vars:
+  project_id: ## Set GCP Project ID Here ##
+  deployment_name: slurm6-tpu
+  region: us-central2
+  zone: us-central2-b
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  - id: script
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: shell
+        destination: tpu_setup.sh
+        content: |
+          #!/bin/bash
+          mkdir -p /opt/apps/scripts/tpu-test
+          chmod a+rwx /opt/apps/scripts/tpu-test
+
+      - type: data
+        destination: /opt/apps/scripts/tpu-test/run_maxtest.sh
+        content: |
+          #!/bin/bash
+          # Update the following parameters in the python3 command in this script.
+          # RUN_NAME: (required, see https://github.com/google/maxtext?tab=readme-ov-file#overview)
+          # STORAGE_BUCKET: GCS bucket where dataset is stored. (i.e.: gs://dataset-tpu/dataset)
+          # ATTENTION: (i.e. dot_product, flash)
+          # STEPS: steps to run (i.e. 100, 1000)
+
+          # Start virtual environment.
+          virtualenv venv
+          source venv/bin/activate
+
+          # Clone maxtest repository and install dependencies.
+          git clone https://github.com/google/maxtext
+          cd maxtext/
+          bash setup.sh
+
+          # Run maxtest benchmark test.
+          python3 MaxText/train.py MaxText/configs/base.yml run_name=<RUN_NAME> base_output_directory=/opt/apps/scripts/tpu-test/output/ dataset_path=<STORAGE_BUCKET> async_checkpointing=False attention=<ATTENTION> steps=<STEPS>
+
+  - id: tpu_nodeset
+    source: ./community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu
+    use: [network]
+    settings:
+      name: v4x8
+      node_type: v4-8
+      tf_version: 2.14.0
+      # Preemptible TPUs cost much less than non-preemptible TPUs.
+      # The Cloud TPU service might preempt (shut down) these TPUs at any time.
+      # https://cloud.google.com/tpu/docs/preemptible
+      preemptible: false
+      # Specify whether to preserve TPU on suspend.
+      # If set to true, suspended VM will be stopped.
+      # If set to false, suspended VM will be deleted.
+      preserve_tpu: false
+      node_count_dynamic_max: 1
+
+  - id: tpu_partition
+    source: ./community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [tpu_nodeset]
+    settings:
+      partition_name: tpu
+
+  - id: compute_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      name: ns2
+      node_count_dynamic_max: 20
+      bandwidth_tier: gvnic_enabled
+
+  - id: compute_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [compute_nodeset]
+    settings:
+      partition_name: compute
+      is_default: true
+
+  - id: slurm_login
+    source: ./community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      disable_login_public_ips: false
+      name_prefix: "v6tpu"
+      machine_type: n2-standard-16
+
+  - id: slurm_controller
+    source: ./community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - tpu_partition
+    - compute_partition
+    - slurm_login
+    - network
+    settings:
+      disable_controller_public_ips: false
+      machine_type: n2-standard-16
+      login_startup_script: $(script.startup_script)

--- a/community/examples/hpc-slurm6-tpu.yaml
+++ b/community/examples/hpc-slurm6-tpu.yaml
@@ -17,7 +17,7 @@
 blueprint_name: slurm6-tpu
 
 vars:
-  project_id:
+  project_id: ## Set GCP Project ID Here ##
   deployment_name: slurm6-tpu
   region: us-central1
   zone: us-central1-b


### PR DESCRIPTION
This PR runs TPU benchmark test `maxtest` using Slurm Cluster + TPU v4. This also contains tutorial document to demonstrate how to run TPU workload using this blueprint. 


### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
