### PR TITLE
Move `runners` from `map(string)` to `object`

### DIFF
--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -253,7 +253,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
@@ -301,7 +301,7 @@ No modules.
 | <a name="input_prepend_ansible_installer"></a> [prepend\_ansible\_installer](#input\_prepend\_ansible\_installer) | DEPRECATED. Use `install_ansible=false` to prevent ansible installation. | `bool` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to deploy to | `string` | n/a | yes |
-| <a name="input_runners"></a> [runners](#input\_runners) | List of runners to run on remote VM.<br>    Runners can be of type ansible-local, shell or data.<br>    A runner must specify one of 'source' or 'content'.<br>    All runners must specify 'destination'. If 'destination' does not include a<br>    path, it will be copied in a temporary folder and deleted after running.<br>    Runners may also pass 'args', which will be passed as argument to shell runners only. | `list(map(string))` | `[]` | no |
+| <a name="input_runners"></a> [runners](#input\_runners) | List of runners to run on remote VM.<br>    Runners can be of type ansible-local, shell or data.<br>    A runner must specify one of 'source' or 'content'.<br>    All runners must specify 'destination'. If 'destination' does not include a<br>    path, it will be copied in a temporary folder and deleted after running.<br>    Runners may also pass 'args', which will be passed as argument to shell runners only. | <pre>list(object({<br>    type        = string,<br>    destination = string,<br>    source      = optional(string, null),<br>    content     = optional(string, null),<br>    args        = optional(string, null)<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -134,10 +134,10 @@ locals {
       no_proxy   = var.http_no_proxy,
       runners = [
         for runner in local.runners : {
-          object      = google_storage_bucket_object.scripts[basename(runner["destination"])].output_name
-          type        = runner["type"]
-          destination = runner["destination"]
-          args        = contains(keys(runner), "args") ? runner["args"] : ""
+          object      = google_storage_bucket_object.scripts[basename(runner.destination)].output_name
+          type        = runner.type
+          destination = runner.destination
+          args        = coalesce(lookup(runner, "args", null), "")
         }
       ]
     }
@@ -159,9 +159,9 @@ locals {
   stdlib = join("", local.stdlib_list)
 
   runners_map = { for runner in local.runners :
-    basename(runner["destination"]) => {
-      content = lookup(runner, "content", null)
-      source  = lookup(runner, "source", null)
+    basename(runner.destination) => {
+      content = runner.content
+      source  = runner.source
     }
   }
 }

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.34.1"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
* Limit changes to `startup-script` module only.
* Improve testing around data types by using regex name matching.