### PR TITLE
Initial commit of A3 blueprint and documentation

### DIFF
--- a/examples/machine-learning/README.md
+++ b/examples/machine-learning/README.md
@@ -1,0 +1,319 @@
+# Objective
+
+This document will guide you to successfully provisioning a Slurm cluster with
+A3 VM family compute nodes running NVIDIA H100 GPUs.
+
+## Required initial setup
+
+Please follow the initial instructions for:
+
+- Installing Cloud HPC Toolkit [dependencies][tkdeps] (Go, Terraform, Packer)
+- Installing the Cloud HPC [Toolkit][tkinstall]
+
+[tkdeps]: https://cloud.google.com/hpc-toolkit/docs/setup/install-dependencies
+[tkinstall]: https://github.com/GoogleCloudPlatform/hpc-toolkit/#quickstart
+
+Verify that your release of the HPC Toolkit is 1.29.0 or later.
+
+```shell
+ghpc --version
+```
+
+Additional features of the solution require several Python packages to be
+installed in your execution environment. We recommend using a Python virtual
+environment to manage them as shown below
+
+```shell
+python3 -m venv toolkit-a3
+source toolkit-a3/bin/activate
+pip3 install -r \
+    https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.10.6/scripts/requirements.txt
+```
+
+**Always** activate the environment before running any ghpc commands such as
+deploy or destroy.
+
+```shell
+source /absolute/path/to/toolkit-a3/bin/activate
+```
+
+Install the beta gcloud components to enable beta APIs:
+
+```shell
+gcloud components install beta
+```
+
+## Top-Level Design of Solution
+
+The solution is split into 3 HPC Toolkit blueprints:
+
+1. Provision 5 VPCs (1 system network, 4 GPU networks) and 1 Filestore for
+mounting /home across the cluster
+2. Build a custom image installing Slurm in an Ubuntu 20.04 image. The image
+runs a kernel patched with performance enhancements for the A3 VM family.
+3. Provision a Slurm cluster using the custom image
+
+The 1st and 2nd blueprints should be provisioned once and rarely need further
+modification. This approach separates the lifecycle of a Filestore instance from
+the lifecycle of the cluster, allowing the cluster to be deleted while retaining
+access to data and home directories. The 3rd cluster blueprint may be more
+frequently updated and re-provisioned as discussed below.
+
+## First time considerations
+
+_These steps do not need to be repeated when a cluster is re-provisioned. They
+are initial setup steps in a project._
+
+The following steps create a compact placement policy and VM reservation that
+improves the performance of tightly-coupled workloads and ensures capacity for
+A3 VMs. Values in the blueprint must be modified as shown below.
+
+Replace the values for `PROJECT_ID`, `REGION`, and `ZONE` with the project,
+region, and zone in which you have an A3 VM family allocation. The value for
+`BUCKET` must be unique and will be used to create a new bucket. After replacing
+the values, execute them so that they automatically populate parameters in the
+commands shown below.
+
+```shell
+export PROJECT_ID=customer-project-id
+export BUCKET=customer-bucket
+export REGION=customer-region
+export ZONE=customer-zone
+export N_VMS=32
+export POLICY=policy-compact-0
+export RESERVATION=slurm-res-0
+```
+
+Each A3 VM (`N_VMS`) contains 8 NVIDIA H100 GPUs.  Create a bucket with
+versioning enabled to store Terraform state:
+
+```shell
+gcloud storage buckets create gs://${BUCKET} --project=${PROJECT_ID} \
+    --default-storage-class=STANDARD --location=${REGION} \
+    --uniform-bucket-level-access
+gcloud storage buckets update gs://${BUCKET} --versioning
+```
+
+If Google Cloud staff have created a reservation for you, then skip this step
+and use the reservation name visible in the Cloud Console.  Otherwise, create
+a compact placement policy attached to a reservation of A3 VMs.
+
+First, create a compact placement policy:
+
+```shell
+gcloud beta compute resource-policies create group-placement ${POLICY} \
+    --region=${REGION} \
+    --collocation=COLLOCATED \
+    --project=${PROJECT_ID}
+```
+
+And then create the reservation with the policy attached:
+
+```shell
+gcloud compute reservations create ${RESERVATION} \
+    --project=${PROJECT_ID} \
+    --machine-type=a3-highgpu-8g \
+    --vm-count=${N_VMS} \
+    --zone=${ZONE} \
+    --require-specific-reservation \
+    --resource-policies=placement=${POLICY} \
+    --log-http
+```
+
+Modify the the blueprint deployment variables `project_id`, `region`, `zone`,
+and `zones` in the `vars` block of `ml-slurm-a3-0-base.yaml`,
+`ml-slurm-a3-1-image.yaml` and `ml-slurm-h100-2-cluster.yaml`:
+
+```yaml
+  project_id: customer-project
+  region: customer-region
+  zone: customer-zone
+```
+
+Obtain values for `source_image_project_id` and `source_image` from your Google
+Cloud representative. Set them at approximately lines 33 and 34 of
+`ml-slurm-a3-1-image.yaml`. Set the reservation name in the blueprint
+deployment variable `a3_reservation_name` at approximately line 39 of
+`ml-slurm-a3-2-cluster.yaml`. If the reservation has been supplied to you
+by Google Cloud staff, use its name below.
+
+```yaml
+  a3_reservation_name: slurm-res-0
+```
+
+## Cluster creation
+
+The blueprint `ml-slurm-a3-0-base.yaml` will create 5 VPCs (1 system, 4 GPU)
+and a Filestore `/home` filesystem. This should take approximately 5 minutes. We
+recommend the use of Cloud Storage for storing Terraform state. This should be
+set directly in the blueprint:
+
+```yaml
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: customer-bucket # modify to bucket created above
+```
+
+Then run the standard Toolkit workflow at the command line:
+
+```shell
+ghpc create -l ERROR ml-slurm-a3-0-base.yaml
+ghpc deploy slurm-a3-base --auto-approve
+```
+
+Several values will be output to the screen. The output will be similar to:
+
+```hcl
+network_name_sysnet = "sys-net"
+network_storage_homefs = {
+  "client_install_runner" = {
+    "destination" = "install-nfs_home.sh"
+    "source" = "modules/embedded/modules/file-system/filestore/scripts/install-nfs-client.sh"
+    "type" = "shell"
+  }
+  "fs_type" = "nfs"
+  "local_mount" = "/home"
+  "mount_options" = "defaults,_netdev"
+  "mount_runner" = {
+    "args" = "\"10.224.153.226\" \"/nfsshare\" \"/home\" \"nfs\" \"defaults,_netdev\""
+    "destination" = "mount_home.sh"
+    "source" = "modules/embedded/modules/file-system/filestore/scripts/mount.sh"
+    "type" = "shell"
+  }
+  "remote_mount" = "/nfsshare"
+  "server_ip" = "10.224.153.226"
+}
+subnetwork_name_sysnet = "sys-subnet"
+subnetwork_self_link_gpunet0 = "https://www.googleapis.com/compute/v1/projects/customer-project/regions/customer-region/subnetworks/gpu-subnet0"
+subnetwork_self_link_gpunet1 = "https://www.googleapis.com/compute/v1/projects/customer-project/regions/customer-region/subnetworks/gpu-subnet1"
+subnetwork_self_link_gpunet2 = "https://www.googleapis.com/compute/v1/projects/customer-project/regions/customer-region/subnetworks/gpu-subnet2"
+subnetwork_self_link_gpunet3 = "https://www.googleapis.com/compute/v1/projects/customer-project/regions/customer-region/subnetworks/gpu-subnet3"
+```
+
+Build the custom image using ml-slurm-a3-1-image.yaml and the same workflow
+as above. We recommend using Terraform state in Cloud Storage by modifying the
+blueprint to include:
+
+```yaml
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: customer-bucket
+```
+
+And run at the command line:
+
+```shell
+ghpc create -l ERROR ml-slurm-a3-1-image.yaml
+ghpc deploy slurm-a3-image --auto-approve
+```
+
+The image will take approximately 30 minutes to build. If you made no
+modifications to `ml-slurm-a3-0-base.yaml` or `ml-slurm-h100-1-image.yaml`,
+you must make only 1 modification to `ml-slurm-a3-2-cluster.yaml` to update
+the IP address of the Filestore instance for `/home`:
+
+```yaml
+  server_ip_homefs: 10.224.153.226 # replace with IP address from output from slurm-a3-base!
+```
+
+Provision the cluster blueprint. Again, we recommend the use of Cloud Storage
+for Terraform state.
+
+```yaml
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: customer-bucket
+```
+
+It will take approximately 5-10 minutes to provision the cluster.
+
+```shell
+ghpc create -w -l ERROR ml-slurm-a3-2-cluster.yaml
+ghpc deploy slurm-a3-cluster --auto-approve
+```
+
+## Receive Data Path Manager (RxDM)
+
+To achieve optimal application performance, an additional service called the
+"Receive Data Path Manager" (RxDM) must run with the same lifetime as the job.
+Additionally, a NCCL plugin must be installed into the execution environment of
+the workload. Both the RxDM and plugin are distributed by Docker container
+images.
+
+This blueprint includes a Slurm "Prolog" and "Epilog" script that will run
+before and after every job running on more than 1 A3 compute node. The Prolog
+will perform the following actions:
+
+- Install the NCCL plugin into /var/lib of the host
+- Run the RxDM service
+  - This is a long-lived service that runs alongside the job
+  - Mounts `/var/lib/nvidia/lib64` into `/usr/lib/nvidia/lib64` of the container
+  - Mount `/opt/tcpdirect_benchmark/` from the host into the container so that a
+  textproto file defining the mapping from GPU to NIC is available. This file
+  is present in the Deep Learning VM (DLVM) images that contain TCPDirect
+  patches.
+  - Mount `/run/tcpx-${SLURM_JOB_ID}` from the container into the host. This is
+  set to the environment variables `${UDS_PATH}` in the script. This directory
+  contains Unix socket files that implement a TCPx interface available to the
+  user workload at `${UDS_PATH}`. The job must be configured to be aware of this
+  path using `NCCL_GPUDIRECTTCPX_UNIX_CLIENT_PREFIX` environment variable!
+
+The Epilog will
+
+- Stop the RxDM service
+- Prune any stopped containers (freeing up disk space)
+- Remove the directory at `${UDS_PATH}`
+
+## Jobs using the RxDM / TCPx
+
+Jobs that are running across multiple A3 VMs will benefit from using the RxDM
+and the NCCL plugin. An example containerized job is located at
+`/opt/apps/scripts/run-nccl-tests.sh`. In addition to setting standard NCCL
+configuration values, a job must:
+
+- Set `NCCL_GPUDIRECTTCPX_UNIX_CLIENT_PREFIX` to `${UDS_PATH}`
+- Set the `LD_LIBRARY_PATH` to include `/var/lib/tcpx/lib64` and `/usr/local/nvidia/lib64`
+
+If job is containerized
+
+- Mount `${UDS_PATH}` into the container at the same path
+- Mount `/var/lib/tcpx/lib64` to `/var/lib/tcpx/lib64` in the container (to make the
+  NCCL plugin available)
+- Paths can be modified if `LD_LIBRARY_PATH` is likewise modified
+
+## Example workload (NCCL benchmark)
+
+The example workload below demonstrates the pattern recommended in Activating
+the Receive Data Path Manager during jobs while running the standard nccl-tests
+benchmark. It assumes the availability of a GPU/NIC topology file at
+`/opt/tcpdirect_benchmark/gpu_rxq_configuration.textproto`. This file is built
+into the DLVM images used by this solution, but may need to be provided if
+using an alternative image.
+
+### Clone the HPC Toolkit repository containing the NCCL benchmark
+
+```shell
+git clone https://github.com/GoogleCloudPlatform/hpc-toolkit
+cd hpc-toolkit/examples/machine-learning/nccl-tests
+```
+
+### Import the PyTorch image from the NVIDIA Container Registry
+
+```shell
+import_pytorch_container.sh
+```
+
+### Build NCCL
+
+```shell
+sbatch build-nccl-tests.sh
+```
+
+### Run NCCL tests
+
+```shell
+sbatch run-nccl-tests.sh
+```

--- a/examples/machine-learning/ml-slurm-a3-0-base.yaml
+++ b/examples/machine-learning/ml-slurm-a3-0-base.yaml
@@ -1,0 +1,109 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+blueprint_name: slurm-a3-base
+
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: customer-tf-state-bucket
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: slurm-a3-base
+  region: customer-region
+  zone: customer-zone
+  sys_net_range: 172.16.0.0/16
+  gpu_net0_range: 10.0.0.0/16
+  gpu_net1_range: 10.1.0.0/16
+  gpu_net2_range: 10.2.0.0/16
+  gpu_net3_range: 10.3.0.0/16
+  filestore_ip_range: 192.168.0.0/29
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: sysnet
+    source: modules/network/vpc
+    settings:
+      network_name: slurm-sys-net
+      network_address_range: $(vars.sys_net_range)
+      mtu: 8244
+      # using explicit var.subnetworks to allow for easier addition
+      # of multiple system subnetworks in other regions
+      subnetworks:
+      - subnet_name: slurm-sys-subnet
+        subnet_region: $(vars.region)
+        new_bits: 4
+        subnet_private_access: true
+        description: primary subnetwork in slurm-sys-net
+    outputs:
+    - network_name
+    - subnetwork_name
+
+  - id: gpunet0
+    source: modules/network/vpc
+    settings:
+      network_name: slurm-gpu-net0
+      subnetwork_name: slurm-gpu-subnet0
+      network_address_range: $(vars.gpu_net0_range)
+      default_primary_subnetwork_size: 4
+      mtu: 8244
+    outputs:
+    - subnetwork_self_link
+
+  - id: gpunet1
+    source: modules/network/vpc
+    settings:
+      network_name: slurm-gpu-net1
+      subnetwork_name: slurm-gpu-subnet1
+      network_address_range: $(vars.gpu_net1_range)
+      default_primary_subnetwork_size: 4
+      mtu: 8244
+    outputs:
+    - subnetwork_self_link
+
+  - id: gpunet2
+    source: modules/network/vpc
+    settings:
+      network_name: slurm-gpu-net2
+      subnetwork_name: slurm-gpu-subnet2
+      network_address_range: $(vars.gpu_net2_range)
+      default_primary_subnetwork_size: 4
+      mtu: 8244
+    outputs:
+    - subnetwork_self_link
+
+  - id: gpunet3
+    source: modules/network/vpc
+    settings:
+      network_name: slurm-gpu-net3
+      subnetwork_name: slurm-gpu-subnet3
+      network_address_range: $(vars.gpu_net3_range)
+      default_primary_subnetwork_size: 4
+      mtu: 8244
+    outputs:
+    - subnetwork_self_link
+
+  - id: homefs
+    source: modules/file-system/filestore
+    use:
+    - sysnet
+    settings:
+      filestore_tier: BASIC_SSD
+      size_gb: 2560
+      local_mount: /home
+      reserved_ip_range: $(vars.filestore_ip_range)
+    outputs:
+    - network_storage

--- a/examples/machine-learning/ml-slurm-a3-1-image.yaml
+++ b/examples/machine-learning/ml-slurm-a3-1-image.yaml
@@ -1,0 +1,297 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+blueprint_name: slurm-a3-image
+
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: customer-tf-state-bucket
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: slurm-a3-image
+  region: customer-region
+  zone: customer-zone
+  disk_size: 200
+  final_image_family: slurm-dlvm
+  network_name_system: slurm-sys-net
+  subnetwork_name_system: slurm-sys-subnet
+  slurm_cluster_name: slurm0
+  source_image_project_id: source-image-project-id # use value supplied by Google Cloud staff
+  source_image: source-image-name                  # use value supplied by Google Cloud staff
+
+deployment_groups:
+- group: build_script
+  modules:
+  - id: sysnet
+    source: modules/network/pre-existing-vpc
+    settings:
+      network_name: $(vars.network_name_system)
+      subnetwork_name: $(vars.subnetwork_name_system)
+
+  - id: image_build_script
+    source: modules/scripts/startup-script
+    settings:
+      install_ansible: true
+      configure_ssh_host_patterns:
+      - 10.0.0.*
+      - 10.1.0.*
+      - 10.2.0.*
+      - 10.3.0.*
+      - $(vars.slurm_cluster_name)*
+      runners:
+      - type: shell
+        destination: workaround_apt_change.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          rm -f /etc/apt/sources.list.d/kubernetes.list
+          apt-get update --allow-releaseinfo-change
+      - type: shell
+        destination: disable_dlvm_builtin_services.sh
+        content: |
+          #!/bin/bash
+          # many extra services are being started via /etc/rc.local; disable
+          # them on future boots of image
+          echo -e '#!/bin/bash\n/usr/bin/nvidia-persistenced --user root\nexit 0' > /etc/rc.local
+          # disable jupyter and notebooks-collection-agent services
+          systemctl stop jupyter.service notebooks-collection-agent.service
+          systemctl disable jupyter.service notebooks-collection-agent.service
+      - type: data
+        destination: /var/tmp/slurm_vars.json
+        content: |
+          {
+            "reboot": false,
+            "slurm_version": "23.02.7",
+            "install_cuda": false,
+            "nvidia_version": "latest",
+            "install_ompi": true,
+            "install_lustre": true,
+            "install_gcsfuse": true,
+            "monitoring_agent": "cloud-ops"
+          }
+      - type: shell
+        destination: install_slurm.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          ansible-galaxy role install googlecloudplatform.google_cloud_ops_agents
+          ansible-pull \
+              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C 5.10.6 \
+              -i localhost, --limit localhost --connection=local \
+              -e @/var/tmp/slurm_vars.json \
+              ansible/playbook.yml
+      # this duplicates the ulimits configuration of the HPC VM Image
+      - type: data
+        destination: /etc/security/limits.d/99-unlimited.conf
+        content: |
+          * - memlock unlimited
+          * - nproc unlimited
+          * - stack unlimited
+          * - nofile 1048576
+          * - cpu unlimited
+          * - rtprio unlimited
+      - type: data
+        destination: /etc/systemd/system/slurmd.service.d/file_ulimit.conf
+        content: |
+          [Service]
+          LimitNOFILE=infinity
+      - type: data
+        destination: /etc/systemd/system/delay-a3.service
+        content: |
+          [Unit]
+          Description=Delay A3 boot until all network interfaces are routable
+          After=network-online.target
+          Wants=network-online.target
+          Before=google-startup-scripts.service
+
+          [Service]
+          ExecCondition=/bin/bash -c '/usr/bin/curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/machine-type | grep -q "/a3-highgpu-8g$"'
+          ExecStart=/usr/lib/systemd/systemd-networkd-wait-online -i enp6s0 -i enp12s0 -i enp134s0 -i enp140s0 -o routable --timeout=120
+          ExecStartPost=/bin/sleep 60
+
+          [Install]
+          WantedBy=multi-user.target
+      - type: shell
+        destination: configure_docker.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          # allow any user to use Docker
+          DOCKER_SOCKET_DROPIN_DIR="/etc/systemd/system/docker.socket.d"
+          if [ ! -d "${DOCKER_SOCKET_DROPIN_DIR}" ]; then
+              mkdir "${DOCKER_SOCKET_DROPIN_DIR}"
+          fi
+          DOCKER_SOCKET_DROPIN_FILE="group-override.conf"
+          if [ ! -f "${DOCKER_SOCKET_DROPIN_DIR}/${DOCKER_SOCKET_DROPIN_FILE}" ]; then
+              # indentation matters in EOT below; do not blindly edit!
+              cat <<EOT > "${DOCKER_SOCKET_DROPIN_DIR}/${DOCKER_SOCKET_DROPIN_FILE}"
+          [Socket]
+          SocketMode=0666
+          EOT
+          fi
+      - type: shell
+        destination: install_enroot_pyxis.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          ### Setting up Enroot
+          if ! dpkg -l enroot &>/dev/null; then
+              arch=\$(dpkg --print-architecture)
+              curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot_3.4.1-1_${arch}.deb
+              curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot+caps_3.4.1-1_${arch}.deb # optional
+              apt-get update
+              apt-get install --assume-yes ./*.deb
+              rm enroot*.deb
+          fi
+          # configure enroot
+          # use single quotes around EOT to avoid shell interpolation
+          cat <<'EOT' > /etc/enroot/enroot.conf
+          ENROOT_RUNTIME_PATH    /mnt/localssd/${UID}/enroot/runtime
+          ENROOT_CACHE_PATH      /mnt/localssd/${UID}/enroot/cache
+          ENROOT_DATA_PATH       /mnt/localssd/${UID}/enroot/data
+          EOT
+          ### Install Pyxis
+          if [ ! -f "/usr/local/lib/slurm/spank_pyxis.so" ]; then
+              git clone --depth 1 https://github.com/NVIDIA/pyxis.git
+              cd pyxis && make install && cd -
+              rm -rf pyxis
+              echo "required /usr/local/lib/slurm/spank_pyxis.so" > /etc/slurm/plugstack.conf
+          fi
+      - type: shell
+        destination: install_mdadm.sh
+        content: |
+          #!/bin/bash
+          apt-get update
+          apt-get install mdadm --no-install-recommends --assume-yes
+      - type: data
+        destination: /usr/local/ghpc/mount_localssd.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+
+          RAID_DEVICE=/dev/md0
+          DST_MNT=/mnt/localssd
+          DISK_LABEL=LOCALSSD
+          OPTIONS=discard,defaults
+
+          # if mount is successful, do nothing
+          if mount --source LABEL="$DISK_LABEL" --target="$DST_MNT" -o "$OPTIONS"; then
+                  exit 0
+          fi
+
+          # Create new RAID, format ext4 and mount
+          # TODO: handle case of zero or 1 local SSD disk
+          # TODO: handle case when /dev/md0 exists but was not mountable for
+          # some reason
+          DEVICES=`nvme list | grep nvme_ | grep -v nvme_card-pd | awk '{print $1}' | paste -sd ' '`
+          NB_DEVICES=`nvme list | grep nvme_ | grep -v nvme_card-pd | awk '{print $1}' | wc -l`
+          mdadm --create "$RAID_DEVICE" --level=0 --raid-devices=$NB_DEVICES $DEVICES
+          mkfs.ext4 -F "$RAID_DEVICE"
+          tune2fs "$RAID_DEVICE" -r 131072
+          e2label "$RAID_DEVICE" "$DISK_LABEL"
+          mkdir -p "$DST_MNT"
+          mount --source LABEL="$DISK_LABEL" --target="$DST_MNT" -o "$OPTIONS"
+          chmod 1777 "$DST_MNT"
+      - type: data
+        destination: /etc/systemd/system/mount-local-ssd.service
+        content: |
+          [Unit]
+          Description=Assemble local SSDs as software RAID; then format and mount
+
+          [Service]
+          ExecCondition=bash -c '/usr/bin/curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/machine-type | grep -q "/a3-highgpu-8g$"'
+          ExecStart=/bin/bash /usr/local/ghpc/mount_localssd.sh
+
+          [Install]
+          WantedBy=local-fs.target
+      - type: shell
+        destination: install_dcgm.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          apt-key del 7fa2af80
+          distribution=\$(. /etc/os-release;echo $ID$VERSION_ID | sed -e 's/\.//g')
+          wget https://developer.download.nvidia.com/compute/cuda/repos/$distribution/x86_64/cuda-keyring_1.0-1_all.deb
+          dpkg -i cuda-keyring_1.0-1_all.deb
+          apt-get update
+          apt-get install -y datacenter-gpu-manager
+          # libnvidia-nscq needed for A100/A800 and H100/H800 systems
+          apt-get install -y libnvidia-nscq-550
+      - type: shell
+        destination: add_dcgm_to_op_config.sh
+        content: |
+          #!/bin/bash
+          tee -a /etc/google-cloud-ops-agent/config.yaml > /dev/null << EOF
+          metrics:
+            receivers:
+              dcgm:
+                type: dcgm
+            service:
+              pipelines:
+                dcgm:
+                  receivers:
+                    - dcgm
+          EOF
+      - type: shell
+        destination: systemctl_services.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          # workaround b/309016676 (systemd-resolved restarts 4 times causing DNS
+          # resolution failures during google-startup-scripts.service)
+          systemctl daemon-reload
+          systemctl enable delay-a3.service
+          systemctl enable mount-local-ssd.service
+          systemctl enable nvidia-dcgm
+      - type: shell
+        destination: remove_snap_gcloud.sh
+        content: |
+          #!/bin/bash
+          # THIS RUNNER MUST BE THE LAST RUNNER BECAUSE IT WILL BREAK GSUTIL IN
+          # PARENT SCRIPT OF STARTUP-SCRIPT MODULE
+          set -e -o pipefail
+          # Remove original DLVM gcloud, lxds install due to conflict with snapd and NFS
+          snap remove google-cloud-cli lxd
+          # Install key and google-cloud-cli from apt repo
+          GCLOUD_APT_SOURCE="/etc/apt/sources.list.d/google-cloud-sdk.list"
+          if [ ! -f "${GCLOUD_APT_SOURCE}" ]; then
+              # indentation matters in EOT below; do not blindly edit!
+              cat <<EOT > "${GCLOUD_APT_SOURCE}"
+          deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt cloud-sdk main
+          EOT
+          fi
+          curl -o /usr/share/keyrings/cloud.google.asc https://packages.cloud.google.com/apt/doc/apt-key.gpg
+          apt-get update
+          apt-get install --assume-yes google-cloud-cli
+          # Clean up the bash executable hash for subsequent steps using gsutil
+          hash -r
+
+- group: slurm-build
+  modules:
+  - id: slurm-image
+    source: modules/packer/custom-image
+    kind: packer
+    use:
+    - image_build_script
+    - sysnet
+    settings:
+      # building this image does not require a GPU-enabled VM but must *not* be
+      # run on a N-series VM otherwise, the "open" drivers will not install
+      machine_type: c2d-standard-32
+      source_image_project_id: [$(vars.source_image_project_id)]
+      source_image: $(vars.source_image)
+      image_family: $(vars.final_image_family)

--- a/examples/machine-learning/ml-slurm-a3-2-cluster.yaml
+++ b/examples/machine-learning/ml-slurm-a3-2-cluster.yaml
@@ -1,0 +1,244 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+blueprint_name: slurm-a3-cluster
+
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: customer-tf-state-bucket  # modify to be a bucket owned and writable by customer
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: slurm-a3-cluster
+  region: customer-region
+  zone: customer-zone
+  zones:
+  - $(vars.zone)
+  disk_size_gb: 200
+  final_image_family: slurm-dlvm
+  slurm_cluster_name: slurm0
+  enable_reconfigure: true
+  enable_cleanup_compute: true
+  enable_cleanup_subscriptions: true
+  a3_partition_name: a3
+  a3_static_cluster_size: 32
+  # reservation name provided by Google
+  a3_reservation_name: slurm-res-0
+  # a3_maintenance_interval should be empty string by default; may be set to
+  # PERIODIC by direction of Google Cloud staff
+  a3_maintenance_interval: ""
+  # network parameters should match base blueprint unless network names were modified
+  network_name_system: slurm-sys-net
+  subnetwork_name_system: slurm-sys-subnet
+  subnetwork_self_link_gpunet0: https://www.googleapis.com/compute/v1/projects/$(vars.project_id)/regions/$(vars.region)/subnetworks/slurm-gpu-subnet0
+  subnetwork_self_link_gpunet1: https://www.googleapis.com/compute/v1/projects/$(vars.project_id)/regions/$(vars.region)/subnetworks/slurm-gpu-subnet1
+  subnetwork_self_link_gpunet2: https://www.googleapis.com/compute/v1/projects/$(vars.project_id)/regions/$(vars.region)/subnetworks/slurm-gpu-subnet2
+  subnetwork_self_link_gpunet3: https://www.googleapis.com/compute/v1/projects/$(vars.project_id)/regions/$(vars.region)/subnetworks/slurm-gpu-subnet3
+  server_ip_homefs: 0.0.0.0 # MUST set to IP address of Filestore instance from base deployment!
+  remote_mount_homefs: /nfsshare
+  local_mount_homefs: /home
+
+deployment_groups:
+- group: cluster
+  modules:
+  - id: sysnet
+    source: modules/network/pre-existing-vpc
+    settings:
+      network_name: $(vars.network_name_system)
+      subnetwork_name: $(vars.subnetwork_name_system)
+
+  - id: homefs
+    source: modules/file-system/pre-existing-network-storage
+    settings:
+      server_ip: $(vars.server_ip_homefs)
+      remote_mount: $(vars.remote_mount_homefs)
+      local_mount: $(vars.local_mount_homefs)
+
+  - id: compute_sa
+    source: community/modules/project/service-account
+    settings:
+      name: compute
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - pubsub.subscriber
+      - storage.objectAdmin
+
+  - id: debug_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      node_count_static: 0
+      node_count_dynamic_max: 4
+      machine_type: n2-standard-2
+      instance_image_custom: true
+      instance_image:
+        family: $(vars.final_image_family)
+        project: $(vars.project_id)
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - debug_node_group
+    - sysnet
+    - homefs
+    settings:
+      partition_name: debug
+      exclusive: false
+      enable_placement: false
+
+  - id: a3_node_group
+    source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    settings:
+      reservation_name: $(vars.a3_reservation_name)
+      maintenance_interval: $(vars.a3_maintenance_interval)
+      node_count_static: $(vars.a3_static_cluster_size)
+      node_count_dynamic_max: 0
+      disk_type: pd-ssd
+      machine_type: a3-highgpu-8g
+      instance_image_custom: true
+      disable_public_ips: true
+      enable_smt: true
+      instance_image:
+        family: $(vars.final_image_family)
+        project: $(vars.project_id)
+      node_conf:
+        CoresPerSocket: 52
+        ThreadsPerCore: 2
+      on_host_maintenance: TERMINATE
+      service_account:
+        email: $(compute_sa.service_account_email)
+        scopes:
+        - cloud-platform
+      bandwidth_tier: gvnic_enabled
+      additional_networks:
+      - network: null
+        subnetwork: $(vars.subnetwork_self_link_gpunet0)
+        subnetwork_project: $(vars.project_id)
+        network_ip: ""
+        nic_type: GVNIC
+        stack_type: IPV4_ONLY
+        queue_count: null
+        access_config: []
+        ipv6_access_config: []
+        alias_ip_range: []
+      - network: null
+        subnetwork: $(vars.subnetwork_self_link_gpunet1)
+        subnetwork_project: $(vars.project_id)
+        network_ip: ""
+        nic_type: GVNIC
+        stack_type: IPV4_ONLY
+        queue_count: null
+        access_config: []
+        ipv6_access_config: []
+        alias_ip_range: []
+      - network: null
+        subnetwork: $(vars.subnetwork_self_link_gpunet2)
+        subnetwork_project: $(vars.project_id)
+        network_ip: ""
+        nic_type: GVNIC
+        stack_type: IPV4_ONLY
+        queue_count: null
+        access_config: []
+        ipv6_access_config: []
+        alias_ip_range: []
+      - network: null
+        subnetwork: $(vars.subnetwork_self_link_gpunet3)
+        subnetwork_project: $(vars.project_id)
+        network_ip: ""
+        nic_type: GVNIC
+        stack_type: IPV4_ONLY
+        queue_count: null
+        access_config: []
+        ipv6_access_config: []
+        alias_ip_range: []
+
+  - id: a3_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    use:
+    - a3_node_group
+    - sysnet
+    - homefs
+    settings:
+      partition_name: $(vars.a3_partition_name)
+      enable_placement: false
+      exclusive: false
+      is_default: true
+      partition_conf:
+        OverSubscribe: EXCLUSIVE
+
+  - id: controller_startup
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: shell
+        destination: stage_scripts.sh
+        content: |
+          #!/bin/bash
+          curl -s --create-dirs -o /opt/apps/adm/slurm/scripts/receive-data-path-manager \
+              https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/v5/tools/prologs-epilogs/receive-data-path-manager
+          chmod 0755 /opt/apps/adm/slurm/scripts/receive-data-path-manager
+          mkdir -p /opt/apps/adm/slurm/partition-$(vars.a3_partition_name)-prolog_slurmd.d
+          mkdir -p /opt/apps/adm/slurm/partition-$(vars.a3_partition_name)-epilog_slurmd.d
+          ln -s /opt/apps/adm/slurm/scripts/receive-data-path-manager /opt/apps/adm/slurm/partition-$(vars.a3_partition_name)-prolog_slurmd.d/start-rxdm.prolog_slurmd
+          ln -s /opt/apps/adm/slurm/scripts/receive-data-path-manager /opt/apps/adm/slurm/partition-$(vars.a3_partition_name)-epilog_slurmd.d/stop-rxdm.epilog_slurmd
+      - type: shell
+        destination: reset_enroot.sh
+        content: |
+          #!/bin/bash
+          # reset enroot to defaults of files under /home and running under /run
+          # allows basic enroot testing on login/controller nodes (reduced I/O)
+          rm -f /etc/enroot/enroot.conf
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    use:
+    - sysnet
+    - a3_partition
+    - debug_partition
+    - homefs
+    settings:
+      machine_type: c2-standard-8
+      cloud_parameters:
+        resume_rate: 0
+        resume_timeout: 900
+        suspend_rate: 0
+        suspend_timeout: 600
+        no_comma_params: false
+      instance_image_custom: true
+      instance_image:
+        family: $(vars.final_image_family)
+        project: $(vars.project_id)
+      slurm_conf_tpl: modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/etc/long-prolog-slurm.conf.tpl
+      controller_startup_script: $(controller_startup.startup_script)
+      enable_external_prolog_epilog: true
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    use:
+    - sysnet
+    - slurm_controller
+    settings:
+      disk_type: pd-balanced
+      instance_image_custom: true
+      instance_image:
+        family: $(vars.final_image_family)
+        project: $(vars.project_id)
+      machine_type: c2-standard-4
+      startup_script: |
+        #!/bin/bash
+        # reset enroot to defaults of files under /home and running under /run
+        # allows basic enroot testing on login node (reduced I/O)
+        rm -f /etc/enroot/enroot.conf


### PR DESCRIPTION
This commit adds the first Toolkit solution for provisioning Slurm clusters with A3 compute nodes each with 8 NVIDIA H100 GPUs. The associated provisioning guide documents for the user how to create base networking infrastructure, build a custom image, and provision the A3 cluster itself.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
