### PR TITLE
Simplify release-candidate creation script

### DIFF
--- a/tools/create-release-candidate.sh
+++ b/tools/create-release-candidate.sh
@@ -40,11 +40,6 @@ if ! type -P gh 1>/dev/null; then
 	exit 1
 fi
 
-if ! type -P jq 1>/dev/null; then
-	echo "Must install jq"
-	exit 1
-fi
-
 if ! gh auth status; then
 	echo 'Must authenticate using "gh auth login"'
 	exit 1
@@ -61,7 +56,7 @@ while getopts "t:" opt; do
 done
 TYPE="${ARG_TYPE:-minor}"
 
-OLD_VERSION=$(gh release list -R GoogleCloudPlatform/hpc-toolkit -L 1 --json tagName | jq -r '.[] | .tagName')
+OLD_VERSION=$(gh release list -R GoogleCloudPlatform/hpc-toolkit -L 1 --json tagName --jq '.[] | .tagName')
 OLD_MAJOR=$(echo "${OLD_VERSION}" | cut -f1 -d. | sed 's,v,,')
 OLD_MINOR=$(echo "${OLD_VERSION}" | cut -f2 -d.)
 OLD_PATCH=$(echo "${OLD_VERSION}" | cut -f3 -d.)


### PR DESCRIPTION
Use the `--jq` flag which does not actually require the `jq` binary to be installed:

https://github.com/v1v/cli/blob/2c0236d0965d3fddf8ca19a228734f6bc9dcded1/pkg/cmd/root/help_topic.go#L93

(Verified by testing)

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
