### PR TITLE
HTCondor: support user-managed secret replication

### DIFF
--- a/community/modules/scheduler/htcondor-pool-secrets/README.md
+++ b/community/modules/scheduler/htcondor-pool-secrets/README.md
@@ -118,7 +118,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -158,6 +158,7 @@ No modules.
 | <a name="input_pool_password"></a> [pool\_password](#input\_pool\_password) | HTCondor Pool Password | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which HTCondor pool will be created | `string` | n/a | yes |
 | <a name="input_trust_domain"></a> [trust\_domain](#input\_trust\_domain) | Trust domain for HTCondor pool (if not supplied, will be set based on project\_id) | `string` | `""` | no |
+| <a name="input_user_managed_replication"></a> [user\_managed\_replication](#input\_user\_managed\_replication) | Replication parameters that will be used for defined secrets | <pre>list(object({<br>    location     = string<br>    kms_key_name = optional(string)<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/community/modules/scheduler/htcondor-pool-secrets/variables.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/variables.tf
@@ -56,3 +56,12 @@ variable "trust_domain" {
   type        = string
   default     = ""
 }
+
+variable "user_managed_replication" {
+  type = list(object({
+    location     = string
+    kms_key_name = optional(string)
+  }))
+  description = "Replication parameters that will be used for defined secrets"
+  default     = []
+}

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -29,5 +29,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.28.1"
   }
 
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
 }


### PR DESCRIPTION
Add a new parameter which must specify location (typically a region) and optionally specify customer KMS keys.

Customers have requested location control over secret replication, likely due to geographic constraints imposed by organization policy.

Tested with community/examples/htc-htcondor.yaml with the additional settings:

```yaml
  - id: htcondor_secrets
     source: community/modules/scheduler/htcondor-pool-secrets
     use:
     - htcondor_service_accounts
+    settings:
+      user_managed_replication:
+      - location: us-central1
+      - location: us-east4
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
