### PR TITLE
Eliminate resource naming collision in PBS Pro integration test

### DIFF
--- a/tools/validate_configs/test_configs/pbs-unwrapped.yaml
+++ b/tools/validate_configs/test_configs/pbs-unwrapped.yaml
@@ -21,9 +21,9 @@ vars:
   region: us-central1
   zone: us-central1-c
   client_host_count: 1
-  client_hostname_prefix: pbs-client
+  client_hostname_prefix: $(vars.deployment_name)-client
   execution_host_count: 3
-  execution_hostname_prefix: pbs-execution
+  execution_hostname_prefix: $(vars.deployment_name)-execution
   pbs_client_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-client-2021.1.3.20220217134230-0.el7.x86_64.rpm
   pbs_execution_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-execution-2021.1.3.20220217134230-0.el7.x86_64.rpm
   pbs_server_rpm_url: gs://replace-pbspro-rpm-bucket/pbspro-server-2021.1.3.20220217134230-0.el7.x86_64.rpm


### PR DESCRIPTION
Use newer feature that allows "recursive" variable definitions to eliminate source of resource naming conflict

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
