### PR TITLE
Adopt latest release of google Terraform providers

### DIFF
--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -359,8 +359,8 @@ func (s *zeroSuite) TestGetProviders(c *C) {
 	// no vars
 	c.Check(
 		getProviders(config.Blueprint{}), DeepEquals, []provider{
-			{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, <= 5.28.0", config: config.Dict{}},
-			{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, <= 5.28.0", config: config.Dict{}}})
+			{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, < 5.30.0", config: config.Dict{}},
+			{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, < 5.30.0", config: config.Dict{}}})
 
 	{ // all vars
 		allSet := config.NewDict(map[string]cty.Value{
@@ -376,8 +376,8 @@ func (s *zeroSuite) TestGetProviders(c *C) {
 					"zone":       cty.StringVal("some"),
 				}),
 			}), DeepEquals, []provider{
-				{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, <= 5.28.0", config: allSet},
-				{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, <= 5.28.0", config: allSet}})
+				{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, < 5.30.0", config: allSet},
+				{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, < 5.30.0", config: allSet}})
 	}
 }
 

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -205,8 +205,8 @@ func getProviders(bp config.Blueprint) []provider {
 	}
 
 	return []provider{
-		{"google", "hashicorp/google", ">= 4.84.0, <= 5.28.0", gglConf},
-		{"google-beta", "hashicorp/google-beta", ">= 4.84.0, <= 5.28.0", gglConf},
+		{"google", "hashicorp/google", ">= 4.84.0, < 5.30.0", gglConf},
+		{"google-beta", "hashicorp/google-beta", ">= 4.84.0, < 5.30.0", gglConf},
 	}
 }
 

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84.0, <= 5.28.0"
+      version = ">= 4.84.0, < 5.30.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.84.0, <= 5.28.0"
+      version = ">= 4.84.0, < 5.30.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84.0, <= 5.28.0"
+      version = ">= 4.84.0, < 5.30.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.84.0, <= 5.28.0"
+      version = ">= 4.84.0, < 5.30.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84.0, <= 5.28.0"
+      version = ">= 4.84.0, < 5.30.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.84.0, <= 5.28.0"
+      version = ">= 4.84.0, < 5.30.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84.0, <= 5.28.0"
+      version = ">= 4.84.0, < 5.30.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.84.0, <= 5.28.0"
+      version = ">= 4.84.0, < 5.30.0"
     }
   }
 }


### PR DESCRIPTION
Adopt latest release of google Terraform providers (5.29.x). Change existing pattern to ensure we automatically adopt any patch (X.Y.1) releases if a bug in provider is hotfixed.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
