### PR TITLE
Project cleanup. Look only at relevant builds.

### DIFF
--- a/tools/cloud-build/project-cleanup.yaml
+++ b/tools/cloud-build/project-cleanup.yaml
@@ -35,9 +35,14 @@ steps:
             sleep $wait
         fi
 
-        active_builds=$(gcloud builds list --project "${PROJECT_ID}" --filter="id!=\"${BUILD_ID}\"" --ongoing 2>/dev/null)
+        # look only for tests that either use Slurm5, Slurm6 or Filestore
+        builds_filter="tags=m.schedmd-slurm-gcp-v6-controller OR tags=m.schedmd-slurm-gcp-v5-controller OR tags=m.filestore"
+        builds_format="value(substitutions.TRIGGER_NAME,logUrl)"
+        active_builds=$(gcloud builds list --project "${PROJECT_ID}" --filter="${builds_filter}" --format="${builds_format}" --ongoing 2>/dev/null)
         if [[ -n "$active_builds" ]]; then
-            echo "There are active Cloud Build jobs. Skipping cleanup."
+            echo "There are active Cloud Build jobs."
+            echo "$active_builds"
+            echo "Skipping cleanup."
             # set failures to non-0 in case this is last retry
             ((failures++))
             ((attempt++))


### PR DESCRIPTION
* Limit search by tags:
```
m.schedmd-slurm-gcp-v6-controller
m.schedmd-slurm-gcp-v5-controller
m.filestore
```
* Print list of builds that are blocking.

```sh
...
Retry attempt 5 of 10 with exponential backoff: 32 seconds.
There are active Cloud Build jobs.
PR-test-slurm-gcp-v6-ubuntu     https://console.cloud.google.com/cloud-build/builds/xxxx
PR-test-spack-gromacs   https://console.cloud.google.com/cloud-build/builds/xxxxx
PR-test-slurm-gcp-v6-rocky8     https://console.cloud.google.com/cloud-build/builds/xxxx
PR-test-slurm-gcp-v6-tpu        https://console.cloud.google.com/cloud-build/builds/xxxx
PR-test-hpc-build-slurm-image   https://console.cloud.google.com/cloud-build/builds/xxxx
Skipping cleanup.
Retry attempt 6 of 10 ...
```