### PR TITLE
Fix output precondition for #2441

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -26,9 +26,9 @@ output "nodeset" {
   }
 
   precondition {
-    condition     = (var.reservation_name == null) || !var.enable_placement
+    condition     = var.reservation_name == "" || !var.enable_placement
     error_message = <<-EOD
-      If reservation is specified, `var.enable_placement` must be `false`.
+      If a reservation is specified, `var.enable_placement` must be `false`.
       If the specified reservation has a placement policy then it will be used automatically.
     EOD
   }


### PR DESCRIPTION
#2441 introduced an inadvertent error in an output precondition testing for valid placement policy and reservation combinations. This fixes the test to work as it did previously.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
