### PR TITLE
Slurm v6: add extended prolog/epilog configuration template

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl
@@ -1,0 +1,70 @@
+# slurm.conf
+# https://slurm.schedmd.com/slurm.conf.html
+# https://slurm.schedmd.com/configurator.html
+
+ProctrackType=proctrack/cgroup
+SlurmctldPidFile=/var/run/slurm/slurmctld.pid
+SlurmdPidFile=/var/run/slurm/slurmd.pid
+TaskPlugin=task/affinity,task/cgroup
+MaxNodeCount=64000
+
+#
+#
+# SCHEDULING
+SchedulerType=sched/backfill
+SelectType=select/cons_tres
+SelectTypeParameters=CR_Core_Memory
+
+#
+#
+# LOGGING AND ACCOUNTING
+AccountingStoreFlags=job_comment
+JobAcctGatherFrequency=30
+JobAcctGatherType=jobacct_gather/cgroup
+SlurmctldDebug=info
+SlurmdDebug=info
+DebugFlags=Power
+
+#
+#
+# TIMERS
+MessageTimeout=60
+BatchStartTimeout=600
+PrologEpilogTimeout=600
+PrologFlags=Contain
+
+################################################################################
+#              vvvvv  WARNING: DO NOT MODIFY SECTION BELOW  vvvvv              #
+################################################################################
+
+SlurmctldHost={control_host}({control_addr})
+
+AuthType=auth/munge
+AuthInfo=cred_expire=120
+AuthAltTypes=auth/jwt
+CredType=cred/munge
+MpiDefault={mpi_default}
+ReturnToService=2
+SlurmctldPort={control_host_port}
+SlurmdPort=6818
+SlurmdSpoolDir=/var/spool/slurmd
+SlurmUser=slurm
+StateSaveLocation={state_save}
+
+#
+#
+# LOGGING AND ACCOUNTING
+AccountingStorageType=accounting_storage/slurmdbd
+AccountingStorageHost={control_host}
+ClusterName={name}
+SlurmctldLogFile={slurmlog}/slurmctld.log
+SlurmdLogFile={slurmlog}/slurmd-%n.log
+
+#
+#
+# GENERATED CLOUD CONFIGURATIONS
+include cloud.conf
+
+################################################################################
+#              ^^^^^  WARNING: DO NOT MODIFY SECTION ABOVE  ^^^^^              #
+################################################################################

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -70,6 +70,10 @@ duplicates = [
     [
         "community/modules/scripts/spack-setup/scripts/install_spack_deps.yml",
         "community/modules/scripts/ramble-setup/scripts/install_ramble_deps.yml",
+    ],
+    [
+        "community/modules/scheduler/schedmd-slurm-gcp-v5-controller/etc/long-prolog-slurm.conf.tpl",
+        "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl",
     ]
 ]
 


### PR DESCRIPTION
Copy v5 slurm.conf template for long execution time prologs and epilogs to v6 controller module. In the long term, these files may diverge. For now, treat them as duplicates.


### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
