### PR TITLE
Resolve Ansible crash in Spack installation

### DIFF
--- a/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
+++ b/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
@@ -103,6 +103,7 @@
       owner: "{{ system_user.name }}"
       group: "{{ system_user.group }}"
       recurse: true
+      follow: false
     when: lock_out.rc == 0
 
   - name: Finalize setup
@@ -116,6 +117,7 @@
       path: "{{ install_dir }}"
       mode: "{{ chmod_mode | default(omit, true)  }}"
       recurse: true
+      follow: false
     when: (lock_out.rc == 0) and (chmod_mode != None)
 
   - name: Release lock

--- a/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
+++ b/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
@@ -40,7 +40,7 @@
 
   - name: Look up user to use for install
     block:
-    
+
     - name: Check if user already exists
       ansible.builtin.getent:
         database: passwd
@@ -52,7 +52,7 @@
       register: system_user
 
     rescue:
-    - name: User did not exist, create group for system user 
+    - name: User did not exist, create group for system user
       ansible.builtin.group:
         name: "{{ system_user_name }}"
         gid: "{{ system_user_gid }}"
@@ -112,7 +112,7 @@
     become: true
     become_user: "{{ system_user.name }}"
 
-  - name: Apply chmod 
+  - name: Apply chmod
     ansible.builtin.file:
       path: "{{ install_dir }}"
       mode: "{{ chmod_mode | default(omit, true)  }}"

--- a/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
+++ b/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
@@ -103,6 +103,7 @@
       owner: "{{ system_user.name }}"
       group: "{{ system_user.group }}"
       recurse: true
+      follow: false
     when: lock_out.rc == 0
 
   - name: Finalize setup
@@ -116,6 +117,7 @@
       path: "{{ install_dir }}"
       mode: "{{ chmod_mode | default(omit, true)  }}"
       recurse: true
+      follow: false
     when: (lock_out.rc == 0) and (chmod_mode != None)
 
   - name: Release lock

--- a/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
+++ b/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
@@ -40,7 +40,7 @@
 
   - name: Look up user to use for install
     block:
-    
+
     - name: Check if user already exists
       ansible.builtin.getent:
         database: passwd
@@ -52,7 +52,7 @@
       register: system_user
 
     rescue:
-    - name: User did not exist, create group for system user 
+    - name: User did not exist, create group for system user
       ansible.builtin.group:
         name: "{{ system_user_name }}"
         gid: "{{ system_user_gid }}"
@@ -112,7 +112,7 @@
     become: true
     become_user: "{{ system_user.name }}"
 
-  - name: Apply chmod 
+  - name: Apply chmod
     ansible.builtin.file:
       path: "{{ install_dir }}"
       mode: "{{ chmod_mode | default(omit, true)  }}"


### PR DESCRIPTION
Do not follow symbolic links in recursive chmod. Should resolve observed problems with filenames that are so long:

```
    /sw/spack/lib/spack/docs/../../../lib/spack/docs/../../../...
```

> ### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
