### PR TITLE
Remove `login` infix from instance name

### DIFF
--- a/community/examples/AMD/hpc-amd-slurm-v6.yaml
+++ b/community/examples/AMD/hpc-amd-slurm-v6.yaml
@@ -210,7 +210,6 @@ deployment_groups:
     settings:
       # need at least 8 physical cores to run OpenFOAM test
       machine_type: c2d-standard-16
-      name_prefix: login
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller

--- a/community/examples/hpc-slurm-gromacs.yaml
+++ b/community/examples/hpc-slurm-gromacs.yaml
@@ -109,7 +109,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network1]
     settings:
-      name_prefix: login
       enable_login_public_ips: true
 
   - id: slurm_controller

--- a/community/examples/hpc-slurm-local-ssd-v6.yaml
+++ b/community/examples/hpc-slurm-local-ssd-v6.yaml
@@ -101,7 +101,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n1-standard-4
       enable_login_public_ips: true
 

--- a/community/examples/hpc-slurm-ramble-gromacs-v6.yaml
+++ b/community/examples/hpc-slurm-ramble-gromacs-v6.yaml
@@ -129,7 +129,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
 

--- a/community/examples/hpc-slurm-sharedvpc.yaml
+++ b/community/examples/hpc-slurm-sharedvpc.yaml
@@ -88,7 +88,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network1]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
 

--- a/community/examples/hpc-slurm-ubuntu2004-v6.yaml
+++ b/community/examples/hpc-slurm-ubuntu2004-v6.yaml
@@ -90,7 +90,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network1]
     settings:
-      name_prefix: login
       instance_image: $(vars.slurm_image)
       machine_type: n2-standard-4
       enable_login_public_ips: true

--- a/community/examples/hpc-slurm6-tpu-maxtext.yaml
+++ b/community/examples/hpc-slurm6-tpu-maxtext.yaml
@@ -113,7 +113,6 @@ deployment_groups:
     use: [network]
     settings:
       enable_login_public_ips: true
-      name_prefix: "v6tpu"
       machine_type: n2-standard-16
 
   - id: slurm_controller

--- a/community/examples/hpc-slurm6-tpu.yaml
+++ b/community/examples/hpc-slurm6-tpu.yaml
@@ -54,7 +54,6 @@ deployment_groups:
     source: ./community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: "v6tpu"
       machine_type: n2-standard-4
       enable_login_public_ips: true
 

--- a/community/examples/htc-slurm-v6.yaml
+++ b/community/examples/htc-slurm-v6.yaml
@@ -137,7 +137,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: $(vars.enable_public_ips)
 

--- a/community/examples/intel/hpc-slurm-daos.yaml
+++ b/community/examples/intel/hpc-slurm-daos.yaml
@@ -158,7 +158,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network1]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
       tags: $(vars.tags)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
@@ -64,7 +64,7 @@ module "slurm_login_instance" {
 
   access_config       = each.value.access_config
   add_hostname_suffix = true
-  hostname            = "${local.slurm_cluster_name}-login-${each.key}"
+  hostname            = "${local.slurm_cluster_name}-${each.key}"
   slurm_instance_role = "login"
 
   project_id         = var.project_id

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
@@ -105,7 +105,7 @@ No modules.
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to create. | `string` | `"c2-standard-4"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
 | <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | Specifies a minimum CPU platform. Applicable values are the friendly names of<br>CPU platforms, such as Intel Haswell or Intel Skylake. See the complete list:<br>https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform | `string` | `null` | no |
-| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Unique name prefix for login nodes | `string` | n/a | yes |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Unique name prefix for login nodes. Automatically populated by the module id if not set.<br>If setting manually, ensure a unique value across all login groups. | `string` | n/a | yes |
 | <a name="input_num_instances"></a> [num\_instances](#input\_num\_instances) | Number of instances to create. This value is ignored if static\_ips is provided. | `number` | `1` | no |
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Instance availability Policy. | `string` | `"MIGRATE"` | no |
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Allow the instance to be preempted. | `bool` | `false` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/main.tf
@@ -33,8 +33,16 @@ locals {
 
   public_access_config = [{ nat_ip = null, network_tier = null }]
 
+  # lower, replace `_` with `-`, and remove any non-alphanumeric characters
+  name_prefix = replace(
+    replace(
+      lower(var.name_prefix),
+    "_", "-"),
+  "/[^-a-z0-9]/", "")
+
+
   login_node = {
-    name_prefix      = var.name_prefix
+    name_prefix      = local.name_prefix
     disk_auto_delete = var.disk_auto_delete
     disk_labels      = merge(var.disk_labels, local.labels)
     disk_size_gb     = var.disk_size_gb

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/metadata.yaml
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/metadata.yaml
@@ -17,4 +17,5 @@ spec:
   requirements:
     services: []
 ghpc:
+  inject_module_id: name_prefix
   has_to_be_used: true

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/variables.tf
@@ -35,7 +35,10 @@ variable "zone" {
 
 variable "name_prefix" {
   type        = string
-  description = "Unique name prefix for login nodes"
+  description = <<-EOD
+    Unique name prefix for login nodes. Automatically populated by the module id if not set.
+    If setting manually, ensure a unique value across all login groups.
+    EOD
 }
 
 variable "num_instances" {

--- a/docs/tutorials/gromacs/spack-gromacs.yaml
+++ b/docs/tutorials/gromacs/spack-gromacs.yaml
@@ -157,8 +157,6 @@ deployment_groups:
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network1]
-    settings:
-      name_prefix: login
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller

--- a/docs/tutorials/hpc-slurm-qwiklabs.yaml
+++ b/docs/tutorials/hpc-slurm-qwiklabs.yaml
@@ -67,7 +67,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
 

--- a/docs/tutorials/openfoam/spack-openfoam.yaml
+++ b/docs/tutorials/openfoam/spack-openfoam.yaml
@@ -169,7 +169,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network1]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
 

--- a/docs/tutorials/wrfv3/spack-wrfv3.yaml
+++ b/docs/tutorials/wrfv3/spack-wrfv3.yaml
@@ -156,8 +156,6 @@ deployment_groups:
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network1]
-    settings:
-      name_prefix: login
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller

--- a/examples/cae/cae-slurm-v6.yaml
+++ b/examples/cae/cae-slurm-v6.yaml
@@ -194,7 +194,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2-standard-8
 
   ####### Scheduler: SLURM #######

--- a/examples/hcls-blueprint-v6.yaml
+++ b/examples/hcls-blueprint-v6.yaml
@@ -328,8 +328,6 @@ deployment_groups:
   - id: slurm_login
     source: ./community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
-    settings:
-      name_prefix: "login"
 
   - id: slurm_controller
     source: ./community/modules/scheduler/schedmd-slurm-gcp-v6-controller

--- a/examples/hpc-enterprise-slurm-v6.yaml
+++ b/examples/hpc-enterprise-slurm-v6.yaml
@@ -258,7 +258,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network, login_sa]
     settings:
-      name_prefix: login
       instance_image: $(vars.slurm_image)
       machine_type: n2-standard-4
       # we recommend disabling public IPs if possible

--- a/examples/hpc-slurm-static-v6.yaml
+++ b/examples/hpc-slurm-static-v6.yaml
@@ -76,7 +76,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2d-standard-4
       enable_login_public_ips: true
 

--- a/examples/hpc-slurm-v6.yaml
+++ b/examples/hpc-slurm-v6.yaml
@@ -93,7 +93,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
 

--- a/examples/image-builder-v6.yaml
+++ b/examples/image-builder-v6.yaml
@@ -89,7 +89,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       enable_login_public_ips: true
       disk_size_gb: $(vars.disk_size)
       instance_image: $(vars.custom_image)

--- a/examples/ml-slurm-v6.yaml
+++ b/examples/ml-slurm-v6.yaml
@@ -235,7 +235,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: "login"
       enable_login_public_ips: true
       instance_image: $(vars.new_image)
       instance_image_custom: true

--- a/tools/cloud-build/daily-tests/blueprints/lustre-slurm-v6.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-slurm-v6.yaml
@@ -127,7 +127,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       enable_login_public_ips: true
 
   - id: slurm_controller

--- a/tools/cloud-build/daily-tests/tests/hcls-v6.yml
+++ b/tools/cloud-build/daily-tests/tests/hcls-v6.yml
@@ -23,7 +23,7 @@ zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hcls-blueprint-v6.yaml"
 network: "{{ test_name }}-net"
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 cli_deployment_vars:
   network_name: "{{ network }}"

--- a/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm-v6.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm-v6.yml
@@ -29,7 +29,7 @@ blueprint_yaml: "{{ workspace }}/examples/hpc-enterprise-slurm-v6.yaml"
 network: "{{ test_name }}-net"
 
 # Note: Pattern matching in gcloud only supports 1 wildcard.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-mounts.yml

--- a/tools/cloud-build/daily-tests/tests/htc-slurm-v6.yml
+++ b/tools/cloud-build/daily-tests/tests/htc-slurm-v6.yml
@@ -28,7 +28,7 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/htc-slurm-v6.yaml"
 network: "{{ test_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-mounts.yml

--- a/tools/cloud-build/daily-tests/tests/lustre-slurm-v6.yml
+++ b/tools/cloud-build/daily-tests/tests/lustre-slurm-v6.yml
@@ -25,7 +25,7 @@ cli_deployment_vars:
   region: "{{ region }}"
   zone: "{{ zone }}"
 # Note: Pattern matching in gcloud only supports 1 wildcard.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-mounts.yml

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-centos7.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-centos7.yml
@@ -31,7 +31,7 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004-v6.yaml"
 network: "{{ test_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-mounts.yml

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml
@@ -31,7 +31,7 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004-v6.yaml"
 network: "{{ test_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-mounts.yml

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
@@ -30,7 +30,7 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-slurm-v6.yaml"
 network: "{{ test_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-mounts.yml

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml
@@ -24,7 +24,7 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-local-ssd-v6.yaml"
 network: "{{ test_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-partitions.yml

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml
@@ -24,7 +24,7 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/tools/validate_configs/test_configs/slurm-gcp-v6-startup-scripts.yaml"
 network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-partitions.yml

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-tpu.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-tpu.yml
@@ -29,7 +29,7 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm6-tpu.yaml"
 network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-slurm-v6-tpu.yml

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml
@@ -24,7 +24,7 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004-v6.yaml"
 network: "{{ test_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 post_deploy_tests:
 - test-validation/test-mounts.yml

--- a/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
+++ b/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
@@ -21,7 +21,7 @@ zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-gromacs.yaml"
 network: "{{ test_name }}-net"
-login_node: "{{ slurm_cluster_name }}-login-*"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 # Image name to be used to filter logs from /var/log/messages for startup script.
 image_name: "slurm-gcp-dev-hpc-rocky-linux-8-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/validate_configs/test_configs/config-ssh.yaml
+++ b/tools/validate_configs/test_configs/config-ssh.yaml
@@ -76,7 +76,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
 

--- a/tools/validate_configs/test_configs/gpu-v6.yaml
+++ b/tools/validate_configs/test_configs/gpu-v6.yaml
@@ -180,7 +180,6 @@ deployment_groups:
     use:
     - network_slurm
     settings:
-      name_prefix: login
       enable_login_public_ips: true
       machine_type: a2-highgpu-1g
 

--- a/tools/validate_configs/test_configs/hpc-cluster-simple-nfs-sql.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-simple-nfs-sql.yaml
@@ -76,5 +76,4 @@ deployment_groups:
     use:
     - network1
     settings:
-      name_prefix: login
       enable_login_public_ips: true

--- a/tools/validate_configs/test_configs/node-groups-v6.yaml
+++ b/tools/validate_configs/test_configs/node-groups-v6.yaml
@@ -156,7 +156,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
 

--- a/tools/validate_configs/test_configs/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/validate_configs/test_configs/slurm-gcp-v6-startup-scripts.yaml
@@ -103,7 +103,6 @@ deployment_groups:
     use:
     - network
     settings:
-      name_prefix: login
       enable_login_public_ips: true
 
   - id: slurm_controller

--- a/tools/validate_configs/test_configs/zone-policies-slurm-v6.yaml
+++ b/tools/validate_configs/test_configs/zone-policies-slurm-v6.yaml
@@ -76,7 +76,6 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [network]
     settings:
-      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
 


### PR DESCRIPTION
* Avoid instance names like `xxx-slurm-login-login-yyy`;
* Makes blueprints more compact by removing need to always specify `var. name_prefix`.
