### PR TITLE
Update Slurm troubleshooting docs to clarify behavior on stockout

### DIFF
--- a/docs/slurm-troubleshooting.md
+++ b/docs/slurm-troubleshooting.md
@@ -96,17 +96,21 @@ The solution here is to [request more of the specified quota](#gcp-quotas),
 It may be that the zone the partition is deployed in has no remaining capacity to create the
 compute nodes required to run your submitted job.
 
-You can confirm this by SSHing into the `controller` VM and checking the
-`resume.log` file:
+Check the `resume.log` file for possible errors by SSH-ing into the controller VM and running the following:
 
 ```shell
-$ cat /var/log/slurm/resume.log
-... bulkInsert operation errors: VM_MIN_COUNT_NOT_REACHED ...
+sudo cat /var/log/slurm/resume.log
+```
+
+One example of an error message which appears in `resume.log` due to insufficient capacity is:
+
+```text
+bulkInsert operation errors: VM_MIN_COUNT_NOT_REACHED
 ```
 
 When this happens, the the output of `sacct` will show the job's status as `NODE_FAIL`.
 
-Jobs submitted via `srun` will not be retried, however jobs submitted via `sbatch` will be retried.
+Jobs submitted via `srun` will not be requeued, however jobs submitted via `sbatch` will be requeued.
 
 #### Placement Groups (Slurm)
 

--- a/docs/slurm-troubleshooting.md
+++ b/docs/slurm-troubleshooting.md
@@ -65,6 +65,7 @@ srun: error: Job allocation 2 has been revoked
 ```
 
 Possible causes could be [insufficient quota](#insufficient-quota),
+[insufficient capacity](#insufficient-capacity),
 [placement groups](#placement-groups-slurm), or
 [insufficient permissions](#insufficient-service-account-permissions)
 for the service account attached to the controller. Also see the
@@ -89,6 +90,23 @@ The solution here is to [request more of the specified quota](#gcp-quotas),
 [machine type][partition-machine-type], to one which has sufficient quota.
 
 [partition-machine-type]: community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md#input_machine_type
+
+#### Insufficient Capacity
+
+It may be that the zone the partition is deployed in has no remaining capacity to create the
+compute nodes required to run your submitted job.
+
+You can confirm this by SSHing into the `controller` VM and checking the
+`resume.log` file:
+
+```shell
+$ cat /var/log/slurm/resume.log
+... bulkInsert operation errors: VM_MIN_COUNT_NOT_REACHED ...
+```
+
+When this happens, the the output of `sacct` will show the job's status as `NODE_FAIL`.
+
+Jobs submitted via `srun` will not be retried, however jobs submitted via `sbatch` will be retried.
 
 #### Placement Groups (Slurm)
 


### PR DESCRIPTION
Updating documentation to clarify Slurm behavior when there is a stockout while Slurm is trying to bring up compute nodes.

The behavior is consistent for both v5 and v6, for both `srun` and `sbatch (I have tested all combinations).