### PR TITLE
Roll forward "Add example using Slurm static compute nodes"

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [hpc-slurm.yaml](#hpc-slurmyaml-) ![core-badge]
   * [hpc-slurm-v6.yaml](#hpc-slurm-v6yaml--) ![core-badge] ![experimental-badge]
   * [hpc-enterprise-slurm.yaml](#hpc-enterprise-slurmyaml-) ![core-badge]
+  * [hpc-slurm-static-v6.yaml](#hpc-slurm-static-v6yaml--) ![core-badge] ![experimental-badge]
   * [hpc-slurm6-tpu.yaml](#hpc-slurm6-tpuyaml--) ![community-badge] ![experimental-badge]
   * [hpc-slurm6-tpu-maxtext.yaml](#hpc-slurm6-tpu-maxtextyaml--) ![community-badge] ![experimental-badge]
   * [ml-slurm.yaml](#ml-slurmyaml-) ![core-badge]
@@ -396,6 +397,42 @@ to 256
   _not needed for `n2` partition_
 
 [hpc-enterprise-slurm.yaml]: ./hpc-enterprise-slurm.yaml
+
+### [hpc-slurm-static-v6.yaml] ![core-badge] ![experimental-badge]
+
+> **Warning**: Requires additional dependencies **to be installed on the system deploying the infrastructure**.
+>
+> ```shell
+> # Install Python3 and run
+> pip3 install -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/6.4.2/scripts/requirements.txt
+> ```
+
+This example demonstrates how to create a partition with static compute nodes.
+See [Best practices for static compute nodes] for instructions on setting up a
+reservation and compact placement policy.
+
+Before deploying this example the following fields must be populated in the bluerpint:
+
+```yaml
+  project_id: ## Set GCP Project ID Here ##
+  static_reservation_name:  ## Set your reservation name here ##
+  static_reservation_machine_type: ## Machine must match reservation above ##
+  static_node_count: ## Must be <= number of reserved machines ##
+```
+
+For more resources on static compute nodes see the following cloud docs pages:
+
+* [About [Slurm] node types](https://cloud.google.com/hpc-toolkit/docs/slurm/node-types)
+* [Best practices for static compute nodes]
+* [Reconfigure a running cluster](http://cloud/hpc-toolkit/docs/slurm/reconfigure-cluster)
+* [Manage static compute nodes](http://cloud/hpc-toolkit/docs/slurm/manage-static-nodes)
+
+For a similar, more advanced, example which demonstrates static node
+functionality with GPUs, see the
+[ML Slurm A3 example](./machine-learning/README.md).
+
+[Best practices for static compute nodes]: http://cloud/hpc-toolkit/docs/slurm/static-nodes-best-practices
+[hpc-slurm-static-v6.yaml]: ./hpc-slurm-static-v6.yaml
 
 ### [hpc-slurm6-tpu.yaml] ![community-badge] ![experimental-badge]
 

--- a/examples/hpc-slurm-static-v6.yaml
+++ b/examples/hpc-slurm-static-v6.yaml
@@ -1,0 +1,95 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+blueprint_name: hpc-slurm-static
+
+vars:
+  project_id: ## Set GCP Project ID Here ##
+  deployment_name: static-1
+  region: us-central1
+  zone: us-central1-a
+
+  ## EDIT THE BLOCK BELOW ##
+  # For instructions on creating a reservation see:
+  # http://cloud/hpc-toolkit/docs/slurm/static-nodes-best-practices
+  static_reservation_name: <reservation_name> ## Set your reservation name here ##
+  static_reservation_machine_type: <machine_type> ## Machine must match reservation above ##
+  static_node_count: 2 ## Must be <= number of reserved machines ##
+
+  slurm_instance_image:
+    family: slurm-gcp-6-4-hpc-rocky-linux-8
+    project: schedmd-slurm-public
+  instance_image_custom: false  # true if using custom image in lines above
+  bandwidth_tier: gvnic_enabled
+  # Follow steps to setup environment to allow for reconfiguration
+  # https://cloud.google.com/hpc-toolkit/docs/slurm/reconfigure-cluster#setup-environment
+  enable_cleanup_compute: true
+
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  - id: static_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      node_count_static: $(vars.static_node_count)
+      node_count_dynamic_max: 0
+      enable_placement: false  # placement is done on reservation
+      reservation_name: $(vars.static_reservation_name)
+      machine_type: $(vars.static_reservation_machine_type)
+      instance_image: $(vars.slurm_instance_image)
+  - id: static_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [static_nodeset]
+    settings:
+      partition_name: static
+      exclusive: false
+      is_default: true
+
+  - id: dynamic_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      machine_type: c2d-standard-112
+      node_count_dynamic_max: 100
+      instance_image: $(vars.slurm_instance_image)
+  - id: dynamic_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [dynamic_nodeset]
+    settings:
+      partition_name: dyn
+
+  - id: login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      name_prefix: login
+      machine_type: n2d-standard-4
+      disable_login_public_ips: false
+
+  - id: controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - network
+    - static_partition
+    - dynamic_partition
+    - login
+    settings:
+      machine_type: n2d-standard-16
+      disable_controller_public_ips: false

--- a/tools/cloud-build/daily-tests/ansible_playbooks/post-destroy-tasks/delete-reservation.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/post-destroy-tasks/delete-reservation.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - project is defined
+    - zone is defined
+    - custom_vars.reservation_name is defined
+
+- name: Delete Reservation
+  register: delete_reservation_result
+  changed_when: delete_reservation_result.rc == 0
+  ansible.builtin.command: gcloud compute reservations delete {{ custom_vars.reservation_name }} --project={{ project }}  --zone={{ zone }} --quiet

--- a/tools/cloud-build/daily-tests/ansible_playbooks/pre-deploy-tasks/create-reservation.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/pre-deploy-tasks/create-reservation.yml
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - project is defined
+    - zone is defined
+    - custom_vars.reservation_name is defined
+    - custom_vars.reservation_machine_type is defined
+    - custom_vars.reservation_machine_count is defined
+
+- name: Create Reservation
+  register: create_reservation_result
+  changed_when: create_reservation_result.rc == 0
+  ansible.builtin.command: gcloud compute reservations create {{ custom_vars.reservation_name }} --vm-count={{ custom_vars.reservation_machine_count }} --machine-type={{ custom_vars.reservation_machine_type }} --require-specific-reservation --project={{ project }} --zone={{ zone }}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -49,7 +49,7 @@
 
     - name: Run Pre Deploy Tasks
       ansible.builtin.include_tasks: "{{ pre_deploy_task }}"
-      loop: "{{ pre_deploy_tasks }}"
+      loop: "{{ pre_deploy_tasks | default([]) }}"
       loop_control:
         loop_var: pre_deploy_task
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -46,6 +46,13 @@
 
   - name: Create Infrastructure and test
     block:
+
+    - name: Run Pre Deploy Tasks
+      ansible.builtin.include_tasks: "{{ pre_deploy_task }}"
+      loop: "{{ pre_deploy_tasks }}"
+      loop_control:
+        loop_var: pre_deploy_task
+
     - name: Create Cluster with GHPC
       register: deployment
       changed_when: deployment.changed

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_ghpc_failure.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_ghpc_failure.yml
@@ -30,12 +30,22 @@
     - delete
     - "{{ deployment_name }}"
 
-- name: Destroy deployment
-  register: ghpc_destroy
-  changed_when: ghpc_destroy.changed
-  run_once: true
-  ansible.builtin.command: ./ghpc destroy {{ deployment_name }} --auto-approve
-  args:
-    chdir: "{{ workspace }}"
-  environment:
-    TF_IN_AUTOMATION: "TRUE"
+- name: Destroy block
+  block:
+
+  - name: Destroy deployment
+    register: ghpc_destroy
+    changed_when: ghpc_destroy.changed
+    run_once: true
+    ansible.builtin.command: ./ghpc destroy {{ deployment_name }} --auto-approve
+    args:
+      chdir: "{{ workspace }}"
+    environment:
+      TF_IN_AUTOMATION: "TRUE"
+
+  always:
+  - name: Run post destroy tasks
+    ansible.builtin.include_tasks: "{{ post_destroy_task }}"
+    loop: "{{ post_destroy_tasks }}"
+    loop_control:
+      loop_var: post_destroy_task

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_ghpc_failure.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_ghpc_failure.yml
@@ -46,6 +46,6 @@
   always:
   - name: Run post destroy tasks
     ansible.builtin.include_tasks: "{{ post_destroy_task }}"
-    loop: "{{ post_destroy_tasks }}"
+    loop: "{{ post_destroy_tasks | default([]) }}"
     loop_control:
       loop_var: post_destroy_task

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
@@ -1,0 +1,61 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- slurm6
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.vpc
+
+timeout: 14400s  # 4hr
+steps:
+## Test simple golang build
+- id: build_ghpc
+  waitFor: ["-"]
+  name: "golang:bullseye"
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    cd /workspace
+    make
+- id: fetch_builder
+  waitFor: ["-"]
+  name: >-
+    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - echo "done fetching builder"
+
+- id: slurm-gcp-v6-static
+  waitFor: ["fetch_builder", "build_ghpc"]
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-static.yml"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-static.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-static.yml
@@ -1,0 +1,51 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+test_name: hpc-slurm6-static
+deployment_name: "static-{{ build }}"
+# Manually adding the slurm_cluster_name for use in node names, which filters
+# non-alphanumeric chars and is capped at 10 chars.
+slurm_cluster_name: "static{{ build[0:4] }}"
+
+cli_deployment_vars:
+   region: us-west4
+   zone: us-west4-c
+   static_reservation_name: "res-{{ build }}"
+   static_reservation_machine_type: n2d-standard-2
+   static_node_count: 2
+
+zone: us-west4-c
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/hpc-slurm-static-v6.yaml"
+network: "{{ deployment_name }}-net"
+# Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
+login_node: "{{ slurm_cluster_name }}-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+pre_deploy_tasks:
+- pre-deploy-tasks/create-reservation.yml
+post_deploy_tests:
+- test-validation/test-partitions.yml
+post_destroy_tasks:
+- post-destroy-tasks/delete-reservation.yml
+custom_vars:
+   partitions:
+   - static
+   - dyn
+   mounts:
+   - /home
+   reservation_name: "{{ cli_deployment_vars.static_reservation_name }}"
+   reservation_machine_type: "{{ cli_deployment_vars.static_reservation_machine_type }}"
+   reservation_machine_count: "{{ cli_deployment_vars.static_node_count }}"


### PR DESCRIPTION
Original PR #2393 caused test failures.  
Original PR was reverted in GoogleCloudPlatform/hpc-toolkit#2404.  

This PR is the roll-forward and contains the fix to the broken tests in a new commit. It makes the new task lists optional by providing a default of an empty list.