### PR TITLE
Slurm tests. Don't "ensure all nodes are powered down" by default

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -226,7 +226,7 @@
     always:
     - name: Ensure all nodes are powered down
       vars:
-        wait_for_compute_nodes_to_go_down: true
+        wait_for_compute_nodes_to_go_down: false
       ansible.builtin.command: sinfo -t 'POWERED_DOWN' --noheader --format "%n"
       register: final_node_count
       changed_when: False

--- a/tools/cloud-build/daily-tests/tests/hcls.yml
+++ b/tools/cloud-build/daily-tests/tests/hcls.yml
@@ -42,3 +42,4 @@ custom_vars:
   - /apps
   - /data_input
   - /data_output
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
@@ -47,3 +47,4 @@ custom_vars:
   - /home
   - /projects
   - /scratch
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
@@ -39,3 +39,4 @@ custom_vars:
   partitions:
   - desktop
   - compute
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/lustre-slurm.yml
@@ -40,3 +40,4 @@ custom_vars:
   - centos
   - rocky
   # - ubuntu
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/ml-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-slurm.yml
@@ -20,3 +20,4 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/ml-slurm.yaml"
 packer_group_name: packer
 packer_module_id: custom-image
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-debian.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-debian.yml
@@ -42,3 +42,4 @@ custom_vars:
   - debug
   mounts:
   - /home
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
@@ -41,3 +41,4 @@ custom_vars:
   - debug
   mounts:
   - /home
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-rocky8.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-rocky8.yml
@@ -42,3 +42,4 @@ custom_vars:
   - debug
   mounts:
   - /home
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-startup-scripts.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-startup-scripts.yml
@@ -35,3 +35,4 @@ custom_vars:
   mounts:
   - /home
   - /data
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml
@@ -37,3 +37,4 @@ custom_vars:
   - /home
 cli_deployment_vars:
   network_name: "{{ network }}"
+wait_for_compute_nodes_to_go_down: true

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml
@@ -42,3 +42,6 @@ custom_vars:
   - debug
   mounts:
   - /home
+# Assert that machines are getting shut down eventually
+# This is the only SlurmV6 test that checks this.
+wait_for_compute_nodes_to_go_down: true


### PR DESCRIPTION
* set `wait_for_compute_nodes_to_go_down` default value to `false`;
* update **all** Slurm5 tests to set it to `true`;
* update **single** Slurm6 test to set it to `true`.
