### PR TITLE
Move tests `{h|l|m}.*` to the better flow

### DIFF
--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -34,29 +34,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
-# Test hcls
 - id: hcls
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -65,6 +44,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -24,28 +24,8 @@ tags:
 
 timeout: 5400s  # 1.5h
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
 - id: hpc-build-slurm-image
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -54,6 +34,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -27,29 +27,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-## Test examples/hpc-enterprise-slurm.yaml
 - id: hpc-enterprise-slurm
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -58,6 +37,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/hpc-slurm-chromedesktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-slurm-chromedesktop.yaml
@@ -26,29 +26,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-## Test community/examples/hpc-slurm-chromedesktop.yaml
 - id: hpc-slurm-chromedesktop
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -57,6 +36,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/htc-slurm-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm-v6.yaml
@@ -26,29 +26,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
-# Test htc-slurm deployment.
 - id: htc-slurm-v6
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -57,6 +36,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -29,29 +29,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
-# Test htcondor
 - id: htcondor
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -60,6 +39,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/lustre-slurm-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/lustre-slurm-v6.yaml
@@ -24,29 +24,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-## Test the blueprint
 - id: lustre-slurm-v6
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -55,6 +34,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/lustre-slurm.yaml
@@ -24,29 +24,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-## Test the blueprint
 - id: lustre-slurm
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -55,6 +34,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/lustre-vm.yaml
@@ -23,29 +23,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
-## Test lustre-vm
 - id: lustre-vm
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -54,6 +33,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/ml-slurm-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm-v6.yaml
@@ -26,30 +26,10 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it
 - id: ml-slurm-v6
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -58,6 +38,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -27,30 +27,10 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it
 - id: ml-slurm
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -59,6 +39,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 


### PR DESCRIPTION
Improve duration (~ -2min) and simplify flow (3 steps -> 1 step).
