### PR TITLE
Fix edge cases of path arguments

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -61,7 +61,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 
 	for _, group := range groups {
 		groupDir := filepath.Join(deplRoot, string(group.Name))
-		checkErr(shell.ImportInputs(groupDir, artDir, expandedBlueprintFile))
+		checkErr(shell.ImportInputs(groupDir, artDir, bp))
 
 		switch group.Kind() {
 		case config.PackerKind:

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -42,7 +42,8 @@ var (
 )
 
 func parseExportImportArgs(args []string) (string, string) {
-	gd := filepath.Clean(args[0])
+	gd, err := filepath.Abs(args[0])
+	checkErr(err)
 	return filepath.Join(gd, ".."), gd
 }
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -51,5 +51,5 @@ func runImportCmd(cmd *cobra.Command, args []string) {
 	checkErr(err)
 
 	checkErr(shell.ValidateDeploymentDirectory(bp.DeploymentGroups, deplRoot))
-	checkErr(shell.ImportInputs(groupDir, artifactsDir, expandedBlueprintFile))
+	checkErr(shell.ImportInputs(groupDir, artifactsDir, bp))
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -53,13 +53,9 @@ func addAutoApproveFlag(c *cobra.Command) *cobra.Command {
 
 func checkDir(cmd *cobra.Command, args []string) error {
 	path := args[0]
-	if path == "" {
-		return nil
-	}
 	if isDir, _ := shell.DirInfo(path); !(isDir) {
-		return fmt.Errorf("%s must be a directory", path)
+		return fmt.Errorf("%q must be a directory", path)
 	}
-
 	return nil
 }
 

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -365,13 +365,8 @@ func gatherUpstreamOutputs(deploymentRoot string, artifactsDir string, g config.
 // ImportInputs will search artifactsDir for files produced by ExportOutputs and
 // combine/filter them for the input values needed by the group in the Terraform
 // working directory
-func ImportInputs(deploymentGroupDir string, artifactsDir string, expandedBlueprintFile string) error {
+func ImportInputs(deploymentGroupDir string, artifactsDir string, bp config.Blueprint) error {
 	deploymentRoot := filepath.Clean(filepath.Join(deploymentGroupDir, ".."))
-
-	bp, _, err := config.NewBlueprint(expandedBlueprintFile)
-	if err != nil {
-		return err
-	}
 
 	g, err := bp.Group(config.GroupName(filepath.Base(deploymentGroupDir)))
 	if err != nil {


### PR DESCRIPTION
```sh
$ ./ghpc deploy ""   # BEFORE
Error: .ghpc/artifacts must be a writable directory

$ ./ghpc deploy ""   # AFTER
Error: "" must be a directory
```

```sh
$ ../../ghpc import-inputs .  # BEFORE
Error: could not find group . in blueprint

$ ../../ghpc import-inputs .  # AFTER
$ # OK
```