### PR TITLE
Updating garther startup script and integration test

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -137,17 +137,19 @@
 
     ## Cleanup and fail gracefully
     rescue:
-    - name: Capture terraform stderr
+    - name: Capture ghpc stderr
+      failed_when: false
       ansible.builtin.set_fact:
-        terraform_apply_stderr_one_line: "{{ terraform_output.results.1.stderr | replace('\n',' ') }}"
+        ghpc_stderr: "{{ deployment.stderr | replace('\n',' ') }}"
 
     - name: Gather logs
+      failed_when: false
       ansible.builtin.include_tasks:
         file: tasks/gather_startup_script_logs.yml
         apply:
           delegate_to: localhost
 
-    - name: Cleanup firewall and infrastructure
+    - name: Include rescue from ghpc failure
       ansible.builtin.include_tasks:
         file: tasks/rescue_ghpc_failure.yml
         apply:
@@ -159,7 +161,6 @@
     - name: Trigger failure (rescue blocks otherwise revert failures)
       ansible.builtin.fail:
         msg: "Failed while setting up test infrastructure"
-      when: true
 
 - name: Run Integration Tests
   hosts: remote_host

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -143,7 +143,6 @@
         ghpc_stderr: "{{ deployment.stderr | replace('\n',' ') }}"
 
     - name: Gather logs
-      failed_when: false
       ansible.builtin.include_tasks:
         file: tasks/gather_startup_script_logs.yml
         apply:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -161,7 +161,6 @@
         ghpc_stderr: "{{ deployment.stderr }}"
 
     - name: Gather logs
-      failed_when: false
       ansible.builtin.include_tasks:
         file: tasks/gather_startup_script_logs.yml
         apply:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -156,9 +156,12 @@
     ## Cleanup and fail gracefully
     rescue:
     - name: Capture ghpc stderr
+      failed_when: false
       ansible.builtin.set_fact:
-        terraform_apply_stderr_one_line: "{{ deployment.stderr }}"
+        ghpc_stderr: "{{ deployment.stderr }}"
+
     - name: Gather logs
+      failed_when: false
       ansible.builtin.include_tasks:
         file: tasks/gather_startup_script_logs.yml
         apply:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
@@ -18,22 +18,24 @@
     that:
     - ghpc_stderr is defined
 
+# Searches the ghpc stderr for a command that gathers the serial logs from the
+# deployed VM, defaults to an empty string if the command is not found
 - name: Get serial port command
   failed_when: false
   ansible.builtin.set_fact:
-    serial_port_cmd: '{{ ghpc_stderr | regex_findall("please run:\s+(.+?\s+--project\s+\S+)", "\\1") | first }}'
+    serial_port_cmd: '{{ ghpc_stderr | regex_findall("please run:\s+(.+?\s+--project\s+\S+)", "\\1") | first | default("") }}'
 
 - name: Print serial port command
+  failed_when: false
   ansible.builtin.debug:
     msg: '{{ serial_port_cmd }}'
-  when: serial_port_cmd is defined
+  when: serial_port_cmd | length >  0
 
-# Searches the ghpc stderr for a command that to run to get stdout from the deployed VM
 - name: Get Startup Script Logs
   failed_when: false
   ansible.builtin.command: "{{ serial_port_cmd }}"
   register: serial_port_1_output
-  when: serial_port_cmd is defined
+  when: serial_port_cmd | length >  0
 
 - name: Log Startup Script Failure
   changed_when: false

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
@@ -16,18 +16,28 @@
 - name: Assert variables are defined
   ansible.builtin.assert:
     that:
-    - terraform_apply_stderr_one_line is defined
+    - ghpc_stderr is defined
 
-- name: Get Startup Script Logs
-  when: 'terraform_apply_stderr_one_line | regex_findall("please run: (.+)", "\\1") | list | length > 0'
-  changed_when: false
+- name: Get serial port command
   failed_when: false
-  ansible.builtin.command: '{{ terraform_apply_stderr_one_line | regex_findall("please run: (.+)", "\\1") | first }}'
+  ansible.builtin.set_fact:
+    serial_port_cmd: '{{ ghpc_stderr | regex_findall("please run:\s+(.+?\s+--project\s+\S+)", "\\1") | first }}'
+
+- name: Print serial port command
+  ansible.builtin.debug:
+    msg: '{{ serial_port_cmd }}'
+  when: serial_port_cmd is defined
+
+# Searches the ghpc stderr for a command that to run to get stdout from the deployed VM
+- name: Get Startup Script Logs
+  failed_when: false
+  ansible.builtin.command: "{{ serial_port_cmd }}"
   register: serial_port_1_output
+  when: serial_port_cmd is defined
 
 - name: Log Startup Script Failure
   changed_when: false
   failed_when: false
   ansible.builtin.debug:
-    var: serial_port_1_output
+    var: serial_port_1_output | ansible.utils.remove_keys(target=['stdout'])
   when: serial_port_1_output is defined


### PR DESCRIPTION
The rescue block was broken in the base integration test when the deploy phase went from terraform to ghpc.  This attempts to fix that, make the integration tests more consistent, and cleans up the serial port output.  It also makes it so if the serial log collection fails, that the infrastructure is still deleted.

Tested running the monitoring integration test with an wait-for-startup block that only waits 1 sec to create failures during deployments.

Direct issue:
```
TASK [Capture terraform stderr] ************************************************
fatal: [localhost]: FAILED! => {}

MSG:

The task includes an option with an undefined variable. The error was: 'terraform_output' is undefined. 'terraform_output' is undefined

The error appears to be in '/workspace/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml': line 140, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    rescue:
    - name: Capture terraform stderr
      ^ here
```