### PR TITLE
Initial commit for adding in `terraform_providers` block to ghpc

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,6 +363,14 @@ func (bp Blueprint) ListUnusedVariables() []string {
 	for _, v := range bp.Validators {
 		ns["validator_"+v.Validator] = v.Inputs.AsObject()
 	}
+	for k, v := range bp.TerraformProviders {
+		ns["bp_provider_"+k] = v.Configuration.AsObject()
+	}
+	for _, grp := range bp.Groups {
+		for k, v := range grp.TerraformProviders {
+			ns["grp_"+string(grp.Name)+"_provider_"+k] = v.Configuration.AsObject()
+		}
+	}
 
 	var used = map[string]bool{
 		"labels":          true, // automatically added

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,9 +68,10 @@ func (n GroupName) Validate() error {
 
 // Group defines a group of Modules that are all executed together
 type Group struct {
-	Name             GroupName        `yaml:"group"`
-	TerraformBackend TerraformBackend `yaml:"terraform_backend,omitempty"`
-	Modules          []Module         `yaml:"modules"`
+	Name               GroupName                     `yaml:"group"`
+	TerraformBackend   TerraformBackend              `yaml:"terraform_backend,omitempty"`
+	TerraformProviders map[string]TerraformProviders `yaml:"terraform_providers,omitempty"`
+	Modules            []Module                      `yaml:"modules"`
 	// DEPRECATED fields
 	deprecatedKind interface{} `yaml:"kind,omitempty"` //lint:ignore U1000 keep in the struct for backwards compatibility
 }
@@ -176,6 +177,11 @@ type TerraformBackend struct {
 	Configuration Dict
 }
 
+// TerraformProvider defines the configuration for the terraform providers
+type TerraformProviders struct {
+	Providers Dict
+}
+
 // ModuleKind abstracts Toolkit module kinds (presently: packer/terraform)
 type ModuleKind struct {
 	kind string
@@ -261,8 +267,9 @@ type Blueprint struct {
 	Validators               []Validator `yaml:"validators,omitempty"`
 	ValidationLevel          int         `yaml:"validation_level,omitempty"`
 	Vars                     Dict
-	Groups                   []Group          `yaml:"deployment_groups"`
-	TerraformBackendDefaults TerraformBackend `yaml:"terraform_backend_defaults,omitempty"`
+	Groups                   []Group                       `yaml:"deployment_groups"`
+	TerraformBackendDefaults TerraformBackend              `yaml:"terraform_backend_defaults,omitempty"`
+	TerraformProviders       map[string]TerraformProviders `yaml:"terraform_providers,omitempty"`
 
 	// internal & non-serializable fields
 
@@ -299,6 +306,9 @@ func (bp *Blueprint) Expand() error {
 		return err
 	}
 	if err := checkBackend(Root.Backend, bp.TerraformBackendDefaults); err != nil {
+		return err
+	}
+	if err := checkProviders(Root.Provider, bp.TerraformProviders); err != nil {
 		return err
 	}
 	if err := bp.expandVars(); err != nil {
@@ -464,6 +474,7 @@ func checkModulesAndGroups(bp Blueprint) error {
 		}
 
 		errs.Add(checkBackend(pg.Backend, grp.TerraformBackend))
+		errs.Add(checkProviders(pg.Provider, grp.TerraformProviders))
 	}
 	return errs.OrNil()
 }
@@ -482,6 +493,29 @@ func checkBackend(bep backendPath, be TerraformBackend) error {
 	val, perr := parseYamlString(be.Type)
 	if _, is := IsExpressionValue(val); is || perr != nil {
 		return BpError{bep.Type, errors.New("can not use expression as a terraform_backend type")}
+	}
+	return nil
+}
+
+func checkProviders(pp providerPath, tp map[string]TerraformProviders) error {
+	for k, v := range tp {
+		if k != "google" && k != "google-beta" {
+			if !v.Providers.Has("source") {
+				return BpError{pp.Type, errors.New(
+					fmt.Sprintf("non-google or google-beta provider, %s, is missing source", k))}
+			} else if !v.Providers.Has("version") {
+				return BpError{pp.Type, errors.New(
+					fmt.Sprintf("non-google or google-beta provider, %s, is missing version", k))}
+			}
+		} else {
+			if v.Providers.Has("source") {
+				return BpError{pp.Type, errors.New(
+					fmt.Sprintf("%s provider was specified, do not include source", k))}
+			} else if v.Providers.Has("version") {
+				return BpError{pp.Type, errors.New(
+					fmt.Sprintf("%s provider was specified, do not include version", k))}
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -549,6 +549,8 @@ func (s *zeroSuite) TestCheckBackend(c *C) {
 	}
 }
 
+// TODO: Add CheckProviders
+
 func (s *zeroSuite) TestSkipValidator(c *C) {
 	{
 		bp := Blueprint{Validators: nil}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -553,12 +553,12 @@ func (s *zeroSuite) TestCheckProviders(c *C) {
 	p := Root.Groups.At(173).Provider
 
 	{ // OK. Absent
-		c.Check(checkProviders(p, map[string]TerraformProviders{}), IsNil)
+		c.Check(checkProviders(p, map[string]TerraformProvider{}), IsNil)
 	}
 
 	{ // OK. All required values used
-		tp := map[string]TerraformProviders{
-			"test-provider": TerraformProviders{
+		tp := map[string]TerraformProvider{
+			"test-provider": TerraformProvider{
 				Source:  "test-src",
 				Version: "test-ver",
 				Configuration: Dict{}.
@@ -570,8 +570,8 @@ func (s *zeroSuite) TestCheckProviders(c *C) {
 	}
 
 	{ // FAIL. Missing Source
-		tp := map[string]TerraformProviders{
-			"test-provider": TerraformProviders{
+		tp := map[string]TerraformProvider{
+			"test-provider": TerraformProvider{
 				Version: "test-ver",
 				Configuration: Dict{}.
 					With("project", cty.StringVal("test-prj")).
@@ -582,23 +582,11 @@ func (s *zeroSuite) TestCheckProviders(c *C) {
 	}
 
 	{ // FAIL. Missing Version
-		tp := map[string]TerraformProviders{
-			"test-provider": TerraformProviders{
+		tp := map[string]TerraformProvider{
+			"test-provider": TerraformProvider{
 				Source: "test-src",
 				Configuration: Dict{}.
 					With("project", cty.StringVal("test-prj")).
-					With("region", cty.StringVal("reg1")).
-					With("zone", cty.StringVal("zone1")).
-					With("universe_domain", cty.StringVal("test-universe.com"))}}
-		c.Check(checkProviders(p, tp), NotNil)
-	}
-
-	{ // FAIL. Missing required Dict entry
-		tp := map[string]TerraformProviders{
-			"test-provider": TerraformProviders{
-				Source:  "test-src",
-				Version: "test-ver",
-				Configuration: Dict{}.
 					With("region", cty.StringVal("reg1")).
 					With("zone", cty.StringVal("zone1")).
 					With("universe_domain", cty.StringVal("test-universe.com"))}}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -549,7 +549,62 @@ func (s *zeroSuite) TestCheckBackend(c *C) {
 	}
 }
 
-// TODO: Add CheckProviders
+func (s *zeroSuite) TestCheckProviders(c *C) {
+	p := Root.Groups.At(173).Provider
+
+	{ // OK. Absent
+		c.Check(checkProviders(p, map[string]TerraformProviders{}), IsNil)
+	}
+
+	{ // OK. All required values used
+		tp := map[string]TerraformProviders{
+			"test-provider": TerraformProviders{
+				Source:  "test-src",
+				Version: "test-ver",
+				Configuration: Dict{}.
+					With("project", cty.StringVal("test-prj")).
+					With("region", cty.StringVal("reg1")).
+					With("zone", cty.StringVal("zone1")).
+					With("universe_domain", cty.StringVal("test-universe.com"))}}
+		c.Check(checkProviders(p, tp), IsNil)
+	}
+
+	{ // FAIL. Missing Source
+		tp := map[string]TerraformProviders{
+			"test-provider": TerraformProviders{
+				Version: "test-ver",
+				Configuration: Dict{}.
+					With("project", cty.StringVal("test-prj")).
+					With("region", cty.StringVal("reg1")).
+					With("zone", cty.StringVal("zone1")).
+					With("universe_domain", cty.StringVal("test-universe.com"))}}
+		c.Check(checkProviders(p, tp), NotNil)
+	}
+
+	{ // FAIL. Missing Version
+		tp := map[string]TerraformProviders{
+			"test-provider": TerraformProviders{
+				Source: "test-src",
+				Configuration: Dict{}.
+					With("project", cty.StringVal("test-prj")).
+					With("region", cty.StringVal("reg1")).
+					With("zone", cty.StringVal("zone1")).
+					With("universe_domain", cty.StringVal("test-universe.com"))}}
+		c.Check(checkProviders(p, tp), NotNil)
+	}
+
+	{ // FAIL. Missing required Dict entry
+		tp := map[string]TerraformProviders{
+			"test-provider": TerraformProviders{
+				Source:  "test-src",
+				Version: "test-ver",
+				Configuration: Dict{}.
+					With("region", cty.StringVal("reg1")).
+					With("zone", cty.StringVal("zone1")).
+					With("universe_domain", cty.StringVal("test-universe.com"))}}
+		c.Check(checkProviders(p, tp), NotNil)
+	}
+}
 
 func (s *zeroSuite) TestSkipValidator(c *C) {
 	{

--- a/pkg/config/materialize.go
+++ b/pkg/config/materialize.go
@@ -31,6 +31,10 @@ func (bp *Blueprint) Materialize() error {
 		return err
 	}
 
+	if err := bp.evalGhpcStageInTerraformProviderConfiguration(); err != nil {
+		return err
+	}
+
 	for ig := range bp.Groups {
 		if err := materizalizeGroup(bp, &bp.Groups[ig]); err != nil {
 			return err

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -135,7 +135,7 @@ type rootPath struct {
 	Vars            dictPath                    `path:"vars"`
 	Groups          arrayPath[groupPath]        `path:"deployment_groups"`
 	Backend         backendPath                 `path:"terraform_backend_defaults"`
-	Provider        providerPath                `path:"terraform_providers"`
+	Provider        mapPath[providerPath]       `path:"terraform_providers"`
 }
 
 type validatorCfgPath struct {
@@ -155,15 +155,16 @@ type backendPath struct {
 
 type providerPath struct {
 	basePath
-	Type          basePath `path:".type"`
-	Configuration dictPath `path:".provider_configuration"`
+	Source        basePath `path:".source"`
+	Version       basePath `path:".version"`
+	Configuration dictPath `path:".configuration"`
 }
 
 type groupPath struct {
 	basePath
 	Name     basePath              `path:".group"`
 	Backend  backendPath           `path:".terraform_backend"`
-	Provider providerPath          `path:".terraform_provider"`
+	Provider mapPath[providerPath] `path:".terraform_provider"`
 	Modules  arrayPath[ModulePath] `path:".modules"`
 }
 

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -135,6 +135,7 @@ type rootPath struct {
 	Vars            dictPath                    `path:"vars"`
 	Groups          arrayPath[groupPath]        `path:"deployment_groups"`
 	Backend         backendPath                 `path:"terraform_backend_defaults"`
+	Provider        providerPath                `path:"terraform_providers"`
 }
 
 type validatorCfgPath struct {
@@ -152,11 +153,18 @@ type backendPath struct {
 	Configuration dictPath `path:".configuration"`
 }
 
+type providerPath struct {
+	basePath
+	Type          basePath `path:".type"`
+	Configuration dictPath `path:".provider_configuration"`
+}
+
 type groupPath struct {
 	basePath
-	Name    basePath              `path:".group"`
-	Backend backendPath           `path:".terraform_backend"`
-	Modules arrayPath[ModulePath] `path:".modules"`
+	Name     basePath              `path:".group"`
+	Backend  backendPath           `path:".terraform_backend"`
+	Provider providerPath          `path:".terraform_provider"`
+	Modules  arrayPath[ModulePath] `path:".modules"`
 }
 
 type ModulePath struct {

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -36,6 +36,7 @@ func TestPath(t *testing.T) {
 		{r.Vars, "vars"},
 		{r.Groups, "deployment_groups"},
 		{r.Backend, "terraform_backend_defaults"},
+		{r.Provider, "terraform_providers"},
 
 		{r.Validators.At(2), "validators[2]"},
 		{r.Validators.At(2).Validator, "validators[2].validator"},
@@ -72,6 +73,12 @@ func TestPath(t *testing.T) {
 		{r.Backend.Type, "terraform_backend_defaults.type"},
 		{r.Backend.Configuration, "terraform_backend_defaults.configuration"},
 		{r.Backend.Configuration.Dot("goo"), "terraform_backend_defaults.configuration.goo"},
+
+		{r.Provider.Dot("goo"), "terraform_providers.goo"},
+		{r.Provider.Dot("goo").Source, "terraform_providers.goo.source"},
+		{r.Provider.Dot("goo").Version, "terraform_providers.goo.version"},
+		{r.Provider.Dot("goo").Configuration, "terraform_providers.goo.configuration"},
+		{r.Provider.Dot("goo").Configuration.Dot("googoo"), "terraform_providers.goo.configuration.googoo"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.want, func(t *testing.T) {

--- a/pkg/config/staging_test.go
+++ b/pkg/config/staging_test.go
@@ -146,6 +146,10 @@ func TestEvalModuleSettings(t *testing.T) {
 		t.Errorf("got unexpected error: %v", err)
 	}
 
+	if err := bp.evalGhpcStageInTerraformProviderConfiguration(); err != nil {
+		t.Errorf("got unexpected error: %v", err)
+	}
+
 	updated := bp.Groups[0].Modules[0].Settings
 	{ // No changes
 		want := `never("changes")`

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -355,59 +355,77 @@ func (s *zeroSuite) TestWriteVariables(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *zeroSuite) TestGetProviders(c *C) {
-	// no vars
-	c.Check(
-		getProviders(config.Blueprint{}, config.Group{}), DeepEquals, []provider{
-			{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, < 5.30.0", config: config.Dict{}},
-			{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, < 5.30.0", config: config.Dict{}}})
-
-	{ // all vars
-		allSet := config.NewDict(map[string]cty.Value{
-			"project": config.GlobalRef("project_id").AsValue(),
-			"region":  config.GlobalRef("region").AsValue(),
-			"zone":    config.GlobalRef("zone").AsValue(),
-		})
-		c.Check(
-			getProviders(config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{
-					"project_id": cty.StringVal("some"),
-					"region":     cty.StringVal("some"),
-					"zone":       cty.StringVal("some"),
-				})}, config.Group{},
-			), DeepEquals, []provider{
-				{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, < 5.30.0", config: allSet},
-				{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, < 5.30.0", config: allSet}})
-	}
-}
-
 func (s *zeroSuite) TestWriteProviders(c *C) {
 	// Setup
 	dir := c.MkDir()
-	zebra := provider{alias: "zebra", source: "hashicorp/zebra", version: "~> 2", config: config.Dict{}}
-	elephant := provider{
-		alias:   "elephant",
-		source:  "savannah/elephant",
-		version: "~> 8",
-		config: config.NewDict(map[string]cty.Value{
-			"smeller":   config.GlobalRef("long").AsValue(),
-			"listeners": config.GlobalRef("spacious").AsValue()})}
-
+	providers := map[string]config.TerraformProvider{
+		"elephant": config.TerraformProvider{
+			Source:  "savannah/elephant",
+			Version: "~> 8",
+			Configuration: config.NewDict(map[string]cty.Value{
+				"smeller":   config.GlobalRef("long").AsValue(),
+				"listeners": config.GlobalRef("spacious").AsValue()})},
+		"zebra": config.TerraformProvider{
+			Source:        "hashicorp/zebra",
+			Version:       "~> 2",
+			Configuration: config.Dict{}}}
 	{ // FAIL, non existing path
-		c.Check(writeProviders([]provider{zebra}, "not/a/real/path"), NotNil)
+		c.Check(writeProviders(providers, "not/a/real/path"), NotNil)
 	}
 
 	{ // OK
-		c.Check(writeProviders([]provider{zebra, elephant}, dir), IsNil)
+		c.Check(writeProviders(providers, dir), IsNil)
 		b, err := os.ReadFile(filepath.Join(dir, "providers.tf"))
 		c.Assert(err, IsNil)
 		c.Check(string(b), Equals, license+`
-provider "zebra" {
-}
-
 provider "elephant" {
   listeners = var.spacious
   smeller   = var.long
+}
+
+provider "zebra" {
+}
+`)
+	}
+}
+
+func (s *zeroSuite) TestWriteVersions(c *C) {
+	// Setup
+	dir := c.MkDir()
+	providers := map[string]config.TerraformProvider{
+		"elephant": config.TerraformProvider{
+			Source:  "savannah/elephant",
+			Version: "~> 8",
+			Configuration: config.NewDict(map[string]cty.Value{
+				"smeller":   config.GlobalRef("long").AsValue(),
+				"listeners": config.GlobalRef("spacious").AsValue()})},
+		"zebra": config.TerraformProvider{
+			Source:        "hashicorp/zebra",
+			Version:       "~> 2",
+			Configuration: config.Dict{}}}
+
+	{ // FAIL, non existing path
+		c.Check(writeVersions(providers, "not/a/real/path"), NotNil)
+	}
+
+	{ // OK
+		c.Check(writeVersions(providers, dir), IsNil)
+		b, err := os.ReadFile(filepath.Join(dir, "versions.tf"))
+		c.Assert(err, IsNil)
+		c.Check(string(b), Equals, license+`
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    elephant = {
+      source  = "savannah/elephant"
+      version = "~> 8"
+    }
+    zebra = {
+      source  = "hashicorp/zebra"
+      version = "~> 2"
+    }
+  }
 }
 `)
 	}

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -358,9 +358,9 @@ func (s *zeroSuite) TestWriteVariables(c *C) {
 func (s *zeroSuite) TestGetProviders(c *C) {
 	// no vars
 	c.Check(
-		getProviders(config.Blueprint{}), DeepEquals, []provider{
-			{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, < 5.32.0", config: config.Dict{}},
-			{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, < 5.32.0", config: config.Dict{}}})
+		getProviders(config.Blueprint{}, config.Group{}), DeepEquals, []provider{
+			{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, < 5.30.0", config: config.Dict{}},
+			{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, < 5.30.0", config: config.Dict{}}})
 
 	{ // all vars
 		allSet := config.NewDict(map[string]cty.Value{
@@ -374,10 +374,10 @@ func (s *zeroSuite) TestGetProviders(c *C) {
 					"project_id": cty.StringVal("some"),
 					"region":     cty.StringVal("some"),
 					"zone":       cty.StringVal("some"),
-				}),
-			}), DeepEquals, []provider{
-				{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, < 5.32.0", config: allSet},
-				{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, < 5.32.0", config: allSet}})
+				})}, config.Group{},
+			), DeepEquals, []provider{
+				{alias: "google", source: "hashicorp/google", version: ">= 4.84.0, < 5.30.0", config: allSet},
+				{alias: "google-beta", source: "hashicorp/google-beta", version: ">= 4.84.0, < 5.30.0", config: allSet}})
 	}
 }
 

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -211,17 +211,7 @@ func getProviders(bp config.Blueprint, g config.Group) []provider {
 	}
 	var providers []provider
 	for k, v := range g.TerraformProviders {
-		pv := v.Providers.Items()
-		delete(pv, "source")
-		delete(pv, "version")
-		gglConf = config.NewDict(pv)
-		if k == "google" {
-			providers = append(providers, provider{"google", "hashicorp/google", ">= 4.84.0, < 5.30.0", gglConf})
-		} else if k == "google-beta" {
-			providers = append(providers, provider{"google-beta", "hashicorp/google-beta", ">= 4.84.0, < 5.30.0", gglConf})
-		} else {
-			providers = append(providers, provider{k, v.Providers.Get("source").AsString(), v.Providers.Get("version").AsString(), gglConf})
-		}
+		providers = append(providers, provider{k, v.Source, v.Version, v.Configuration})
 	}
 	return providers
 }

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -186,52 +186,23 @@ func writeMain(
 	return writeHclFile(filepath.Join(dst, "main.tf"), hclFile)
 }
 
-type provider struct {
-	alias   string
-	source  string
-	version string
-	config  config.Dict
-}
-
-func getProviders(bp config.Blueprint, g config.Group) []provider {
-	gglConf := config.Dict{}
-	if len(g.TerraformProviders) == 0 {
-		for s, v := range map[string]string{
-			"project": "project_id",
-			"region":  "region",
-			"zone":    "zone"} {
-			if bp.Vars.Has(v) {
-				gglConf = gglConf.With(s, config.GlobalRef(v).AsValue())
-			}
-		}
-		return []provider{
-			{"google", "hashicorp/google", ">= 4.84.0, < 5.30.0", gglConf},
-			{"google-beta", "hashicorp/google-beta", ">= 4.84.0, < 5.30.0", gglConf},
-		}
-	}
-	var providers []provider
-	for k, v := range g.TerraformProviders {
-		providers = append(providers, provider{k, v.Source, v.Version, v.Configuration})
-	}
-	return providers
-}
-
-func writeProviders(providers []provider, dst string) error {
+func writeProviders(providers map[string]config.TerraformProvider, dst string) error {
 	hclFile := hclwrite.NewEmptyFile()
 	hclBody := hclFile.Body()
 
-	for _, prov := range providers {
+	for _, k := range orderKeys(providers) {
 		hclBody.AppendNewline()
-		pb := hclBody.AppendNewBlock("provider", []string{prov.alias}).Body()
+		v := providers[k]
+		pb := hclBody.AppendNewBlock("provider", []string{k}).Body()
 
-		for _, s := range orderKeys(prov.config.Items()) {
-			pb.SetAttributeRaw(s, config.TokensForValue(prov.config.Get(s)))
+		for _, s := range orderKeys(v.Configuration.Items()) {
+			pb.SetAttributeRaw(s, config.TokensForValue(v.Configuration.Get(s)))
 		}
 	}
 	return writeHclFile(filepath.Join(dst, "providers.tf"), hclFile)
 }
 
-func writeVersions(providers []provider, dst string) error {
+func writeVersions(providers map[string]config.TerraformProvider, dst string) error {
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 	body.AppendNewline()
@@ -241,10 +212,11 @@ func writeVersions(providers []provider, dst string) error {
 
 	pb := tfb.AppendNewBlock("required_providers", []string{}).Body()
 
-	for _, p := range providers {
-		pb.SetAttributeValue(p.alias, cty.ObjectVal(map[string]cty.Value{
-			"source":  cty.StringVal(p.source),
-			"version": cty.StringVal(p.version),
+	for _, k := range orderKeys(providers) {
+		v := providers[k]
+		pb.SetAttributeValue(k, cty.ObjectVal(map[string]cty.Value{
+			"source":  cty.StringVal(v.Source),
+			"version": cty.StringVal(v.Version),
 		}))
 	}
 	return writeHclFile(filepath.Join(dst, "versions.tf"), f)
@@ -282,6 +254,8 @@ func (w TFWriter) writeGroup(
 		intergroupInputs[igVar.Name] = true
 	}
 
+	tp := g.TerraformProviders
+
 	// Write main.tf file
 	doctoredModules, err := substituteIgcReferences(g.Modules, intergroupVars)
 	if err != nil {
@@ -306,14 +280,13 @@ func (w TFWriter) writeGroup(
 		return fmt.Errorf("error writing terraform.tfvars file for deployment group %s: %w", g.Name, err)
 	}
 
-	providers := getProviders(bp, g)
 	// Write providers.tf file
-	if err := writeProviders(providers, groupPath); err != nil {
+	if err := writeProviders(tp, groupPath); err != nil {
 		return fmt.Errorf("error writing providers.tf file for deployment group %s: %w", g.Name, err)
 	}
 
 	// Write versions.tf file
-	if err := writeVersions(providers, groupPath); err != nil {
+	if err := writeVersions(tp, groupPath); err != nil {
 		return fmt.Errorf("error writing versions.tf file for deployment group %s: %v", g.Name, err)
 	}
 
@@ -371,8 +344,8 @@ func getUsedDeploymentVars(group config.Group, bp config.Blueprint) map[string]c
 	for _, m := range group.Modules {
 		used = append(used, config.GetUsedDeploymentVars(m.Settings.AsObject())...)
 	}
-	for _, p := range getProviders(bp, group) {
-		used = append(used, config.GetUsedDeploymentVars(p.config.AsObject())...)
+	for _, v := range group.TerraformProviders {
+		used = append(used, config.GetUsedDeploymentVars(v.Configuration.AsObject())...)
 	}
 	for _, v := range used {
 		res[v] = bp.Vars.Get(v)

--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -26,6 +26,7 @@ while (<>){
     pkg/logging 0
     pkg/validators 13
     pkg/inspect 60
+    pkg/modulewriter 79
     pkg 80
   );
 

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -35,6 +35,21 @@ vars:
   zone: us-east4-c
 deployment_groups:
   - group: zero
+    terraform_providers:
+      google:
+        source: hashicorp/google
+        version: '>= 4.84.0, < 5.32.0'
+        configuration:
+          project: ((var.project_id))
+          region: ((var.region))
+          zone: ((var.zone))
+      google-beta:
+        source: hashicorp/google-beta
+        version: '>= 4.84.0, < 5.32.0'
+        configuration:
+          project: ((var.project_id))
+          region: ((var.region))
+          zone: ((var.zone))
     modules:
       - source: modules/network/vpc
         kind: terraform

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
@@ -41,6 +41,21 @@ deployment_groups:
       configuration:
         bucket: ((var.zone))
         prefix: (("igc/${var.deployment_name}/zero"))
+    terraform_providers:
+      google:
+        source: hashicorp/google
+        version: '>= 4.84.0, < 5.32.0'
+        configuration:
+          project: ((var.project_id))
+          region: ((var.region))
+          zone: ((var.zone))
+      google-beta:
+        source: hashicorp/google-beta
+        version: '>= 4.84.0, < 5.32.0'
+        configuration:
+          project: ((var.project_id))
+          region: ((var.region))
+          zone: ((var.zone))
     modules:
       - source: modules/network/vpc
         kind: terraform
@@ -61,6 +76,21 @@ deployment_groups:
       configuration:
         bucket: ((var.zone))
         prefix: (("igc/${var.deployment_name}/one"))
+    terraform_providers:
+      google:
+        source: hashicorp/google
+        version: '>= 4.84.0, < 5.32.0'
+        configuration:
+          project: ((var.project_id))
+          region: ((var.region))
+          zone: ((var.zone))
+      google-beta:
+        source: hashicorp/google-beta
+        version: '>= 4.84.0, < 5.32.0'
+        configuration:
+          project: ((var.project_id))
+          region: ((var.region))
+          zone: ((var.zone))
     modules:
       - source: modules/file-system/filestore
         kind: terraform

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
@@ -36,6 +36,21 @@ vars:
   zone: (("${var.region}-c"))
 deployment_groups:
   - group: zero
+    terraform_providers:
+      google:
+        source: hashicorp/google
+        version: '>= 4.84.0, < 5.32.0'
+        configuration:
+          project: ((var.project_id))
+          region: ((var.region))
+          zone: ((var.zone))
+      google-beta:
+        source: hashicorp/google-beta
+        version: '>= 4.84.0, < 5.32.0'
+        configuration:
+          project: ((var.project_id))
+          region: ((var.region))
+          zone: ((var.zone))
     modules:
       - source: modules/network/vpc
         kind: terraform


### PR DESCRIPTION
As part of a push to decouple the HPC Toolkit from using specific endpoints and universe domains, this PR attempts to add in a new block called `terraform_providers` that allows users to specify new Terraform provider information, allowing them to override the default universe domain and add custom endpoints.

Tested under staging with basic blueprint to create VMs, networks, using staging images.
Currently under test.