### PR TITLE
Allow wait-for-startup to accept a list of instance names

### DIFF
--- a/community/modules/scripts/wait-for-startup/README.md
+++ b/community/modules/scripts/wait-for-startup/README.md
@@ -69,6 +69,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the instance we are waiting for | `string` | n/a | yes |
+| <a name="input_instance_names"></a> [instance\_names](#input\_instance\_names) | Names of the instances we are waiting for | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout in seconds | `number` | `1200` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone where the instance is running | `string` | n/a | yes |

--- a/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
+++ b/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ -z "${INSTANCE_NAME}" ]]; then
-	echo "INSTANCE_NAME is unset"
-	exit 1
-fi
 if [[ -z "${ZONE}" ]]; then
 	echo "ZONE is unset"
 	exit 1
@@ -29,56 +25,148 @@ if [[ -z "${TIMEOUT}" ]]; then
 	echo "TIMEOUT is unset"
 	exit 1
 fi
+if [[ -z "${INSTANCE_NAMES}" ]]; then
+	echo "INSTANCE_NAMES is unset"
+	exit 1
+fi
 
-# Wrapper around grep that swallows the error status code 1
-c1grep() { grep "$@" || test $? = 1; }
+IFS=' ' read -r -a waiting_for_startup <<<"${INSTANCE_NAMES[@]}"
+echo "Instance names:"
+for instance_name in "${waiting_for_startup[@]}"; do
+	echo "- $instance_name"
+done
+
+fetch_cmd() {
+	instance_name=$1
+	echo "gcloud compute instances get-serial-port-output ${instance_name} --port 1 --zone ${ZONE} --project ${PROJECT_ID}"
+}
+
+instance_status_cmd() {
+	instance_name=$1
+	echo "gcloud compute instances list --filter 'name=${instance_name}' --format 'value(status)' --project '${PROJECT_ID}' --zones '${ZONE}'"
+}
+
+failed=()
+succeeded=()
+remove_instance_names() {
+	new_array=()
+	for ((i = 0; i < "${#waiting_for_startup[@]}"; i++)); do
+		current_name="${waiting_for_startup[$i]}"
+		if ! [[ "${failed[*]}" =~ $current_name ]]; then
+			new_array+=("$current_name")
+		fi
+		if ! [[ "${succeeded[*]}" =~ $current_name ]]; then
+			new_array+=("$current_name")
+		fi
+	done
+	waiting_for_startup=("${new_array[@]}")
+}
 
 now=$(date +%s)
 deadline=$((now + TIMEOUT))
 error_file=$(mktemp)
-fetch_cmd="gcloud compute instances get-serial-port-output ${INSTANCE_NAME} \
-           --port 1 --zone ${ZONE} --project ${PROJECT_ID}"
 # Match string for all finish types of the old guest agent and successful
 # finishes on the new guest agent
-FINISH_LINE="startup-script exit status"
+finish_line="startup-script exit status"
 # Match string for failures on the new guest agent
-FINISH_LINE_ERR="Script.*failed with error:"
-
-until [[ now -gt deadline ]]; do
-	ser_log=$(
-		set -o pipefail
-		${fetch_cmd} 2>"${error_file}" |
-			c1grep "${FINISH_LINE}\|${FINISH_LINE_ERR}"
-	) || {
-		cat "${error_file}"
-		exit 1
-	}
-	if [[ -n "${ser_log}" ]]; then break; fi
-	echo "Could not detect end of startup script. Sleeping."
-	sleep 5
-	now=$(date +%s)
-done
-
-# This line checks for an exit code - the assumption is that there is a number
-# at the end of the line and it is an exit code
-STATUS=$(sed -r 's/.*([0-9]+)\s*$/\1/' <<<"${ser_log}" | uniq)
+finish_line_err="Script.*failed with error:"
 # This specific text is monitored for in tests, do not change.
-INSPECT_OUTPUT_TEXT="To inspect the startup script output, please run:"
-if [[ "${STATUS}" == 0 ]]; then
-	echo "startup-script finished successfully"
-elif [[ "${STATUS}" == 1 ]]; then
-	echo "startup-script finished with errors, ${INSPECT_OUTPUT_TEXT}"
-	echo "${fetch_cmd}"
-elif [[ now -ge deadline ]]; then
-	echo "startup-script timed out after ${TIMEOUT} seconds"
-	echo "${INSPECT_OUTPUT_TEXT}"
-	echo "${fetch_cmd}"
-	exit 1
-else
-	echo "Invalid return status: '${STATUS}'"
-	echo "${INSPECT_OUTPUT_TEXT}"
-	echo "${fetch_cmd}"
-	exit 1
+inspect_output_text="To inspect the startup script output, please run:"
+
+while [[ $now -lt $deadline ]]; do
+
+	for ((i = 0; i < "${#waiting_for_startup[@]}"; i++)); do
+		instance_name="${waiting_for_startup[$i]}"
+
+		# Get serial logs
+		ser_log_cmd=$(fetch_cmd "$instance_name")
+
+		# Check if we got serial logs successfully
+		if ! ser_log=$(eval "$ser_log_cmd" 2>"${error_file}"); then
+			# Failure - print out error and stop checking this instance
+			cat "${error_file}"
+
+			failed+=("$instance_name")
+			unset "waiting_for_startup[$i]"
+
+			continue
+		fi
+
+		# Success - try to find the line which signifies that the script completed
+		final_line=$(echo "$ser_log" | grep "${finish_line}\|${finish_line_err}")
+		ret_code=$?
+		if [[ $ret_code -ne 0 ]]; then
+			if [[ $ret_code -eq 1 ]]; then
+				# Didn't find the final line
+				echo "[$instance_name] Could not detect end of startup script. Sleeping."
+			else
+				# grep failed (we should never get here) - keep checking this instance
+				echo "[$instance_name] The 'grep' command failed" 1>&2
+			fi
+
+			continue
+		fi
+
+		# Found the final line - get the status
+		# This line checks for an exit code - the assumption is that there is a number
+		# at the end of the line and it is an exit code
+		status=$(sed -r 's/.*([0-9]+)\s*$/\1/' <<<"${final_line}" | uniq)
+		if [[ "${status}" -eq 0 ]]; then
+			echo "[$instance_name] startup-script finished successfully"
+			# Stop checking this instance
+			succeeded+=("$instance_name")
+			unset "waiting_for_startup[$i]"
+		else
+			if [[ "${status}" -eq 1 ]]; then
+				echo "[$instance_name] startup-script finished with errors, ${inspect_output_text}"
+			else
+				echo "[$instance_name] Invalid return status: '${status}'"
+				echo "${inspect_output_text}"
+				echo "$ser_log_cmd"
+			fi
+			# Stop checking this instance
+			failed+=("$instance_name")
+			unset "waiting_for_startup[$i]"
+		fi
+	done
+
+	# Remove successes/failures from the array
+	# remove_instance_names
+	waiting_for_startup=("${waiting_for_startup[@]}")
+
+	if ! [[ ${#waiting_for_startup[@]} -gt 0 ]]; then
+		break
+	fi
+
+	# Sleep before checking all instances again
+	sleep 5
+done
+echo
+
+# Print status of instances
+if [[ "${#succeeded[@]}" -gt 0 ]]; then
+	echo "startup-script completed successfully on instances:"
+	for instance_name in "${succeeded[@]}"; do
+		echo "- $instance_name"
+	done
+	echo
 fi
 
-exit "${STATUS}"
+if [[ "${#failed[@]}" -gt 0 ]]; then
+	echo "startup-script failed on instances:"
+	for instance_name in "${failed[@]}"; do
+		echo "- $instance_name"
+	done
+	echo
+fi
+
+if [[ "${#waiting_for_startup[@]}" -gt 0 ]]; then
+	echo "startup-script timed out after ${TIMEOUT}s on instances:"
+	for instance_name in "${waiting_for_startup[@]}"; do
+		echo "- $instance_name"
+	done
+	echo
+fi
+
+echo "${inspect_output_text}"
+fetch_cmd "<instance_name>"

--- a/community/modules/scripts/wait-for-startup/variables.tf
+++ b/community/modules/scripts/wait-for-startup/variables.tf
@@ -19,6 +19,16 @@ variable "instance_name" {
   type        = string
 }
 
+variable "instance_names" {
+  description = "Names of the instances we are waiting for"
+  type        = list(string)
+  default     = []
+  validation {
+    condition     = var.instance_names != null
+    error_message = "The list of instances cannot be null (empty list is ok)"
+  }
+}
+
 variable "zone" {
   description = "The GCP zone where the instance is running"
   type        = string


### PR DESCRIPTION
This PR adds an input `instance_names` (note: plural) to allow users to specify a list of instances to wait on.  This is particularly useful when deploying a cluster of machines using the `vm-instance` module.

Note that this is not a breaking change, because the `instance_name` (note: singular) input has not been removed, and works the same way as before.

I tested this change using the following blueprint:
```
blueprint_name: wait-for-startup-test

vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: wait-for-startup-test
  region: us-central1
  zone: us-central1-a

deployment_groups:
- group: primary
  modules:
  - id: network1
    source: modules/network/vpc

  - id: startup-sleep
    source: modules/scripts/startup-script
    settings:
      # timeout: 20
      configure_ssh_host_patterns:
      - '*'
      runners:
        - type: shell
          destination: /tmp/sleep_test.sh
          content: |
            #!/bin/bash
            sleep 30
            # exit 42
  - id: workstation
    source: modules/compute/vm-instance
    use:
    - network1
    - startup-sleep
    settings:
      instance_count: 3
      name_prefix: roramu-test
  - id: wait
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(workstation.name[0])
      instance_names: $(workstation.name)
```