### PR TITLE
Allow only specific reservation for nodeset in slurm-gcp v6 nodeset

### DIFF
--- a/community/examples/intel/README.md
+++ b/community/examples/intel/README.md
@@ -1,5 +1,8 @@
 # Intel Solutions for the HPC Toolkit
 
+> **_NOTE:_** The [hpc-slurm-daos.yaml](hpc-slurm-daos.yaml) will not be compatible
+> for newer version of slurm-gcp v6.
+
 <!-- TOC generated with: md_toc github community/examples/intel/README.md | sed -e "s/\s-\s/ * /"-->
 <!-- TOC -->
 

--- a/community/examples/intel/hpc-slurm-daos.yaml
+++ b/community/examples/intel/hpc-slurm-daos.yaml
@@ -37,10 +37,10 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: modules/network/vpc
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//modules/network/vpc?ref=v1.33.0&depth=1
 
   - id: homefs
-    source: modules/file-system/filestore
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//modules/file-system/filestore?ref=v1.33.0&depth=1
     use: [network1]
     settings:
       local_mount: /home
@@ -97,7 +97,7 @@ deployment_groups:
         containers: []
 
   - id: daos-client-script
-    source: modules/scripts/startup-script
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=v1.33.0&depth=1
     settings:
       runners:
       - type: data
@@ -114,7 +114,7 @@ deployment_groups:
         destination: /tmp/daos_client_config.sh
 
   - id: debug_nodeset
-    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/compute/schedmd-slurm-gcp-v6-nodeset?ref=v1.33.0&depth=1
     use: [network1]
     settings:
       name: ns1
@@ -128,7 +128,7 @@ deployment_groups:
       - "https://www.googleapis.com/auth/cloud-platform"
 
   - id: debug_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/compute/schedmd-slurm-gcp-v6-partition?ref=v1.33.0&depth=1
     use: [debug_nodeset]
     settings:
       partition_name: debug
@@ -136,7 +136,7 @@ deployment_groups:
       is_default: true
 
   - id: compute_nodeset
-    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/compute/schedmd-slurm-gcp-v6-nodeset?ref=v1.33.0&depth=1
     use: [network1]
     settings:
       name: ns2
@@ -149,15 +149,16 @@ deployment_groups:
       - "https://www.googleapis.com/auth/cloud-platform"
 
   - id: compute_partition
-    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/compute/schedmd-slurm-gcp-v6-partition?ref=v1.33.0&depth=1
     use: [compute_nodeset]
     settings:
       partition_name: compute
 
   - id: slurm_login
-    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/scheduler/schedmd-slurm-gcp-v6-login?ref=v1.33.0&depth=1
     use: [network1]
     settings:
+      name_prefix: login
       machine_type: n2-standard-4
       enable_login_public_ips: true
       tags: $(vars.tags)
@@ -168,7 +169,7 @@ deployment_groups:
       - "https://www.googleapis.com/auth/cloud-platform"
 
   - id: slurm_controller
-    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    source: github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/scheduler/schedmd-slurm-gcp-v6-controller?ref=v1.33.0&depth=1
     use:
     - network1
     - debug_partition

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -131,13 +131,13 @@ modules. For support with the underlying modules, see the instructions in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.11 |
 
 ## Modules
 
@@ -149,6 +149,7 @@ No modules.
 |------|------|
 | [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 | [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+| [google_compute_reservation.reservation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 
 ## Inputs
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.83"
+      version = ">= 5.11"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
For automatic reservation
```
│   condition     = self.specific_reservation_required
│     ├────────────────
│     │ self.specific_reservation_required is false
│
│ your reservation has to be specific
```

For specific reservation
```
  + specific_reservation = true
```

For reservation doesn't exist
```
couldn't find the reservation
```

Also, this PR pins `hpc-slurm-daos` blueprint to previous version since it will not be supported for future slurm-gcp v6 version due to terraform provider version dependancy.  Other option here would be to update DAOS to use TPG 5.x.


### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
