### PR TITLE
Default to instance_image_custom false in Slurm enterprise

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -27,6 +27,8 @@ vars:
     # for a list of valid family options with Slurm
     family: slurm-gcp-5-10-hpc-centos-7
     project: schedmd-slurm-public
+  # If image above is changed to use custom image, then setting below must be set to true
+  instance_image_custom: false
   # Set to true for active cluster reconfiguration.
   # Note that setting this option requires additional dependencies to be installed locally.
   # https://github.com/GoogleCloudPlatform/hpc-toolkit/tree/main/community/modules/scheduler/schedmd-slurm-gcp-v5-controller#description
@@ -111,7 +113,6 @@ deployment_groups:
       node_count_dynamic_max: 4
       machine_type: n2-standard-2
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       service_account:
         email: $(compute_sa.service_account_email)
         scopes:
@@ -134,7 +135,6 @@ deployment_groups:
       node_count_dynamic_max: 20
       machine_type: c2-standard-60  # this is the default
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       bandwidth_tier: tier_1_enabled
       disk_type: pd-ssd
       disk_size_gb: 100
@@ -160,7 +160,6 @@ deployment_groups:
       node_count_dynamic_max: 20
       machine_type: c2d-standard-112
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       bandwidth_tier: tier_1_enabled
       disk_type: pd-ssd
       disk_size_gb: 100
@@ -181,7 +180,6 @@ deployment_groups:
       node_count_dynamic_max: 20
       machine_type: c3-highcpu-176
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       bandwidth_tier: tier_1_enabled
       disk_type: pd-ssd
       disk_size_gb: 100
@@ -203,7 +201,6 @@ deployment_groups:
       machine_type: a2-ultragpu-8g
       bandwidth_tier: gvnic_enabled
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       disk_type: pd-ssd
       disk_size_gb: 100
       node_conf:
@@ -236,7 +233,6 @@ deployment_groups:
       machine_type: a2-megagpu-16g
       bandwidth_tier: gvnic_enabled
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       disk_type: pd-ssd
       disk_size_gb: 100
       node_conf:
@@ -269,7 +265,6 @@ deployment_groups:
       machine_type: h3-standard-88
       bandwidth_tier: gvnic_enabled  # https://cloud.google.com/compute/docs/compute-optimized-machines#h3_network
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       service_account:
         email: $(compute_sa.service_account_email)
         scopes:
@@ -294,7 +289,6 @@ deployment_groups:
           h3_partition]
     settings:
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       # the following allow for longer boot time
       # which is useful for large GPU nodes
       cloud_parameters:
@@ -319,7 +313,6 @@ deployment_groups:
     - slurm_controller
     settings:
       instance_image: $(vars.slurm_image)
-      instance_image_custom: true
       machine_type: n2-standard-4
       disable_login_public_ips: false
       service_account:


### PR DESCRIPTION
It was confusing to see this setting when a custom image was not being used.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
