### PR TITLE
Migrate config-ssh.yaml to Slurm-GCP v6

### DIFF
--- a/tools/validate_configs/test_configs/config-ssh.yaml
+++ b/tools/validate_configs/test_configs/config-ssh.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,12 +31,12 @@ deployment_groups:
   # Source is an embedded resource, denoted by "resources/*" without ./, ../, /
   # as a prefix. To refer to a local resource, prefix with ./, ../ or /
   # Example - ./resources/network/vpc
-  - id: network1
+  - id: network
     source: modules/network/vpc
 
   - id: homefs
     source: modules/file-system/filestore
-    use: [network1]
+    use: [network]
     settings:
       local_mount: /home
 
@@ -46,54 +46,53 @@ deployment_groups:
       configure_ssh_host_patterns: ['10.182.0.*', 'hpcsm*']
 
   - id: debug_node_group
-    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
     settings:
       node_count_dynamic_max: 4
       machine_type: n2-standard-2
+      enable_placement: false # the default is: true
 
   - id: debug_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
     use:
-    - network1
     - homefs
     - debug_node_group
     settings:
       partition_name: debug
       exclusive: false # allows nodes to stay up after jobs are done
-      enable_placement: false # the default is: true
       is_default: true
 
   - id: compute_node_group
-    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
     settings:
       node_count_dynamic_max: 20
 
   - id: compute_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
     use:
-    - network1
     - homefs
     - compute_node_group
     settings:
       partition_name: compute
 
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      name_prefix: login
+      machine_type: n2-standard-4
+      disable_login_public_ips: false
+
   - id: slurm_controller
-    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
-    - network1
+    - network
+    - slurm_login
     - debug_partition
     - compute_partition
     - homefs
     - script
     settings:
       disable_controller_public_ips: false
-
-  - id: slurm_login
-    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
-    use:
-    - network1
-    - slurm_controller
-    - script
-    settings:
-      machine_type: n2-standard-4
-      disable_login_public_ips: false


### PR DESCRIPTION
This PR updates `config-ssh.yaml` to Slurm-GCP v6.

Calling `sinfo` shows the nodes.
```
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
compute      up   infinite     20  idle~ hpcsmall-comput-[0-19]
debug*       up   infinite      4  idle~ hpcsmall-debugn-[0-3]
```

Manually submitting the job `sbatch -N 1 -p compute --wrap "sleep 10"` successfully completes.
```
JobId=2 JobName=wrap
   UserId=alyssasm_hpctoolkit_joonix_net(1027357380) GroupId=alyssasm_hpctoolkit_joonix_net(1027357380) MCS_label=N/A
   Priority=1 Nice=0 Account=(null) QOS=normal
   JobState=COMPLETED Reason=None Dependency=(null)
   Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
   RunTime=00:00:10 TimeLimit=UNLIMITED TimeMin=N/A
   SubmitTime=2024-03-13T05:07:30 EligibleTime=2024-03-13T05:07:30
   AccrueTime=2024-03-13T05:07:30
   StartTime=2024-03-13T05:10:59 EndTime=2024-03-13T05:11:09 Deadline=N/A
   SuspendTime=None SecsPreSuspend=0 LastSchedEval=2024-03-13T05:07:31 Scheduler=Main
   Partition=compute AllocNode:Sid=hpcsmall-controller:4157
   ReqNodeList=(null) ExcNodeList=(null)
   NodeList=hpcsmall-comput-0
   BatchHost=hpcsmall-comput-0
   NumNodes=1 NumCPUs=30 NumTasks=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
   ReqTRES=cpu=1,mem=7938M,node=1,billing=1
   AllocTRES=cpu=30,mem=238140M,node=1,billing=30
   Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*
   MinCPUsNode=1 MinMemoryCPU=7938M MinTmpDiskNode=0
   Features=(null) DelayBoot=00:00:00
   OverSubscribe=NO Contiguous=0 Licenses=(null) Network=(null)
   Command=(null)
   WorkDir=/home/alyssasm_hpctoolkit_joonix_net
   StdErr=/home/alyssasm_hpctoolkit_joonix_net/slurm-2.out
   StdIn=/dev/null
   StdOut=/home/alyssasm_hpctoolkit_joonix_net/slurm-2.out
   Power=
```

