### PR TITLE
Slurm-GCP-V6. Add local SSD example

### DIFF
--- a/community/examples/hpc-slurm-local-ssd-v6.yaml
+++ b/community/examples/hpc-slurm-local-ssd-v6.yaml
@@ -1,0 +1,119 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: hpc-slurm-local-ssd-v6
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: hpc-localssd
+  region: us-central1
+  zone: us-central1-a
+
+# Documentation for each of the modules used below can be found at
+# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network]
+    settings:
+      local_mount: /home
+
+  - id: nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      additional_disks:
+      - device_name: test-disk-1
+        disk_name: null
+        disk_size_gb: 375
+        disk_type: local-ssd
+        disk_labels: {}
+        auto_delete: true
+        boot: false
+      - device_name: test-disk-2
+        disk_name: null
+        disk_size_gb: 375
+        disk_type: local-ssd
+        disk_labels: {}
+        auto_delete: true
+        boot: false
+      bandwidth_tier: gvnic_enabled
+      machine_type: c2-standard-4
+      node_count_dynamic_max: 5
+      node_count_static: 0
+      startup_script: |
+        #!/bin/bash
+        set -e -o pipefail
+
+        # this script assumes it is running on a RedHat-derivative OS
+        yum install -y mdadm
+
+        RAID_DEVICE=/dev/md0
+        DST_MNT=/mnt/localssd
+        DISK_LABEL=LOCALSSD
+        OPTIONS=discard,defaults
+
+        # if mount is successful, do nothing
+        if mount --source LABEL="$DISK_LABEL" --target="$DST_MNT" -o "$OPTIONS"; then
+                exit 0
+        fi
+
+        # Create new RAID, format ext4 and mount
+        # TODO: handle case of zero or 1 local SSD disk
+        # TODO: handle case when /dev/md0 exists but was not mountable
+        DEVICES=`nvme list | grep nvme_ | grep -v nvme_card-pd | awk '{print $1}' | paste -sd ' '`
+        NB_DEVICES=`nvme list | grep nvme_ | grep -v nvme_card-pd | awk '{print $1}' | wc -l`
+        mdadm --create "$RAID_DEVICE" --level=0 --raid-devices=$NB_DEVICES $DEVICES
+        mkfs.ext4 -F "$RAID_DEVICE"
+        tune2fs "$RAID_DEVICE" -r 131072
+        e2label "$RAID_DEVICE" "$DISK_LABEL"
+        mkdir -p "$DST_MNT"
+        mount --source LABEL="$DISK_LABEL" --target="$DST_MNT" -o "$OPTIONS"
+        chmod 1777 "$DST_MNT"
+
+  - id: partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [nodeset]
+    settings:
+      is_default: true
+      partition_name: ssdcomp
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      name_prefix: login
+      machine_type: n1-standard-4
+      disable_login_public_ips: false
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use: [network, homefs, partition, slurm_login]
+    settings:
+      cloud_parameters:
+        resume_rate: 0
+        resume_timeout: 300
+        suspend_rate: 0
+        suspend_timeout: 300
+        no_comma_params: false
+      machine_type: n1-standard-4
+      disable_controller_public_ips: false

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [client-google-cloud-storage.yaml](#client-google-cloud-storageyaml--) ![community-badge] ![experimental-badge]
   * [hpc-slurm-gromacs.yaml](#hpc-slurm-gromacsyaml--) ![community-badge] ![experimental-badge]
   * [hpc-slurm-local-ssd.yaml](#hpc-slurm-local-ssdyaml--) ![community-badge] ![experimental-badge]
+  * [hpc-slurm-local-ssd-v6.yaml](#hpc-slurm-local-ssd-v6yaml--) ![community-badge] ![experimental-badge]
   * [hpc-gke.yaml](#hpc-gkeyaml--) ![community-badge] ![experimental-badge]
   * [ml-gke](#ml-gkeyaml--) ![community-badge] ![experimental-badge]
   * [storage-gke](#storage-gkeyaml--) ![community-badge] ![experimental-badge]
@@ -1221,6 +1222,13 @@ machine communications, for NFS and also for communications between the Slurm
 nodes)
 
 [hpc-slurm-local-ssd.yaml]: ../community/examples/hpc-slurm-local-ssd.yaml
+
+### [hpc-slurm-local-ssd-v6.yaml] ![community-badge] ![experimental-badge]
+
+This blueprint demonstrates the use of Slurm and Filestore, with compute nodes
+that have local ssd drives deployed.
+
+[hpc-slurm-local-ssd-v6.yaml]: ../community/examples/hpc-slurm-local-ssd-v6.yaml
 
 ### [hpc-gke.yaml] ![community-badge] ![experimental-badge]
 

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -1,0 +1,62 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.filestore
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.vpc
+- slurm6
+
+timeout: 14400s  # 4hr
+steps:
+## Test simple golang build
+- id: build_ghpc
+  waitFor: ["-"]
+  name: "golang:bullseye"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    cd /workspace
+    make
+- id: fetch_builder
+  waitFor: ["-"]
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - echo "done fetching builder"
+
+- id: slurm-gcp-v6-ssd
+  waitFor: ["fetch_builder", "build_ghpc"]
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+test_name: hpc-slurm-v6-ssd
+deployment_name: "ssd-v6-{{ build }}"
+# Manually adding the slurm_cluster_name for use in node names, which filters
+# non-alphanumeric chars and is capped at 10 chars.
+slurm_cluster_name: "ssdv6{{ build[0:5] }}"
+zone: us-central1-a
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-local-ssd-v6.yaml"
+network: "{{ deployment_name }}-net"
+max_nodes: 5
+# Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
+login_node: "{{ slurm_cluster_name }}-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+post_deploy_tests:
+- test-validation/test-partitions.yml
+custom_vars:
+  partitions:
+  - ssdcomp
+  mounts:
+  - /home
+  - /mnt/localssd


### PR DESCRIPTION
**Testing done:**
* Tested with `exclusive=true` (default)
* Tested with `exclusive=false & enable_placement=false`

```sh
$ srun -N 1 -p ssdcomp df
Filesystem                      1K-blocks     Used Available Use% Mounted on
devtmpfs                          8042704        0   8042704   0% /dev
tmpfs                             8062276        0   8062276   0% /dev/shm
tmpfs                             8062276    16836   8045440   1% /run
tmpfs                             8062276        0   8062276   0% /sys/fs/cgroup
/dev/sda2                        52211760 17552484  34659276  34% /
/dev/sda1                          204580     5888    198692   3% /boot/efi
tmpfs                             1612452        0   1612452   0% /run/user/0
hpclocalss-controller:/opt/apps  52212736 16410624  35802112  32% /opt/apps
hpclocalss-controller:/home      52212736 16410624  35802112  32% /home
/dev/md0                        772706776       28 772166076   1% /mnt/localssd 
                                                                      ^ 🧐 
```

