### PR TITLE
Update naming convention for hpc-slurm blueprint for v5 and v6 versions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -33,8 +33,8 @@ After ~6 months (~September) Slurm v5 modules will be removed from the HPC Toolk
 * [Instructions](#instructions)
   * [(Optional) Setting up a remote terraform state](#optional-setting-up-a-remote-terraform-state)
 * [Blueprint Descriptions](#blueprint-descriptions)
-  * [hpc-slurm.yaml](#hpc-slurmyaml--) ![core-badge] ![experimental-badge]
-  * [hpc-slurm-v5-legacy.yaml](#hpc-slurm-v5-legacyyaml-) ![core-badge]
+  * [hpc-slurm.yaml](#hpc-slurmyaml-) ![core-badge]
+  * [hpc-slurm-v6.yaml](#hpc-slurm-v6yaml--) ![core-badge] ![experimental-badge]
   * [hpc-enterprise-slurm.yaml](#hpc-enterprise-slurmyaml-) ![core-badge]
   * [hpc-slurm6-tpu.yaml](#hpc-slurm6-tpuyaml--) ![community-badge] ![experimental-badge]
   * [ml-slurm.yaml](#ml-slurmyaml-) ![core-badge]
@@ -136,13 +136,15 @@ Toolkit team, partners, etc.) and are labeled with the community badge
 Blueprints that are still in development and less stable are also labeled with
 the experimental badge (![experimental-badge]).
 
-### [hpc-slurm.yaml] ![core-badge] ![experimental-badge]
+### [hpc-slurm.yaml] ![core-badge]
 
-> **Warning**: Requires additional dependencies **to be installed on the system deploying the infrastructure**.
+> **Warning**: The variables `enable_reconfigure`,
+> `enable_cleanup_compute`, and `enable_cleanup_subscriptions`, if set to
+> `true`, require additional dependencies **to be installed on the system deploying the infrastructure**.
 >
 > ```shell
 > # Install Python3 and run
-> pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/6.4.2/scripts/requirements.txt
+> pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.10.4/scripts/requirements.txt
 > ```
 
 Creates a basic auto-scaling Slurm cluster with mostly default settings. The
@@ -193,15 +195,13 @@ For this example the following is needed in the selected region:
 * Compute Engine API: Resource policies: **one for each job in parallel** -
   _only needed for the `compute` partition_
 
-### [hpc-slurm-v5-legacy.yaml] ![core-badge]
+### [hpc-slurm-v6.yaml] ![core-badge] ![experimental-badge]
 
-> **Warning**: The variables `enable_reconfigure`,
-> `enable_cleanup_compute`, and `enable_cleanup_subscriptions`, if set to
-> `true`, require additional dependencies **to be installed on the system deploying the infrastructure**.
+> **Warning**: Requires additional dependencies **to be installed on the system deploying the infrastructure**.
 >
 > ```shell
 > # Install Python3 and run
-> pip3 install -r https://raw.githubusercontent.com/SchedMD/slurm-gcp/5.9.1/scripts/requirements.txt
+> pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/6.4.2/scripts/requirements.txt
 > ```
 
 Creates a basic auto-scaling Slurm cluster with mostly default settings. The
@@ -214,7 +214,7 @@ needing to request additional quota. The purpose of the `debug` partition is to
 make sure that first time users are not immediately blocked by quota
 limitations.
 
-[hpc-slurm-v5-legacy.yaml]: ./hpc-slurm-v5-legacy.yaml
+[hpc-slurm-v6.yaml]: ./hpc-slurm-v6.yaml
 
 #### Compute Partition
 
@@ -229,7 +229,7 @@ select the compute partition using the `-p compute` argument when running `srun`
 There is an `h3` partition that uses compute-optimized `h3-standard-88` machine type.
 You can read more about the H3 machine series [here](https://cloud.google.com/compute/docs/compute-optimized-machines#h3_series).
 
-#### Quota Requirements for hpc-slurm-v5-legacy.yaml
+#### Quota Requirements for hpc-slurm-v6.yaml
 
 For this example the following is needed in the selected region:
 

--- a/examples/hpc-slurm-v6.yaml
+++ b/examples/hpc-slurm-v6.yaml
@@ -18,7 +18,7 @@ blueprint_name: hpc-slurm
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: hpc-small
+  deployment_name: hpc-slurm
   region: us-central1
   zone: us-central1-a
 
@@ -31,50 +31,51 @@ deployment_groups:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
   # Example - ./modules/network/vpc
-  - id: network1
+  - id: network
     source: modules/network/vpc
 
   - id: homefs
     source: modules/file-system/filestore
-    use: [network1]
+    use: [network]
     settings:
       local_mount: /home
 
-  - id: debug_node_group
-    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+  - id: debug_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
     settings:
       node_count_dynamic_max: 4
       machine_type: n2-standard-2
+      enable_placement: false # the default is: true
 
   - id: debug_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
     use:
-    - network1
     - homefs
-    - debug_node_group
+    - debug_nodeset
     settings:
       partition_name: debug
       exclusive: false # allows nodes to stay up after jobs are done
-      enable_placement: false # the default is: true
       is_default: true
 
-  - id: compute_node_group
-    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+  - id: compute_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
     settings:
       node_count_dynamic_max: 20
       bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
     use:
-    - network1
     - homefs
-    - compute_node_group
+    - compute_nodeset
     settings:
       partition_name: compute
 
-  - id: h3_node_group
-    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+  - id: h3_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
     settings:
       node_count_dynamic_max: 20
       machine_type: h3-standard-88
@@ -84,30 +85,29 @@ deployment_groups:
       bandwidth_tier: gvnic_enabled
 
   - id: h3_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
     use:
-    - network1
     - homefs
-    - h3_node_group
+    - h3_nodeset
     settings:
       partition_name: h3
 
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      name_prefix: login
+      machine_type: n2-standard-4
+      disable_login_public_ips: false
+
   - id: slurm_controller
-    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
-    - network1
+    - network
     - debug_partition
     - compute_partition
     - h3_partition
     - homefs
+    - slurm_login
     settings:
       disable_controller_public_ips: false
-
-  - id: slurm_login
-    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
-    use:
-    - network1
-    - slurm_controller
-    settings:
-      machine_type: n2-standard-4
-      disable_login_public_ips: false

--- a/examples/hpc-slurm.yaml
+++ b/examples/hpc-slurm.yaml
@@ -18,7 +18,7 @@ blueprint_name: hpc-slurm
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: hpc-slurm
+  deployment_name: hpc-small
   region: us-central1
   zone: us-central1-a
 
@@ -31,51 +31,50 @@ deployment_groups:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
   # Example - ./modules/network/vpc
-  - id: network
+  - id: network1
     source: modules/network/vpc
 
   - id: homefs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network1]
     settings:
       local_mount: /home
 
-  - id: debug_nodeset
-    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
-    use: [network]
+  - id: debug_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: 4
       machine_type: n2-standard-2
-      enable_placement: false # the default is: true
 
   - id: debug_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
     use:
+    - network1
     - homefs
-    - debug_nodeset
+    - debug_node_group
     settings:
       partition_name: debug
       exclusive: false # allows nodes to stay up after jobs are done
+      enable_placement: false # the default is: true
       is_default: true
 
-  - id: compute_nodeset
-    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
-    use: [network]
+  - id: compute_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: 20
       bandwidth_tier: gvnic_enabled
 
   - id: compute_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
     use:
+    - network1
     - homefs
-    - compute_nodeset
+    - compute_node_group
     settings:
       partition_name: compute
 
-  - id: h3_nodeset
-    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
-    use: [network]
+  - id: h3_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
     settings:
       node_count_dynamic_max: 20
       machine_type: h3-standard-88
@@ -85,29 +84,30 @@ deployment_groups:
       bandwidth_tier: gvnic_enabled
 
   - id: h3_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
     use:
+    - network1
     - homefs
-    - h3_nodeset
+    - h3_node_group
     settings:
       partition_name: h3
 
-  - id: slurm_login
-    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
-    use: [network]
-    settings:
-      name_prefix: login
-      machine_type: n2-standard-4
-      disable_login_public_ips: false
-
   - id: slurm_controller
-    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
     use:
-    - network
+    - network1
     - debug_partition
     - compute_partition
     - h3_partition
     - homefs
-    - slurm_login
     settings:
       disable_controller_public_ips: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    use:
+    - network1
+    - slurm_controller
+    settings:
+      machine_type: n2-standard-4
+      disable_login_public_ips: false

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
@@ -26,7 +26,7 @@ cli_deployment_vars:
   zone: "{{ zone }}"
   zones: "[us-west4-a,us-west4-b,us-west4-c]"
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/examples/hpc-slurm-v5-legacy.yaml"
+blueprint_yaml: "{{ workspace }}/examples/hpc-slurm.yaml"
 network: "{{ deployment_name }}-net"
 max_nodes: 5
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
@@ -26,7 +26,7 @@ cli_deployment_vars:
 
 zone: us-west4-c
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/examples/hpc-slurm.yaml"
+blueprint_yaml: "{{ workspace }}/examples/hpc-slurm-v6.yaml"
 network: "{{ deployment_name }}-net"
 max_nodes: 5
 # Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.


### PR DESCRIPTION
This PR updates naming convention for hpc-slurm blueprint in example/ folder for Slurm v5 and Slurm v6 version. 

For Slurm v5, it would be `hpc-slurm.yaml` and for Slurm v6, it would be `hpc-slurm-v6.yaml`.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
