### PR TITLE
Add an option to skip `Ensure all nodes are powered down` in slurm tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -225,10 +225,12 @@
     ## Always cleanup, even on failure
     always:
     - name: Ensure all nodes are powered down
+      vars:
+        wait_for_compute_nodes_to_go_down: true
       ansible.builtin.command: sinfo -t 'POWERED_DOWN' --noheader --format "%n"
       register: final_node_count
       changed_when: False
-      when: initial_node_count is defined and initial_node_count.stdout_lines is iterable
+      when: wait_for_compute_nodes_to_go_down and initial_node_count is defined and initial_node_count.stdout_lines is iterable
       until: final_node_count.stdout_lines | length == initial_node_count.stdout_lines | length
       retries: 60
       delay: 15


### PR DESCRIPTION
**Motivations:**
* to tests `compute_cleanup`;
* can save a few minutes of test time.