### PR TITLE
Add SlurmGCP v6 version of hcls blueprint and integration test

### DIFF
--- a/docs/videos/healthcare-and-life-sciences/README.md
+++ b/docs/videos/healthcare-and-life-sciences/README.md
@@ -1,5 +1,9 @@
 # Healthcare and Life Science Blueprint
 
+> [!NOTE]
+> This document uses SlurmGCP v5 version of hcls blueprint. If you want to
+> use SlurmGCP v6 version, please refer to this [blueprint](../examples/hcls-blueprint.yaml).
+
 The Healthcare and Life Science (HCLS) [blueprint](./hcls-blueprint.yaml) in
 this folder captures an advanced architecture that can be used to run GROMACS
 with GPUs or CPUs on Google Cloud.

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [hpc-slurm-gromacs.yaml](#hpc-slurm-gromacsyaml--) ![community-badge] ![experimental-badge]
   * [hpc-slurm-local-ssd.yaml](#hpc-slurm-local-ssdyaml--) ![community-badge] ![experimental-badge]
   * [hpc-slurm-local-ssd-v6.yaml](#hpc-slurm-local-ssd-v6yaml--) ![community-badge] ![experimental-badge]
+  * [hcls-blueprint-v6.yaml](#hcls-blueprint-v6yaml--) ![core-badge] ![experimental-badge]
   * [hpc-gke.yaml](#hpc-gkeyaml--) ![community-badge] ![experimental-badge]
   * [ml-gke](#ml-gkeyaml--) ![community-badge] ![experimental-badge]
   * [storage-gke](#storage-gkeyaml--) ![community-badge] ![experimental-badge]
@@ -1263,6 +1264,15 @@ This blueprint demonstrates the use of Slurm and Filestore, with compute nodes
 that have local ssd drives deployed.
 
 [hpc-slurm-local-ssd-v6.yaml]: ../community/examples/hpc-slurm-local-ssd-v6.yaml
+
+### [hcls-blueprint-v6.yaml]: ![core-badge] ![experimental-badge]
+
+This blueprint demonstrates an advanced architecture that can be used to run
+GROMACS with GPUs and CPUs on Google Cloud. For full documentation, refer
+[document].
+
+[document]: ../docs/videos/healthcare-and-life-sciences/README.md
+[hcls-blueprint-v6.yaml]:  ../example/hcls-blueprint-v6.yaml
 
 ### [hpc-gke.yaml] ![community-badge] ![experimental-badge]
 

--- a/examples/hcls-blueprint-v6.yaml
+++ b/examples/hcls-blueprint-v6.yaml
@@ -1,0 +1,344 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: hcls-cluster-v6
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: hcls-cluster-v6
+  region: asia-southeast1
+  zone: asia-southeast1-b
+  bucket_force_destroy: false
+
+deployment_groups:
+- group: enable_apis
+  modules:
+
+  ### Enable APIs ###
+
+  - id: services-api
+    source: community/modules/project/service-enablement
+    settings:
+      gcp_service_list:
+      - file.googleapis.com
+      - iam.googleapis.com
+      - pubsub.googleapis.com
+      - secretmanager.googleapis.com
+      - serviceusage.googleapis.com
+      - compute.googleapis.com
+      - stackdriver.googleapis.com
+
+- group: setup
+  modules:
+
+  ### Network ###
+
+  - id: network
+    source: modules/network/vpc
+
+  ### Resource Monitoring ###
+
+  - id: hpc-dash
+    source: modules/monitoring/dashboard
+
+  ### Storage ###
+
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network]
+    settings:
+      filestore_share_name: homeshare
+      local_mount: /home
+
+  - id: appsfs
+    source: modules/file-system/filestore
+    use: [network]
+    settings:
+      filestore_share_name: appsshare
+      local_mount: /apps
+
+  - id: bucket-software
+    source: community/modules/file-system/cloud-storage-bucket
+    settings:
+      name_prefix: hcls-user-provided-software
+      random_suffix: true
+      local_mount: /user_provided_software
+      force_destroy: $(vars.bucket_force_destroy)
+    outputs: [gcs_bucket_path]
+
+  - id: bucket-input
+    source: community/modules/file-system/cloud-storage-bucket
+    settings:
+      name_prefix: hcls-inputs
+      random_suffix: true
+      local_mount: /data_input
+      mount_options: defaults,_netdev,implicit_dirs,allow_other,dir_mode=0777,file_mode=766
+      force_destroy: $(vars.bucket_force_destroy)
+
+  - id: bucket-output
+    source: community/modules/file-system/cloud-storage-bucket
+    settings:
+      name_prefix: hcls-outputs
+      random_suffix: true
+      local_mount: /data_output
+      mount_options: defaults,_netdev,implicit_dirs,allow_other,dir_mode=0777,file_mode=766
+      force_destroy: $(vars.bucket_force_destroy)
+
+- group: software_installation
+  modules:
+
+  ### Software ###
+
+  - id: spack-setup
+    source: community/modules/scripts/spack-setup
+    settings:
+      install_dir: /apps/spack
+
+  - id: spack-execute
+    source: community/modules/scripts/spack-execute
+    use: [spack-setup]
+    settings:
+      data_files:
+      - destination: /tmp/projections-config.yaml
+        content: |
+          modules:
+            default:
+              tcl:
+                hash_length: 0
+                all:
+                  conflict:
+                    - '{name}'
+                projections:
+                  all: '{name}/{version}-{compiler.name}-{compiler.version}'
+      - destination: /tmp/slurm-external-config.yaml
+        content: |
+          packages:
+            slurm:
+              externals:
+                - spec: slurm@21-08-8-2
+                  prefix: /usr/local
+              buildable: False
+      - destination: /share/spack/gromacs_env.yaml
+        content: |
+          spack:
+            definitions:
+            - compilers:
+                - gcc@11.3.0
+            - cudas:
+                - cuda@11.8.0
+            - cuda_mpis:
+                - openmpi@4.1.4+cuda
+            - mpi_cuda_packages:
+                - gromacs@2022.3+cuda+mpi
+            specs:
+            - $compilers
+            - matrix:
+                - [$cudas]
+                - [$%compilers]
+            - matrix:
+                - [$cuda_mpis]
+                - [$%compilers]
+                - [$^cudas]
+                - [target=skylake]
+            - matrix:
+                - [$mpi_cuda_packages]
+                - [$^cudas]
+                - [$^cuda_mpis]
+                - [$%compilers]
+                - [target=skylake]
+      commands: |
+        spack config --scope defaults add config:build_stage:/apps/spack/spack-stage
+        spack config --scope defaults add -f /tmp/projections-config.yaml
+        spack config --scope site add -f /tmp/slurm-external-config.yaml
+
+        NVCC_PREPEND_FLAGS='-arch=all'
+        spack install gcc@11.3.0 target=x86_64
+        spack load gcc@11.3.0 target=x86_64
+        spack compiler find --scope site
+
+        if ! spack env list | grep -q gromacs; then
+          spack env create gromacs /share/spack/gromacs_env.yaml
+          spack env activate gromacs
+          spack concretize
+          spack install
+        fi
+
+  - id: spack-builder-startup
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - $(spack-execute.spack_runner)
+
+      - type: shell
+        destination: data_staging.sh
+        content: |
+          #!/bin/bash
+          wget --no-verbose -P /data_input/protein_data_bank/ https://files.rcsb.org/download/1AKI.pdb
+          wget --no-verbose -P /tmp/ https://ftp.gromacs.org/pub/benchmarks/water_GMX50_bare.tar.gz && \
+            mkdir -p /data_input/gromacs_inputs/ && \
+            tar xzf /tmp/water_GMX50_bare.tar.gz -C /data_input/gromacs_inputs/ && \
+            rm /tmp/water_GMX50_bare.tar.gz
+
+          # Set permissions for Spack environment
+          chmod -R a+rwX /apps/spack/var/spack/environments/gromacs
+
+      - type: data
+        destination: /apps/gromacs/submit_gromacs_water_cpu.sh
+        content: |
+          #!/bin/bash
+          #SBATCH -N 1
+          #SBATCH --ntasks-per-node 30
+          #SBATCH -p compute
+
+          # Size can be 0000.65  0000.96  0001.5  0003  0006  0012  0024  0048  0096  0192  0384  0768  1536  3072
+          # Type can be 'pme' or 'rf'
+
+          source /apps/spack/share/spack/setup-env.sh
+          spack env activate gromacs
+
+          # Check that gmx_mpi exists
+          which gmx_mpi
+          cd $SLURM_SUBMIT_DIR
+          cp /data_input/gromacs_inputs/water-cut1.0_GMX50_bare/1536/* .
+          mpirun -n 1 gmx_mpi grompp -f pme.mdp -c conf.gro -p topol.top -o input.tpr
+          mpirun -n 30 gmx_mpi mdrun -notunepme -dlb yes -v -resethway -noconfout -nsteps 4000 -s input.tpr
+
+      - type: data
+        destination: /apps/gromacs/submit_gromacs_water_gpu.sh
+        content: |
+          #!/bin/bash
+          #SBATCH -N 1
+          #SBATCH --ntasks-per-node 1
+          #SBATCH -p gpu
+          #SBATCH --gpus 1
+
+          # Size can be 0000.65  0000.96  0001.5  0003  0006  0012  0024  0048  0096  0192  0384  0768  1536  3072
+          # Type can be 'pme' or 'rf'
+
+          source /apps/spack/share/spack/setup-env.sh
+          spack env activate gromacs
+
+          # Check that gmx_mpi exists
+          which gmx_mpi
+          cd $SLURM_SUBMIT_DIR
+          cp /data_input/gromacs_inputs/water-cut1.0_GMX50_bare/1536/* .
+
+          # Significant GPU Optimizations only support constraints=h-bonds
+          # so we change this here for the water benchmark.
+          for a in *.mdp; do
+              sed -i 's/constraints[[:blank:]].*=.*all-bonds.*/constraints = h-bonds/' $a
+          done
+          mpirun -n 1 gmx_mpi grompp -f pme.mdp -c conf.gro -p topol.top -o input.tpr
+
+          mpirun -n 1 -H localhost \
+            env GMX_ENABLE_DIRECT_GPU_COMM=1 \
+            gmx_mpi mdrun -v -nsteps 100000 -resetstep 90000 -noconfout \
+            -pme gpu -update gpu -nb gpu -gputasks 00 -s input.tpr
+
+      - type: shell
+        destination: shutdown.sh
+        content: |
+          #!/bin/bash
+          if [ ! -f /etc/block_auto_shutdown ]; then
+                  touch /etc/block_auto_shutdown
+                  shutdown -h +1
+          fi
+
+  - id: spack-builder
+    source: modules/compute/vm-instance
+    use: [network, appsfs, bucket-input, spack-builder-startup]
+    settings:
+      name_prefix: spack-builder
+      add_deployment_name_before_prefix: true
+      threads_per_core: 2
+      machine_type: c2-standard-16
+
+- group: cluster
+  modules:
+
+  ### Remote Desktop ###
+
+  - id: desktop
+    source: community/modules/remote-desktop/chrome-remote-desktop
+    use:
+    - network
+    - homefs
+    - appsfs
+    - bucket-input
+    - bucket-output
+    - bucket-software
+    settings:
+      add_deployment_name_before_prefix: true
+      name_prefix: chrome-remote-desktop
+      install_nvidia_driver: true
+      startup_script: |
+        find /user_provided_software -name vmd-1.9.*.bin.LINUXAMD64*.tar.gz -exec tar xvzf '{}' -C . \;
+        cd vmd-1.9.*/
+        ./configure
+        cd src/
+        sudo make install
+
+  ### Slurm Cluster ###
+
+  - id: compute_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      name: ns
+      node_count_dynamic_max: 20
+      machine_type: c2-standard-60
+
+  - id: compute_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use:
+    - compute_nodeset
+    settings:
+      partition_name: compute
+
+  - id: gpu_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      name: gpu
+      enable_smt: true
+      node_count_dynamic_max: 20
+      machine_type: g2-standard-4
+      enable_placement: False
+
+  - id: gpu_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use:
+    - gpu_nodeset
+    settings:
+      partition_name: gpu
+
+  - id: slurm_login
+    source: ./community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      name_prefix: "login"
+
+  - id: slurm_controller
+    source: ./community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - network
+    - compute_partition
+    - gpu_partition
+    - homefs
+    - appsfs
+    - bucket-input
+    - bucket-output
+    - slurm_login

--- a/tools/cloud-build/daily-tests/builds/hcls-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls-v6.yaml
@@ -1,0 +1,73 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.chrome-remote-desktop
+- m.cloud-storage-bucket
+- m.dashboard
+- m.filestore
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.service-enablement
+- m.spack-execute
+- m.spack-setup
+- m.startup-script
+- m.vm-instance
+- m.vpc
+- spack
+- crd
+- slurm6
+
+timeout: 14400s  # 4hr
+steps:
+## Test simple golang build
+- id: build_ghpc
+  waitFor: ["-"]
+  name: "golang:bullseye"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    cd /workspace
+    make
+- id: fetch_builder
+  waitFor: ["-"]
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - echo "done fetching builder"
+
+# Test hcls-v6
+- id: hcls-v6
+  waitFor: ["fetch_builder", "build_ghpc"]
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/hcls-v6.yml"

--- a/tools/cloud-build/daily-tests/tests/hcls-v6.yml
+++ b/tools/cloud-build/daily-tests/tests/hcls-v6.yml
@@ -1,0 +1,43 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+test_name: hcls-cluster-v6
+deployment_name: "hcls-v6-{{ build }}"
+# No non-alphanumerical characters in the slurm cluster name - they will be
+# removed by HPC Toolkit slurm wrappers, which will break the playbook
+slurm_cluster_name: "hclsv6{{ build[0:4] }}"
+zone: us-central1-c
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/hcls-blueprint-v6.yaml"
+network: "{{ deployment_name }}-net"
+login_node: "{{ slurm_cluster_name }}-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+cli_deployment_vars:
+  region: us-central1
+  zone: "{{ zone }}"
+  disable_login_public_ips: "false"
+  disable_controller_public_ips: "false"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+- test-validation/test-partitions.yml
+custom_vars:
+  partitions:
+  - compute
+  mounts:
+  - /home
+  - /apps
+  - /data_input
+  - /data_output


### PR DESCRIPTION
In the manual test, I deployed the blueprint, set up chrome remote desktop and ran below command to visualize.
```
harshthakkar_google_com@hcls-cluster-v6-chrome-remote-desktop-0:~$ cd water_run/
harshthakkar_google_com@hcls-cluster-v6-chrome-remote-desktop-0:~/water_run$ ls
conf.gro  ener.edr  input.tpr  md.log  mdout.mdp  pme.mdp  rf.mdp  slurm-1.out	topol.top
harshthakkar_google_com@hcls-cluster-v6-chrome-remote-desktop-0:~/water_run$ vmd conf.gro 
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
