### PR TITLE
Allow specific reservation for node-group in slurm-gcp v5

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
@@ -96,13 +96,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.11 |
 
 ## Modules
 

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.83"
+      version = ">= 5.11"
     }
   }
   provider_meta "google" {

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
@@ -134,13 +134,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.11 |
 
 ## Modules
 
@@ -152,6 +152,7 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
+| [google_compute_reservation.reservation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 
 ## Inputs

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.83"
+      version = ">= 5.11"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
Manual testing with 3 node-groups

For all specific reservation: --> No errors.

For 1 automatic reservation:
```
│   79:       condition     = coalesce(self.specific_reservation_required, true)
│     ├────────────────
│     │ self.specific_reservation_required is false
│
│ your reservation has to be specific,
│       see https://cloud.google.com/compute/docs/instances/reservations-overview#how-reservations-work
│       for more information. if it's intentionally automatic, don't specify
│       it in the blueprint.
```

For 2 automatic reservation:
```
Plan: 33 to add, 0 to change, 0 to destroy.
╷
│ Error: Resource postcondition failed
│
│   on modules/embedded/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf line 79, in data "google_compute_reservation" "reservation":
│   79:       condition     = coalesce(self.specific_reservation_required, true)
│     ├────────────────
│     │ self.specific_reservation_required is false
│
│ your reservation has to be specific,
│       see https://cloud.google.com/compute/docs/instances/reservations-overview#how-reservations-work
│       for more information. if it's intentionally automatic, don't specify
│       it in the blueprint.
╵
╷
│ Error: Resource postcondition failed
│
│   on modules/embedded/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf line 79, in data "google_compute_reservation" "reservation":
│   79:       condition     = coalesce(self.specific_reservation_required, true)
│     ├────────────────
│     │ self.specific_reservation_required is false
│
│ your reservation has to be specific,
│       see https://cloud.google.com/compute/docs/instances/reservations-overview#how-reservations-work
│       for more information. if it's intentionally automatic, don't specify
│       it in the blueprint.
```

For 1 automatic and 1 not found.
```
Plan: 33 to add, 0 to change, 0 to destroy.
╷
│ Error: Resource postcondition failed
│
│   on modules/embedded/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf line 74, in data "google_compute_reservation" "reservation":
│   74:       condition     = self.self_link != null
│     ├────────────────
│     │ self.self_link is null
│
│ couldn't find the reservation helloautomaticreservation123}
╵
╷
│ Error: Resource postcondition failed
│
│   on modules/embedded/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf line 79, in data "google_compute_reservation" "reservation":
│   79:       condition     = coalesce(self.specific_reservation_required, true)
│     ├────────────────
│     │ self.specific_reservation_required is false
│
│ your reservation has to be specific,
│       see https://cloud.google.com/compute/docs/instances/reservations-overview#how-reservations-work
│       for more information. if it's intentionally automatic, don't specify
│       it in the blueprint.
```
### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
