### PR TITLE
Go binary downloads must include patch version

### DIFF
--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
@@ -159,6 +159,10 @@ EOF
 # Install go version specified in go.mod file
 #
 GO_VERSION=$(awk '/^go/ {print $2}' "/opt/gcluster/hpc-toolkit/go.mod")
+# Check if the version string has only two numbers separated by dots
+if [[ $GO_VERSION =~ ^([0-9]+\.[0-9]+)$ ]]; then
+	GO_VERSION="$GO_VERSION.0" # Append .0 if missing patch version
+fi
 GO_DOWNLOAD_URL="https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz"
 curl --silent --show-error --location "${GO_DOWNLOAD_URL}" --output "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
 rm -rf /usr/local/go && tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"


### PR DESCRIPTION
PR assumes go version of 0 of none is specified.

OFE tries to install go version from go.mod. Version bumped from 1.20 to 1.21 in ghpc v1.29.0 and beyond [commit](https://github.com/GoogleCloudPlatform/hpc-toolkit/commit/c32b3d114c291f96991713ebbd54a8ce3f8ccdbe).

Go provided binary installs for 1.20 but not for 1.21. We must use 1.21.0 instead.

Tested:
- Manually deployed and verified go was properly installed and `make` of ghpc succeeds.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
