### PR TITLE
Simplify & speed up integraion tests

### DIFF
--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -25,29 +25,9 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
 ## Test monitoring dashboard and install script
 - id: monitoring
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -56,6 +36,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make ghpc
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/images/test-runner/Dockerfile
+++ b/tools/cloud-build/images/test-runner/Dockerfile
@@ -1,0 +1,48 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:bullseye
+
+ENV GOCACHE=/ghpc_go_cache
+
+# copy the source code, to build the binary
+# use `/workspace` to match path in cache for future builds
+COPY ./ /workspace
+
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
+    apt-get -y update && apt-get -y install \
+    # `software-properties-common` providers `add-apt-repository`
+    software-properties-common \
+    keychain \
+    # `dnsutils` provides `dig` used by integration tests
+    dnsutils && \
+    # install terraform and packer
+    apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com bullseye main" && \
+    apt-get -y update && apt-get install -y unzip python3-pip python3-netaddr terraform packer && \
+    # install gcloud
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+      | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get -y update && apt-get -y install google-cloud-sdk && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # install ansible and python dependencies
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/v5/scripts/requirements.txt && \
+    pip install --no-cache-dir ansible && \
+    rm -rf ~/.cache/pip/* && \
+    # compile the binary to warm up `/ghpc_go_cache`
+    cd /workspace && make ghpc && \
+    # remove /workspace to reduce image size
+    rm -rf /workspace

--- a/tools/cloud-build/images/test-runner/config.yaml
+++ b/tools/cloud-build/images/test-runner/config.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  script: |
+    docker build \
+      -t us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:latest \
+      -f tools/cloud-build/images/test-runner/Dockerfile .
+  automapSubstitutions: true
+images:
+- 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:latest'

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -35,6 +35,7 @@ When prompted for project, use integration test project.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_daily_image_test_runner_schedule"></a> [daily\_image\_test\_runner\_schedule](#module\_daily\_image\_test\_runner\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_daily_project_cleanup_schedule"></a> [daily\_project\_cleanup\_schedule](#module\_daily\_project\_cleanup\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_daily_test_schedule"></a> [daily\_test\_schedule](#module\_daily\_test\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_weekly_build_dependency_check_schedule"></a> [weekly\_build\_dependency\_check\_schedule](#module\_weekly\_build\_dependency\_check\_schedule) | ./trigger-schedule | n/a |
@@ -46,6 +47,7 @@ When prompted for project, use integration test project.
 |------|------|
 | [google_cloudbuild_trigger.daily_project_cleanup](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.daily_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.image_build_test_runner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_go_build_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_ofe_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_ofe_venv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |

--- a/tools/cloud-build/provision/image-build-test-runner.tf
+++ b/tools/cloud-build/provision/image-build-test-runner.tf
@@ -1,0 +1,38 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloudbuild_trigger" "image_build_test_runner" {
+  name        = "DAILY-image-build-test-runner"
+  description = "Builds a container tailored to run integration tests"
+  tags        = [local.notify_chat_tag]
+
+  git_file_source {
+    path      = "tools/cloud-build/images/test-runner/config.yaml"
+    revision  = local.ref_develop
+    uri       = var.repo_uri
+    repo_type = "GITHUB"
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.ref_develop
+    repo_type = "GITHUB"
+  }
+}
+
+module "daily_image_test_runner_schedule" {
+  source   = "./trigger-schedule"
+  trigger  = google_cloudbuild_trigger.image_build_test_runner
+  schedule = "10 0 * * *" # every day at 00:10
+}


### PR DESCRIPTION
## Current test flow
```
golang:alpine -> fetch(30s) + make ghpc (3m) ↘
                                              ghpc:builder -> actual test (?s)
ghpc:builder -> just fetch (3m)              ↗

duration: max(3m, 3m30s) + ?s = 3m30s + ?s
```

## New test flow
```
ghpc:tester -> fetch (1m30s) +  make ghpc(3s) + actual test (?s)
duration:  1m33s + ?s
```

## Actions taken
* Create a new image `test-runner` that only has dependencies for tests (compare with builder):
  *  smaller (1GB vs 1.2GB);
  * less layers (9 vs 16);
  * fetches faster (1m30s vs 3m) 
* Preserve `go build` on the image cache to speed up `make ghpc ~3m -> ~3s`
* Update `monitoring` test to new flow, to showcase (9m40 vs 12m).

## Followups
Update rest of tests