### PR TITLE
Allow nodeset to be used by multiple partitions

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
@@ -13,9 +13,14 @@
 # limitations under the License.
 
 locals {
-  nodeset_map     = { for x in var.nodeset : x.nodeset_name => x }
-  nodeset_tpu_map = { for x in var.nodeset_tpu : x.nodeset_name => x }
-  nodeset_dyn_map = { for x in var.nodeset_dyn : x.nodeset_name => x }
+  nodeset_map_ell = { for x in var.nodeset : x.nodeset_name => x... }
+  nodeset_map     = { for k, vs in local.nodeset_map_ell : k => vs[0] }
+
+  nodeset_tpu_map_ell = { for x in var.nodeset_tpu : x.nodeset_name => x... }
+  nodeset_tpu_map     = { for k, vs in local.nodeset_tpu_map_ell : k => vs[0] }
+
+  nodeset_dyn_map_ell = { for x in var.nodeset_dyn : x.nodeset_name => x... }
+  nodeset_dyn_map     = { for k, vs in local.nodeset_dyn_map_ell : k => vs[0] }
 
   partition_map = { for x in var.partitions : x.partition_name => x }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
@@ -84,8 +84,7 @@ locals {
     filename = "ghpc_startup.sh"
     content  = var.compute_startup_script
   }]
-  nodeset_startup_scripts = {
-  for ns in var.nodeset : ns.nodeset_name => ns.startup_script }
+  nodeset_startup_scripts = { for k, v in local.nodeset_map : k => v.startup_script }
 }
 
 module "slurm_files" {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -240,11 +240,6 @@ variable "nodeset" {
     content = string })), [])
   }))
   default = []
-
-  validation {
-    condition     = length(distinct([for x in var.nodeset : x.nodeset_name])) == length(var.nodeset)
-    error_message = "All nodesets must have a unique name."
-  }
 }
 
 variable "nodeset_tpu" {
@@ -277,11 +272,6 @@ variable "nodeset_tpu" {
     reserved   = optional(string, false)
   }))
   default = []
-
-  validation {
-    condition     = length(distinct([for x in var.nodeset_tpu : x.nodeset_name])) == length(var.nodeset_tpu)
-    error_message = "All TPU nodesets must have a unique name."
-  }
 }
 
 
@@ -292,11 +282,6 @@ variable "nodeset_dyn" {
     nodeset_feature = string
   }))
   default = []
-
-  validation {
-    condition     = length(distinct([for x in var.nodeset_dyn : x.nodeset_name])) == length(var.nodeset_dyn)
-    error_message = "All nodesets must have a unique name."
-  }
 }
 
 #############


### PR DESCRIPTION
### Side effects:
Removes validation for uniqueness of nodeset name. Given default value guaranteed to be unique this doesn't seem to be a big problem.
There are some avenues to restore this validation, but it's rather complex and should be addressed separately.

### Testing done:

```yaml
  - id: ns
    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
    ...

  - id: p1
    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
    use: [ns]
    ...

  - id: p2
    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
    use: [ns]
    ...

  - id: slurm_controller
    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
    use: [network, p1, p2]
    ...
```

```sh
$ srun -N 1 -p p1 hostname
orlovmulti-ns-0
$ srun -N 1 -p p2 hostname
orlovmulti-ns-0
```