### PR TITLE
Make deployment file command line option visible

### DIFF
--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -28,8 +28,7 @@ func addExpandFlags(c *cobra.Command, addOutFlag bool) *cobra.Command {
 	}
 
 	c.Flags().StringVarP(&expandFlags.deploymentFile, "deployment-file", "d", "",
-		"Toolkit Deployment File.")
-	c.Flags().MarkHidden("deployment-file")
+		"Deployment file to override blueprint variables and backend configuration")
 
 	c.Flags().StringSliceVar(&expandFlags.cliVariables, "vars", nil,
 		"Comma-separated list of name=value variables to override YAML configuration. Can be used multiple times.")


### PR DESCRIPTION
The deployment file flag has now been [documented on cloud.google.com](https://cloud.google.com/hpc-toolkit/docs/deploy/hpc-deployment-files). This PR presents it to users via ghpc create/expand/deploy --help.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
