### PR TITLE
Decoupling private access from Cloud SQL to allow multiple instances in same VPC

### DIFF
--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -45,7 +45,6 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
@@ -53,7 +52,6 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 3.83 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -64,8 +62,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google-beta_google_compute_global_address.private_ip_address](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_global_address) | resource |
-| [google-beta_google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_service_networking_connection) | resource |
 | [google_bigquery_connection.connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_connection) | resource |
 | [google_sql_database.database](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
 | [google_sql_database_instance.instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
@@ -81,6 +77,7 @@ No modules.
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the instances. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is going to be created in.:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
+| <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection, used only as dependency for Cloud SQL creation. | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region where SQL instance will be configured | `string` | n/a | yes |
 | <a name="input_sql_instance_name"></a> [sql\_instance\_name](#input\_sql\_instance\_name) | name given to the sql instance for ease of identificaion | `string` | n/a | yes |

--- a/community/modules/database/slurm-cloudsql-federation/variables.tf
+++ b/community/modules/database/slurm-cloudsql-federation/variables.tf
@@ -73,3 +73,9 @@ variable "network_id" {
     error_message = "The network id must be provided in the following format: projects/<project_id>/global/networks/<network_name>."
   }
 }
+
+variable "private_vpc_connection_peering" {
+  description = "The name of the VPC Network peering connection, used only as dependency for Cloud SQL creation."
+  type        = string
+  default     = null
+}

--- a/community/modules/network/private-service-access/README.md
+++ b/community/modules/network/private-service-access/README.md
@@ -44,7 +44,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/community/modules/network/private-service-access/README.md
+++ b/community/modules/network/private-service-access/README.md
@@ -1,0 +1,85 @@
+## Description
+
+This module configures [private service access][psa] for the VPC specified by the `network_id` variable. It can be used by the  [Cloud SQL Federation module][sql].
+
+It will automatically perform the following steps, as described in the [Private Service Access][psa-creation] creation page:
+
+* Create an IP Allocation with the prefix_length specified by the `ip_alloc_prefix_length` variable.
+* Create a private connection that establishes a [VPC Network Peering][vpcnp] connection between your VPC network and the service producer's network
+
+[sql](https://github.com/GoogleCloudPlatform/hpc-toolkit/tree/main/community/modules/database/slurm-cloudsql-federation)
+[psa](https://cloud.google.com/vpc/docs/configure-private-services-access)
+[psa-creation](https://cloud.google.com/vpc/docs/configure-private-services-access#procedure)
+[vpcnp](https://cloud.google.com/vpc/docs/vpc-peering)
+
+### Example
+
+```yaml
+  - source: modules/network/vpc
+    id: network
+
+  - source: community/modules/network/private-service-access
+    id: ps_connect
+    use: [network]
+```
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.83 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 3.83 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_compute_global_address.private_ip_alloc](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_global_address) | resource |
+| [google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
+| [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to supporting resources. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to configure private service Access.:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
+| <a name="input_prefix_length"></a> [prefix\_length](#input\_prefix\_length) | The prefix length of the IP range allocated for the private service access. | `number` | `16` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#output\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection that was created by the service provider. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/network/private-service-access/main.tf
+++ b/community/modules/network/private-service-access/main.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "private-service-access", ghpc_role = "network" })
+}
+
+resource "random_id" "resource_name_suffix" {
+  byte_length = 4
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  provider      = google-beta
+  name          = "global-psconnect-ip-${random_id.resource_name_suffix.hex}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  network       = var.network_id
+  prefix_length = var.prefix_length
+  labels        = local.labels
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = var.network_id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}

--- a/community/modules/network/private-service-access/metadata.yaml
+++ b/community/modules/network/private-service-access/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - compute.googleapis.com
+    - servicenetworking.googleapis.com

--- a/community/modules/network/private-service-access/outputs.tf
+++ b/community/modules/network/private-service-access/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,8 @@
  * limitations under the License.
 */
 
-terraform {
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 3.83"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.0"
-    }
-  }
-  provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.31.1"
-  }
-  provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.31.1"
-  }
-
-  required_version = ">= 0.13.0"
+output "private_vpc_connection_peering" {
+  description = "The name of the VPC Network peering connection that was created by the service provider."
+  sensitive   = true
+  value       = google_service_networking_connection.private_vpc_connection.peering
 }

--- a/community/modules/network/private-service-access/variables.tf
+++ b/community/modules/network/private-service-access/variables.tf
@@ -1,0 +1,36 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "network_id" {
+  description = <<-EOT
+    The ID of the GCE VPC network to configure private service Access.:
+    `projects/<project_id>/global/networks/<network_name>`"
+    EOT
+  type        = string
+  validation {
+    condition     = length(split("/", var.network_id)) == 5
+    error_message = "The network id must be provided in the following format: projects/<project_id>/global/networks/<network_name>."
+  }
+}
+
+variable "labels" {
+  description = "Labels to add to supporting resources. Key-value pairs."
+  type        = map(string)
+}
+
+variable "prefix_length" {
+  description = "The prefix length of the IP range allocated for the private service access."
+  type        = number
+  default     = 16
+}

--- a/community/modules/network/private-service-access/versions.tf
+++ b/community/modules/network/private-service-access/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,12 +12,16 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
       version = ">= 3.83"
     }
     random = {
@@ -26,11 +30,12 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.31.1"
-  }
-  provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.31.1"
+    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.31.1"
   }
 
-  required_version = ">= 0.13.0"
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.31.1"
+  }
+
+  required_version = ">= 1.3"
 }

--- a/community/modules/network/private-service-access/versions.tf
+++ b/community/modules/network/private-service-access/versions.tf
@@ -37,5 +37,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.31.1"
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.2"
 }

--- a/tools/validate_configs/test_configs/hpc-cluster-simple-nfs-sql.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-simple-nfs-sql.yaml
@@ -71,7 +71,7 @@ deployment_groups:
     settings:
       disable_controller_public_ips: true
 
-  - id: slurm-login
+  - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use:
     - network1

--- a/tools/validate_configs/test_configs/hpc-cluster-simple-nfs-sql.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-simple-nfs-sql.yaml
@@ -28,6 +28,10 @@ deployment_groups:
   - id: network1
     source: modules/network/vpc
 
+  - id: ps_connect
+    source: community/modules/network/private-service-access
+    use: [network1]
+
   - id: homefs
     source: community/modules/file-system/nfs-server
     use: [network1]
@@ -35,24 +39,24 @@ deployment_groups:
       labels:
         ghpc_role: storage-home
 
-  - id: slurm-sql
+  - id: slurm_sql
     source: community/modules/database/slurm-cloudsql-federation
-    use: [network1]
+    use: [network1, ps_connect]
     settings:
       sql_instance_name: slurm-sql8
       tier: "db-f1-micro"
 
-  - id: compute-nodeset
+  - id: compute_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network1]
     settings:
       node_count_dynamic_max: 20
       machine_type: c2-standard-4
 
-  - id: compute-partition
+  - id: compute_partition
     source: community/modules/compute/schedmd-slurm-gcp-v6-partition
     use:
-    - compute-nodeset
+    - compute_nodeset
     settings:
       partition_name: compute
 
@@ -60,9 +64,9 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
     - homefs
-    - compute-partition
-    - slurm-login
-    - slurm-sql
+    - compute_partition
+    - slurm_login
+    - slurm_sql
     - network1
     settings:
       disable_controller_public_ips: true

--- a/tools/validate_configs/test_configs/two-clusters-sql.yaml
+++ b/tools/validate_configs/test_configs/two-clusters-sql.yaml
@@ -1,0 +1,155 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+blueprint_name: two-clusters
+
+vars:
+  project_id: hpc-toolkit-demo
+  deployment_name: clstr2
+  region: us-east1
+  zone: us-east1-b
+  enable_reconfigure: True
+  enable_cleanup_compute: False
+  enable_cleanup_subscriptions: True
+  enable_bigquery_load: True
+  instance_image_custom: True
+
+deployment_groups:
+- group: net
+  modules:
+  - source: modules/network/vpc
+    id: hpc_network
+
+  - source: community/modules/network/private-service-access
+    id: ps_connect
+    use: [hpc_network]
+
+- group: cluster1
+  modules:
+  - source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    kind: terraform
+    id: c1partition_0
+    use:
+    - c1partition_0_group
+    - hpc_network
+    settings:
+      partition_name: c1batch
+      enable_placement: False
+      exclusive: False
+
+  - source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    id: c1partition_0_group
+    use:
+    settings:
+      enable_smt: False
+      machine_type: c2-standard-60
+      node_count_dynamic_max: 4
+      node_count_static: 0
+      disk_size_gb: 50
+      disk_type: pd-standard
+
+  - source: community/modules/database/slurm-cloudsql-federation
+    kind: terraform
+    id: c1slurm_sql
+    use: [hpc_network, ps_connect]
+    settings:
+      sql_instance_name: sql-cluster-1
+      tier: "db-g1-small"
+
+
+  - source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    kind: terraform
+    id: c1slurm_controller
+    settings:
+      cloud_parameters:
+        resume_rate: 0
+        resume_timeout: 500
+        suspend_rate: 0
+        suspend_timeout: 300
+        no_comma_params: false
+      machine_type: n2-standard-2
+      disk_type: pd-standard
+      disk_size_gb: 50
+      slurm_cluster_name: cluster1
+    use:
+    - hpc_network
+    - c1partition_0
+    - c1slurm_sql
+
+  - source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    kind: terraform
+    id: c1slurm_login
+    use: [c1slurm_controller, hpc_network]
+    settings:
+      num_instances: 1
+      machine_type: n2-standard-2
+      disk_type: pd-standard
+      disk_size_gb: 50
+
+- group: cluster2
+  modules:
+  - source: community/modules/compute/schedmd-slurm-gcp-v5-partition
+    kind: terraform
+    id: c2partition_0
+    use: [c2partition_0_group, hpc_network]
+    settings:
+      partition_name: c2batch
+      enable_placement: False
+      exclusive: False
+
+  - source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
+    id: c2partition_0_group
+    settings:
+      enable_smt: False
+      machine_type: c2-standard-60
+      node_count_dynamic_max: 4
+      node_count_static: 0
+      disk_size_gb: 50
+      disk_type: pd-standard
+
+  - source: community/modules/database/slurm-cloudsql-federation
+    kind: terraform
+    id: c2slurm_sql
+    use: [hpc_network, ps_connect]
+    settings:
+      sql_instance_name: sql-cluster-2
+      tier: "db-g1-small"
+
+
+  - source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
+    kind: terraform
+    id: c2slurm_controller
+    use: [hpc_network, c2partition_0, c2slurm_sql]
+    settings:
+      cloud_parameters:
+        resume_rate: 0
+        resume_timeout: 500
+        suspend_rate: 0
+        suspend_timeout: 300
+        no_comma_params: false
+      machine_type: n2-standard-2
+      disk_type: pd-standard
+      disk_size_gb: 50
+      slurm_cluster_name: cluster2
+
+
+  - source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
+    kind: terraform
+    id: c2slurm_login
+    use: [c2slurm_controller, hpc_network]
+    settings:
+      num_instances: 1
+      machine_type: n2-standard-2
+      disk_type: pd-standard
+      disk_size_gb: 50

--- a/tools/validate_configs/test_configs/two-clusters-sql.yaml
+++ b/tools/validate_configs/test_configs/two-clusters-sql.yaml
@@ -15,7 +15,7 @@
 blueprint_name: two-clusters
 
 vars:
-  project_id: hpc-toolkit-demo
+  project_id: ## Set GCP Project ID Here ##
   deployment_name: clstr2
   region: us-east1
   zone: us-east1-b


### PR DESCRIPTION
On this PR I propose to decouple the configuration of Private Service Access from the Cloud SQL creation. This would allow us to configure it once for the lifetime of the VPC and then use it across multiple clusters in that same VPC. 

With this change, the following blueprint can be deployed successfully:

```
blueprint_name: two-clusters

vars:
  project_id: hpc-toolkit-demo
  deployment_name: clstr2
  region: us-east1
  zone: us-east1-b
  enable_reconfigure: True
  enable_cleanup_compute: False
  enable_cleanup_subscriptions: True
  enable_bigquery_load: True
  instance_image_custom: True

deployment_groups:
- group: net
  modules:
  - source: modules/network/vpc
    id: hpc_network

  - source: ./community/modules/network/private-service-access
    id: ps-connect
    use: [ hpc_network ]

- group: cluster1
  modules:
  - source: community/modules/compute/schedmd-slurm-gcp-v5-partition
    kind: terraform
    id: c1partition_0
    use:
    - c1partition_0-group
    - hpc_network
    settings:
      partition_name: c1batch
      enable_placement: False
      exclusive: False

  - source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
    id: c1partition_0-group
    use:
    settings:
      enable_smt: False
      machine_type: c2-standard-60
      node_count_dynamic_max: 4
      node_count_static: 0
      disk_size_gb: 50
      disk_type: pd-standard

  - source: ./community/modules/database/slurm-cloudsql-federation
    kind: terraform
    id: c1slurm-sql
    use: [hpc_network, ps-connect]
    settings:
      sql_instance_name: sql-cluster-1
      tier: "db-g1-small"


  - source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
    kind: terraform
    id: c1slurm_controller
    settings:
      cloud_parameters:
        resume_rate: 0
        resume_timeout: 500
        suspend_rate: 0
        suspend_timeout: 300
        no_comma_params: false
      machine_type: n2-standard-2
      disk_type: pd-standard
      disk_size_gb: 50
      slurm_cluster_name: cluster1
    use:
    - hpc_network
    - c1partition_0
    - c1slurm-sql

  - source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
    kind: terraform
    id: c1slurm_login
    use: [c1slurm_controller, hpc_network]
    settings:
      num_instances: 1
      machine_type: n2-standard-2
      disk_type: pd-standard
      disk_size_gb: 50

- group: cluster2
  modules:
  - source: community/modules/compute/schedmd-slurm-gcp-v5-partition
    kind: terraform
    id: c2partition_0
    use: [c2partition_0-group, hpc_network]
    settings:
      partition_name: c2batch
      enable_placement: False
      exclusive: False

  - source: community/modules/compute/schedmd-slurm-gcp-v5-node-group
    id: c2partition_0-group
    settings:
      enable_smt: False
      machine_type: c2-standard-60
      node_count_dynamic_max: 4
      node_count_static: 0
      disk_size_gb: 50
      disk_type: pd-standard

  - source: ./community/modules/database/slurm-cloudsql-federation
    kind: terraform
    id: c2slurm-sql
    use: [hpc_network, ps-connect]
    settings:
      sql_instance_name: sql-cluster-2
      tier: "db-g1-small"


  - source: community/modules/scheduler/schedmd-slurm-gcp-v5-controller
    kind: terraform
    id: c2slurm_controller
    use: [hpc_network, c2partition_0, c2slurm-sql]
    settings:
      cloud_parameters:
        resume_rate: 0
        resume_timeout: 500
        suspend_rate: 0
        suspend_timeout: 300
        no_comma_params: false
      machine_type: n2-standard-2
      disk_type: pd-standard
      disk_size_gb: 50
      slurm_cluster_name: cluster2


  - source: community/modules/scheduler/schedmd-slurm-gcp-v5-login
    kind: terraform
    id: c2slurm_login
    use: [c2slurm_controller, hpc_network]
    settings:
      num_instances: 1
      machine_type: n2-standard-2
      disk_type: pd-standard
      disk_size_gb: 50
```

Please note that the CloudSQL Federation does not really need to receive `ps-connect` as it is only used to inform the terraform dependency graph and prevent the attempt to create the Cloud SQL instance before private access is configured. 

I believe this addresses https://github.com/GoogleCloudPlatform/hpc-toolkit/issues/2054. 

Please not that after this PR is merged, a follow-up PR needs to be submitted to avoid breaking OFE deployments with Cloud SQL. This transition is necessary to support multiple clusters in the same VPC. 