### PR TITLE
Make Netapp Volumes work with pre-existing nfs shares

### DIFF
--- a/community/modules/file-system/cloud-storage-bucket/scripts/mount.sh
+++ b/community/modules/file-system/cloud-storage-bucket/scripts/mount.sh
@@ -56,3 +56,6 @@ fi
 echo "Mounting --target ${LOCAL_MOUNT} from fstab"
 mkdir -p "${LOCAL_MOUNT}"
 mount --target "${LOCAL_MOUNT}"
+
+# Support for Netapp Volumes
+chmod a+x "${LOCAL_MOUNT}"

--- a/community/modules/file-system/nfs-server/scripts/mount.sh
+++ b/community/modules/file-system/nfs-server/scripts/mount.sh
@@ -56,3 +56,6 @@ fi
 echo "Mounting --target ${LOCAL_MOUNT} from fstab"
 mkdir -p "${LOCAL_MOUNT}"
 mount --target "${LOCAL_MOUNT}"
+
+# Support for Netapp Volumes
+chmod a+x "${LOCAL_MOUNT}"

--- a/modules/file-system/filestore/scripts/mount.sh
+++ b/modules/file-system/filestore/scripts/mount.sh
@@ -56,3 +56,6 @@ fi
 echo "Mounting --target ${LOCAL_MOUNT} from fstab"
 mkdir -p "${LOCAL_MOUNT}"
 mount --target "${LOCAL_MOUNT}"
+
+# Support for Netapp Volumes
+chmod a+x "${LOCAL_MOUNT}"

--- a/modules/file-system/pre-existing-network-storage/scripts/mount.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount.sh
@@ -56,3 +56,6 @@ fi
 echo "Mounting --target ${LOCAL_MOUNT} from fstab"
 mkdir -p "${LOCAL_MOUNT}"
 mount --target "${LOCAL_MOUNT}"
+
+# Support for Netapp Volumes
+chmod a+x "${LOCAL_MOUNT}"


### PR DESCRIPTION
When using Netapp Volumes as existing mount point world wide execute permissions are missing.
