### PR TITLE
Remove pre-commit.ci action

### DIFF
--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -49,11 +49,5 @@ jobs:
         # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
         GITHUB_TOKEN: ${{ github.token }}
     - uses: pre-commit/action@v3.0.1
-    - uses: pre-commit-ci/lite-action@v1.0.2
-      # this if statement looks funny but it ensures that this step runs
-      # only if: user has applied "pre-commit-autofix" label
-      # even if: job has failed
-      # not if: job is canceled
-      if: |
-        (success() || failure()) &&
-        contains(github.event.pull_request.labels.*.name, 'pre-commit-autofix')
+      with:
+        extra_args: --show-diff-on-failure --all-files


### PR DESCRIPTION
The contributions from pre-commit.ci bot cannot pass CLA requirements because pre-commit is potentially arbitrary in its modifications.

This commit replaces the functionality with a "show diff on failure" flag to the pre-commit check. This will cause any file differences to be displayed in GitHub Actions / PR checks.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
