### PR TITLE
Prevent multiple instances of these tests because will fail due to static network name & multi-group fails to cleanup

### DIFF
--- a/tools/cloud-build/daily-tests/builds/hcls-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls-v6.yaml
@@ -34,6 +34,22 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
+# While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -x -e
+    echo $TRIGGER_BUILD_CONFIG_PATH
+    MATCHING_BUILDS=$(gcloud builds list --ongoing --format 'value(id)' --filter='substitutions.TRIGGER_BUILD_CONFIG_PATH="$TRIGGER_BUILD_CONFIG_PATH"')
+    MATCHING_COUNT=$(echo $$MATCHING_BUILDS | wc -w)
+    if [ "$$MATCHING_COUNT" -gt 1 ]; then
+        echo "Found more than 1 matching running builds"
+        echo "$$MATCHING_BUILDS"
+        exit 1
+    fi
 ## Test simple golang build
 - id: build_ghpc
   waitFor: ["-"]
@@ -55,7 +71,7 @@ steps:
 
 # Test hcls-v6
 - id: hcls-v6
-  waitFor: ["fetch_builder", "build_ghpc"]
+  waitFor: ["fetch_builder", "build_ghpc", "check_for_running_build"]
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash
   env:

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -34,6 +34,22 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
+# While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -x -e
+    echo $TRIGGER_BUILD_CONFIG_PATH
+    MATCHING_BUILDS=$(gcloud builds list --ongoing --format 'value(id)' --filter='substitutions.TRIGGER_BUILD_CONFIG_PATH="$TRIGGER_BUILD_CONFIG_PATH"')
+    MATCHING_COUNT=$(echo $$MATCHING_BUILDS | wc -w)
+    if [ "$$MATCHING_COUNT" -gt 1 ]; then
+        echo "Found more than 1 matching running builds"
+        echo "$$MATCHING_BUILDS"
+        exit 1
+    fi
 - id: hcls
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash

--- a/tools/cloud-build/daily-tests/builds/ml-slurm-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm-v6.yaml
@@ -26,6 +26,22 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
+# While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -x -e
+    echo $TRIGGER_BUILD_CONFIG_PATH
+    MATCHING_BUILDS=$(gcloud builds list --ongoing --format 'value(id)' --filter='substitutions.TRIGGER_BUILD_CONFIG_PATH="$TRIGGER_BUILD_CONFIG_PATH"')
+    MATCHING_COUNT=$(echo $$MATCHING_BUILDS | wc -w)
+    if [ "$$MATCHING_COUNT" -gt 1 ]; then
+        echo "Found more than 1 matching running builds"
+        echo "$$MATCHING_BUILDS"
+        exit 1
+    fi
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it
 - id: ml-slurm-v6


### PR DESCRIPTION
Until we can roll back #2530, these tests will fail and fail to cleanup if multiple instances are running at the same time.

Manually tested by submitting multiple runs.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
