### PR TITLE
Move packer and slurm5 tests to the better flow

### DIFF
--- a/tools/cloud-build/daily-tests/builds/packer-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer-v6.yaml
@@ -26,30 +26,10 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it
 - id: packer-v6
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -58,6 +38,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -25,30 +25,10 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it
 - id: packer
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -57,6 +37,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/pbspro.yaml
+++ b/tools/cloud-build/daily-tests/builds/pbspro.yaml
@@ -28,27 +28,8 @@ availableSecrets:
     env: PBSPRO_RPM_BUCKET
 steps:
 ## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
 - id: pbspro
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -58,6 +39,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=tools/validate_configs/test_configs/pbs-unwrapped.yaml

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-debian.yaml
@@ -24,29 +24,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
-## Test Slurm v5 Debian Example
 - id: slurm-gcp-v5-debian
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -55,6 +34,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-hpc-centos7.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-hpc-centos7.yaml
@@ -24,29 +24,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-## Test Slurm v5 HPC Centos7 Example
 - id: slurm-gcp-v5-hpc-centos7
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -55,6 +34,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-rocky8.yaml
@@ -24,29 +24,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
-## Test Slurm v5 rocky8 Example
 - id: slurm-gcp-v5-rocky8
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -55,6 +34,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-startup-scripts.yaml
@@ -26,30 +26,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
-## Test Slurm on GCP v5 with Startup Scripts
 - id: slurm-gcp-v5-startup-scripts
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -58,6 +36,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-ubuntu2004.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v5-ubuntu2004.yaml
@@ -24,29 +24,8 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-## Test simple golang build
-- id: build_ghpc
-  waitFor: ["-"]
-  name: "golang:bullseye"
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    cd /workspace
-    make
-- id: fetch_builder
-  waitFor: ["-"]
-  name: >-
-    us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - echo "done fetching builder"
-
-## Test Slurm v5 Ubuntu Example
 - id: slurm-gcp-v5-ubuntu2004
-  waitFor: ["fetch_builder", "build_ghpc"]
-  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
@@ -55,6 +34,7 @@ steps:
   - -c
   - |
     set -x -e
+    cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 


### PR DESCRIPTION
* Improve duration (~ -2min) and simplify flow (3 steps -> 1 step).
* Auto-run test if test build file was touched

