### PR TITLE
Test tags: set a tag for each module used in tested blueprint.

### DIFF
--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.batch-job-template
+- m.batch-login-node
+- m.filestore
+- m.pre-existing-vpc
+- m.spack-execute
+- m.spack-setup
+- m.startup-script
+- m.vm-instance
+
 timeout: 14400s  # 4hr
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.chrome-remote-desktop
+- m.vpc
+- m.wait-for-startup
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.chrome-remote-desktop
+- m.vpc
+- m.wait-for-startup
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.batch-job-template
+- m.batch-login-node
+- m.filestore
+- m.pre-existing-vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.pre-existing-vpc
+- m.vm-instance
+
 timeout: 3600s  # 1hr
 steps:
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -13,7 +13,15 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.cloud-storage-bucket
+- m.filestore
+- m.gke-cluster
+- m.gke-job-template
+- m.gke-node-pool
+- m.gke-persistent-volume
+- m.vpc
+
 timeout: 14400s  # 4hr
 
 steps:

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.gke-cluster
+- m.gke-job-template
+- m.gke-node-pool
+- m.vpc
+
 timeout: 14400s  # 4hr
 
 steps:

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -13,7 +13,22 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.chrome-remote-desktop
+- m.cloud-storage-bucket
+- m.dashboard
+- m.filestore
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.service-enablement
+- m.spack-execute
+- m.spack-setup
+- m.startup-script
+- m.vm-instance
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.custom-image
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.startup-script
+- m.vpc
+
 timeout: 5400s  # 1.5h
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -13,7 +13,17 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.DDN-EXAScaler
+- m.dashboard
+- m.filestore
+- m.pre-existing-vpc
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.service-account
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/hpc-high-io-v5.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-high-io-v5.yaml
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.DDN-EXAScaler
+- m.dashboard
+- m.filestore
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/hpc-slurm-chromedesktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-slurm-chromedesktop.yaml
@@ -13,7 +13,15 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.chrome-remote-desktop
+- m.filestore
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -13,7 +13,18 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.custom-image
+- m.htcondor-access-point
+- m.htcondor-central-manager
+- m.htcondor-execute-point
+- m.htcondor-install
+- m.htcondor-pool-secrets
+- m.htcondor-service-accounts
+- m.htcondor-setup
+- m.startup-script
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/lustre-slurm.yaml
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.DDN-EXAScaler
+- m.pre-existing-vpc
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/lustre-vm.yaml
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.DDN-EXAScaler
+- m.pre-existing-vpc
+- m.startup-script
+- m.vm-instance
+- m.wait-for-startup
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -13,7 +13,17 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.custom-image
+- m.filestore
+- m.firewall-rules
+- m.pre-existing-vpc
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.startup-script
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -13,7 +13,15 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.cloud-storage-bucket
+- m.dashboard
+- m.nfs-server
+- m.startup-script
+- m.vm-instance
+- m.vpc
+- m.wait-for-startup
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/packer-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer-v6.yaml
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.custom-image
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.service-account
+- m.startup-script
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.custom-image
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.service-account
+- m.startup-script
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/pbspro.yaml
+++ b/tools/cloud-build/daily-tests/builds/pbspro.yaml
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.filestore
+- m.pbspro-client
+- m.pbspro-execution
+- m.pbspro-server
+- m.pre-existing-vpc
+
 timeout: 14400s  # 4hr
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-debian.yaml
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.filestore
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-hpc-centos7.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-hpc-centos7.yaml
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.filestore
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-rocky8.yaml
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.filestore
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-startup-scripts.yaml
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.cloud-storage-bucket
+- m.nfs-server
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.startup-script
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-ubuntu2004.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-ubuntu2004.yaml
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.filestore
+- m.schedmd-slurm-gcp-v5-controller
+- m.schedmd-slurm-gcp-v5-login
+- m.schedmd-slurm-gcp-v5-node-group
+- m.schedmd-slurm-gcp-v5-partition
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 ---
-tags: [slurm6, rocky8]
+tags:
+- slurm6
+- rocky8
+- m.filestore
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -13,7 +13,15 @@
 # limitations under the License.
 
 ---
-tags: [slurm6, tpu]
+tags:
+- slurm6
+- tpu
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset-tpu
+- m.schedmd-slurm-gcp-v6-partition
+- m.vpc
+
 timeout: 14400s  # 4hr
 steps:
 ## Test simple golang build

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -13,7 +13,17 @@
 # limitations under the License.
 
 ---
-tags: []
+tags:
+- m.filestore
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.spack-execute
+- m.spack-setup
+- m.startup-script
+- m.vpc
+
 timeout: 14400s  # 4hr
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/validate_tests_metadata.py
+++ b/tools/cloud-build/daily-tests/validate_tests_metadata.py
@@ -16,46 +16,134 @@ import unittest
 import glob
 import os
 import yaml # pip install pyyaml
+import re
+from typing import Optional
+import itertools
 
 CATEGORICAL_TAGS = frozenset([
-    "slurm5", "slurm6", "tpu", 
+    "slurm5", "slurm6", "tpu",  "huy.tam"
 ])
 OS_TAGS = frozenset([
     "rocky8"
 ])
 
-VALID_TAGS = CATEGORICAL_TAGS | OS_TAGS
+def module_tag(src: str) -> Optional[str]:
+    """
+    Returns tag for a specific module source.
+    Remote sources are not supported (None).
+    Ex: "modules/network/vpc" -> "m.vpc"
+    """
+    if not src.startswith(("modules/", "community/modules/", "./modules/", "./community/modules/")):
+        return None
+    return f"m.{os.path.basename(src)}"
+
+
+MODULE_TAGS = frozenset(
+    filter(None, 
+           map(module_tag, 
+               glob.glob("modules/*/*") + glob.glob("community/modules/*/*"))),
+)
+
+
+ALL_TAGS = CATEGORICAL_TAGS | OS_TAGS | MODULE_TAGS
+
+BUILDS_DIR="tools/cloud-build/daily-tests/builds"
+
+def read_yaml(path: str) -> dict:
+    with open(path) as yf:
+        return yaml.safe_load(yf)
+
+def get_blueprint(build_path: str) -> Optional[str]:
+    """
+    Extracts the blueprint path by inspecting build (and test) files
+    """
+    SPECIAL_CASES = {
+        f"{BUILDS_DIR}/e2e.yaml": "tools/cloud-build/daily-tests/blueprints/e2e.yaml",
+        f"{BUILDS_DIR}/ofe-deployment.yaml": None,
+        f"{BUILDS_DIR}/chrome-remote-desktop.yaml": "tools/cloud-build/daily-tests/blueprints/crd-default.yaml",
+        f"{BUILDS_DIR}/chrome-remote-desktop-ubuntu.yaml": "tools/cloud-build/daily-tests/blueprints/crd-ubuntu.yaml",
+    }
+    if build_path in SPECIAL_CASES:
+        return SPECIAL_CASES[build_path]
+
+    with open(build_path) as yf:
+        data = yf.read()
+    m = re.search(r'cloud-build/daily-tests/tests/.*\.yml', data)
+    if not m:
+        raise ValueError(f"Couldn't find test file reference in {build_path}\nConsider adding it to validate_tests_metadata.py:SPECIAL_CASES")
+    
+    tst_path = "tools/" + m.group()
+    tst_yaml = read_yaml(tst_path)
+    if "blueprint_yaml" not in tst_yaml:
+        raise ValueError(f"{tst_path} doesn't specify a `blueprint_yaml`")
+    bp_path = tst_yaml["blueprint_yaml"]
+    if bp_path.startswith("{{ workspace }}/"):
+        bp_path = bp_path[len("{{ workspace }}/"):]
+    return bp_path
+
+def get_modules_tags(build_path) -> set[str]:
+    bp_path = get_blueprint(build_path)
+    if bp_path is None:
+        return set()
+    bp = read_yaml(bp_path)
+    tags = set()
+    for group in bp["deployment_groups"]:
+        for module in group["modules"]:
+            tag = module_tag(module["source"])
+            if tag:
+                tags.add(tag)
+    return tags
 
 class TestIntegrationTestsMeta(unittest.TestCase):
-    def check_tags(self, tags: list[str]) -> None:
-        tags = set(tags)
-        self.assertEqual(tags - VALID_TAGS, set(), msg="Invalid tags")
+    def check_tags(self, build_path: str) -> None:
+        y = read_yaml(build_path)
+        if not "tags" in y: 
+            self.fail("All integration tests must have `tags`")
+        tags = set(y["tags"]) # specified tags
+
+        # Common checks
+        self.assertEqual(tags - ALL_TAGS, set(), msg="Invalid tags")
+        self.assertLessEqual(len(tags), 64, msg="Too many tags")
+
+        # Module tags check
+        declared_mod_tags = set(filter(lambda t: t.startswith("m."), tags))
+        required_mod_tags = get_modules_tags(build_path)
+        # do "missing entries" comparison explicitly to get copy-pastable error message for addition
+        missing_mod_tags = required_mod_tags - declared_mod_tags
+        if missing_mod_tags:
+            hint = "\n- ".join([""] + sorted(missing_mod_tags))
+            self.fail(msg=f"Some used modules aren't declared\nHINT: add following tags to {build_path}: {hint}")
+        self.assertEquals(declared_mod_tags, required_mod_tags)
 
         # TODO: check that all tests have at least one categorical tag
-        # TODO: inspect referenced blueprint to extract used modules
 
     def check_metadata(self, path: str) -> None:
-        with open(path) as yf:
-            y = yaml.safe_load(yf)
+        y = read_yaml(path)
 
         # NOTE: don't use assertIn to avoid printing the whole yaml
         if not "timeout" in y:
             self.fail("All integration tests must have a `timeout`")
 
-        if not "tags" in y: 
-            self.fail("All integration tests must have `tags`")
-
-        self.check_tags(y["tags"])
+        self.check_tags(path)
 
     def test_integration_tests_meta(self) -> None:
-        its = glob.glob("tools/cloud-build/daily-tests/builds/*.yaml")
+        its = glob.glob(f"{BUILDS_DIR}/*.yaml")
         self.assertNotEqual(len(its), 0, msg="No integration tests found")
         for it in its:
             with self.subTest(os.path.basename(it)):
                 self.check_metadata(it)
 
-    def test_sanity(self) -> None:
-        self.assertEqual(CATEGORICAL_TAGS & OS_TAGS, set(), msg="tag types intersect")
+    def test_sanity_intersections(self) -> None:
+        for (a, b) in itertools.combinations([CATEGORICAL_TAGS, OS_TAGS, MODULE_TAGS], 2):
+            self.assertEqual(a & b, set(), msg="tag types intersect")
 
+    def test_sanity_tag_limits(self) -> None:
+        # see https://cloud.google.com/build/docs/view-build-results#filter_build_results_by_using_tags
+        for tag in ALL_TAGS:
+            with self.subTest(tag):
+                self.assertLessEqual(len(tag), 128)
+                self.assertRegex(tag, r'^[a-zA-Z0-9_\-\.]+$')
+                
 if __name__ == "__main__":
     unittest.main()
+    


### PR DESCRIPTION
Inspect test CloudBuild config and find out all modules used. Add a tag for each one:

**Motivation:** Step toward automatic discovery of tests to run by looking at the list of files touched by PR.

```sh
$ git commit -a
...
tests-metadata...........................................................Failed
- hook id: tests-metadata
- exit code: 1

...
======================================================================
FAIL: test_integration_tests_meta (__main__.TestIntegrationTestsMeta.test_integration_tests_meta) [hpc-build-slurm-image.yaml]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/orlov/wp/hpc-toolkit_too/tools/cloud-build/daily-tests/validate_tests_metadata.py", line 134, in test_integration_tests_meta
    self.check_metadata(it)
  File "/usr/local/google/home/orlov/wp/hpc-toolkit_too/tools/cloud-build/daily-tests/validate_tests_metadata.py", line 127, in check_metadata
    self.check_tags(path)
  File "/usr/local/google/home/orlov/wp/hpc-toolkit_too/tools/cloud-build/daily-tests/validate_tests_metadata.py", line 115, in check_tags
    self.assertTrue(missing_mod_tags == set(), msg=hint)
AssertionError: Some used modules aren't declared
HINT: add following tags:
- m.custom-image
- m.schedmd-slurm-gcp-v6-controller
- m.schedmd-slurm-gcp-v6-nodeset
- m.schedmd-slurm-gcp-v6-partition
- m.startup-script
- m.vpc
```