### PR TITLE
Add link to newly published A3 Mega documentation

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/README.md
+++ b/examples/machine-learning/a3-megagpu-8g/README.md
@@ -1,7 +1,6 @@
 # A3 Mega / Slurm Blueprint for Google Cloud
 
-Complete instructions for deploying an a3-megagpu-8g cluster running Slurm on
-Google Cloud will be published on cloud.google.com. In the interim, please
-contact your [Technical Account Manager][tam] for guidance.
+To deploy an a3-megagpu-8g cluster running Slurm on Google Cloud, please follow
+these [instructions].
 
-[tam]: https://cloud.google.com/tam
+[instructions]: https://cloud.google.com/hpc-toolkit/docs/deploy/deploy-a3-mega-cluster


### PR DESCRIPTION
This cleanly reverts commit a81fb88bd9e5e8fb29261d1f278fccd02d51e57b to point to our public A3 mega blueprint documentation.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
