### PR TITLE
Update gcc to 13.1.0 on Rocky 8 Gromacs example

### DIFF
--- a/community/examples/hpc-slurm-gromacs.yaml
+++ b/community/examples/hpc-slurm-gromacs.yaml
@@ -78,12 +78,12 @@ deployment_groups:
         spack config --scope defaults add config:build_stage:/sw/spack/spack-stage
         spack config --scope defaults add -f /tmp/projections-config.yaml
 
-        spack install gcc@10.3.0 target=x86_64
-        spack load gcc@10.3.0 target=x86_64
+        spack install gcc@13.1.0 target=x86_64
+        spack load gcc@13.1.0 target=x86_64
         spack compiler find --scope site
 
-        spack install intel-mpi@2018.4.274%gcc@10.3.0
-        spack install gromacs@2023.1 %gcc@10.3.0 ^intel-mpi@2018.4.274 ^cmake@3.26.3 %gcc@8.5.0
+        spack install intel-mpi@2018.4.274%gcc@13.1.0
+        spack install gromacs@2023.1 %gcc@13.1.0 ^intel-mpi@2018.4.274 ^cmake@3.26.3 %gcc@8.5.0
 
   - id: script
     source: modules/scripts/startup-script
@@ -110,7 +110,6 @@ deployment_groups:
     use: [network1]
     settings:
       name_prefix: login
-      machine_type: n2-standard-4
       disable_login_public_ips: false
 
   - id: slurm_controller


### PR DESCRIPTION
- gcc to 13.1.0
- machine_type to c2-standard-4 (guarantees Cascade Lake)

These changes increase the number of hits to the Google Cloud public spack build cache and consequently decrease the time to provision the example. Observed new build time: 1h20m, down from approx. 3h.

There are two significant packages that are still not getting cache hits: fftw (20 minutes to build) and gromacs itself. The problem for fftw is subtle; the version and compiler match the copy in cache, but it's still not a hit. The gromacs issue is not subtle; the only version of gromacs in cache is 4 years old.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
