### PR TITLE
Copy labels from the batch-job-template module to the actual Batch job spec

### DIFF
--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -36,6 +36,7 @@ locals {
       log_policy         = var.log_policy
       instance_template  = local.instance_template
       nfs_volumes        = local.native_batch_network_storage
+      labels             = local.labels
     }
   )
 

--- a/modules/scheduler/batch-job-template/templates/batch-job-base.yaml.tftpl
+++ b/modules/scheduler/batch-job-template/templates/batch-job-base.yaml.tftpl
@@ -43,3 +43,9 @@ logsPolicy:
     destination: "PATH"
     logsPath: ## Add logging path here
 %{ endif }
+%{~ if length(labels) > 0 ~}
+labels:
+%{ for k, v in labels ~}
+    ${k}: "${v}"
+%{ endfor }
+%{~ endif ~}


### PR DESCRIPTION
This will allow toolkit users to get special behaviors out of Batch jobs submitted (or merely prepared in job specs) by the toolkit, by using labels. For example a toolkit user could create a Batch Node Pool via a batch-job-template module using the goog-batch-job-group label.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
