### PR TITLE
Make project cleanup more resiliant

### DIFF
--- a/tools/cloud-build/project-cleanup.yaml
+++ b/tools/cloud-build/project-cleanup.yaml
@@ -23,18 +23,46 @@ steps:
   args:
   - -c
   - |
-    failures=0
     trap 'failures=$((failures+1))' ERR
-    echo
-    echo "Cleaning Resource Policies"
-    /workspace/tools/clean-resource-policies.sh
-    echo
-    echo "Cleaning Filestore"
-    /workspace/tools/clean-filestore-limit.sh
-    echo
-    echo "Cleaning Metadata"
-    /workspace/tools/clean-metadata.sh
+    # retry for up to 2047 seconds (34 minutes)
+    attempt=0
+    max_retries=10
+    while [[ $attempt -le $max_retries ]]; do
+        failures=0
+        if [[ $attempt -gt 0 ]]; then
+            wait=$((2 ** attempt))
+            echo "Retry attempt ${attempt} of ${max_retries} with exponential backoff: ${wait} seconds."
+            sleep $wait
+        fi
+
+        active_builds=$(gcloud builds list --project "${PROJECT_ID}" --filter="id!=\"${BUILD_ID}\"" --ongoing 2>/dev/null)
+        if [[ -n "$active_builds" ]]; then
+            echo "There are active Cloud Build jobs. Skipping cleanup."
+            # set failures to non-0 in case this is last retry
+            ((failures++))
+            ((attempt++))
+            continue
+        fi
+
+        echo
+        echo "Cleaning Resource Policies"
+        /workspace/tools/clean-resource-policies.sh
+        echo
+        echo "Cleaning Filestore"
+        /workspace/tools/clean-filestore-limit.sh
+        echo
+        echo "Cleaning Metadata"
+        /workspace/tools/clean-metadata.sh
+
+        if [[ $failures -eq 0 ]]; then
+            break
+        else
+            echo "At least one failure occurred during cleanup."
+            ((attempt++))
+        fi
+    done
+
     if [[ $failures -ne 0 ]]; then
-      echo "Failures during cleanup, check above"
-      exit 1
+        echo "Cleanup did not succeed despite retrying."
+        exit 1
     fi

--- a/tools/cloud-build/provision/daily-cleanup.tf
+++ b/tools/cloud-build/provision/daily-cleanup.tf
@@ -34,6 +34,6 @@ resource "google_cloudbuild_trigger" "daily_project_cleanup" {
 module "daily_project_cleanup_schedule" {
   source      = "./trigger-schedule"
   trigger     = google_cloudbuild_trigger.daily_project_cleanup
-  schedule    = "0 0 * * MON-FRI"
+  schedule    = "0,30 22,23 * * MON-FRI"
   retry_count = 4
 }


### PR DESCRIPTION
Implement a mechanism that retries when:
- there are active builds; cleanup attempt is skipped (but retried) in this case due to the low odds of success
- if any failures occur in cleanup when it is attempted

Will retry for approximately 34 minutes. The schedule change ensures that 4 attempts will be made per night (Pacific Time) to run cleanup, at 30 minute intervals. Therefore, there are no gaps in the schedule. I will provision the schedule change after PR is approved.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
