### PR TITLE
Split `daily_cleanup` on `filestore` and `slurm` parts

### DIFF
--- a/tools/clean-filestore-limit.sh
+++ b/tools/clean-filestore-limit.sh
@@ -47,6 +47,7 @@ fi
 echo "Disabling Filestore API..."
 trap enable_filestore_api EXIT
 gcloud services disable file.googleapis.com --force --project "${PROJECT_ID}"
+echo "Sleeping for 2 minutes for internal limits to fully reset..."
 sleep 120
 
 echo "Deleting all Filestore peering networks"

--- a/tools/cloud-build/project-cleanup-filestore.yaml
+++ b/tools/cloud-build/project-cleanup-filestore.yaml
@@ -35,8 +35,8 @@ steps:
             sleep $wait
         fi
 
-        # look only for tests that either use Slurm5, Slurm6 or Filestore
-        builds_filter="tags=m.schedmd-slurm-gcp-v6-controller OR tags=m.schedmd-slurm-gcp-v5-controller OR tags=m.filestore"
+        # look only for tests that use Filestore
+        builds_filter="tags=m.filestore"
         builds_format="value(substitutions.TRIGGER_NAME,logUrl)"
         active_builds=$(gcloud builds list --project "${PROJECT_ID}" --filter="${builds_filter}" --format="${builds_format}" --ongoing 2>/dev/null)
         if [[ -n "$active_builds" ]]; then
@@ -50,14 +50,8 @@ steps:
         fi
 
         echo
-        echo "Cleaning Resource Policies"
-        /workspace/tools/clean-resource-policies.sh
-        echo
         echo "Cleaning Filestore"
         /workspace/tools/clean-filestore-limit.sh
-        echo
-        echo "Cleaning Metadata"
-        /workspace/tools/clean-metadata.sh
 
         if [[ $failures -eq 0 ]]; then
             break

--- a/tools/cloud-build/project-cleanup-slurm.yaml
+++ b/tools/cloud-build/project-cleanup-slurm.yaml
@@ -1,0 +1,72 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+steps:
+- name: gcr.io/cloud-builders/gcloud
+  entrypoint: /bin/bash
+  env:
+  - "BUILD_ID=${BUILD_ID}"
+  - "PROJECT_ID=${PROJECT_ID}"
+  args:
+  - -c
+  - |
+    trap 'failures=$((failures+1))' ERR
+    # retry for up to 2047 seconds (34 minutes)
+    attempt=0
+    max_retries=10
+    while [[ $attempt -le $max_retries ]]; do
+        failures=0
+        if [[ $attempt -gt 0 ]]; then
+            wait=$((2 ** attempt))
+            echo "Retry attempt ${attempt} of ${max_retries} with exponential backoff: ${wait} seconds."
+            sleep $wait
+        fi
+
+        # look only for tests that either use Slurm5, or Slurm6
+        # v5: clean project metadata
+        # v5+v6: clean resource policies
+        builds_filter="tags=m.schedmd-slurm-gcp-v6-controller OR tags=m.schedmd-slurm-gcp-v5-controller"
+        builds_format="value(substitutions.TRIGGER_NAME,logUrl)"
+        active_builds=$(gcloud builds list --project "${PROJECT_ID}" --filter="${builds_filter}" --format="${builds_format}" --ongoing 2>/dev/null)
+        if [[ -n "$active_builds" ]]; then
+            echo "There are active Cloud Build jobs."
+            echo "$active_builds"
+            echo "Skipping cleanup."
+            # set failures to non-0 in case this is last retry
+            ((failures++))
+            ((attempt++))
+            continue
+        fi
+
+        echo
+        echo "Cleaning Resource Policies"
+        /workspace/tools/clean-resource-policies.sh
+        echo
+        echo "Cleaning Metadata"
+        /workspace/tools/clean-metadata.sh
+
+        if [[ $failures -eq 0 ]]; then
+            break
+        else
+            echo "At least one failure occurred during cleanup."
+            ((attempt++))
+        fi
+    done
+
+    if [[ $failures -ne 0 ]]; then
+        echo "Cleanup did not succeed despite retrying."
+        exit 1
+    fi

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -36,7 +36,8 @@ When prompted for project, use integration test project.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_daily_image_test_runner_schedule"></a> [daily\_image\_test\_runner\_schedule](#module\_daily\_image\_test\_runner\_schedule) | ./trigger-schedule | n/a |
-| <a name="module_daily_project_cleanup_schedule"></a> [daily\_project\_cleanup\_schedule](#module\_daily\_project\_cleanup\_schedule) | ./trigger-schedule | n/a |
+| <a name="module_daily_project_cleanup_filestore_schedule"></a> [daily\_project\_cleanup\_filestore\_schedule](#module\_daily\_project\_cleanup\_filestore\_schedule) | ./trigger-schedule | n/a |
+| <a name="module_daily_project_cleanup_slurm_schedule"></a> [daily\_project\_cleanup\_slurm\_schedule](#module\_daily\_project\_cleanup\_slurm\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_daily_test_schedule"></a> [daily\_test\_schedule](#module\_daily\_test\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_weekly_build_dependency_check_schedule"></a> [weekly\_build\_dependency\_check\_schedule](#module\_weekly\_build\_dependency\_check\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_weekly_builder_image_schedule"></a> [weekly\_builder\_image\_schedule](#module\_weekly\_builder\_image\_schedule) | ./trigger-schedule | n/a |
@@ -45,7 +46,8 @@ When prompted for project, use integration test project.
 
 | Name | Type |
 |------|------|
-| [google_cloudbuild_trigger.daily_project_cleanup](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.daily_project_cleanup_filestore](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.daily_project_cleanup_slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.daily_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.image_build_test_runner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_go_build_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |

--- a/tools/cloud-build/provision/daily-cleanup.tf
+++ b/tools/cloud-build/provision/daily-cleanup.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_cloudbuild_trigger" "daily_project_cleanup" {
+resource "google_cloudbuild_trigger" "daily_project_cleanup_filestore" {
   name        = "DAILY-project-cleanup"
-  description = "A cleanup script to run periodically"
+  description = "A filestore cleanup script to run periodically"
   tags        = [local.notify_chat_tag]
 
   git_file_source {
-    path      = "tools/cloud-build/project-cleanup.yaml"
+    path      = "tools/cloud-build/project-cleanup-filestore.yaml"
     revision  = local.ref_develop
     uri       = var.repo_uri
     repo_type = "GITHUB"
@@ -31,9 +31,35 @@ resource "google_cloudbuild_trigger" "daily_project_cleanup" {
   }
 }
 
-module "daily_project_cleanup_schedule" {
+module "daily_project_cleanup_filestore_schedule" {
   source      = "./trigger-schedule"
-  trigger     = google_cloudbuild_trigger.daily_project_cleanup
+  trigger     = google_cloudbuild_trigger.daily_project_cleanup_filestore
   schedule    = "0,30 22,23 * * *"
+  retry_count = 4
+}
+
+resource "google_cloudbuild_trigger" "daily_project_cleanup_slurm" {
+  name        = "DAILY-project-cleanup"
+  description = "A metadata & resource policies cleanup script to run periodically"
+  tags        = [local.notify_chat_tag]
+
+  git_file_source {
+    path      = "tools/cloud-build/project-cleanup-slurm.yaml"
+    revision  = local.ref_develop
+    uri       = var.repo_uri
+    repo_type = "GITHUB"
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.ref_develop
+    repo_type = "GITHUB"
+  }
+}
+
+module "daily_project_cleanup_slurm_schedule" {
+  source      = "./trigger-schedule"
+  trigger     = google_cloudbuild_trigger.daily_project_cleanup_slurm
+  schedule    = "0 0 * * MON-FRI"
   retry_count = 4
 }


### PR DESCRIPTION
No changes to the scripts, execpt:
* Change filters by build tags;
* Change scripts to be invoced;
* Change schedule:
  * filestore - `"0,30 22,23 * * *"`
  * slurm - `"0 0 * * MON-FRI"`

**Motivation:**
* Reduce scope of tests that block execution;
* Preparation for future changes in filestore cleanup.

```sh
$ terraform plan
...
Plan: 4 to add, 0 to change, 2 to destroy.
```
