### PR TITLE
Cleanup A3 Mega images after building them in integration test

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm.yaml
@@ -41,3 +41,24 @@ steps:
     IMAGE_NAME=$(gcloud compute images list --project "${PROJECT_ID}" \
         --no-standard-images --filter="labels.ghpc_deployment~$${BUILD_ID_SHORT}" \
         --format='get(name)' --limit=1)
+
+    echo $${IMAGE_NAME} > /persistent_volume/image_name
+  volumes:
+  - name: 'persistent_volume'
+    path: '/persistent_volume'
+- id: ml-a3-megagpu-slurm-cluster
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+
+    cat /persistent_volume/image_name | xargs -L1 gcloud compute images delete --project "${PROJECT_ID}" --quiet
+  volumes:
+  - name: 'persistent_volume'
+    path: '/persistent_volume'


### PR DESCRIPTION
#2637 included an integration test that confirms the golden image for a3-megagpu-8g clusters can be built. It did not include any cleanup step for new images. This PR corrects that omission.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
