### PR TITLE
Add instructions output to Slurm controller for SSH command

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -268,6 +268,7 @@ limitations under the License.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_instructions"></a> [instructions](#output\_instructions) | Post deployment instructions. |
 | <a name="output_slurm_bucket_path"></a> [slurm\_bucket\_path](#output\_slurm\_bucket\_path) | Bucket path used by cluster. |
 | <a name="output_slurm_cluster_name"></a> [slurm\_cluster\_name](#output\_slurm\_cluster\_name) | Slurm cluster name. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
@@ -21,3 +21,11 @@ output "slurm_bucket_path" {
   description = "Bucket path used by cluster."
   value       = module.slurm_files.slurm_bucket_path
 }
+
+output "instructions" {
+  description = "Post deployment instructions."
+  value       = <<-EOT
+    To SSH to the controller (may need to add '--tunnel-through-iap'):
+      gcloud compute ssh ${module.slurm_controller_instance.instances_self_links[0]}
+  EOT
+}


### PR DESCRIPTION
Adding `outputs: [instructions]` to controller will print command to SSH.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
