### PR TITLE
Add `self_link` output to `vm-instance` module

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -246,5 +246,6 @@ limitations under the License.
 | <a name="output_external_ip"></a> [external\_ip](#output\_external\_ip) | External IP of the instances (if enabled) |
 | <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions on how to SSH into the created VM. Commands may fail depending on VM configuration and IAM permissions. |
 | <a name="output_internal_ip"></a> [internal\_ip](#output\_internal\_ip) | Internal IP of the instances |
-| <a name="output_name"></a> [name](#output\_name) | Name of any instance created |
+| <a name="output_name"></a> [name](#output\_name) | Names of instances created |
+| <a name="output_self_link"></a> [self\_link](#output\_self\_link) | The tuple URIs of the created instances |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute/vm-instance/outputs.tf
+++ b/modules/compute/vm-instance/outputs.tf
@@ -15,8 +15,13 @@
  */
 
 output "name" {
-  description = "Name of any instance created"
+  description = "Names of instances created"
   value       = google_compute_instance.compute_vm[*].name
+}
+
+output "self_link" {
+  description = "The tuple URIs of the created instances"
+  value       = google_compute_instance.compute_vm[*].self_link
 }
 
 output "external_ip" {
@@ -30,17 +35,16 @@ output "internal_ip" {
 }
 
 locals {
-  no_instance_instructions = "No instances were created."
-  first_instance_name      = try(google_compute_instance.compute_vm[0].name, "no-instance")
-  ssh_instructions         = <<-EOT
+  first_instance_link = try(google_compute_instance.compute_vm[0].self_link, "no-instance")
+  ssh_instructions    = <<-EOT
     Use the following commands to SSH into the first VM created:
-      gcloud compute ssh --zone ${var.zone} ${local.first_instance_name} --project ${var.project_id}
+      gcloud compute ssh ${local.first_instance_link}
     If not accessible from the public internet, use an SSH tunnel through IAP:
-      gcloud compute ssh --zone ${var.zone} ${local.first_instance_name} --project ${var.project_id} --tunnel-through-iap
+      gcloud compute ssh ${local.first_instance_link} --tunnel-through-iap
   EOT
 }
 
 output "instructions" {
   description = "Instructions on how to SSH into the created VM. Commands may fail depending on VM configuration and IAM permissions."
-  value       = var.instance_count > 0 ? local.ssh_instructions : local.no_instance_instructions
+  value       = var.instance_count > 0 ? local.ssh_instructions : "No instances were created."
 }


### PR DESCRIPTION
* Add `self_link` output to `vm-instance` module;
* Update `name` description;
* Update SSH instruction to use short-form.

**Motivation:** to remove any guess-work about what `zone` and `project` given instance belongs to.