### PR TITLE
Fix: allow tasks_per_node to pass through as null

### DIFF
--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -22,7 +22,7 @@ locals {
 locals {
   instance_template = coalesce(var.instance_template, module.instance_template.self_link)
 
-  tasks_per_node = coalesce(var.task_count_per_node, (var.mpi_mode ? 1 : null))
+  tasks_per_node = var.task_count_per_node != null ? var.task_count_per_node : (var.mpi_mode ? 1 : null)
 
   job_template_contents = templatefile(
     "${path.module}/templates/batch-job-base.yaml.tftpl",


### PR DESCRIPTION
This reverts a bug introduced in #2259. The template is designed to take accept null value. `coalesce` does not allow for null value leading to the following error under some conditions:

```
Error: Error in function call

  on modules/batch-job-template-ef98/main.tf line 25, in locals:
  25:   tasks_per_node = coalesce(var.task_count_per_node, (var.mpi_mode ? 1 : null))
    ├────────────────
    │ while calling coalesce(vals...)
    │ var.mpi_mode is false
    │ var.task_count_per_node is null

Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
