### PR TITLE
Revert private-service-access usage in Filestore examples

### DIFF
--- a/examples/hpc-enterprise-slurm-v6.yaml
+++ b/examples/hpc-enterprise-slurm-v6.yaml
@@ -50,10 +50,6 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
-  - id: private-service-access
-    source: community/modules/network/private-service-access
-    use: [network]
-
   - id: controller_sa
     source: community/modules/project/service-account
     settings:
@@ -92,10 +88,9 @@ deployment_groups:
 
   - id: projectsfs
     source: modules/file-system/filestore
-    use: [network, private-service-access]
+    use: [network]
     settings:
       local_mount: /projects
-      connect_mode: PRIVATE_SERVICE_ACCESS
 
   # This file system has an associated license cost.
   # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -57,10 +57,6 @@ deployment_groups:
   - id: network1
     source: modules/network/pre-existing-vpc
 
-  - id: private-service-access
-    source: community/modules/network/private-service-access
-    use: [network1]
-
   - id: controller_sa
     source: community/modules/project/service-account
     settings:
@@ -99,10 +95,9 @@ deployment_groups:
 
   - id: projectsfs
     source: modules/file-system/filestore
-    use: [network1, private-service-access]
+    use: [network1]
     settings:
       local_mount: /projects
-      connect_mode: PRIVATE_SERVICE_ACCESS
 
   # This file system has an associated license cost.
   # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm-v6.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm-v6.yaml
@@ -18,7 +18,6 @@ tags:
 - m.DDN-EXAScaler
 - m.dashboard
 - m.filestore
-- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -18,7 +18,6 @@ tags:
 - m.dashboard
 - m.filestore
 - m.pre-existing-vpc
-- m.private-service-access
 - m.schedmd-slurm-gcp-v5-controller
 - m.schedmd-slurm-gcp-v5-login
 - m.schedmd-slurm-gcp-v5-node-group


### PR DESCRIPTION
This commit cleanly reverts commit 1ccdbb9c2ba460fd97f040d7674599f2cf52fc2c (i.e. directly reverses the change).

Reasoning: we have observed failures of the integration tests after this update. It may be related to the nearly simultaneous upgrade to TPG 5.x:

https://github.com/hashicorp/terraform-provider-google/issues/16697

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
