### PR TITLE
Address feature requests for HTCondor functionality in Windows

### DIFF
--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -137,6 +137,7 @@ No resources.
 | <a name="input_condor_version"></a> [condor\_version](#input\_condor\_version) | Yum/DNF-compatible version string; leave unset to use latest 23.0 LTS release (examples: "23.0.0","23.*")) | `string` | `"23.*"` | no |
 | <a name="input_enable_docker"></a> [enable\_docker](#input\_enable\_docker) | Install and enable docker daemon alongside HTCondor | `bool` | `true` | no |
 | <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy) | Set system default web (http and https) proxy for Windows HTCondor installation | `string` | `""` | no |
+| <a name="input_python_windows_installer_url"></a> [python\_windows\_installer\_url](#input\_python\_windows\_installer\_url) | URL of Python installer for Windows | `string` | `"https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe"` | no |
 
 ## Outputs
 

--- a/community/modules/scripts/htcondor-install/main.tf
+++ b/community/modules/scripts/htcondor-install/main.tf
@@ -39,8 +39,9 @@ locals {
 
   install_htcondor_ps1 = templatefile(
     "${path.module}/templates/install-htcondor.ps1.tftpl", {
-      condor_version = var.condor_version,
-      http_proxy     = var.http_proxy,
+      condor_version               = var.condor_version,
+      http_proxy                   = var.http_proxy,
+      python_windows_installer_url = var.python_windows_installer_url,
   })
 
   required_apis = [

--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -50,6 +50,10 @@ Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor
 $python_installer = 'C:\python-installer.exe'
 Invoke-WebRequest -Uri "${python_windows_installer_url}" -OutFile "$python_installer"
 Start-Process -FilePath "$python_installer" -Wait -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_test=0'
+%{ if http_proxy == "" ~}
 Start-Process "py.exe" -Wait -ArgumentList "-3.11 -m pip install --no-warn-script-location requests"
+%{ else ~}
+Start-Process "py.exe" -Wait -ArgumentList "-3.11 -m pip install --proxy ${http_proxy} --no-warn-script-location requests"
+%{ endif ~}
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/htcondor/htcondor/main/src/condor_scripts/common-cloud-attributes-google.py" -OutFile "C:\Condor\bin\common-cloud-attributes-google.py"
 Remove-Item "$python_installer"

--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -48,7 +48,7 @@ Set-Content -Path "C:\Condor\condor_config" -Value (Get-Content -Path "C:\Condor
 
 # install Python so that custom ClassAd hooks can execute
 $python_installer = 'C:\python-installer.exe'
-Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.11.4/python-3.11.4-amd64.exe" -OutFile "$python_installer"
+Invoke-WebRequest -Uri "${python_windows_installer_url}" -OutFile "$python_installer"
 Start-Process -FilePath "$python_installer" -Wait -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_test=0'
 Start-Process "py.exe" -Wait -ArgumentList "-3.11 -m pip install --no-warn-script-location requests"
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/htcondor/htcondor/main/src/condor_scripts/common-cloud-attributes-google.py" -OutFile "C:\Condor\bin\common-cloud-attributes-google.py"

--- a/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
+++ b/community/modules/scripts/htcondor-install/templates/install-htcondor.ps1.tftpl
@@ -7,9 +7,9 @@
 Set-StrictMode -Version latest
 $ErrorActionPreference = 'Stop'
 
-%{ if http_proxy != "" }
+%{ if http_proxy != "" ~}
 [System.Net.WebRequest]::DefaultWebProxy = New-Object System.Net.WebProxy("${http_proxy}")
-%{ endif }
+%{ endif ~}
 
 # do not show progress bar when running Invoke-WebRequest
 $ProgressPreference = 'SilentlyContinue'

--- a/community/modules/scripts/htcondor-install/variables.tf
+++ b/community/modules/scripts/htcondor-install/variables.tf
@@ -42,3 +42,10 @@ variable "http_proxy" {
   default     = ""
   nullable    = false
 }
+
+variable "python_windows_installer_url" {
+  description = "URL of Python installer for Windows"
+  type        = string
+  default     = "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe"
+  nullable    = false
+}

--- a/community/modules/scripts/windows-startup-script/README.md
+++ b/community/modules/scripts/windows-startup-script/README.md
@@ -94,10 +94,12 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy) | Set system default web (http and https) proxy for use by Invoke-WebRequest | `string` | `""` | no |
+| <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy) | Set http and https proxy for use by Invoke-WebRequest commands | `string` | `""` | no |
+| <a name="input_http_proxy_set_environment"></a> [http\_proxy\_set\_environment](#input\_http\_proxy\_set\_environment) | Set system default environment variables http\_proxy and https\_proxy for all commands | `bool` | `false` | no |
 | <a name="input_install_nvidia_driver"></a> [install\_nvidia\_driver](#input\_install\_nvidia\_driver) | Install NVIDIA GPU drivers and the CUDA Toolkit using script specified by var.install\_nvidia\_driver\_script | `bool` | `false` | no |
 | <a name="input_install_nvidia_driver_args"></a> [install\_nvidia\_driver\_args](#input\_install\_nvidia\_driver\_args) | Arguments to supply to NVIDIA driver install script | `string` | `"/s /n"` | no |
 | <a name="input_install_nvidia_driver_script"></a> [install\_nvidia\_driver\_script](#input\_install\_nvidia\_driver\_script) | Install script for NVIDIA drivers specified by http/https URL | `string` | `"https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_531.14_windows.exe"` | no |
+| <a name="input_no_proxy"></a> [no\_proxy](#input\_no\_proxy) | Environment variables no\_proxy (only used if var.http\_proxy\_set\_environment is enabled) | `string` | `"169.254.169.254,metadata,metadata.google.internal,.googleapis.com"` | no |
 
 ## Outputs
 

--- a/community/modules/scripts/windows-startup-script/main.tf
+++ b/community/modules/scripts/windows-startup-script/main.tf
@@ -15,6 +15,13 @@
  */
 
 locals {
+  setx_http_proxy_ps1 = !var.http_proxy_set_environment ? [] : [
+    templatefile("${path.module}/templates/setx_http_proxy.ps1", {
+      "http_proxy" : var.http_proxy,
+      "no_proxy" : var.no_proxy,
+    })
+  ]
+
   nvidia_ps1 = !var.install_nvidia_driver ? [] : [
     templatefile("${path.module}/templates/install_gpu_driver.ps1.tftpl", {
       "url" : var.install_nvidia_driver_script
@@ -23,5 +30,5 @@ locals {
     })
   ]
 
-  startup_ps1 = local.nvidia_ps1
+  startup_ps1 = concat(local.setx_http_proxy_ps1, local.nvidia_ps1)
 }

--- a/community/modules/scripts/windows-startup-script/templates/setx_http_proxy.ps1
+++ b/community/modules/scripts/windows-startup-script/templates/setx_http_proxy.ps1
@@ -1,0 +1,5 @@
+#Requires -RunAsAdministrator
+
+setx http_proxy ${http_proxy} /m
+setx https_proxy ${http_proxy} /m
+setx no_proxy ${no_proxy} /m

--- a/community/modules/scripts/windows-startup-script/variables.tf
+++ b/community/modules/scripts/windows-startup-script/variables.tf
@@ -33,8 +33,22 @@ variable "install_nvidia_driver_args" {
 }
 
 variable "http_proxy" {
-  description = "Set system default web (http and https) proxy for use by Invoke-WebRequest"
+  description = "Set http and https proxy for use by Invoke-WebRequest commands"
   type        = string
   default     = ""
+  nullable    = false
+}
+
+variable "http_proxy_set_environment" {
+  description = "Set system default environment variables http_proxy and https_proxy for all commands"
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "no_proxy" {
+  description = "Environment variables no_proxy (only used if var.http_proxy_set_environment is enabled)"
+  type        = string
+  default     = "169.254.169.254,metadata,metadata.google.internal,.googleapis.com"
   nullable    = false
 }


### PR DESCRIPTION
This PR includes several feature requests from a customer for Windows functionality:

- support installation of pip packages via an http proxy
- option (off by default) to permanently set http_proxy, https_proxy, no_proxy variables
- parameterize the URL for Python installer so that a customer-specific release of Python may be used

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
