### PR TITLE
Revert "Allow specific reservation for node-group in slurm-gcp v5"

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md
@@ -96,13 +96,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.11 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.11"
+      version = ">= 3.83"
     }
   }
   provider_meta "google" {

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
@@ -134,13 +134,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.11 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 
@@ -152,7 +152,6 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
-| [google_compute_reservation.reservation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 
 ## Inputs

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/main.tf
@@ -30,8 +30,6 @@ locals {
 
   all_zones      = toset(concat([var.zone], tolist(var.zones)))
   excluded_zones = [for z in data.google_compute_zones.available.names : z if !contains(local.all_zones, z)]
-
-  reservation_map = { for x in var.node_groups : x.reservation_name => x }
 }
 
 data "google_compute_zones" "available" {
@@ -59,30 +57,4 @@ module "slurm_partition" {
   partition_conf                    = local.partition_conf
   partition_startup_scripts         = local.ghpc_startup_script
   partition_startup_scripts_timeout = var.partition_startup_scripts_timeout
-}
-
-# tflint-ignore: terraform_unused_declarations
-data "google_compute_reservation" "reservation" {
-  project = var.project_id
-  zone    = var.zone
-
-  for_each = local.reservation_map
-  name     = each.value.reservation_name
-
-  lifecycle {
-    postcondition {
-      condition     = self.self_link != null
-      error_message = "couldn't find the reservation ${each.value.reservation_name}}"
-    }
-
-    postcondition {
-      condition     = coalesce(self.specific_reservation_required, true)
-      error_message = <<EOT
-      your reservation has to be specific,
-      see https://cloud.google.com/compute/docs/instances/reservations-overview#how-reservations-work
-      for more information. if it's intentionally automatic, don't specify
-      it in the blueprint.
-      EOT
-    }
-  }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-partition/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.11"
+      version = ">= 3.83"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/hpc-toolkit#2614 - clean rollback.

Errors seen in deployments that did not include reservations.