### PR TITLE
Improve Private Service Access experience

### DIFF
--- a/community/modules/network/private-service-access/README.md
+++ b/community/modules/network/private-service-access/README.md
@@ -86,5 +86,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_connect_mode"></a> [connect\_mode](#output\_connect\_mode) | Services that use Private Service Access typically specify connect\_mode<br>"PRIVATE\_SERVICE\_ACCESS". This output value sets connect\_mode and additionally<br>blocks terraform actions until the VPC connection has been created. |
 | <a name="output_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#output\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection that was created by the service provider. |
+| <a name="output_reserved_ip_range"></a> [reserved\_ip\_range](#output\_reserved\_ip\_range) | Named IP range to be used by services connected with Private Service Access. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/network/private-service-access/outputs.tf
+++ b/community/modules/network/private-service-access/outputs.tf
@@ -19,3 +19,20 @@ output "private_vpc_connection_peering" {
   sensitive   = true
   value       = google_service_networking_connection.private_vpc_connection.peering
 }
+
+output "connect_mode" {
+  description = <<-EOT
+    Services that use Private Service Access typically specify connect_mode
+    "PRIVATE_SERVICE_ACCESS". This output value sets connect_mode and additionally
+    blocks terraform actions until the VPC connection has been created.
+    EOT
+  value       = "PRIVATE_SERVICE_ACCESS"
+  depends_on = [
+    google_service_networking_connection.private_vpc_connection,
+  ]
+}
+
+output "reserved_ip_range" {
+  description = "Named IP range to be used by services connected with Private Service Access."
+  value       = google_compute_global_address.private_ip_alloc.name
+}

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -183,10 +183,9 @@ No modules.
 | <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | NFS mount options to mount file system. | `string` | `"defaults,_netdev"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resource name of the instance. | `string` | `null` | no |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is connected given in the format:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
-| <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | Peering name for private access service on VPC | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Filestore instance will be created. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Location for Filestore instances at Enterprise tier. | `string` | n/a | yes |
-| <a name="input_reserved_ip_range"></a> [reserved\_ip\_range](#input\_reserved\_ip\_range) | Reserved IP range for Filestore instance (set to null to enable automatic selection) | `string` | `null` | no |
+| <a name="input_reserved_ip_range"></a> [reserved\_ip\_range](#input\_reserved\_ip\_range) | Reserved IP range for Filestore instance. Users are encouraged to set to null<br>for automatic selection. If supplied, it must be:<br><br>CIDR format when var.connect\_mode == "DIRECT\_PEERING"<br>Named IP Range when var.connect\_mode == "PRIVATE\_SERVICE\_ACCESS"<br><br>See Cloud documentation for more details:<br><br>https://cloud.google.com/filestore/docs/creating-instances#configure_a_reserved_ip_address_range | `string` | `null` | no |
 | <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `1024` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Location for Filestore instances below Enterprise tier. | `string` | n/a | yes |
 

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -107,28 +107,32 @@ variable "connect_mode" {
   description = "Used to select mode - supported values DIRECT_PEERING and PRIVATE_SERVICE_ACCESS."
   type        = string
   default     = "DIRECT_PEERING"
+  nullable    = false
+  validation {
+    condition     = contains(["DIRECT_PEERING", "PRIVATE_SERVICE_ACCESS"], var.connect_mode)
+    error_message = "Allowed values for connect_mode are \"DIRECT_PEERING\" or \"PRIVATE_SERVICE_ACCESS\"."
+  }
 }
 
 variable "reserved_ip_range" {
-  description = "Reserved IP range for Filestore instance (set to null to enable automatic selection)"
+  description = <<-EOT
+    Reserved IP range for Filestore instance. Users are encouraged to set to null
+    for automatic selection. If supplied, it must be:
+
+    CIDR format when var.connect_mode == "DIRECT_PEERING"
+    Named IP Range when var.connect_mode == "PRIVATE_SERVICE_ACCESS"
+
+    See Cloud documentation for more details:
+
+    https://cloud.google.com/filestore/docs/creating-instances#configure_a_reserved_ip_address_range
+  EOT
   type        = string
   default     = null
   nullable    = true
-
-  validation {
-    condition     = var.reserved_ip_range == null || can(cidrhost(var.reserved_ip_range, 0))
-    error_message = "IP address range must be in CIDR format."
-  }
 }
 
 variable "mount_options" {
   description = "NFS mount options to mount file system."
   type        = string
   default     = "defaults,_netdev"
-}
-
-variable "private_vpc_connection_peering" {
-  description = "Peering name for private access service on VPC"
-  type        = string
-  default     = null
 }


### PR DESCRIPTION
- output the reserved IP range by name which is necessary for Filestore API when using Private Service Access
- output connect_mode to PRIVATE_SERVICE_ACCESS with dependency upon the peering being established; this services as useful graph dependency and for Toolkit "use" keyword
- modify the Filestore module to perform cross-variable validation when values are provided from the private-services-access module

The following error can be triggered at "terraform plan" by setting `reserved_ip_range: 10.0.0.0/28` in any of our Filestore examples

```
╷
│ Error: Resource precondition failed
│
│   on modules/embedded/modules/file-system/filestore/main.tf line 84, in resource "google_filestore_instance" "filestore_instance":
│   84:       condition = (
│   85:         var.reserved_ip_range == null ||
│   86:         var.connect_mode == "DIRECT_PEERING" && can(cidrhost(var.reserved_ip_range, 0)) && contains(["24", "29"], try(split("/", var.reserved_ip_range)[1], "")) ||
│   87:         var.connect_mode == "PRIVATE_SERVICE_ACCESS" && var.private_vpc_connection_peering != null && var.reserved_ip_range != null
│   88:       )
│     ├────────────────
│     │ var.connect_mode is "DIRECT_PEERING"
│     │ var.private_vpc_connection_peering is null
│     │ var.reserved_ip_range is "10.0.0.0/28"
│
│ If connect_mode is set to DIRECT_PEERING and reserved_ip_range is
│ specified then it must be a CIDR IP range with suffix range size 29.
│ If connect_mode is set to PRIVATE_SERVICE_ACCESS, then the name
│ of the private VPC connection peering and the name of reserved IP
│ range must also be supplied.
╵
```

From the relevant help section:

```
         reserved-ip-range
            The reserved-ip-range can have one of the following two types of
            values: a CIDR range value when using DIRECT_PEERING connect mode
            or an allocated IP address range
            (https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)
            when using PRIVATE_SERVICE_ACCESS connect mode. When the name of an
            allocated IP address range is specified, it must be one of the
            ranges associated with the private service access connection. When
            specified as a direct CIDR value, it must be a /29 CIDR block for
            Basic tier or a /24 CIDR block for High Scale, Zonal, Enterprise or
            Regional tier in one of the internal IP address ranges
            (https://www.arin.net/knowledge/address_filters.html) that
            identifies the range of IP addresses reserved for this instance.
            For example, 10.0.0.0/29 or 192.168.0.0/24. The range you specify
            can't overlap with either existing subnets or assigned IP address
            ranges for other Cloud Filestore instances in the selected VPC
            network.
         connect-mode
            Network connection mode used by instances. CONNECT_MODE must be one
            of: DIRECT_PEERING or PRIVATE_SERVICE_ACCESS.
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
