### PR TITLE
Update TPU v4 blueprint maxtext script to point to the working reference

### DIFF
--- a/community/examples/hpc-slurm6-tpu-v4.yaml
+++ b/community/examples/hpc-slurm6-tpu-v4.yaml
@@ -14,11 +14,11 @@
 
 ---
 
-blueprint_name: slurm6-tpu
+blueprint_name: slurm6-tpu-v4
 
 vars:
   project_id: ## Set GCP Project ID Here ##
-  deployment_name: slurm6-tpu
+  deployment_name: slurm6-tpu-v4
   region: us-central2
   zone: us-central2-b
 
@@ -49,16 +49,21 @@ deployment_groups:
           # ATTENTION: (i.e. dot_product, flash)
           # STEPS: steps to run (i.e. 100, 1000)
 
+          set -e -o pipefail
+
           # Start virtual environment.
           virtualenv venv
-          source venv/bin/activate
+          source venv/local/bin/activate
 
-          # Clone maxtext repository and install dependencies.
+          # Clone maxtext repository, lock version of maxtext and
+          # install dependencies.
           git clone https://github.com/google/maxtext
           cd maxtext/
+          git reset --hard 39a3f19e832016741be803ef5253333e2f434cb8
           bash setup.sh
 
           # Run maxtext benchmark test.
+          # (i.e.) python3 MaxText/train.py MaxText/configs/base.yml run_name=1xv4-128 base_output_directory=/opt/apps/scripts/tpu-test/output/ dataset_path=gs://dataset_tpu/dataset async_checkpointing=False attention=dot_product steps=100
           python3 MaxText/train.py MaxText/configs/base.yml run_name=<RUN_NAME> base_output_directory=/opt/apps/scripts/tpu-test/output/ dataset_path=<STORAGE_BUCKET> async_checkpointing=False attention=<ATTENTION> steps=<STEPS>
 
   - id: tpu_nodeset


### PR DESCRIPTION
This PR points to the previous working version of setup script. Right now, we see the script failing for `sbatch` command and only work if we use it under `root` account.

For this test, I did manual testing to deploy the cluster and run maxtext job.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
