### PR TITLE
Fixing Makefile `terraform-format` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,11 @@ validate_golden_copy: ghpc
 terraform-format:
 	$(info *********** cleaning terraform files syntax and generating terraform documentation ***********)
 	@for folder in ${TERRAFORM_FOLDERS}; do \
-	  echo "cleaning syntax for $${folder}";\
+	  echo "checking syntax for $${folder}";\
 		terraform fmt -list=true $${folder};\
 	done
 	@for folder in ${TERRAFORM_FOLDERS}; do \
 		terraform-docs markdown $${folder} --config .tfdocs-markdown.yaml;\
-		terraform-docs json $${folder} --config .tfdocs-json.yaml;\
 	done
 
 endif


### PR DESCRIPTION
`make terraform-format` can be used to call terraform-docs to clean up terraform format and generate README.md files.  A long time ago, we this called `terraform-docs json` which is no longer in use. 
This change makes removes the json part and improves the message.