### PR TITLE
Increase MessageTimeout to 600 in long prolog Slurm configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     entry: python3 tools/duplicate-diff.py
     language: python
     language_version: python3
-    files: '.*(\.sh|\.tf|\.tftpl)$'
+    files: '.*(\.sh|\.tf|\.tftpl|\.tpl)$'
     pass_filenames: true
     require_serial: true
   - id: module-label-check

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/etc/long-prolog-slurm.conf.tpl
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/etc/long-prolog-slurm.conf.tpl
@@ -28,7 +28,7 @@ DebugFlags=Power
 #
 #
 # TIMERS
-MessageTimeout=60
+MessageTimeout=600
 BatchStartTimeout=600
 PrologEpilogTimeout=600
 PrologFlags=Contain

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl
@@ -28,7 +28,7 @@ DebugFlags=Power
 #
 #
 # TIMERS
-MessageTimeout=60
+MessageTimeout=600
 BatchStartTimeout=600
 PrologEpilogTimeout=600
 PrologFlags=Contain


### PR DESCRIPTION
When srun jobs encounter a long-running Prolog or Epilog, it will generate a warning "srun: Prolog hung on node X". The job does not fail, but it is potentially confusing to the user. This change will silence that warning.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
