### PR TITLE
Slurm6. Fix order of clean up.

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/scripts/cleanup_compute.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/scripts/cleanup_compute.sh
@@ -29,19 +29,6 @@ if ! type -P gcloud 1>/dev/null; then
 	exit 1
 fi
 
-echo "Deleting resource policies"
-policies_filter="name:${cluster_name}-*"
-while true; do
-	policies=$(gcloud compute resource-policies list --project "${project}" --format="value(selfLink)" --filter="${policies_filter}" --limit=10 | paste -sd " " -)
-	if [[ -z "${policies}" ]]; then
-		break
-	fi
-	# The lack of quotes is intentional and causes each new space-separated "word" to
-	# be treated as independent arguments. See PR#2523
-	# shellcheck disable=SC2086
-	gcloud compute resource-policies delete --quiet ${policies}
-done
-
 echo "Deleting compute nodes"
 node_filter="labels.slurm_cluster_name=${cluster_name} AND labels.slurm_instance_role=compute"
 while true; do
@@ -53,4 +40,17 @@ while true; do
 	# be treated as independent arguments. See PR#2523
 	# shellcheck disable=SC2086
 	gcloud compute instances delete --quiet ${nodes}
+done
+
+echo "Deleting resource policies"
+policies_filter="name:${cluster_name}-*"
+while true; do
+	policies=$(gcloud compute resource-policies list --project "${project}" --format="value(selfLink)" --filter="${policies_filter}" --limit=10 | paste -sd " " -)
+	if [[ -z "${policies}" ]]; then
+		break
+	fi
+	# The lack of quotes is intentional and causes each new space-separated "word" to
+	# be treated as independent arguments. See PR#2523
+	# shellcheck disable=SC2086
+	gcloud compute resource-policies delete --quiet ${policies}
 done


### PR DESCRIPTION
No other changes, just swapping places of two blocks of code

Correct order:

1. Delete instances;
2. Delete resource policies.

