### PR TITLE
Set default validation level to `ERROR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ In the right side, expand the Filters view and then filter by label, specifying 
 
 ## Troubleshooting
 
+### Authentication
+
+Confirm that you have [properly setup Google Cloud credentials](#gcp-credentials)
+
 ### Slurm Clusters
 
 Please see the dedicated [troubleshooting guide for Slurm](docs/slurm-troubleshooting.md).

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -35,7 +35,7 @@ func addExpandFlags(c *cobra.Command, addOutFlag bool) *cobra.Command {
 		"Comma-separated list of name=value variables to override YAML configuration. Can be used multiple times.")
 	c.Flags().StringSliceVar(&expandFlags.cliBEConfigVars, "backend-config", nil,
 		"Comma-separated list of name=value variables to set Terraform backend configuration. Can be used multiple times.")
-	c.Flags().StringVarP(&expandFlags.validationLevel, "validation-level", "l", "WARNING",
+	c.Flags().StringVarP(&expandFlags.validationLevel, "validation-level", "l", "ERROR",
 		"Set validation level to one of (\"ERROR\", \"WARNING\", \"IGNORE\")")
 	c.Flags().StringSliceVar(&expandFlags.validatorsToSkip, "skip-validators", nil, "Validators to skip")
 	return c

--- a/docs/blueprint-validation.md
+++ b/docs/blueprint-validation.md
@@ -120,12 +120,12 @@ validators:
 ### Validation levels
 
 They can also be set to 3 differing levels of behavior using the command-line
-`--validation-level` flag for the `create` and `expand` commands:
+`--validation-level` flag:
 
-* `"ERROR"`: If any validator fails, the deployment directory will not be
+* `"ERROR"` (default): If any validator fails, the deployment directory will not be
   written. Error messages will be printed to the screen that indicate which
   validator(s) failed and how.
-* `"WARNING"` (default): The deployment directory will be written even if any
+* `"WARNING"`: The deployment directory will be written even if any
   validators fail. Warning messages will be printed to the screen that indicate
   which validator(s) failed and how.
 * `"IGNORE"`: Do not execute any validators, even if they are explicitly defined

--- a/docs/hpc-slurm6-tpu-maxtext.md
+++ b/docs/hpc-slurm6-tpu-maxtext.md
@@ -12,7 +12,7 @@ the dataset in your GCS. After that you can update the blueprint to use the
 dataset from GCS bucket in training script.
 
 ```bash
-./ghpc create community/examples/hpc-slurm6-tpu-maxtext.yaml -l ERROR --vars project_id=<project-id>;
+./ghpc create community/examples/hpc-slurm6-tpu-maxtext.yaml --vars project_id=<project-id>;
 ./ghpc deploy slurm6-tpu --auto-approve
 ```
 

--- a/tools/cloud-build/daily-tests/e2e.sh
+++ b/tools/cloud-build/daily-tests/e2e.sh
@@ -22,7 +22,7 @@ vars="project_id=$PROJECT_ID,deployment_name=$depl_name,region=$region,zone=$zon
 
 # Already in a root of the repo
 make
-./ghpc deploy tools/cloud-build/daily-tests/blueprints/e2e.yaml --vars="$vars" -l ERROR --auto-approve
+./ghpc deploy tools/cloud-build/daily-tests/blueprints/e2e.yaml --vars="$vars" --auto-approve
 
 # check instance was created
 gcloud compute instances describe "${depl_name}-0" --project="$PROJECT_ID" --zone="$zone" >/dev/null


### PR DESCRIPTION
**Motivation:** to safe new user from common deployment-time errors (e.g. APIs disabled)
