### PR TITLE
Add SlurmGCP v6 example of slurm compatible with startup scripts and integration test

### DIFF
--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -1,0 +1,66 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.cloud-storage-bucket
+- m.nfs-server
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.startup-script
+- m.vpc
+- slurm6
+
+timeout: 14400s  # 4hr
+steps:
+## Test simple golang build
+- id: build_ghpc
+  waitFor: ["-"]
+  name: "golang:bullseye"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    cd /workspace
+    make
+- id: fetch_builder
+  waitFor: ["-"]
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - echo "done fetching builder"
+
+## Test Slurm on GCP v6 with Startup Scripts
+- id: slurm-gcp-v6-startup-scripts
+  waitFor: ["fetch_builder", "build_ghpc"]
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+test_name: hpc-cluster-slurm-v6
+deployment_name: "ss-v6-{{ build }}"
+# Manually adding the slurm_cluster_name for use in node names, which filters
+# non-alphanumeric chars and is capped at 10 chars.
+slurm_cluster_name: "ssv6{{ build[0:6] }}"
+zone: us-west4-c
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/tools/validate_configs/test_configs/slurm-gcp-v6-startup-scripts.yaml"
+network: "{{ deployment_name }}-net"
+max_nodes: 5
+# Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
+login_node: "{{ slurm_cluster_name }}-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+post_deploy_tests:
+- test-validation/test-partitions.yml
+custom_vars:
+  partitions:
+  - compute
+  - debug
+  mounts:
+  - /home
+  - /data

--- a/tools/validate_configs/test_configs/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/validate_configs/test_configs/slurm-gcp-v6-startup-scripts.yaml
@@ -1,0 +1,128 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: hpc-cluster-slurm-v6
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: hpc-small-v6
+  region: us-west4
+  zone: us-west4-c
+
+deployment_groups:
+- group: primary
+  modules:
+  # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
+  # as a prefix. To refer to a local resource, prefix with ./, ../ or /
+  # Example - ./resources/network/vpc
+  - id: network
+    source: modules/network/vpc
+
+  - id: homefs
+    source: community/modules/file-system/nfs-server
+    use: [network]
+    settings:
+      local_mounts: [/home]
+      auto_delete_disk: true
+
+  - id: bucket
+    source: community/modules/file-system/cloud-storage-bucket
+    settings:
+      name_prefix: input-data
+      local_mount: /data
+      random_suffix: true
+      mount_options: defaults,_netdev,implicit_dirs,allow_other
+
+  # Used by the nodesets, this tests startup scripts that are nodeset specific
+  - id: startup-nodeset
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: shell
+        destination: startup-test-partition.sh
+        content: |
+          #!/bin/bash
+          set -ex
+          echo "Hello partition! Hostname: \$(hostname)"
+
+  - id: debug_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      node_count_dynamic_max: 4
+      machine_type: n2-standard-2
+      enable_placement: false
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use:
+    - homefs
+    - bucket
+    - debug_nodeset
+    settings:
+      partition_name: debug
+      is_default: true
+
+  - id: compute_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use:
+    - network
+    - startup-nodeset
+    settings:
+      node_count_dynamic_max: 20
+
+  - id: compute_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use:
+    - homefs
+    - bucket
+    - compute_nodeset
+    settings:
+      partition_name: compute
+
+  # Used by the login and controller, the controller applies it to all partitions as well.
+  - id: startup-all
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: shell
+        destination: startup-test-all.sh
+        content: |
+          #!/bin/bash
+          set -ex
+          echo "Hello world! Hostname: \$(hostname)"
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use:
+    - network
+    settings:
+      name_prefix: login
+      disable_login_public_ips: false
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - network
+    - debug_partition
+    - compute_partition
+    - homefs
+    - bucket
+    - slurm_login
+    settings:
+      disable_controller_public_ips: false
+      controller_startup_script: $(startup-all.startup_script)
+      login_startup_script: $(startup-all.startup_script)


### PR DESCRIPTION
This PR adds blueprint for SlurmGCP v6 version of Slurm + startup script support and also adds integration test for coverage.


### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
