### PR TITLE
Remove dependency between controller instance and cleanup_compute_nodes

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -111,11 +111,6 @@ module "slurm_controller_instance" {
   labels = merge(local.labels, {
     slurm_files_checksum = module.slurm_files.checksum
   })
-
-  depends_on = [
-    # Ensure nodes are destroyed before controller is
-    module.cleanup_compute_nodes[0],
-  ]
 }
 
 # SECRETS: CLOUDSQL


### PR DESCRIPTION
### Testing done:

* Create a cluster with `enable_cleanup_compute: false`;
* Start long running `srun`;
* Update deployment `enable_cleanup_compute: true` - WAI;
* Destroy deployment - WAI.