### PR TITLE
IGC. Split `apply` and `output` into different steps.

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -86,5 +86,6 @@ func destroyTerraformGroup(groupDir string) error {
 		return err
 	}
 
-	return shell.Destroy(tf, getApplyBehavior())
+	_, err = shell.Destroy(tf, getApplyBehavior())
+	return err
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -71,5 +71,5 @@ func runExportCmd(cmd *cobra.Command, args []string) {
 	tf, err := shell.ConfigureTerraform(groupDir)
 	checkErr(err, ctx)
 
-	checkErr(shell.ExportOutputs(tf, artifactsDir, shell.NeverApply), ctx)
+	checkErr(shell.ExportOutputs(tf, artifactsDir), ctx)
 }


### PR DESCRIPTION
* Changes to behavior: export-outputs no longer performs apply;
* Make `applyOrDestroy` to output if changes were applied (or no changes required);
* Make `ExportOutputs` to do `output` only, without `apply`;
* Minor refactoring. 