### PR TITLE
Use `ghpc_stage` in slurm-htc examples

### DIFF
--- a/community/examples/htc-slurm-v6.yaml
+++ b/community/examples/htc-slurm-v6.yaml
@@ -30,6 +30,9 @@ vars:
   # By default, public IPs are set in the login and controller to allow easier
   # SSH access. To turn this behavior off, set this to true.
   disable_public_ips: false
+  # Stage `community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/*` into the deployment folder.
+  # If you move the blueprint, make sure the relative path is correct.
+  staged_configs: $(ghpc_stage("../modules/scheduler/schedmd-slurm-gcp-v6-controller/etc"))
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -151,8 +154,8 @@ deployment_groups:
     settings:
       machine_type: c2-standard-8
       disable_controller_public_ips: $(vars.disable_public_ips)
-      slurm_conf_tpl: modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/htc-slurm.conf.tpl
-      slurmdbd_conf_tpl: modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/htc-slurmdbd.conf.tpl
+      slurm_conf_tpl: $(vars.staged_configs)/htc-slurm.conf.tpl
+      slurmdbd_conf_tpl: $(vars.staged_configs)/htc-slurmdbd.conf.tpl
 
   - id: hpc_dashboard
     source: modules/monitoring/dashboard

--- a/community/examples/htc-slurm.yaml
+++ b/community/examples/htc-slurm.yaml
@@ -30,6 +30,9 @@ vars:
   # By default, public IPs are set in the login and controller to allow easier
   # SSH access. To turn this behavior off, set this to true.
   disable_public_ips: false
+  # Stage `community/modules/scheduler/schedmd-slurm-gcp-v5-controller/etc/*` into the deployment folder.
+  # If you move the blueprint, make sure the relative path is correct.
+  staged_configs: $(ghpc_stage("../modules/scheduler/schedmd-slurm-gcp-v5-controller/etc"))
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -146,8 +149,8 @@ deployment_groups:
     settings:
       machine_type: c2-standard-8
       disable_controller_public_ips: $(vars.disable_public_ips)
-      slurm_conf_tpl: modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/etc/htc-slurm.conf.tpl
-      slurmdbd_conf_tpl: modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/etc/htc-slurmdbd.conf.tpl
+      slurm_conf_tpl: $(vars.staged_configs)/htc-slurm.conf.tpl
+      slurmdbd_conf_tpl: $(vars.staged_configs)/htc-slurmdbd.conf.tpl
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v5-login

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -23,11 +23,11 @@ run_test() {
 	PROJECT="invalid-project"
 	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region"
 	GHPC_PATH="${cwd}/ghpc"
+	BP_PATH="${cwd}/${example}"
 	# Cover the three possible starting sequences for local sources: ./ ../ /
 	LOCAL_SOURCE_PATTERN='source:\s\+\(\./\|\.\./\|/\)'
 
 	echo "testing ${example} in ${tmpdir}"
-	cp "${example}" "${tmpdir}/"
 
 	# Only run from the repo directory if there are local modules, otherwise
 	# run the test from the test directory using the installed ghpc binary.
@@ -36,10 +36,9 @@ run_test() {
 	else
 		cd "${tmpdir}"
 	fi
-	${GHPC_PATH} create -l ERROR \
+	${GHPC_PATH} create "${BP_PATH}" -l ERROR \
 		--skip-validators="${VALIDATORS_TO_SKIP}" \
-		--vars="project_id=${PROJECT},deployment_name=${DEPLOYMENT}" \
-		"${tmpdir}"/"${exampleFile}" >/dev/null ||
+		--vars="project_id=${PROJECT},deployment_name=${DEPLOYMENT}" >/dev/null ||
 		{
 			echo "*** ERROR: error creating deployment with ghpc for ${exampleFile}"
 			exit 1


### PR DESCRIPTION
* Use `ghpc_stage` in slurm-htc examples;
* Update `validate_configs.sh` to not move blueprint around.