### PR TITLE
MultiVPC Module

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -124,7 +124,7 @@ Modules that are still in development and less stable are labeled with the
   [Virtual Private Cloud (VPC)](https://cloud.google.com/vpc) network with
   regional subnetworks and firewall rules.
 * **[multivpc]** ![core-badge] ![experimental-badge]: Creates a variable
-  number of vpcs using the [vpc] module.
+  number of VPC networks using the [vpc] module.
 * **[pre-existing-vpc]** ![core-badge] : Used to connect newly
   built components to a pre-existing VPC network.
 * **[firewall-rules]** ![core-badge] ![experimental-badge]: Add custom firewall

--- a/modules/README.md
+++ b/modules/README.md
@@ -123,12 +123,15 @@ Modules that are still in development and less stable are labeled with the
 * **[vpc]** ![core-badge] : Creates a
   [Virtual Private Cloud (VPC)](https://cloud.google.com/vpc) network with
   regional subnetworks and firewall rules.
+* **[multivpc]** ![core-badge] ![experimental-badge]: Creates a variable
+  number of vpcs using the [vpc] module.
 * **[pre-existing-vpc]** ![core-badge] : Used to connect newly
   built components to a pre-existing VPC network.
 * **[firewall-rules]** ![core-badge] ![experimental-badge]: Add custom firewall
   rules to existing networks (commonly used with [pre-existing-vpc])
 
 [vpc]: network/vpc/README.md
+[multivpc]: network/multivpc/README.md
 [pre-existing-vpc]: network/pre-existing-vpc/README.md
 [firewall-rules]: network/firewall-rules/README.md
 

--- a/modules/network/multivpc/README.md
+++ b/modules/network/multivpc/README.md
@@ -1,0 +1,73 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpcs"></a> [vpcs](#module\_vpcs) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/network/vpc | v1.31.1&depth=1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.vpc_validation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allowed_ssh_ip_ranges"></a> [allowed\_ssh\_ip\_ranges](#input\_allowed\_ssh\_ip\_ranges) | A list of CIDR IP ranges from which to allow ssh access | `list(string)` | `[]` | no |
+| <a name="input_delete_default_internet_gateway_routes"></a> [delete\_default\_internet\_gateway\_routes](#input\_delete\_default\_internet\_gateway\_routes) | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
+| <a name="input_enable_iap_rdp_ingress"></a> [enable\_iap\_rdp\_ingress](#input\_enable\_iap\_rdp\_ingress) | Enable a firewall rule to allow Windows Remote Desktop Protocol access using IAP tunnels | `bool` | `false` | no |
+| <a name="input_enable_iap_ssh_ingress"></a> [enable\_iap\_ssh\_ingress](#input\_enable\_iap\_ssh\_ingress) | Enable a firewall rule to allow SSH access using IAP tunnels | `bool` | `true` | no |
+| <a name="input_enable_iap_winrm_ingress"></a> [enable\_iap\_winrm\_ingress](#input\_enable\_iap\_winrm\_ingress) | Enable a firewall rule to allow Windows Remote Management (WinRM) access using IAP tunnels | `bool` | `false` | no |
+| <a name="input_enable_internal_traffic"></a> [enable\_internal\_traffic](#input\_enable\_internal\_traffic) | Enable a firewall rule to allow all internal TCP, UDP, and ICMP traffic within the network | `bool` | `true` | no |
+| <a name="input_extra_iap_ports"></a> [extra\_iap\_ports](#input\_extra\_iap\_ports) | A list of TCP ports for which to create firewall rules that enable IAP for TCP forwarding (use dedicated enable\_iap variables for standard ports) | `list(string)` | `[]` | no |
+| <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | List of firewall rules | `any` | `[]` | no |
+| <a name="input_ips_per_nat"></a> [ips\_per\_nat](#input\_ips\_per\_nat) | The number of IP addresses to allocate for each regional Cloud NAT (set to 0 to disable NAT) | `number` | `2` | no |
+| <a name="input_mtu"></a> [mtu](#input\_mtu) | The network MTU (default: 8896). Recommended values: 0 (use Compute Engine default), 1460 (default outside HPC environments), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively. | `number` | `8896` | no |
+| <a name="input_network_cidr_prefix"></a> [network\_cidr\_prefix](#input\_network\_cidr\_prefix) | The size, in CIDR prefix notation, for each network (e.g. 24 for 172.16.0.0/24); changing this will destroy every network. | `number` | `16` | no |
+| <a name="input_network_count"></a> [network\_count](#input\_network\_count) | The number of vpc nettworks to create | `number` | `4` | no |
+| <a name="input_network_description"></a> [network\_description](#input\_network\_description) | An optional description of this resource (changes will trigger resource destroy/create) | `string` | `""` | no |
+| <a name="input_network_routing_mode"></a> [network\_routing\_mode](#input\_network\_routing\_mode) | The network dynamic routing mode | `string` | `"REGIONAL"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The default region for Cloud resources | `string` | n/a | yes |
+| <a name="input_secondary_ranges"></a> [secondary\_ranges](#input\_secondary\_ranges) | Secondary ranges that will be used in some of the subnets. Please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions. | `map(list(object({ range_name = string, ip_cidr_range = string })))` | `{}` | no |
+| <a name="input_super_global_ip_address_range"></a> [super\_global\_ip\_address\_range](#input\_super\_global\_ip\_address\_range) | IP address range (CIDR) that will span entire set of VPC networks | `string` | `"172.16.0.0"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_additional_networks"></a> [additional\_networks](#output\_additional\_networks) | Network interfaces for each subnetwork created by this module |
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | IDs of the new VPC network |
+| <a name="output_network_names"></a> [network\_names](#output\_network\_names) | Names of the new VPC networks |
+| <a name="output_network_self_links"></a> [network\_self\_links](#output\_network\_self\_links) | Self link of the new VPC network |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/network/multivpc/README.md
+++ b/modules/network/multivpc/README.md
@@ -1,3 +1,62 @@
+## Description
+
+This module accomplishes the following:
+
+* Creates 2 to 8 [VPC networks][vpc]
+  * Each VPC contains exactly 1 subnetwork
+  * Each subnetwork contains distinct IP address ranges
+* Outputs the `additional_networks` parameter, which is compatible with Slurm
+  modules
+
+There are 4 variables that differentiate this module from the standard VPC
+module.
+
+1. `network_prefix`: The name prefix of the VPCs to be created.  All
+   networks and subnetworks will start with this and end with a unique number.
+1. `network_count`: The number of VPCs to be created.
+1. `global_ip_address_range`: [CIDR-formatted IP range][cidr]
+1. `network_cidr_suffix`: The CIDR suffix that defines the address
+   space that the individual VPCs will cover.
+
+> [!WARNING]
+> The `network_cidr_suffix` should be always be larger than the CIDR suffix on
+> `global_ip_address_range`.  The difference between these two suffixes should
+> be large enough to accommodate the number of VPCs that are being deployed
+> (e.g. CIDR suffix bit difference <= `ceil(log2(network_count)))`).
+<!-- MD028/no-blanks-blockquote -->
+> [!NOTE]
+> For deployments that need multiple VPCs that do not meet this use-case, users
+> should deploy multiple individual VPC modules.
+
+[vpc]: ../vpc/README.md
+[cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
+
+### Example
+
+This snippet uses the multivpc module to create 8 new VPC networks named
+`multivpc-net-#` where # ranges from 0 to 7. Additionally, it creates 1
+subnetwork in each VPC.
+
+```yaml
+  - id: network
+    source: modules/network/vpc
+
+  - id: multinetwork
+    source: modules/network/multivpc
+    settings:
+      network_name_prefix: multivpc-net
+      network_count: 8
+      global_ip_address_range: 172.16.0.0/12
+      subnetwork_cidr_suffix: 16
+
+  - id: a3_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network, multinetwork]
+    settings:
+      machine_type: a3-highgpu-8g
+      ...
+```
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2024 Google LLC
 
@@ -17,14 +76,13 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -36,7 +94,7 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
-| [null_resource.vpc_validation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [terraform_data.global_ip_cidr_suffix](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 
 ## Inputs
 
@@ -51,23 +109,27 @@ limitations under the License.
 | <a name="input_enable_internal_traffic"></a> [enable\_internal\_traffic](#input\_enable\_internal\_traffic) | Enable a firewall rule to allow all internal TCP, UDP, and ICMP traffic within the network | `bool` | `true` | no |
 | <a name="input_extra_iap_ports"></a> [extra\_iap\_ports](#input\_extra\_iap\_ports) | A list of TCP ports for which to create firewall rules that enable IAP for TCP forwarding (use dedicated enable\_iap variables for standard ports) | `list(string)` | `[]` | no |
 | <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | List of firewall rules | `any` | `[]` | no |
+| <a name="input_global_ip_address_range"></a> [global\_ip\_address\_range](#input\_global\_ip\_address\_range) | IP address range (CIDR) that will span entire set of VPC networks | `string` | `"172.16.0.0/12"` | no |
 | <a name="input_ips_per_nat"></a> [ips\_per\_nat](#input\_ips\_per\_nat) | The number of IP addresses to allocate for each regional Cloud NAT (set to 0 to disable NAT) | `number` | `2` | no |
 | <a name="input_mtu"></a> [mtu](#input\_mtu) | The network MTU (default: 8896). Recommended values: 0 (use Compute Engine default), 1460 (default outside HPC environments), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively. | `number` | `8896` | no |
-| <a name="input_network_cidr_prefix"></a> [network\_cidr\_prefix](#input\_network\_cidr\_prefix) | The size, in CIDR prefix notation, for each network (e.g. 24 for 172.16.0.0/24); changing this will destroy every network. | `number` | `16` | no |
 | <a name="input_network_count"></a> [network\_count](#input\_network\_count) | The number of vpc nettworks to create | `number` | `4` | no |
 | <a name="input_network_description"></a> [network\_description](#input\_network\_description) | An optional description of this resource (changes will trigger resource destroy/create) | `string` | `""` | no |
+| <a name="input_network_interface_defaults"></a> [network\_interface\_defaults](#input\_network\_interface\_defaults) | The template of the network settings to be used on all vpcs. | <pre>object({<br>    network            = optional(string)<br>    subnetwork         = optional(string)<br>    subnetwork_project = optional(string)<br>    network_ip         = optional(string, "")<br>    nic_type           = optional(string, "GVNIC")<br>    stack_type         = optional(string, "IPV4_ONLY")<br>    queue_count        = optional(string)<br>    access_config = optional(list(object({<br>      nat_ip                 = string<br>      network_tier           = string<br>      public_ptr_domain_name = string<br>    })), [])<br>    ipv6_access_config = optional(list(object({<br>      network_tier           = string<br>      public_ptr_domain_name = string<br>    })), [])<br>    alias_ip_range = optional(list(object({<br>      ip_cidr_range         = string<br>      subnetwork_range_name = string<br>    })), [])<br>  })</pre> | <pre>{<br>  "access_config": [],<br>  "alias_ip_range": [],<br>  "ipv6_access_config": [],<br>  "network": null,<br>  "network_ip": "",<br>  "nic_type": "GVNIC",<br>  "queue_count": null,<br>  "stack_type": "IPV4_ONLY",<br>  "subnetwork": null,<br>  "subnetwork_project": null<br>}</pre> | no |
+| <a name="input_network_name_prefix"></a> [network\_name\_prefix](#input\_network\_name\_prefix) | The base name of the vpcs and their subnets, will be appended with a sequence number | `string` | `null` | no |
 | <a name="input_network_routing_mode"></a> [network\_routing\_mode](#input\_network\_routing\_mode) | The network dynamic routing mode | `string` | `"REGIONAL"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The default region for Cloud resources | `string` | n/a | yes |
-| <a name="input_secondary_ranges"></a> [secondary\_ranges](#input\_secondary\_ranges) | Secondary ranges that will be used in some of the subnets. Please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions. | `map(list(object({ range_name = string, ip_cidr_range = string })))` | `{}` | no |
-| <a name="input_super_global_ip_address_range"></a> [super\_global\_ip\_address\_range](#input\_super\_global\_ip\_address\_range) | IP address range (CIDR) that will span entire set of VPC networks | `string` | `"172.16.0.0"` | no |
+| <a name="input_subnetwork_cidr_suffix"></a> [subnetwork\_cidr\_suffix](#input\_subnetwork\_cidr\_suffix) | The size, in CIDR suffix notation, for each network (e.g. 24 for 172.16.0.0/24); changing this will destroy every network. | `number` | `16` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_additional_networks"></a> [additional\_networks](#output\_additional\_networks) | Network interfaces for each subnetwork created by this module |
-| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | IDs of the new VPC network |
+| <a name="output_network_ids"></a> [network\_ids](#output\_network\_ids) | IDs of the new VPC network |
 | <a name="output_network_names"></a> [network\_names](#output\_network\_names) | Names of the new VPC networks |
 | <a name="output_network_self_links"></a> [network\_self\_links](#output\_network\_self\_links) | Self link of the new VPC network |
+| <a name="output_subnetwork_addresses"></a> [subnetwork\_addresses](#output\_subnetwork\_addresses) | IP address range of the primary subnetwork |
+| <a name="output_subnetwork_names"></a> [subnetwork\_names](#output\_subnetwork\_names) | Names of the subnetwork created in each network |
+| <a name="output_subnetwork_self_links"></a> [subnetwork\_self\_links](#output\_subnetwork\_self\_links) | Self link of the primary subnetwork |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/network/multivpc/main.tf
+++ b/modules/network/multivpc/main.tf
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+locals {
+  # this input variable is validated to be in CIDR format
+  super_global_ip_cidr_prefix = split("/", var.super_global_ip_address_range)[1]
+  network_new_bits            = var.network_cidr_prefix - local.super_global_ip_cidr_prefix
+  subnetwork_bits             = ceil(log(var.network_count, 2))
+  additional_networks = [
+    for vpc in module.vpcs :
+    {
+      network            = null
+      subnetwork         = vpc.subnetwork_name
+      subnetwork_project = var.project_id
+      network_ip         = ""
+      nic_type           = "GVNIC"
+      stack_type         = "IPV4_ONLY"
+      queue_count        = null
+      access_config      = []
+      ipv6_access_config = []
+      alias_ip_range     = []
+    }
+  ]
+}
+
+resource "null_resource" "vpc_validation" {
+  lifecycle {
+    precondition {
+      condition     = local.network_new_bits >= local.subnetwork_bits
+      error_message = "network_cidr_prefix must be greater than super_global_ip_address_range's CIDR prefix by enough to accommodate the network_count"
+    }
+  }
+}
+
+module "vpcs" {
+  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/network/vpc?ref=v1.31.1&depth=1"
+
+  count = var.network_count
+
+  project_id            = var.project_id
+  deployment_name       = var.deployment_name
+  region                = var.region
+  network_address_range = cidrsubnet(var.super_global_ip_address_range, local.network_new_bits, count.index)
+
+  network_name                           = "${replace(var.deployment_name, "_", "-")}-${count.index}"
+  subnetwork_name                        = "${replace(var.deployment_name, "_", "-")}-subnet-${count.index}"
+  allowed_ssh_ip_ranges                  = var.allowed_ssh_ip_ranges
+  delete_default_internet_gateway_routes = var.delete_default_internet_gateway_routes
+  enable_iap_rdp_ingress                 = var.enable_iap_rdp_ingress
+  enable_iap_ssh_ingress                 = var.enable_iap_ssh_ingress
+  enable_iap_winrm_ingress               = var.enable_iap_winrm_ingress
+  enable_internal_traffic                = var.enable_internal_traffic
+  extra_iap_ports                        = var.extra_iap_ports
+  firewall_rules                         = var.firewall_rules
+  ips_per_nat                            = var.ips_per_nat
+  mtu                                    = var.mtu
+  network_description                    = var.network_description
+  network_routing_mode                   = var.network_routing_mode
+  secondary_ranges                       = var.secondary_ranges
+  default_primary_subnetwork_size        = 0
+}

--- a/modules/network/multivpc/metadata.yaml
+++ b/modules/network/multivpc/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - compute.googleapis.com

--- a/modules/network/multivpc/outputs.tf
+++ b/modules/network/multivpc/outputs.tf
@@ -19,7 +19,7 @@ output "network_names" {
   value       = module.vpcs[*].network_name
 }
 
-output "network_id" {
+output "network_ids" {
   description = "IDs of the new VPC network"
   value       = module.vpcs[*].network_id
 }
@@ -34,18 +34,17 @@ output "additional_networks" {
   value       = local.additional_networks
 }
 
-# output "subnetwork_names" {
-#   description = "Names of the subnetwork created in each network"
-#   value       = local.output_primary_subnetwork_name
-# }
-#
-# output "subnetwork_self_links" {
-#   description = "Self link of the primary subnetwork"
-#   value       = local.output_primary_subnetwork_self_link
-# }
-#
-# output "subnetwork_address" {
-#   description = "IP address range of the primary subnetwork"
-#   value       = local.output_primary_subnetwork_ip_cidr_range
-# }
-#
+output "subnetwork_names" {
+  description = "Names of the subnetwork created in each network"
+  value       = module.vpcs[*].subnetwork_name
+}
+
+output "subnetwork_self_links" {
+  description = "Self link of the primary subnetwork"
+  value       = module.vpcs[*].subnetwork_self_link
+}
+
+output "subnetwork_addresses" {
+  description = "IP address range of the primary subnetwork"
+  value       = module.vpcs[*].subnetwork_address
+}

--- a/modules/network/multivpc/outputs.tf
+++ b/modules/network/multivpc/outputs.tf
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+output "network_names" {
+  description = "Names of the new VPC networks"
+  value       = module.vpcs[*].network_name
+}
+
+output "network_id" {
+  description = "IDs of the new VPC network"
+  value       = module.vpcs[*].network_id
+}
+
+output "network_self_links" {
+  description = "Self link of the new VPC network"
+  value       = module.vpcs[*].network_self_link
+}
+
+output "additional_networks" {
+  description = "Network interfaces for each subnetwork created by this module"
+  value       = local.additional_networks
+}
+
+# output "subnetwork_names" {
+#   description = "Names of the subnetwork created in each network"
+#   value       = local.output_primary_subnetwork_name
+# }
+#
+# output "subnetwork_self_links" {
+#   description = "Self link of the primary subnetwork"
+#   value       = local.output_primary_subnetwork_self_link
+# }
+#
+# output "subnetwork_address" {
+#   description = "IP address range of the primary subnetwork"
+#   value       = local.output_primary_subnetwork_ip_cidr_range
+# }
+#

--- a/modules/network/multivpc/variables.tf
+++ b/modules/network/multivpc/variables.tf
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+variable "project_id" {
+  description = "Project in which the HPC deployment will be created"
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "The name of the current deployment"
+  type        = string
+}
+
+variable "region" {
+  description = "The default region for Cloud resources"
+  type        = string
+}
+
+variable "network_count" {
+  description = "The number of vpc nettworks to create"
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.network_count > 1
+    error_message = "The minimum VPCs able to be created by this module is 2. Use the standard Toolkit module at modules/network/vpc for count = 1"
+  }
+  validation {
+    condition     = var.network_count < 9
+    error_message = "The maximum VPCs able to be created by this module is 8"
+  }
+}
+
+variable "super_global_ip_address_range" {
+  description = "IP address range (CIDR) that will span entire set of VPC networks"
+  type        = string
+  default     = "172.16.0.0"
+
+  validation {
+    condition     = can(cidrhost(var.super_global_ip_address_range, 0))
+    error_message = "var.super_global_ip_address_range must be an IPv4 CIDR range (e.g. \"172.16.0.0/9\")."
+  }
+}
+
+variable "network_cidr_prefix" {
+  description = "The size, in CIDR prefix notation, for each network (e.g. 24 for 172.16.0.0/24); changing this will destroy every network."
+  type        = number
+  default     = 16
+}
+
+variable "mtu" {
+  type        = number
+  description = "The network MTU (default: 8896). Recommended values: 0 (use Compute Engine default), 1460 (default outside HPC environments), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively."
+  default     = 8896
+}
+
+variable "secondary_ranges" {
+  type        = map(list(object({ range_name = string, ip_cidr_range = string })))
+  description = "Secondary ranges that will be used in some of the subnets. Please see https://goo.gle/hpc-toolkit-vpc-deprecation for migration instructions."
+  default     = {}
+}
+
+variable "network_routing_mode" {
+  type        = string
+  default     = "REGIONAL"
+  description = "The network dynamic routing mode"
+
+  validation {
+    condition     = contains(["GLOBAL", "REGIONAL"], var.network_routing_mode)
+    error_message = "The network routing mode must either be \"GLOBAL\" or \"REGIONAL\"."
+  }
+}
+
+variable "network_description" {
+  type        = string
+  description = "An optional description of this resource (changes will trigger resource destroy/create)"
+  default     = ""
+}
+
+variable "ips_per_nat" {
+  type        = number
+  description = "The number of IP addresses to allocate for each regional Cloud NAT (set to 0 to disable NAT)"
+  default     = 2
+}
+
+variable "delete_default_internet_gateway_routes" {
+  type        = bool
+  description = "If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted"
+  default     = false
+}
+
+variable "enable_iap_ssh_ingress" {
+  type        = bool
+  description = "Enable a firewall rule to allow SSH access using IAP tunnels"
+  default     = true
+}
+
+variable "enable_iap_rdp_ingress" {
+  type        = bool
+  description = "Enable a firewall rule to allow Windows Remote Desktop Protocol access using IAP tunnels"
+  default     = false
+}
+
+variable "enable_iap_winrm_ingress" {
+  type        = bool
+  description = "Enable a firewall rule to allow Windows Remote Management (WinRM) access using IAP tunnels"
+  default     = false
+}
+
+variable "enable_internal_traffic" {
+  type        = bool
+  description = "Enable a firewall rule to allow all internal TCP, UDP, and ICMP traffic within the network"
+  default     = true
+}
+
+variable "extra_iap_ports" {
+  type        = list(string)
+  description = "A list of TCP ports for which to create firewall rules that enable IAP for TCP forwarding (use dedicated enable_iap variables for standard ports)"
+  default     = []
+}
+
+variable "allowed_ssh_ip_ranges" {
+  type        = list(string)
+  description = "A list of CIDR IP ranges from which to allow ssh access"
+  default     = []
+
+  validation {
+    condition     = alltrue([for r in var.allowed_ssh_ip_ranges : can(cidrhost(r, 32))])
+    error_message = "Each element of var.allowed_ssh_ip_ranges must be a valid CIDR-formatted IPv4 range."
+  }
+}
+
+variable "firewall_rules" {
+  type        = any
+  description = "List of firewall rules"
+  default     = []
+}

--- a/modules/network/multivpc/versions.tf
+++ b/modules/network/multivpc/versions.tf
@@ -15,11 +15,5 @@
 */
 
 terraform {
-  required_providers {
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.0"
-    }
-  }
-  required_version = ">= 0.15.0"
+  required_version = ">= 1.4.0"
 }

--- a/modules/network/multivpc/versions.tf
+++ b/modules/network/multivpc/versions.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+  required_version = ">= 0.15.0"
+}


### PR DESCRIPTION
This module is designed for A3 and A3+ development where multiple VPCs are used to connect the GPUs.  

Tested using a simple blueprint:

```
blueprint_name: multivpc-test

vars:
  project_id:  dev-pool-prj2
  deployment_name: multivpc-test
  region: us-central1
  zone: us-central1-a

deployment_groups:
- group: primary
  modules:
  - id: network
    source: modules/network/multivpc
    settings:
      network_count: 8
      global_ip_address_range: 172.0.0.0/16
      subnetwork_cidr_suffix: 24
      network_name_prefix: test_vpc
```
