### PR TITLE
Update to show example of the private-service-access in hpc-enterprise-slurm

### DIFF
--- a/examples/hpc-enterprise-slurm-v6.yaml
+++ b/examples/hpc-enterprise-slurm-v6.yaml
@@ -50,6 +50,10 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  - id: private-service-access
+    source: community/modules/network/private-service-access
+    use: [network]
+
   - id: controller_sa
     source: community/modules/project/service-account
     settings:
@@ -88,9 +92,10 @@ deployment_groups:
 
   - id: projectsfs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private-service-access]
     settings:
       local_mount: /projects
+      connect_mode: PRIVATE_SERVICE_ACCESS
 
   # This file system has an associated license cost.
   # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -57,6 +57,10 @@ deployment_groups:
   - id: network1
     source: modules/network/pre-existing-vpc
 
+  - id: private-service-access
+    source: community/modules/network/private-service-access
+    use: [network1]
+
   - id: controller_sa
     source: community/modules/project/service-account
     settings:
@@ -95,9 +99,10 @@ deployment_groups:
 
   - id: projectsfs
     source: modules/file-system/filestore
-    use: [network1]
+    use: [network1, private-service-access]
     settings:
       local_mount: /projects
+      connect_mode: PRIVATE_SERVICE_ACCESS
 
   # This file system has an associated license cost.
   # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm-v6.yaml
@@ -18,6 +18,7 @@ tags:
 - m.DDN-EXAScaler
 - m.dashboard
 - m.filestore
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -18,6 +18,7 @@ tags:
 - m.dashboard
 - m.filestore
 - m.pre-existing-vpc
+- m.private-service-access
 - m.schedmd-slurm-gcp-v5-controller
 - m.schedmd-slurm-gcp-v5-login
 - m.schedmd-slurm-gcp-v5-node-group


### PR DESCRIPTION
Adds the `private-service-access` module to the hpc-enterprise-slurm blueprints and updates the `projectsfs` module to use PSA as an example.