### PR TITLE
Add reference validation to all expressions in blueprint

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -558,7 +558,7 @@ func (s *zeroSuite) TestCheckProviders(c *C) {
 
 	{ // OK. All required values used
 		tp := map[string]TerraformProvider{
-			"test-provider": TerraformProvider{
+			"test-provider": {
 				Source:  "test-src",
 				Version: "test-ver",
 				Configuration: Dict{}.
@@ -571,7 +571,7 @@ func (s *zeroSuite) TestCheckProviders(c *C) {
 
 	{ // FAIL. Missing Source
 		tp := map[string]TerraformProvider{
-			"test-provider": TerraformProvider{
+			"test-provider": {
 				Version: "test-ver",
 				Configuration: Dict{}.
 					With("project", cty.StringVal("test-prj")).
@@ -583,7 +583,7 @@ func (s *zeroSuite) TestCheckProviders(c *C) {
 
 	{ // FAIL. Missing Version
 		tp := map[string]TerraformProvider{
-			"test-provider": TerraformProvider{
+			"test-provider": {
 				Source: "test-src",
 				Configuration: Dict{}.
 					With("project", cty.StringVal("test-prj")).

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -180,11 +180,11 @@ func getDefaultGoogleProviders(bp Blueprint) map[string]TerraformProvider {
 		}
 	}
 	return map[string]TerraformProvider{
-		"google": TerraformProvider{
+		"google": {
 			Source:        "hashicorp/google",
 			Version:       ">= 4.84.0, < 5.32.0",
 			Configuration: gglConf},
-		"google-beta": TerraformProvider{
+		"google-beta": {
 			Source:        "hashicorp/google-beta",
 			Version:       ">= 4.84.0, < 5.32.0",
 			Configuration: gglConf}}

--- a/pkg/config/materialize.go
+++ b/pkg/config/materialize.go
@@ -27,11 +27,7 @@ func (bp *Blueprint) Materialize() error {
 		return err
 	}
 
-	if err := bp.evalGhpcStageInModuleSettings(); err != nil {
-		return err
-	}
-
-	if err := bp.evalGhpcStageInTerraformProviderConfiguration(); err != nil {
+	if err := bp.evalGhpcStage(); err != nil {
 		return err
 	}
 

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -191,3 +191,15 @@ var Root rootPath
 func init() {
 	initPath(&Root, nil, "")
 }
+
+func IsModuleSettingsPath(p Path) bool {
+	parent := p.Parent()
+	if parent == nil {
+		return false
+	}
+	mp, ok := parent.(*ModulePath)
+	if !ok {
+		return false
+	}
+	return p == mp.Settings
+}

--- a/pkg/config/staging.go
+++ b/pkg/config/staging.go
@@ -90,60 +90,23 @@ func (bp *Blueprint) makeGhpcStageFunc() function.Function {
 	})
 }
 
-func evalGhpcStageInDict(items map[string]cty.Value, paths dictPath, ctx *hcl.EvalContext) (map[string]cty.Value, error) {
-	errs := Errors{}
-	us := map[string]cty.Value{}
-	for k, v := range items {
-		uv, err := evalGhpcStageInValue(paths.Dot(k), v, ctx)
-		errs.Add(err)
-		us[k] = uv
-	}
-	return us, errs.OrNil()
-}
-
-// Update module settings in place, evaluating `ghpc_stage` expressions
-func (bp *Blueprint) evalGhpcStageInModuleSettings() error {
+// Partially evaluate all `ghpc_stage` expressions in the blueprint
+func (bp *Blueprint) evalGhpcStage() error {
 	errs := Errors{}
 	ctx, err := bp.evalCtx()
 	if err != nil {
 		return err
 	}
-	bp.WalkModulesSafe(func(mp ModulePath, m *Module) {
-		us, e := evalGhpcStageInDict(m.Settings.Items(), mp.Settings, ctx)
-		m.Settings = NewDict(us)
-		errs.Add(e)
+
+	bp.mutateDicts(func(dp dictPath, d *Dict) Dict {
+		us := map[string]cty.Value{}
+		for k, v := range d.Items() {
+			uv, err := evalGhpcStageInValue(dp.Dot(k), v, ctx)
+			errs.Add(err)
+			us[k] = uv
+		}
+		return NewDict(us)
 	})
-
-	return errs.OrNil()
-}
-
-// Evaluate a terraform provider as an intermediate step
-func evalGhpcStageInProvider(providers map[string]TerraformProvider, path mapPath[providerPath], ctx *hcl.EvalContext) error {
-	errs := Errors{}
-	for k1, v1 := range providers {
-		us, e := evalGhpcStageInDict(v1.Configuration.Items(), path.Dot(k1).Configuration, ctx)
-		v1.Configuration = NewDict(us)
-		errs.Add(e)
-	}
-	return errs.OrNil()
-}
-
-// Update terraform_providers settings in place, evaluating `ghpc_stage` expressions
-func (bp *Blueprint) evalGhpcStageInTerraformProviderConfiguration() error {
-	errs := Errors{}
-	ctx, err := bp.evalCtx()
-	if err != nil {
-		return err
-	}
-
-	// Evaluate default providers
-	errs.Add(evalGhpcStageInProvider(bp.TerraformProviders, Root.Provider, ctx))
-
-	// Evaluate group providers
-	for idx, grp := range bp.Groups {
-		errs.Add(evalGhpcStageInProvider(grp.TerraformProviders, Root.Groups.At(idx).Provider, ctx))
-	}
-
 	return errs.OrNil()
 }
 

--- a/pkg/config/staging_test.go
+++ b/pkg/config/staging_test.go
@@ -130,7 +130,7 @@ func TestPartialEval(t *testing.T) {
 	}
 }
 
-func TestEvalModuleSettings(t *testing.T) {
+func TestEvalGhpcStage(t *testing.T) {
 	mod := Module{
 		Settings: Dict{}.
 			With("war", MustParseExpression(`never("changes")`).AsValue()).
@@ -142,11 +142,7 @@ func TestEvalModuleSettings(t *testing.T) {
 		Groups: []Group{{Modules: []Module{mod}}},
 	}
 
-	if err := bp.evalGhpcStageInModuleSettings(); err != nil {
-		t.Errorf("got unexpected error: %v", err)
-	}
-
-	if err := bp.evalGhpcStageInTerraformProviderConfiguration(); err != nil {
+	if err := bp.evalGhpcStage(); err != nil {
 		t.Errorf("got unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
**BEFORE:**

Only limited set of blocks had reference validation:
* `Vars`;
* `Module.Settings`;
* `TerraformBackend.Configuration` - only would fail after deployment directory is already created.

**AFTER:**

All places that support expressions will perform validation. Added coverage:
* `Validator.Inputs`;
* `TerraformBackend.Configuration` - now validated before materialization;
* `TerraformProvider.Configuration`.

```yaml
...
terraform_providers:
  google:
    version: 3.5.0
    source: well
    configuration:
      cover: $(vars.cover) # is not defined
...
```

```sh
$ make && ./ghpc create tst.yaml -w
**************** building ghpc ************************
Error: variable "cover" not found
35:       cover: $(vars.cover)
```
