### PR TITLE
Add NCCL benchmark to machine-learning solution

### DIFF
--- a/examples/machine-learning/README.md
+++ b/examples/machine-learning/README.md
@@ -303,7 +303,7 @@ cd hpc-toolkit/examples/machine-learning/nccl-tests
 ### Import the PyTorch image from the NVIDIA Container Registry
 
 ```shell
-import_pytorch_container.sh
+bash import_pytorch_container.sh
 ```
 
 ### Build NCCL

--- a/examples/machine-learning/nccl-tests/README.md
+++ b/examples/machine-learning/nccl-tests/README.md
@@ -1,0 +1,5 @@
+# NCCL benchmark
+
+Please follow the instructions the [machine-learning README](../README.md) for
+provisioning an A3-based Slurm cluster and executing the nccl-tests benchmarks
+in these scripts.

--- a/examples/machine-learning/nccl-tests/build-nccl-tests.sh
+++ b/examples/machine-learning/nccl-tests/build-nccl-tests.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#SBATCH --ntasks=1
+#SBATCH --partition=a3
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+
+# Usage: sbatch build-nccl-tests.sh
+
+set -x
+
+CONTAINER_IMAGE=./nvidia+pytorch+23.10-py3.sqsh
+
+# Install nccl-tests using openmpi from within pytorch container
+srun --container-mounts="$PWD:/nccl" \
+	--container-image=${CONTAINER_IMAGE} \
+	--container-name="nccl" \
+	bash -c "
+     export LD_LIBRARY_PATH=/var/lib/tcpx/lib64:$LD_LIBRARY_PATH &&
+       cd /nccl &&
+       git clone https://github.com/NVIDIA/nccl-tests.git &&
+       cd /nccl/nccl-tests/ &&
+       MPI=1 CC=mpicc CXX=mpicxx make -j
+    "

--- a/examples/machine-learning/nccl-tests/import_pytorch_container.sh
+++ b/examples/machine-learning/nccl-tests/import_pytorch_container.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Usage: bash ./import_container.sh
-
 # This creates a file named "nvidia+pytorch+21.10-py3.sqsh", which
 # uses ~18 GB of disk space. This should be run on a filesystem that
 # can be seen by all worker nodes

--- a/examples/machine-learning/nccl-tests/import_pytorch_container.sh
+++ b/examples/machine-learning/nccl-tests/import_pytorch_container.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: bash ./import_container.sh
+
+# This creates a file named "nvidia+pytorch+21.10-py3.sqsh", which
+# uses ~18 GB of disk space. This should be run on a filesystem that
+# can be seen by all worker nodes
+enroot import docker://nvcr.io#nvidia/pytorch:23.10-py3

--- a/examples/machine-learning/nccl-tests/run-nccl-tests.sh
+++ b/examples/machine-learning/nccl-tests/run-nccl-tests.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC2001
+# shellcheck disable=SC2015
+
+#SBATCH --partition=a3
+#SBATCH --exclusive
+#SBATCH --gpus-per-node=8
+#SBATCH --ntasks-per-node=8
+#SBATCH --nodes 2
+
+# Usage: sbatch run-nccl-tests.sh
+echo "Running NCCL Tests on ${SLURM_JOB_NUM_NODES} nodes."
+
+# Echo all the commands, for future reference
+set -x
+
+# This should be set to the squashfs file that you created for your application
+CONTAINER_IMAGE=./nvidia+pytorch+23.10-py3.sqsh
+
+# Important TCPX environment variables
+UDS_PATH="/run/tcpx-${SLURM_JOB_ID}"
+
+# Only use TCPX for multi-node jobs.
+[[ "${SLURM_JOB_NUM_NODES}" -gt 1 ]] && export USE_TCPX=yes || export USE_TCPX=no
+
+# Only use TCPX for multi-node jobs.
+if [[ ${USE_TCPX} = "yes" ]]; then
+	# Set up NCCL Environment variables
+	export NCCL_NET=GPUDirectTCPX_v7
+	# These network interfaces use Ubuntu's consistent naming scheme. See
+	# https://manpages.ubuntu.com/manpages/focal/man7/systemd.net-naming-scheme.7.html
+	export NCCL_SOCKET_IFNAME=enp0s12
+	export NCCL_GPUDIRECTTCPX_CTRL_DEV=enp0s12
+	export NCCL_GPUDIRECTTCPX_SOCKET_IFNAME=enp6s0,enp12s0,enp134s0,enp140s0
+	export NCCL_CROSS_NIC=0
+	export NCCL_ALGO=Ring
+	export NCCL_PROTO=Simple
+	export NCCL_NSOCKS_PERTHREAD=4
+	export NCCL_SOCKET_NTHREADS=1
+	export NCCL_MAX_NCHANNELS=12
+	export NCCL_MIN_NCHANNELS=12
+	export NCCL_DYNAMIC_CHUNK_SIZE=524288
+	export NCCL_P2P_NET_CHUNKSIZE=524288
+	export NCCL_P2P_PCI_CHUNKSIZE=524288
+	export NCCL_P2P_NVL_CHUNKSIZE=1048576
+	export NCCL_BUFFSIZE=4194304
+	export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+	export NCCL_NET_GDR_LEVEL=PIX
+	export NCCL_P2P_PXN_LEVEL=0
+	export NCCL_GPUDIRECTTCPX_UNIX_CLIENT_PREFIX=${UDS_PATH}
+	export NCCL_GPUDIRECTTCPX_PROGRAM_FLOW_STEERING_WAIT_MICROS=1000000
+	export NCCL_GPUDIRECTTCPX_FORCE_ACK=0
+	export NCCL_GPUDIRECTTCPX_TX_COMPLETION_NANOSLEEP=1000
+
+	export LD_LIBRARY_PATH=/var/lib/tcpx/lib64:${LD_LIBRARY_PATH}
+else
+	unset NCCL_NET
+fi
+
+# The following two can be useful for debugging
+# export NCCL_DEBUG=INFO
+# export NCCL_DEBUG_SUBSYS=INIT,GRAPH,ENV,TUNING
+
+# Here we grab all the environment variables that need to be
+# passed down into the container. Slurm would otherwise only pass these env vars
+# to the job environment on the host.
+HOST_VARS=$(sed 's/ \{1,\}/,/g' <<<"${!USE_TCPX*} ${!NCCL*} LD_LIBRARY_PATH")
+
+# Mount /var/tmp to allow the rest of the enroot container to be read-only, and
+# mount current $PWD to /nccl to for accessing nccl-tests binary
+CONTAINER_MOUNTS="/var/tmp:/var/tmp"
+
+# Mount PWD to /nccl in the enroot container
+CONTAINER_MOUNTS=${CONTAINER_MOUNTS},"$PWD:/nccl"
+
+# Mount required directories for TCPX functionality
+if [[ ${USE_TCPX} = "yes" ]]; then
+	CONTAINER_MOUNTS=${CONTAINER_MOUNTS},"/var/lib/tcpx/lib64:/var/lib/tcpx/lib64"
+	CONTAINER_MOUNTS=${CONTAINER_MOUNTS},${UDS_PATH}:${UDS_PATH}
+fi
+
+# Run the workload
+srun --mpi=pmi2 \
+	--cpu-bind=verbose \
+	--export=ALL \
+	--container-name=nccl \
+	--container-image="${CONTAINER_IMAGE}" \
+	--container-env="${HOST_VARS}" \
+	--container-mounts="${CONTAINER_MOUNTS}" \
+	/nccl/nccl-tests/build/all_reduce_perf -b 1G -e 8G -f 2 -g 1 -w 5 --iters 40 -c 0

--- a/examples/machine-learning/nccl-tests/run-topological-nccl-tests.sh
+++ b/examples/machine-learning/nccl-tests/run-topological-nccl-tests.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC2001
+# shellcheck disable=SC2015
+# shellcheck disable=SC2016
+
+#SBATCH --partition=a3
+#SBATCH --exclusive
+#SBATCH --gpus-per-node=8
+#SBATCH --ntasks-per-node=8
+#SBATCH --nodes 2
+
+# Usage: sbatch run-nccl-tests.sh
+echo "Running NCCL Tests on ${SLURM_JOB_NUM_NODES} nodes."
+
+# Echo all the commands, for future reference
+set -x
+
+# This should be set to the squashfs file that you created for your application
+CONTAINER_IMAGE=./nvidia+pytorch+23.10-py3.sqsh
+
+# Important TCPX environment variables
+UDS_PATH="/run/tcpx-${SLURM_JOB_ID}"
+
+# Only use TCPX for multi-node jobs.
+[[ "${SLURM_JOB_NUM_NODES}" -gt 1 ]] && export USE_TCPX=yes || export USE_TCPX=no
+
+# Only use TCPX for multi-node jobs.
+if [[ ${USE_TCPX} = "yes" ]]; then
+	# Set up NCCL Environment variables
+	export NCCL_NET=GPUDirectTCPX_v7
+	# These network interfaces use Ubuntu's consistent naming scheme. See
+	# https://manpages.ubuntu.com/manpages/focal/man7/systemd.net-naming-scheme.7.html
+	export NCCL_SOCKET_IFNAME=enp0s12
+	export NCCL_GPUDIRECTTCPX_CTRL_DEV=enp0s12
+	export NCCL_GPUDIRECTTCPX_SOCKET_IFNAME=enp6s0,enp12s0,enp134s0,enp140s0
+	export NCCL_CROSS_NIC=0
+	export NCCL_ALGO=Ring
+	export NCCL_PROTO=Simple
+	export NCCL_NSOCKS_PERTHREAD=4
+	export NCCL_SOCKET_NTHREADS=1
+	export NCCL_MAX_NCHANNELS=12
+	export NCCL_MIN_NCHANNELS=12
+	export NCCL_DYNAMIC_CHUNK_SIZE=524288
+	export NCCL_P2P_NET_CHUNKSIZE=524288
+	export NCCL_P2P_PCI_CHUNKSIZE=524288
+	export NCCL_P2P_NVL_CHUNKSIZE=1048576
+	export NCCL_BUFFSIZE=4194304
+	export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+	export NCCL_NET_GDR_LEVEL=PIX
+	export NCCL_P2P_PXN_LEVEL=0
+	export NCCL_GPUDIRECTTCPX_UNIX_CLIENT_PREFIX=${UDS_PATH}
+	export NCCL_GPUDIRECTTCPX_PROGRAM_FLOW_STEERING_WAIT_MICROS=1000000
+	export NCCL_GPUDIRECTTCPX_FORCE_ACK=0
+	export NCCL_GPUDIRECTTCPX_TX_COMPLETION_NANOSLEEP=1000
+
+	export LD_LIBRARY_PATH=/var/lib/tcpx/lib64:${LD_LIBRARY_PATH}
+else
+	unset NCCL_NET
+fi
+
+# The following two can be useful for debugging
+# export NCCL_DEBUG=INFO
+# export NCCL_DEBUG_SUBSYS=INIT,GRAPH,ENV,TUNING
+
+# Here we grab all the environment variables that need to be
+# passed down into the container. Slurm would otherwise only pass these env vars
+# to the job environment on the host.
+HOST_VARS=$(sed 's/ \{1,\}/,/g' <<<"${!USE_TCPX*} ${!NCCL*} LD_LIBRARY_PATH")
+
+# Mount /var/tmp to allow the rest of the enroot container to be read-only, and
+# mount current $PWD to /nccl to for accessing nccl-tests binary
+CONTAINER_MOUNTS="/var/tmp:/var/tmp"
+
+# Mount PWD to /nccl in the enroot container
+CONTAINER_MOUNTS=${CONTAINER_MOUNTS},"$PWD:/nccl"
+
+# Mount required directories for TCPX functionality
+if [[ ${USE_TCPX} = "yes" ]]; then
+	CONTAINER_MOUNTS=${CONTAINER_MOUNTS},"/var/lib/tcpx/lib64:/var/lib/tcpx/lib64"
+	CONTAINER_MOUNTS=${CONTAINER_MOUNTS},${UDS_PATH}:${UDS_PATH}
+fi
+
+# Construct topology ordered hostfile
+# The -n, -N, --ntasks-per-node, etc, must match the way the workload is
+# launched in order to ensure proper placement.
+srun --mpi=pmi2 \
+	-n $((SLURM_NNODES * 8)) \
+	--ntasks-per-node=8 \
+	bash -c 'curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/physical_host" -H "Metadata-Flavor: Google"; echo /$SLURMD_NODENAME' |
+	sort -t / -s -k 1,4 |
+	awk -F "/" '{print $NF}' >/var/tmp/topo_sorted_hostfile
+export SLURM_HOSTFILE=/var/tmp/topo_sorted_hostfile
+
+# Run the workload
+srun --mpi=pmi2 \
+	--cpu_bind=verbose \
+	-n $((SLURM_NNODES * 8)) \
+	--ntasks-per-node=8 \
+	--gpus-per-node=8 \
+	--export=ALL \
+	--container-image=${CONTAINER_IMAGE} \
+	--container-name=nccl \
+	--container-env="${HOST_VARS}" \
+	--container-mounts="/var/tmp:/var/tmp,/var/lib/tcpx/lib64:/var/lib/tcpx/lib64,$PWD:/nccl,${UDS_PATH}:${UDS_PATH}" \
+	/nccl/nccl-tests/build/all_reduce_perf -b 1G -e 8G -f 2 -g 1 -w 5 --iters 40 -c 0


### PR DESCRIPTION
#2359 provisions a Slurm cluster using A3 compute nodes. This PR adds a containerized benchmark script that users can use to validate their cluster functionality.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
