### PR TITLE
Add debugging output to spack and ramble installations

### DIFF
--- a/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
+++ b/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
@@ -143,14 +143,15 @@
       when: lock_out.rc != 0
 
     rescue:
-    - name: Timed out on lock, get install directory contents
-      ansible.builtin.command: "ls -ltra {{ lock_dir }}"
+    - name: Timed out on waiting for lock, get lock directory contents
+      ansible.builtin.find: 
+        paths: "{{ lock_dir }}"
       register: lock_dir_contents
 
-    - name: Print install directory contents with host that failed to install spack
+    - name: Print lock directory contents, it should contain name of host that is holding lock
       ansible.builtin.debug:
-        msg: "{{ lock_dir_contents.stdout }}"
+        msg: "{{ lock_dir_contents.files|map(attribute='path')|map('basename')|list }}"
       
     - name: Failed to get lock
       ansible.builtin.fail:
-        msg: "Failed to get lock, exiting"
+        msg: "Timeout waiting on lock for ${sw_name}, exiting"

--- a/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
+++ b/community/modules/scripts/ramble-setup/templates/ramble_setup.yml.tftpl
@@ -84,6 +84,12 @@
     changed_when: lock_out.rc == 0
     failed_when: false
 
+  - name: Add hostname to lock_dir
+    ansible.builtin.file:
+      path:  "{{ lock_dir }}/{{ ansible_hostname }}"
+      state: touch
+    when: lock_out.rc == 0
+
   - name: Clone branch or tag into installation directory
     ansible.builtin.command: git clone --branch {{ git_ref }} {{ git_url }} {{ install_dir }}
     failed_when: false
@@ -127,9 +133,24 @@
     when: lock_out.rc == 0
 
   - name: Wait for lock
-    ansible.builtin.wait_for:
-      path: "{{ lock_dir }}/done"
-      state: present
-      timeout: 600
-      sleep: 10
-    when: lock_out.rc != 0
+    block: 
+    - name: Wait for lock
+      ansible.builtin.wait_for:
+        path: "{{ lock_dir }}/done"
+        state: present
+        timeout: 600
+        sleep: 10
+      when: lock_out.rc != 0
+
+    rescue:
+    - name: Timed out on lock, get install directory contents
+      ansible.builtin.command: "ls -ltra {{ lock_dir }}"
+      register: lock_dir_contents
+
+    - name: Print install directory contents with host that failed to install spack
+      ansible.builtin.debug:
+        msg: "{{ lock_dir_contents.stdout }}"
+      
+    - name: Failed to get lock
+      ansible.builtin.fail:
+        msg: "Failed to get lock, exiting"

--- a/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
+++ b/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
@@ -143,14 +143,15 @@
       when: lock_out.rc != 0
 
     rescue:
-    - name: Timed out on lock, get install directory contents
-      ansible.builtin.command: "ls -ltra {{ lock_dir }}"
+    - name: Timed out on waiting for lock, get lock directory contents
+      ansible.builtin.find: 
+        paths: "{{ lock_dir }}"
       register: lock_dir_contents
 
-    - name: Print install directory contents with host that failed to install spack
+    - name: Print lock directory contents, it should contain name of host that is holding lock
       ansible.builtin.debug:
-        msg: "{{ lock_dir_contents.stdout }}"
+        msg: "{{ lock_dir_contents.files|map(attribute='path')|map('basename')|list }}"
       
     - name: Failed to get lock
       ansible.builtin.fail:
-        msg: "Failed to get lock, exiting"
+        msg: "Timeout waiting on lock for ${sw_name}, exiting"

--- a/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
+++ b/community/modules/scripts/spack-setup/templates/spack_setup.yml.tftpl
@@ -84,6 +84,12 @@
     changed_when: lock_out.rc == 0
     failed_when: false
 
+  - name: Add hostname to lock_dir
+    ansible.builtin.file:
+      path:  "{{ lock_dir }}/{{ ansible_hostname }}"
+      state: touch
+    when: lock_out.rc == 0
+
   - name: Clone branch or tag into installation directory
     ansible.builtin.command: git clone --branch {{ git_ref }} {{ git_url }} {{ install_dir }}
     failed_when: false
@@ -127,9 +133,24 @@
     when: lock_out.rc == 0
 
   - name: Wait for lock
-    ansible.builtin.wait_for:
-      path: "{{ lock_dir }}/done"
-      state: present
-      timeout: 600
-      sleep: 10
-    when: lock_out.rc != 0
+    block: 
+    - name: Wait for lock
+      ansible.builtin.wait_for:
+        path: "{{ lock_dir }}/done"
+        state: present
+        timeout: 600
+        sleep: 10
+      when: lock_out.rc != 0
+
+    rescue:
+    - name: Timed out on lock, get install directory contents
+      ansible.builtin.command: "ls -ltra {{ lock_dir }}"
+      register: lock_dir_contents
+
+    - name: Print install directory contents with host that failed to install spack
+      ansible.builtin.debug:
+        msg: "{{ lock_dir_contents.stdout }}"
+      
+    - name: Failed to get lock
+      ansible.builtin.fail:
+        msg: "Failed to get lock, exiting"


### PR DESCRIPTION
When running the spack and ramble installations if something fails it's difficult to know which node to check for failure because it depends on which got the lock first.  This is the first step to make debugging easier. 

This update prints the hostname of the node that has the lock to the lock directory and if it fails it will print out the contents of the lock directory, which will then have the hostname of the node that failed.

After this PR is approved, the next step should be to get the stderr of any command that fails, write it to a file in the lock directory, then print the contents in the rescue block of the ansible playbook.

This was tested by deploying a blueprint that uses spack and ramble, waiting until a node had gotten the lock, then suspending that node, forcing the other nodes to timeout and print the new debug messages.

Failed output looks like:

```
May 10 13:57:17 ramble-test-0 google_metadata_script_runner: startup-script: TASK [Wait for lock] ***********************************************************
May 10 14:01:01 ramble-test-0 systemd: Started Session 4 of user root.
May 10 14:02:43 ramble-test-0 systemd: Starting GCE Workload Certificate refresh...
May 10 14:02:43 ramble-test-0 gce_workload_cert_refresh: 2024/05/10 14:02:43: Done
May 10 14:02:43 ramble-test-0 systemd: Started GCE Workload Certificate refresh.
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script: fatal: [localhost]: FAILED! => {
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script:     "changed": false,
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script:     "elapsed": 600
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script: }
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script: MSG:
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script: Timeout when waiting for file /shared/.install_spack_lock/done
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:17 ramble-test-0 google_metadata_script_runner: startup-script: TASK [Timed out on lock, get install directory contents] ***********************
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: changed: [localhost]
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: TASK [Print install directory contents with host that failed to install spack] ***
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: ok: [localhost] => {}
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: MSG:
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: total 8
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: -rw-r--r-- 1 root root    0 May 10 13:57 ramble-test-4
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: drwxr-xr-x 2 root root 4096 May 10 13:57 .
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: drwxr-xr-x 4 root root 4096 May 10 13:57 ..
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: TASK [Failed to get lock] ******************************************************
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: fatal: [localhost]: FAILED! => {
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script:     "changed": false
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: }
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: MSG:
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script:
May 10 14:07:18 ramble-test-0 google_metadata_script_runner: startup-script: Failed to get lock, exiting
```