### PR TITLE
Allow multiple static IPs for login nodes

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/variables.tf
@@ -105,10 +105,6 @@ variable "static_ips" {
   type        = list(string)
   description = "List of static IPs for VM instances."
   default     = []
-  validation {
-    condition     = length(var.static_ips) <= 1
-    error_message = "The Slurm modules supports 0 or 1 static IPs on controller instance."
-  }
 }
 
 variable "bandwidth_tier" {


### PR DESCRIPTION
Remove outdated check.

When the list is longer than 1, there are as many instances created as static ips provided.