### PR TITLE
Ensure that Filestore cleanup always re-enables the Filestore API

### DIFF
--- a/tools/clean-filestore-limit.sh
+++ b/tools/clean-filestore-limit.sh
@@ -13,7 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# shellcheck disable=SC2317
+# known issue that shellcheck wrongly detects trap function as unreachable
+
 set -e -o pipefail
+
+function enable_filestore_api() {
+	status=$?
+	echo "Re-enabling Filestore API..."
+	gcloud services enable file.googleapis.com --project "${PROJECT_ID}"
+	exit "$status"
+}
 
 BUILD_ID=${BUILD_ID:-non-existent-build}
 PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value project)}
@@ -35,6 +45,7 @@ fi
 
 # See https://cloud.google.com/filestore/docs/troubleshooting#system_limit_for_internal_resources_has_been_reached_error_when_creating_an_instance
 echo "Disabling Filestore API..."
+trap enable_filestore_api EXIT
 gcloud services disable file.googleapis.com --force --project "${PROJECT_ID}"
 
 echo "Deleting all Filestore peering networks"
@@ -58,8 +69,5 @@ while read -r peering; do
 		fi
 	done
 done <<<"$peerings"
-
-echo "Re-enabling Filestore API..."
-gcloud services enable file.googleapis.com --project "${PROJECT_ID}"
 
 exit 0


### PR DESCRIPTION
Use a bash trap function to ensure that the Filestore API is always enabled. It is safe to run this command even when the API has already been enabled (i.e. it returns code 0 and leaves the service enabled)
 
A build where all commands succeeded:

https://console.cloud.google.com/cloud-build/builds/f42c571b-861b-4e10-be8c-d0c8fe72fb74?project=508417052821&e=13803378&mods=monitoring_api_prod

A build where I introduced a deliberate failure:

https://console.cloud.google.com/cloud-build/builds/c94d8e90-3152-4665-bfa6-ee535a0f0488?project=hpc-toolkit-dev&e=13803378&mods=monitoring_api_prod

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
