### PR TITLE
Better formatting for "deployment already exists" error

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -273,7 +273,9 @@ func checkOverwriteAllowed(depDir string, bp config.Blueprint, overwriteFlag boo
 	}
 
 	if !overwriteFlag {
-		return fmt.Errorf("deployment folder %q already exists, use -w to overwrite", depDir)
+		return config.HintError{
+			Err:  fmt.Errorf("deployment folder %q already exists", depDir),
+			Hint: "use -w to overwrite"}
 	}
 
 	newGroups := map[config.GroupName]bool{}

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -285,7 +285,7 @@ func (s *MySuite) TestIsOverwriteAllowed_Present(c *C) {
 			Groups: []config.Group{
 				{Name: "isildur"},
 				{Name: "elendil"}}}
-		c.Check(checkOverwriteAllowed(p, bp, noW, noForce), ErrorMatches, ".* already exists, use -w to overwrite")
+		c.Check(checkOverwriteAllowed(p, bp, noW, noForce), ErrorMatches, ".* already exists.*")
 		c.Check(checkOverwriteAllowed(p, bp, yesW, noForce), IsNil)
 	}
 
@@ -304,7 +304,7 @@ func (s *MySuite) TestIsOverwriteAllowed_Present(c *C) {
 			GhpcVersion: "TaleOfBygoneYears",
 			Groups: []config.Group{
 				{Name: "aragorn"}}}
-		c.Check(checkOverwriteAllowed(p, bp, noW, noForce), ErrorMatches, `.* already exists, use -w to overwrite`)
+		c.Check(checkOverwriteAllowed(p, bp, noW, noForce), ErrorMatches, `.* already exists.*`)
 		c.Check(checkOverwriteAllowed(p, bp, yesW, noForce), ErrorMatches, `.*remove a deployment group "isildur".*`)
 		c.Check(checkOverwriteAllowed(p, bp, noW, yesForce), IsNil)
 	}


### PR DESCRIPTION
<img width="730" alt="Screenshot 2024-05-20 at 11 07 41 AM" src="https://github.com/GoogleCloudPlatform/hpc-toolkit/assets/1387442/f1f2e1a7-871c-482d-86df-4f7fabfa106a">

to

<img width="612" alt="Screenshot 2024-05-20 at 11 07 03 AM" src="https://github.com/GoogleCloudPlatform/hpc-toolkit/assets/1387442/ecc77bae-ee1b-4dd9-a06a-4cf98ae3b318">
