### PR TITLE
Advise A3 users to request DLVM image earlier and more prominently in documentation

### DIFF
--- a/examples/machine-learning/README.md
+++ b/examples/machine-learning/README.md
@@ -3,7 +3,16 @@
 This document will guide you to successfully provisioning a Slurm cluster with
 A3 VM family compute nodes running NVIDIA H100 GPUs.
 
-## Required initial setup
+## Before starting
+
+> [!IMPORTANT]
+> Before beginning, submit a request to your Google Cloud representative for
+> access to the Deep Learning VM Image for the A3 VM family. It is currently
+> available only by Private Preview request. This image contains patches that
+> significantly enhance the network performance of workloads that span multiple
+> A3 VMs. You will use the image ID in the steps shown below.
+
+## Required setup
 
 Please follow the initial instructions for:
 


### PR DESCRIPTION
Based upon customer feedback, make the requirement to request access to the Deep Learning VM Image for the A3 VM family more prominent early in review of the README.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
