### PR TITLE
Babysit. Add `--auto` mode to discover tests based on files changed

### DIFF
--- a/tools/cloud-build/babysit_tests.py
+++ b/tools/cloud-build/babysit_tests.py
@@ -282,25 +282,55 @@ def get_pr(pr_num: int) -> dict:
     resp.raise_for_status()
     return resp.json()
 
+def get_changed_files_tags(base: str, head: str) -> set[str]:
+    res = subprocess.run(["git", "log", f"{base}..{head}", "--name-only", "--format="], stdout=subprocess.PIPE)
+    assert res.returncode == 0
+    changed_files = res.stdout.decode('ascii').strip().split("\n")
+    tags = set()
+    for f in changed_files:
+        if f.startswith("community/"): f = f[len("community/"):]
+        if not f.startswith("modules/"): continue
+        parts = f.split("/")
+        if len(parts) < 3: continue
+        tags.add(f"m.{parts[2]}")
+    return tags
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser.add_argument("--sha", type=str, help="Short SHA of target PR")
     parser.add_argument("--pr", type=int, help="PR number")
-    parser.add_argument("test_selector", nargs='+', type=str,
+
+    parser.add_argument("test_selector", nargs='*', type=str,
                         help="Selector for test, currently support 'all' and exact name match")
     parser.add_argument("--tags", nargs="*", type=str, help="Filter tests by tags")
+    parser.add_argument("--auto", action="store_true", help="If true, will inspect changed files and run tests for them")
+    
     parser.add_argument("--project", type=str,
                         help="GCP ProjectID, if not set will use default one (`gcloud config get-value project`)")
     parser.add_argument("-c", type=int, default=1,
                         help="Number of tests to run concurrently, default is 1")
     parser.add_argument("-r", type=int, default=1,
                         help="Number of retries, to disable retries set to 0, default is 1")
+    
+    parser.add_argument("--base", type=str, help="Revision to inspect diff from")
+    parser.add_argument("--head", type=str, help="Revision to inspect diff to, may be different in case of merged PRs")
+    
     args = parser.parse_args()
 
     assert (args.sha is None) ^ (args.pr is None), "either --pr or --sha are required"
     if args.pr:
-        sha = get_pr(args.pr)["head"]["sha"]
+        pr = get_pr(args.pr)
+        print(f"Using PR#{args.pr}: {pr['title']}")
+        sha = pr["head"]["sha"]
+
+        if pr["merged"]:
+            print("PR is already merged")
+            if args.head is None:
+                # use merge commit as head, since original PR sha may not be available in Git history.
+                args.head = pr["merge_commit_sha"] 
+            
+        if args.base is None:
+            args.base = pr["base"]["sha"]
     else:
         sha = args.sha
 
@@ -310,8 +340,17 @@ if __name__ == "__main__":
     else:
         project = args.project
 
-    cb = cloudbuild_v1.services.cloud_build.CloudBuildClient()
+    
     selectors = [make_selector(s) for s in args.test_selector] + [selector_by_tag(t) for t in args.tags or []]
+
+    if args.head is None:
+        args.head = sha
+        
+    if args.auto:
+        assert args.base is not None, "--base & [--head] or --pr are required for auto mode"
+        auto_tags = get_changed_files_tags(args.base, args.head)
+        selectors += [selector_by_tag(t) for t in auto_tags]
     
     ui = UI()
+    cb = cloudbuild_v1.services.cloud_build.CloudBuildClient()
     Babysitter(ui, cb, project, sha, selectors, args.c, args.r).do()


### PR DESCRIPTION
Requires both `HEAD` and `base` of the PR to be present in the local git repo.

```sh
$ tools/cloud-build/babysit_tests.py --pr 2320 --auto

Using PR#2320: PLS IGNORE. touching CRD module
found 4 builds:
PENDING PR-test-chrome-remote-desktop   https://console.cloud.google.com/cloud-build/builds/xxx...
PENDING PR-test-chrome-remote-desktop-ubuntu    https://console.cloud.google.com/cloud-build/builds/xxx...
PENDING PR-test-hcls    https://console.cloud.google.com/cloud-build/builds/xxx...
PENDING PR-test-hpc-slurm-chromedesktop https://console.cloud.google.com/cloud-build/builds/xxx...
...
```
