### PR TITLE
Use "wait for startup" instead of "sleep 2min" in base tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -163,6 +163,8 @@
 
 - name: Run Integration Tests
   hosts: remote_host
+  vars:
+    startup_timeout_seconds: 600  # 10 minutes
   gather_facts: false
   tasks:
   - name: Remote Test Block
@@ -170,9 +172,10 @@
       ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
 
     block:
-    - name: Pause for 2 minutes to allow cluster setup
-      ansible.builtin.pause:
-        minutes: 2
+    - name: Include wait for startup script
+      ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
+      vars:
+        timeout_seconds: "{{ startup_timeout_seconds }}"
 
     - name: Run Integration tests for HPC toolkit
       ansible.builtin.include_tasks: "{{ test }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-batch-submission.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-batch-submission.yml
@@ -17,11 +17,6 @@
     that:
     - cli_deployment_vars.region is defined
 
-- name: Include wait for startup script
-  ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
-  vars:
-    timeout_seconds: 600
-
 - name: Batch Job Block
   block:
   - name: Submit batch job

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-monitoring.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-monitoring.yml
@@ -14,11 +14,6 @@
 
 ---
 
-- name: Include wait for startup script
-  ansible.builtin.include_tasks: "tasks/wait-for-startup-script.yml"
-  vars:
-    timeout_seconds: 600
-
 - name: Gather service facts
   become: true
   ansible.builtin.service_facts:


### PR DESCRIPTION
Tried test (`cloud-batch`) runtime reduced by `>1min`