### PR TITLE
Add release-chore to initial release-candidate creation PR

### DIFF
--- a/tools/create-release-candidate.sh
+++ b/tools/create-release-candidate.sh
@@ -103,6 +103,7 @@ git commit -m "Increase version to ${NEW_VERSION}"
 git push -u "${REMOTE_NAME}" "${V_BRANCH}"
 echo "Opening pull request to update release-candidate to version ${NEW_VERSION}"
 gh pr create --base "${RC_BRANCH}" --head "${V_BRANCH}" \
+	--label "release-chore" \
 	--title "Update Toolkit release to ${NEW_TAG}" \
 	--body "Set release-candidate to version ${NEW_VERSION}"
 echo


### PR DESCRIPTION
Improve release-candidate version bump by automatically adding the "release-chore" label.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
