### PR TITLE
Update A3 blueprint guidance for reservations

### DIFF
--- a/examples/machine-learning/README.md
+++ b/examples/machine-learning/README.md
@@ -134,8 +134,8 @@ staff. A common setting is `PERIODIC`, shown below, but this value must be
 confirmed with Google staff.
 
 ```yaml
-  # a3_reservation_name should be empty string by default; if Google staff
-  # have provided you with a reservation, supply it here
+  # a3_reservation_name must be specified; if Google staff have provided you
+  # with a reservation name, use it. Otherwise supply user-created reservation.
   a3_reservation_name: reservation-name-provided-by-google
   # a3_maintenance_interval should be empty string by default; if Google staff
   # have created a reservation, they will also provide a3_maintenance_interval
@@ -158,18 +158,21 @@ gcloud compute reservations create a3-reservation-0 \
     --machine-type=a3-highgpu-8g \
     --vm-count=${N_VMS} \
     --zone=${ZONE} \
+    --require-specific-reservation \
     --log-http
 ```
 
-This reservation will be [automatically consumed by VMs][consume] created
-with matching parameters (e.g. A3 VM type in configured zone). In this
-scenario, you may leave `a3_reservation_name` and `a3_maintenance_interval`
-at their default empty values in `ml-slurm-a3-2-cluster.yaml`.
+This reservation be must be specified when creating VMs with matching parameters
+(e.g. A3 VM type in configured zone). If you executed the command above without
+modification, you may leave `a3_reservation_name` and `a3_maintenance_interval`
+at their default values in `ml-slurm-a3-2-cluster.yaml`. Otherwise, ensure that
+the reservation name in the blueprint matches the name of the user-created
+reservation.
 
 ```yaml
-  # a3_reservation_name should be empty string by default; if Google staff
-  # have provided you with a reservation, supply it here
-  a3_reservation_name: ""
+  # a3_reservation_name must be specified; if Google staff have provided you
+  # with a reservation name, use it. Otherwise supply user-created reservation.
+  a3_reservation_name: a3-reservation-0
   # a3_maintenance_interval should be empty string by default; if Google staff
   # have created a reservation, they will also provide a3_maintenance_interval
   a3_maintenance_interval: ""

--- a/examples/machine-learning/ml-slurm-a3-2-cluster.yaml
+++ b/examples/machine-learning/ml-slurm-a3-2-cluster.yaml
@@ -38,9 +38,9 @@ vars:
   enable_cleanup_subscriptions: true
   a3_partition_name: a3
   a3_static_cluster_size: 32
-  # a3_reservation_name should be empty string by default; if Google staff
-  # have provided you with a reservation, supply it here
-  a3_reservation_name: ""
+  # a3_reservation_name must be specified; if Google staff have provided you
+  # with a reservation name, use it. Otherwise supply user-created reservation.
+  a3_reservation_name: a3-reservation-0
   # a3_maintenance_interval should be empty string by default; if Google staff
   # have created a reservation, they will also provide a3_maintenance_interval
   a3_maintenance_interval: ""


### PR DESCRIPTION
Soon, a3-highgpu-8g VMs will not be consumable via automatic reservations. Update the guidance to use specific reservations only.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
