### PR TITLE
Update instructions to not assume project id is set in gcloud config

### DIFF
--- a/modules/compute/vm-instance/outputs.tf
+++ b/modules/compute/vm-instance/outputs.tf
@@ -38,9 +38,9 @@ locals {
   first_instance_link = try(google_compute_instance.compute_vm[0].self_link, "no-instance")
   ssh_instructions    = <<-EOT
     Use the following commands to SSH into the first VM created:
-      gcloud compute ssh ${local.first_instance_link}
+      gcloud compute ssh ${local.first_instance_link} --project ${var.project_id}
     If not accessible from the public internet, use an SSH tunnel through IAP:
-      gcloud compute ssh ${local.first_instance_link} --tunnel-through-iap
+      gcloud compute ssh ${local.first_instance_link} --tunnel-through-iap --project ${var.project_id}
   EOT
 }
 


### PR DESCRIPTION
Before the command assumed that project id had already been set in gcloud config (and matched existing project).

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
