### PR TITLE
Allow the `wait-for-startup` module to take a list of instance names

### DIFF
--- a/community/modules/scripts/wait-for-startup/README.md
+++ b/community/modules/scripts/wait-for-startup/README.md
@@ -1,9 +1,8 @@
 ## Description
 
 This module will insert a dependency on the completion of the startup script
-for a compute VM and report back if it fails. This can be useful when running
-post-boot installation scripts that require the startup script to finish setting
-up a node.
+for one or more specified compute VMs and report back if it fails. This can be useful when running
+post-boot installation scripts that require the startup script to finish setting up a node.
 
 > **_WARNING:_**: this module is experimental and not fully supported.
 
@@ -15,10 +14,19 @@ up a node.
 ### Example
 
 ```yaml
+- id: workstation
+  source: modules/compute/vm-instance
+  use:
+  - network1
+  - my-startup-script
+  settings:
+    instance_count: 4
+
+# Wait for all instances of the above VM to finish running startup scripts.
 - id: wait
   source: community/modules/scripts/wait-for-startup
   settings:
-    instance_name: $(workstation.name[0])
+    instance_names: $(workstation.name)
 ```
 
 ## License
@@ -43,14 +51,12 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
@@ -61,14 +67,15 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [null_resource.validate_instance_names](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.wait_for_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [google_compute_instance.vm_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the instance we are waiting for | `string` | n/a | yes |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the instance we are waiting for (can be null if 'instance\_names' is not empty) | `string` | `null` | no |
+| <a name="input_instance_names"></a> [instance\_names](#input\_instance\_names) | A list of instance names we are waiting for, in addition to the one mentioned in 'instance\_name' (if any) | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout in seconds | `number` | `1200` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone where the instance is running | `string` | n/a | yes |

--- a/community/modules/scripts/wait-for-startup/variables.tf
+++ b/community/modules/scripts/wait-for-startup/variables.tf
@@ -15,8 +15,15 @@
  */
 
 variable "instance_name" {
-  description = "Name of the instance we are waiting for"
+  description = "Name of the instance we are waiting for (can be null if 'instance_names' is not empty)"
   type        = string
+  default     = null
+}
+
+variable "instance_names" {
+  description = "A list of instance names we are waiting for, in addition to the one mentioned in 'instance_name' (if any)"
+  type        = list(string)
+  default     = []
 }
 
 variable "zone" {

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -20,10 +20,6 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.0"
     }
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 3.83"
-    }
   }
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.32.1"


### PR DESCRIPTION
This PR adds a new setting to the `wait-for-startup` module called `instance_names` (plural), which extends the functionality of this module to wait for startup scripts to complete on multiple VM instances.

The `instance_names` setting takes a list of VM instance names, and allows the `name` output variable from the `compute/vm-instance` module to be passed in.  For example, here is a minimal snippet from a blueprint which was used to test this change:

```yaml
  - id: vm
    source: modules/compute/vm-instance
    use:
    - network1
    - shared-fs
    - config-startup
    settings:
      instance_count: 8
  - id: wait-for-vm
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_names: $(vm.name)
```

Before this change, the above snippet would've had to have been defined like this in order to wait for startup scripts to complete in all 8 instances (notice the plurality of `instance_name` vs. `instance_names`):

```yaml
  - id: vm
    source: modules/compute/vm-instance
    use:
    - network1
    - shared-fs
    - config-startup
    settings:
      instance_count: 8
  - id: wait-for-vm-0
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[0])
  - id: wait-for-vm-1
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[1])
  - id: wait-for-vm-2
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[2])
  - id: wait-for-vm-3
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[3])
  - id: wait-for-vm-4
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[4])
  - id: wait-for-vm-5
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[5])
  - id: wait-for-vm-6
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[6])
  - id: wait-for-vm-7
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[7])
```

I have tested this change with both of the above snippets to ensure behavior stays the same whether the singular or plural version of the setting is used.  I have also tested with the following to ensure the list is combined with the singular setting correctly:

```yaml
  - id: vm
    source: modules/compute/vm-instance
    use:
    - network1
    - shared-fs
    - config-startup
    settings:
      instance_count: 8
  - id: wait-for-vm-0
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm.name[0])
      instance_names: $(vm.name)
```

Here's a full test blueprint (one set of VMs is made to fail to test the error case):

```yaml
blueprint_name: startup-vm-instance

vars:
  project_id:  ## Set project id here
  deployment_name: test-startup
  region: us-east4
  zone: us-east4-c

deployment_groups:
- group: first
  modules:
  - id: network1
    source: modules/network/pre-existing-vpc
    settings:
      # network_name: imb-test
  - id: script
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: shell
        destination: tmp.sh
        content: |
          #!/bin/bash
          sleep 60
  - id: script_fail
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: shell
        destination: tmp.sh
        content: |
          #!/bin/bash
          exit 1

  - id: vm0
    source: modules/compute/vm-instance
    use:
    - network1
    - script
    settings:
      name_prefix: vm0
      machine_type: n1-standard-2
      instance_count: 2
  - id: wait-for-vm0
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_name: $(vm0.name[0])
      instance_names: $(vm0.name)

  - id: vm1
    source: modules/compute/vm-instance
    use:
    - network1
    - script_fail
    settings:
      name_prefix: vm1
      machine_type: n1-standard-2
      instance_count: 4
  - id: wait-for-vm1-0
    source: community/modules/scripts/wait-for-startup
    settings:
      instance_names: $(vm1.name)
```