### PR TITLE
Explicitly set validation to warn on OFE ghpc calls, fallout from #2383

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/cluster_manager/clusterinfo.py
+++ b/community/front-end/ofe/website/ghpcfe/cluster_manager/clusterinfo.py
@@ -531,7 +531,7 @@ deployment_groups:
             with log_out_fn.open("wb") as log_out:
                 with log_err_fn.open("wb") as log_err:
                     subprocess.run(
-                        [self.ghpc_path, "create", "cluster.yaml","-w"],
+                        [self.ghpc_path, "create", "cluster.yaml", "-w", "--validation-level", "WARNING"],
                         cwd=target_dir,
                         stdout=log_out,
                         stderr=log_err,


### PR DESCRIPTION
When default behavior changed, OFE warnings became blocking: https://github.com/GoogleCloudPlatform/hpc-toolkit/pull/2383

This PR returns OFE to previous default behavior of warning on validation failures.

I have manually tested with "IGNORE". Warning should have the same effect. Also previous default behavior was warning.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
