### PR TITLE
Add `--skip` and `--only` to `deploy` and `destroy` commands

### DIFF
--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"hpc-toolkit/pkg/config"
+	"testing"
+)
+
+func TestIsGroupSelected(t *testing.T) {
+	type test struct {
+		only  []string
+		skip  []string
+		group config.GroupName
+		want  bool
+	}
+	tests := []test{
+		{nil, nil, "green", true},
+		{[]string{"green"}, nil, "green", true},
+		{[]string{"green"}, nil, "blue", false},
+		{nil, []string{"green"}, "green", false},
+		{nil, []string{"green"}, "blue", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%v;%v;%q", tc.only, tc.skip, tc.group), func(t *testing.T) {
+			flagOnlyGroups, flagSkipGroups = tc.only, tc.skip
+			got := isGroupSelected(tc.group)
+			if got != tc.want {
+				t.Errorf("isGroupSelected(%v) = %v; want %v", tc.group, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateGroupSelectionFlags(t *testing.T) {
+	type test struct {
+		only   []string
+		skip   []string
+		groups []string
+		err    bool
+	}
+	tests := []test{
+		{nil, nil, []string{"green"}, false},
+		{[]string{"green"}, []string{"blue"}, []string{"green", "blue"}, true},
+		{[]string{"green"}, nil, []string{"green"}, false},
+		{[]string{"green"}, nil, []string{"blue"}, true},
+		{nil, []string{"green"}, []string{"green"}, false},
+		{nil, []string{"green"}, []string{"blue"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%v;%v;%v", tc.only, tc.skip, tc.groups), func(t *testing.T) {
+			flagOnlyGroups, flagSkipGroups = tc.only, tc.skip
+			bp := config.Blueprint{}
+			for _, g := range tc.groups {
+				bp.Groups = append(bp.Groups, config.Group{Name: config.GroupName(g)})
+			}
+
+			err := validateGroupSelectionFlags(bp)
+			if tc.err && err == nil {
+				t.Errorf("validateGroupSelectionFlags(%v) = nil; want error", tc.groups)
+			}
+			if !tc.err && err != nil {
+				t.Errorf("validateGroupSelectionFlags(%v) = %v; want nil", tc.groups, err)
+			}
+		})
+	}
+
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,7 +114,7 @@ func (bp *Blueprint) Module(id ModuleID) (*Module, error) {
 	return mod, nil
 }
 
-func hintSpelling(s string, dict []string, err error) error {
+func HintSpelling(s string, dict []string, err error) error {
 	best, minDist := "", maxHintDist+1
 	for _, w := range dict {
 		d := levenshtein.Distance(s, w, nil)

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -320,7 +320,7 @@ func validateModuleReference(bp Blueprint, from Module, toID ModuleID) error {
 		bp.WalkModulesSafe(func(_ ModulePath, m *Module) {
 			mods = append(mods, string(m.ID))
 		})
-		return hintSpelling(string(toID), mods, err)
+		return HintSpelling(string(toID), mods, err)
 	}
 
 	if to.Kind == PackerKind {
@@ -346,7 +346,7 @@ func validateModuleSettingReference(bp Blueprint, mod Module, r Reference) error
 	if r.GlobalVar {
 		if !bp.Vars.Has(r.Name) {
 			err := fmt.Errorf("module %q references unknown global variable %q", mod.ID, r.Name)
-			return hintSpelling(r.Name, bp.Vars.Keys(), err)
+			return HintSpelling(r.Name, bp.Vars.Keys(), err)
 		}
 		return nil
 	}
@@ -358,7 +358,7 @@ func validateModuleSettingReference(bp Blueprint, mod Module, r Reference) error
 			bp.WalkModulesSafe(func(_ ModulePath, m *Module) {
 				hints = append(hints, string(m.ID))
 			})
-			return hintSpelling(string(unkModErr.ID), hints, unkModErr)
+			return HintSpelling(string(unkModErr.ID), hints, unkModErr)
 		}
 		return err
 	}
@@ -375,7 +375,7 @@ func validateModuleSettingReference(bp Blueprint, mod Module, r Reference) error
 
 	if !slices.Contains(outputs, r.Name) {
 		err := fmt.Errorf("module %q does not have output %q", tm.ID, r.Name)
-		return hintSpelling(r.Name, outputs, err)
+		return HintSpelling(r.Name, outputs, err)
 	}
 	return nil
 }

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -181,7 +181,7 @@ func validateSettings(
 		}
 		// Setting not found
 		if _, ok := cVars.Inputs[k]; !ok {
-			err := hintSpelling(k, maps.Keys(cVars.Inputs), UnknownModuleSetting)
+			err := HintSpelling(k, maps.Keys(cVars.Inputs), UnknownModuleSetting)
 			errs.At(sp, err)
 			continue // do not perform other validations
 		}


### PR DESCRIPTION
```sh
$ ./ghpc deploy community/examples/hpc-build-slurm-image.yaml --only=demo-cluster $TOOLKIT_DEFAULT_VARS
Creating deployment folder "build-slurm-1" ...
skipping group "setup"
skipping group "build-slurm"
collecting outputs for group "demo-cluster" from group "setup"
Error: The configuration file "build-slurm-1/.ghpc/artifacts/setup_outputs.tfvars" could not be read.
Hint: consider running "ghpc export-outputs build-slurm-1/setup"
```

```sh
$ ./ghpc deploy community/examples/hpc-build-slurm-image.yaml --skip=setup,build-slurm $TOOLKIT_DEFAULT_VARS
Creating deployment folder "build-slurm-1" ...
skipping group "setup"
skipping group "build-slurm"
collecting outputs for group "demo-cluster" from group "setup"
Error: The configuration file "build-slurm-1/.ghpc/artifacts/setup_outputs.tfvars" could not be read.
Hint: consider running "ghpc export-outputs build-slurm-1/setup"
```

```sh
$ ./ghpc deploy community/examples/hpc-build-slurm-image.yaml --only=setub $TOOLKIT_DEFAULT_VARS
Creating deployment folder "build-slurm-1" ...
Error: group "setub" not found
Hint: did you mean "setup"?
```