### PR TITLE
Add `pre-deploy` task that removes a module from blueprint

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -39,6 +39,14 @@
       dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
           awk -F'"' '{print $2}'
 
+  - name: Run Pre Deploy Tasks
+    vars:
+      pre_deploy_tasks: []
+    ansible.builtin.include_tasks: "{{ pre_deploy_task }}"
+    loop: "{{ pre_deploy_tasks }}"
+    loop_control:
+      loop_var: pre_deploy_task
+
   ## Create cluster
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/pre-deploy-tasks/remove-modules.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/pre-deploy-tasks/remove-modules.yml
@@ -1,0 +1,26 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - workspace is defined
+    - blueprint_yaml is defined
+    - custom_vars.modules_to_remove is defined
+
+- name: Remove modules
+  ansible.builtin.command: "{{ workspace }}/tools/cloud-build/daily-tests/remove_module.py --blueprint {{ blueprint_yaml }} --module {{ module_to_remove }}"
+  loop: "{{ custom_vars.modules_to_remove }}"
+  loop_control:
+    loop_var: module_to_remove

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -39,6 +39,14 @@
       dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
           awk -F'"' '{print $2}'
 
+  - name: Run Pre Deploy Tasks
+    vars:
+      pre_deploy_tasks: []
+    ansible.builtin.include_tasks: "{{ pre_deploy_task }}"
+    loop: "{{ pre_deploy_tasks }}"
+    loop_control:
+      loop_var: pre_deploy_task
+
   ## Create cluster
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
@@ -46,13 +54,6 @@
 
   - name: Create Infrastructure and test
     block:
-
-    - name: Run Pre Deploy Tasks
-      ansible.builtin.include_tasks: "{{ pre_deploy_task }}"
-      loop: "{{ pre_deploy_tasks | default([]) }}"
-      loop_control:
-        loop_var: pre_deploy_task
-
     - name: Create Cluster with GHPC
       register: deployment
       changed_when: deployment.changed

--- a/tools/cloud-build/daily-tests/builds/hpc-slurm-chromedesktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-slurm-chromedesktop.yaml
@@ -15,7 +15,7 @@
 ---
 tags:
 - m.chrome-remote-desktop
-- m.filestore
+- m.filestore # TODO: mark as removed during pre-deploy
 - m.schedmd-slurm-gcp-v5-controller
 - m.schedmd-slurm-gcp-v5-login
 - m.schedmd-slurm-gcp-v5-node-group

--- a/tools/cloud-build/daily-tests/remove_module.py
+++ b/tools/cloud-build/daily-tests/remove_module.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml # pip install pyyaml
+
+def delete_module(bp, mod_id: str):
+  for g in bp["deployment_groups"]:
+    for im, m in enumerate(g["modules"]):
+      if m["id"] == mod_id:
+        del g["modules"][im]
+        return
+  raise RuntimeError(f"Module {mod_id} not found")
+
+def update_bp(bp, mod_id: str):
+  delete_module(bp, mod_id)
+   # remove module from "use"
+  for g in bp["deployment_groups"]:
+    for m in g["modules"]:
+      if mod_id in m.get("use", []):
+        m["use"].remove(mod_id)
+  # TODO:
+  # - move all settings of removed module into some "/dev/null" to prevent
+  #   "variable not used" validation errors
+  # - treat references to removed module (how ?)
+
+def main():
+  import argparse
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--blueprint", required=True, type=str)
+  parser.add_argument("--module", required=True, type=str, help="Module ID to remove")
+  args = parser.parse_args()
+
+  with open(args.blueprint) as yf:
+    bp = yaml.safe_load(yf)
+  update_bp(bp, mod_id=args.module)
+  with open(args.blueprint, "w") as yf:
+    yaml.dump(bp, yf)
+
+if __name__ == "__main__":
+  main()

--- a/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
@@ -29,12 +29,13 @@ network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard.
 login_node: "{{ slurm_cluster_name }}-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
+pre_deploy_tasks:
+- pre-deploy-tasks/remove-modules.yml
 post_deploy_tests:
-- test-validation/test-mounts.yml
 - test-validation/test-crd.yml
 custom_vars:
-  mounts:
-  - /home
   partitions:
   - desktop
   - compute
+  modules_to_remove:
+  - homefs


### PR DESCRIPTION
* Add `pre-deploy` task that removes a module from blueprint;
* Move `Run Pre Deploy Tasks` **before** `Create Deployment Directory`;
* Add `Run Pre Deploy Tasks` to `base-integration-test`
* Remove `filestore homefs` from `hpc-slurm-chromedesktop`, saved `~6m` of run time.