### PR TITLE
Modify a3-highgpu-8g blueprint cluster blueprint network

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-2-cluster.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-2-cluster.yaml
@@ -44,9 +44,10 @@ vars:
   # a3_maintenance_interval should be empty string by default; if Google staff
   # have created a reservation, they will also provide a3_maintenance_interval
   a3_maintenance_interval: ""
-  # network parameters should match base blueprint unless network names were modified
-  network_name_system: slurm-sys-net
-  subnetwork_name_system: slurm-sys-subnet
+  # network parameters must match base blueprint deployment_name!
+  # these values are accurate if deployment_name was not modified from example
+  network_name_system: slurm-a3-base-sysnet
+  subnetwork_name_system: slurm-a3-base-sysnet-subnet
 
 deployment_groups:
 - group: cluster


### PR DESCRIPTION
a3-highgpu-8g cluster blueprint is modified to match updated values from 5cb9faa4. These are not caught in our integration tests because they use the default network.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
