### PR TITLE
Allow `ghpc deploy blueprint.yaml`

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -64,22 +64,26 @@ var (
 		Short:             "Create a new deployment.",
 		Long:              "Create a new deployment based on a provided blueprint.",
 		Run:               runCreateCmd,
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.MatchAll(cobra.ExactArgs(1), checkExists),
 		ValidArgsFunction: filterYaml,
 	})
 )
 
 func runCreateCmd(cmd *cobra.Command, args []string) {
-	bp := expandOrDie(args[0])
-	deplDir := filepath.Join(createFlags.outputDir, bp.DeploymentName())
-	checkErr(checkOverwriteAllowed(deplDir, bp, createFlags.overwriteDeployment, createFlags.forceOverwrite))
-	checkErr(modulewriter.WriteDeployment(bp, deplDir))
-
+	deplDir := doCreate(args[0])
 	logging.Info("To deploy your infrastructure please run:")
 	logging.Info("")
 	logging.Info(boldGreen("%s deploy %s"), execPath(), deplDir)
 	logging.Info("")
 	printAdvancedInstructionsMessage(deplDir)
+}
+
+func doCreate(path string) string {
+	bp := expandOrDie(path)
+	deplDir := filepath.Join(createFlags.outputDir, bp.DeploymentName())
+	checkErr(checkOverwriteAllowed(deplDir, bp, createFlags.overwriteDeployment, createFlags.forceOverwrite))
+	checkErr(modulewriter.WriteDeployment(bp, deplDir))
+	return deplDir
 }
 
 func printAdvancedInstructionsMessage(deplDir string) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"hpc-toolkit/pkg/modulewriter"
 	"hpc-toolkit/pkg/shell"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -49,6 +50,14 @@ func getApplyBehavior() shell.ApplyBehavior {
 func addAutoApproveFlag(c *cobra.Command) *cobra.Command {
 	c.Flags().BoolVar(&flagAutoApprove, "auto-approve", false, "Automatically approve proposed changes")
 	return c
+}
+
+func checkExists(cmd *cobra.Command, args []string) error {
+	path := args[0]
+	if _, err := os.Lstat(path); err != nil {
+		return fmt.Errorf("%q does not exist", path)
+	}
+	return nil
 }
 
 func checkDir(cmd *cobra.Command, args []string) error {

--- a/tools/cloud-build/daily-tests/e2e.sh
+++ b/tools/cloud-build/daily-tests/e2e.sh
@@ -22,8 +22,7 @@ vars="project_id=$PROJECT_ID,deployment_name=$depl_name,region=$region,zone=$zon
 
 # Already in a root of the repo
 make
-./ghpc create tools/cloud-build/daily-tests/blueprints/e2e.yaml --vars="$vars" -l ERROR
-./ghpc deploy "$depl_name" --auto-approve
+./ghpc deploy tools/cloud-build/daily-tests/blueprints/e2e.yaml --vars="$vars" -l ERROR --auto-approve
 
 # check instance was created
 gcloud compute instances describe "${depl_name}-0" --project="$PROJECT_ID" --zone="$zone" >/dev/null


### PR DESCRIPTION
```sh
$ ./ghpc deploy examples/hpc-slurm-v6.yaml --vars=project_id=bullrun -l ERROR
Initializing deployment group hpc-slurm/primary
Testing if deployment group hpc-slurm/primary requires adding or changing cloud infrastructure
Deployment group hpc-slurm/primary requires adding or changing cloud infrastructure ...

$ ./ghpc deploy hpc-slurm
Testing if deployment group hpc-slurm/primary requires adding or changing cloud infrastructure
Deployment group hpc-slurm/primary requires adding or changing cloud infrastructure ...

$ ./ghpc deploy hpc-slurm --vars=zone=4
Error: cannot specify flag "vars" with DEPLOYMENT_DIRECTORY provided
```