### PR TITLE
Proceed with destruction of other groups even if current failed

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
@@ -23,6 +24,7 @@ import (
 	"hpc-toolkit/pkg/shell"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -78,9 +80,16 @@ func runDestroyCmd(cmd *cobra.Command, args []string) {
 		case config.TerraformKind:
 			err = destroyTerraformGroup(groupDir)
 		default:
-			err = fmt.Errorf("group %s is an unsupported kind %s", groupDir, group.Kind().String())
+			err = fmt.Errorf("group %q is an unsupported kind %q", groupDir, group.Kind().String())
 		}
-		checkErr(err, ctx)
+
+		if err != nil {
+			logging.Error("failed to destroy group %q:\n%s", group.Name, renderError(err, *ctx))
+			if i == 0 || !destroyChoice(bp.Groups[i-1].Name) {
+				logging.Fatal("destruction of %q failed", deplRoot)
+			}
+		}
+
 	}
 
 	modulewriter.WritePackerDestroyInstructions(os.Stdout, packerManifests)
@@ -93,4 +102,32 @@ func destroyTerraformGroup(groupDir string) error {
 	}
 
 	return shell.Destroy(tf, getApplyBehavior())
+}
+
+func destroyChoice(nextGroup config.GroupName) bool {
+	switch getApplyBehavior() {
+	case shell.AutomaticApply:
+		return true
+	case shell.PromptBeforeApply:
+		// pass; proceed with prompt
+	default:
+		return false
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Printf("Do you want to delete the next group %q [y/n]?: ", nextGroup)
+
+		in, err := reader.ReadString('\n')
+		if err != nil {
+			logging.Fatal("%v", err)
+		}
+
+		switch strings.ToLower(strings.TrimSpace(in)) {
+		case "y":
+			return true
+		case "n":
+			return false
+		}
+	}
 }


### PR DESCRIPTION
**Motivation:** to accommodate destruction of multi-group deployments where
non-last group failed to deploy.

* Add a prompt `"Do you want to delete the next group %q [Y/n]?: "`;
* Re-use `--auto-approve` flag.

**Testing:**

```yaml
vars:
  project_id:  xxxx
  deployment_name: grifon

deployment_groups:
- group: a
  modules:
  - id: A
    source: /tools/identity
- group: b
  modules:
  - id: B
    source: /tools/identity
    use: [A]
```

```sh
(p311) @gigi:~/wp/hpc-toolkit (symphony_of_destruction %)$ ./ghpc create tst2.yaml
...
(p311) @gigi:~/wp/hpc-toolkit (symphony_of_destruction %)$ ./ghpc destroy grifon
collecting outputs for group "b" from group "a"
failed to import inputs for group "b": The configuration file "grifon/.ghpc/artifacts/a_outputs.tfvars" could not be read. - consider running "ghpc export-outputs grifon/a"
Initializing deployment group grifon/b
Testing if deployment group grifon/b requires destroying cloud infrastructure
failed to destroy group "b":
Error: exit status 1

Error: No value for required variable

  on variables.tf line 27:
  27: variable "value_A" {

The root module input variable "value_A" is not set, and has no default
value. Use a -var or -var-file command line argument to provide a value for
this variable.

Hint: terraform plan for deployment group grifon/b failed; run "ghpc export-outputs" on previous deployment groups to define inputs
Do you want to delete the next group "a" [Y/n]?:
Do you want to delete the next group "a" [Y/n]?: j
Do you want to delete the next group "a" [Y/n]?: n
destruction of "grifon" failed

(p311) @gigi:~/wp/hpc-toolkit (symphony_of_destruction %)$ ./ghpc destroy grifon
...
Do you want to delete the next group "a" [Y/n]?: y
Initializing deployment group grifon/a
Testing if deployment group grifon/a requires destroying cloud infrastructure
Cloud infrastructure in deployment group grifon/a is already destroyed

(p311) @gigi:~/wp/hpc-toolkit (symphony_of_destruction %)$ ./ghpc destroy grifon --auto-approve
...
failed to destroy group "b":
...
Testing if deployment group grifon/a requires destroying cloud infrastructure
Cloud infrastructure in deployment group grifon/a is already destroyed
```
