### PR TITLE
Babysit. Better interraption

### DIFF
--- a/tools/cloud-build/babysit/runner.py
+++ b/tools/cloud-build/babysit/runner.py
@@ -92,7 +92,10 @@ def run(args: RunnerArgs, ui: UIProto) -> None:
         return
 
     cb = cloudbuild_v1.services.cloud_build.CloudBuildClient()
-    Babysitter(ui, cb, args.project, sha, selectors, args.concurrency, args.retries).do()
+    try:
+        Babysitter(ui, cb, args.project, sha, selectors, args.concurrency, args.retries).do()
+    except KeyboardInterrupt:
+        print("User interrupted") # TODO: use UI to log
 
 def run_from_notebook(
         pr: int,


### PR DESCRIPTION
**Before:**
````sh
...
status update: PENDING > WORKING        PR-test-slurm-gcp-v6-centos7    https://console.cloud.google.com/cloud-build/builds/...
^CTraceback (most recent call last):
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/./tools/cloud-build/babysit/run", line 34, in <module>
    run_from_cli()
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/tools/cloud-build/babysit/runner.py", line 130, in run_from_cli
    help="Number of retries, to disable retries set to 0, default is 1")
^^
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/tools/cloud-build/babysit/runner.py", line 95, in run
    try:
    ^^^^^
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/tools/cloud-build/babysit/core.py", line 146, in do
    self.ui.sleep(10)
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/tools/cloud-build/babysit/cli_ui.py", line 53, in sleep
    time.sleep(sec)
KeyboardInterrupt
````

**After:**
```sh
...
PENDING PR-test-spack-gromacs   https://console.cloud.google.com/cloud-build/builds/...
^CUser interrupted
```