### PR TITLE
feat: Update database version variable in slurm-cloudsql-federation module

### DIFF
--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -73,6 +73,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The version of the database to be created. | `string` | `"MYSQL_5_7"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `string` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the instances. Key-value pairs. | `map(string)` | n/a | yes |

--- a/community/modules/database/slurm-cloudsql-federation/main.tf
+++ b/community/modules/database/slurm-cloudsql-federation/main.tf
@@ -40,7 +40,7 @@ resource "google_sql_database_instance" "instance" {
   name                = local.sql_instance_name
   region              = var.region
   deletion_protection = var.deletion_protection
-  database_version    = "MYSQL_5_7"
+  database_version    = var.database_version
 
   settings {
     user_labels = local.labels

--- a/community/modules/database/slurm-cloudsql-federation/variables.tf
+++ b/community/modules/database/slurm-cloudsql-federation/variables.tf
@@ -14,6 +14,16 @@
  * limitations under the License.
 */
 
+variable "database_version" {
+  description = "The version of the database to be created."
+  type        = string
+  default     = "MYSQL_5_7"
+  validation {
+    condition     = var.database_version == "MYSQL_5_7" || var.database_version == "MYSQL_8_0"
+    error_message = "The database version must be either MYSQL_5_7 or MYSQL_8_0."
+  }
+}
+
 variable "deployment_name" {
   description = "The name of the current deployment"
   type        = string


### PR DESCRIPTION
Adding the ability to pick between database versions in the `slurm-cloudsql-federation` module, defaults to MYSQL_5_7 so as not to break backwards compatibility.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
