### PR TITLE
Update MPI & Gromacs for cache hit and better compatibility w/ Rocky8 default image

### DIFF
--- a/community/examples/hpc-slurm-gromacs.yaml
+++ b/community/examples/hpc-slurm-gromacs.yaml
@@ -82,8 +82,8 @@ deployment_groups:
         spack load gcc@13.1.0 target=x86_64
         spack compiler find --scope site
 
-        spack install intel-mpi@2018.4.274%gcc@13.1.0
-        spack install gromacs@2023.1 %gcc@13.1.0 ^intel-mpi@2018.4.274 ^cmake@3.26.3 %gcc@8.5.0
+        spack install intel-oneapi-mpi@2021.9.0%gcc@13.1.0
+        spack install gromacs@2020.6 %gcc@13.1.0 ^intel-oneapi-mpi@2021.9.0
 
   - id: script
     source: modules/scripts/startup-script


### PR DESCRIPTION
Updating MPI version to 2021.x which will work better with Rocky 8 default Slurm GCP v6 image. Selected 2021.9 to produce cache hit for Google Spack cache. Also updated Gromacs version for cache hit. 

Tested using the [water benchmark](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/a4a3dbc365e8c0479ccd7fd918bce6caec7d3535/docs/videos/healthcare-and-life-sciences/hcls-blueprint.yaml#L189-L217).

Test was previously taking 1h20m. Now takes: 38 min.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
