### PR TITLE
Use SocketsPerBoard instead of Socket in enterprise blueprint

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -189,7 +189,7 @@ deployment_groups:
       disk_type: pd-ssd
       disk_size_gb: 100
       node_conf:
-        Sockets: 2
+        SocketsPerBoard: 2
         CoresPerSocket: 24
 
   # use `-p a208` to submit jobs to this partition:
@@ -218,7 +218,7 @@ deployment_groups:
       disk_type: pd-ssd
       disk_size_gb: 100
       node_conf:
-        Sockets: 2
+        SocketsPerBoard: 2
         CoresPerSocket: 24
 
   # use `-p a216` to submit jobs to this partition:


### PR DESCRIPTION
Recently we updated the logic for calculating SocketsPerBoard: https://github.com/GoogleCloudPlatform/slurm-gcp/pull/113/files

#### Before
```
[ext_harshthakkar_google_com@hpc01-login-login-001 ~]$ sinfo
sinfo: error: NodeNames=hpc01-a216nodeset-[0-15] Sockets=# and SocketsPerBoard=# is invalid , using SocketsPerBoard
sinfo: error: NodeNames=hpc01-a216nodeset-[0-15] CPUs=48 match no Sockets, Sockets*CoresPerSocket or Sockets*CoresPerSocket*ThreadsPerCore. Resetting CPUs.
sinfo: error: NodeNames=hpc01-a28nodeset-[0-15] Sockets=# and SocketsPerBoard=# is invalid , using SocketsPerBoard
sinfo: error: NodeNames=hpc01-a28nodeset-[0-15] CPUs=48 match no Sockets, Sockets*CoresPerSocket or Sockets*CoresPerSocket*ThreadsPerCore. Resetting CPUs.
sinfo: error: NodeNames=hpc01-c2dnodeset-[0-19] Sockets=# and SocketsPerBoard=# is invalid , using SocketsPerBoard
sinfo: error: NodeNames=hpc01-c2nodeset-[0-19] Sockets=# and SocketsPerBoard=# is invalid , using SocketsPerBoard
sinfo: error: NodeNames=hpc01-c3nodeset-[0-19] Sockets=# and SocketsPerBoard=# is invalid , using SocketsPerBoard
sinfo: error: NodeNames=hpc01-h3nodeset-[0-15] Sockets=# and SocketsPerBoard=# is invalid , using SocketsPerBoard
sinfo: error: NodeNames=hpc01-n2nodeset-[0-3] Sockets=# and SocketsPerBoard=# is invalid , using SocketsPerBoard
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
a208         up   infinite     16  idle~ hpc01-a28nodeset-[0-15]
a216         up   infinite     16  idle~ hpc01-a216nodeset-[0-15]
c2           up   infinite     20  idle~ hpc01-c2nodeset-[0-19]
c2d          up   infinite     20  idle~ hpc01-c2dnodeset-[0-19]
c3           up   infinite     20  idle~ hpc01-c3nodeset-[0-19]
h3           up   infinite     16  idle~ hpc01-h3nodeset-[0-15]
n2*          up   infinite      4  idle~ hpc01-n2nodeset-[0-3]
```


#### After
```
[ext_harshthakkar_google_com@hpc01-controller ~]$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
a208         up   infinite     16  idle~ hpc01-a28nodeset-[0-15]
a216         up   infinite     16  idle~ hpc01-a216nodeset-[0-15]
c2           up   infinite     20  idle~ hpc01-c2nodeset-[0-19]
c2d          up   infinite     20  idle~ hpc01-c2dnodeset-[0-19]
c3           up   infinite     20  idle~ hpc01-c3nodeset-[0-19]
h3           up   infinite     16  idle~ hpc01-h3nodeset-[0-15]
n2*          up   infinite      4  idle~ hpc01-n2nodeset-[0-3]
```





### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
