### PR TITLE
Extend timeout by 5 minutes on test

### DIFF
--- a/tools/cloud-build/daily-tests/blueprints/crd-default.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/crd-default.yaml
@@ -33,3 +33,5 @@ deployment_groups:
   - id: wait
     source: community/modules/scripts/wait-for-startup
     use: [crd]
+    settings:
+      timeout: 1500  # bumping to avoid timeout


### PR DESCRIPTION
Default timeout is 20 min. Upper end of install is 20 minutes. Extending timeout by 5 min. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
