### PR TITLE
Add options to specify authorized networks for slurm-cloudsql

### DIFF
--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -73,6 +73,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | IP address ranges as authorized networks of the Cloud SQL for MySQL instances | `list(string)` | `[]` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The version of the database to be created. | `string` | `"MYSQL_5_7"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `string` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |

--- a/community/modules/database/slurm-cloudsql-federation/main.tf
+++ b/community/modules/database/slurm-cloudsql-federation/main.tf
@@ -49,6 +49,15 @@ resource "google_sql_database_instance" "instance" {
       ipv4_enabled                                  = false
       private_network                               = var.network_id
       enable_private_path_for_google_cloud_services = true
+
+      dynamic "authorized_networks" {
+        for_each = var.authorized_networks
+        iterator = ip_range
+
+        content {
+          value = ip_range.value
+        }
+      }
     }
   }
 }

--- a/community/modules/database/slurm-cloudsql-federation/variables.tf
+++ b/community/modules/database/slurm-cloudsql-federation/variables.tf
@@ -14,6 +14,13 @@
  * limitations under the License.
 */
 
+variable "authorized_networks" {
+  description = "IP address ranges as authorized networks of the Cloud SQL for MySQL instances"
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "database_version" {
   description = "The version of the database to be created."
   type        = string


### PR DESCRIPTION
This PR adds the options to specify authorized network range for slurm-cloudsql