### PR TITLE
Add known gpu types and their accelerators to gke module

### DIFF
--- a/community/examples/ml-gke.yaml
+++ b/community/examples/ml-gke.yaml
@@ -50,23 +50,16 @@ deployment_groups:
         cidr_block: $(vars.authorized_cidr)
     outputs: [instructions]
 
-  - id: g2-pool
+  - id: g2_pool
     source: community/modules/compute/gke-node-pool
     use: [gke_cluster]
     settings:
       disk_type: pd-balanced
       machine_type: g2-standard-4
-      guest_accelerator:
-      - type: nvidia-l4
-        count: 1
-        gpu_partition_size: null
-        gpu_sharing_config: null
-        gpu_driver_installation_config:
-        - gpu_driver_version: "DEFAULT"
 
-  - id: job-template
+  - id: job_template
     source: community/modules/compute/gke-job-template
-    use: [g2-pool]
+    use: [g2_pool]
     settings:
       image: nvidia/cuda:11.0.3-runtime-ubuntu20.04
       command:

--- a/community/modules/compute/gke-node-pool/gpu_definition.tf
+++ b/community/modules/compute/gke-node-pool/gpu_definition.tf
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+## Required variables:
+#  guest_accelerator
+#  machine_type
+
+locals {
+  # example state; terraform will ignore diffs if last element of URL matches
+  # guest_accelerator = [
+  #   {
+  #     count = 1
+  #     type  = "https://www.googleapis.com/compute/beta/projects/PROJECT/zones/ZONE/acceleratorTypes/nvidia-tesla-a100"
+  #   },
+  # ]
+  accelerator_machines = {
+    "a2-highgpu-1g"  = { type = "nvidia-tesla-a100", count = 1 },
+    "a2-highgpu-2g"  = { type = "nvidia-tesla-a100", count = 2 },
+    "a2-highgpu-4g"  = { type = "nvidia-tesla-a100", count = 4 },
+    "a2-highgpu-8g"  = { type = "nvidia-tesla-a100", count = 8 },
+    "a2-megagpu-16g" = { type = "nvidia-tesla-a100", count = 16 },
+    "a2-ultragpu-1g" = { type = "nvidia-a100-80gb", count = 1 },
+    "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
+    "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
+    "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
+    "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-12" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-16" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-24" = { type = "nvidia-l4", count = 2 },
+    "g2-standard-32" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-48" = { type = "nvidia-l4", count = 4 },
+    "g2-standard-96" = { type = "nvidia-l4", count = 8 },
+  }
+  generated_guest_accelerator = try([local.accelerator_machines[var.machine_type]], [])
+
+  # Select in priority order:
+  # (1) var.guest_accelerator if not empty
+  # (2) local.generated_guest_accelerator if not empty
+  # (3) default to empty list if both are empty
+  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+}

--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -22,7 +22,8 @@ locals {
 locals {
   sa_email = var.service_account_email != null ? var.service_account_email : data.google_compute_default_service_account.default_sa.email
 
-  has_gpu = var.guest_accelerator != null || contains(["a2", "g2"], local.machine_family)
+  preattached_gpu_machine_family = contains(["a2", "a3", "g2"], local.machine_family)
+  has_gpu                        = local.guest_accelerator != null || local.preattached_gpu_machine_family
   gpu_taint = local.has_gpu ? [{
     key    = "nvidia.com/gpu"
     value  = "present"
@@ -73,16 +74,26 @@ resource "google_container_node_pool" "node_pool" {
   }
 
   node_config {
-    disk_size_gb      = var.disk_size_gb
-    disk_type         = var.disk_type
-    resource_labels   = local.labels
-    labels            = var.kubernetes_labels
-    service_account   = var.service_account_email
-    oauth_scopes      = var.service_account_scopes
-    machine_type      = var.machine_type
-    spot              = var.spot
-    image_type        = var.image_type
-    guest_accelerator = var.guest_accelerator
+    disk_size_gb    = var.disk_size_gb
+    disk_type       = var.disk_type
+    resource_labels = local.labels
+    labels          = var.kubernetes_labels
+    service_account = var.service_account_email
+    oauth_scopes    = var.service_account_scopes
+    machine_type    = var.machine_type
+    spot            = var.spot
+    image_type      = var.image_type
+
+    dynamic "guest_accelerator" {
+      for_each = local.guest_accelerator
+      content {
+        type                           = guest_accelerator.value.type
+        count                          = guest_accelerator.value.count
+        gpu_driver_installation_config = try(guest_accelerator.value.gpu_driver_installation_config, [{ gpu_driver_version = "DEFAULT" }])
+        gpu_partition_size             = try(guest_accelerator.value.gpu_partition_size, null)
+        gpu_sharing_config             = try(guest_accelerator.value.gpu_sharing_config, null)
+      }
+    }
 
     dynamic "taint" {
       for_each = concat(var.taints, local.gpu_taint)
@@ -157,6 +168,12 @@ resource "google_container_node_pool" "node_pool" {
     precondition {
       condition     = !(var.local_ssd_count_ephemeral_storage > 0 && var.local_ssd_count_nvme_block > 0)
       error_message = "Only one of local_ssd_count_ephemeral_storage or local_ssd_count_nvme_block can be set to a non-zero value."
+    }
+
+    # non preattached gpu machine type should always have guest_accelerator config defined
+    precondition {
+      condition     = (local.preattached_gpu_machine_family && length(var.guest_accelerator != null ? var.guest_accelerator : []) >= 0) || (!local.preattached_gpu_machine_family && length(var.guest_accelerator != null ? var.guest_accelerator : []) > 0)
+      error_message = "Non-GPU machine types should have user defined guest_accelerator values"
     }
   }
 }

--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -169,12 +169,6 @@ resource "google_container_node_pool" "node_pool" {
       condition     = !(var.local_ssd_count_ephemeral_storage > 0 && var.local_ssd_count_nvme_block > 0)
       error_message = "Only one of local_ssd_count_ephemeral_storage or local_ssd_count_nvme_block can be set to a non-zero value."
     }
-
-    # non preattached gpu machine type should always have guest_accelerator config defined
-    precondition {
-      condition     = (local.preattached_gpu_machine_family && length(var.guest_accelerator != null ? var.guest_accelerator : []) >= 0) || (!local.preattached_gpu_machine_family && length(var.guest_accelerator != null ? var.guest_accelerator : []) > 0)
-      error_message = "Non-GPU machine types should have user defined guest_accelerator values"
-    }
   }
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1397,8 +1397,11 @@ Toolkit. It includes:
       machine_type: a2-highgpu-2g
   ```
 
-Users only need to provide machine type for standard ["a2", "a3" and "g2"] machine families however for
-other and custom machine families users need to provide the entire configuration as follows:
+  Users only need to provide machine type for standard ["a2", "a3" and "g2"] machine families,
+  while the other settings like `type`, `count` , `gpu_driver_installation_config` will default to
+  machine family specific values.
+  However, for other standard or custom machine families users will need to provide
+  the entire configuration as follows:
 
 ```yaml
 machine_type: n1-standard-1

--- a/examples/README.md
+++ b/examples/README.md
@@ -1382,8 +1382,8 @@ Toolkit. It includes:
 > work. See note below.
 
 * Creation of a regional GKE cluster.
-* Creation of an autoscaling GKE node pool with `g2` machines each with 1
-  attached L4 GPUs. Note: This blueprint has also been tested with `a2` machines,
+* Creation of an autoscaling GKE node pool with `g2` machines.
+  Note: This blueprint has also been tested with `a2` machines,
   but as capacity is hard to find the example uses `g2` machines which have better obtainability.
   If using with `a2` machines it is recommended to first obtain an automatic reservation.
   
@@ -1395,14 +1395,36 @@ Toolkit. It includes:
     settings:
       disk_type: pd-balanced
       machine_type: a2-highgpu-2g
-      guest_accelerator:
-      - type: nvidia-tesla-a100
-        count: 2
-        gpu_partition_size: null
-        gpu_sharing_config: null
-        gpu_driver_installation_config:
-        - gpu_driver_version: "DEFAULT"
   ```
+
+Users only need to provide machine type for standard ["a2", "a3" and "g2"] machine families however for
+other and custom machine families users need to provide the entire configuration as follows:
+
+```yaml
+machine_type: n1-standard-1
+guest_accelerator:
+- type: nvidia-tesla-t4
+  count: 1
+  gpu_partition_size: null
+  gpu_sharing_config: null
+  gpu_driver_installation_config:
+  - gpu_driver_version: "DEFAULT"
+```
+
+Custom g2 pool
+
+```yaml
+machine_type: g2-custom-16-55296
+guest_accelerator:
+- type: nvidia-l4
+  count: 1
+  gpu_partition_size: null
+  gpu_sharing_config:
+  -  max_shared_clients_per_gpu: 2
+      gpu_sharing_strategy: "TIME_SHARING"
+  gpu_driver_installation_config:
+  - gpu_driver_version: "LATEST"
+```
 
 * Configuration of the cluster using default drivers provided by GKE.
 * Creation of a job template yaml file that can be used to submit jobs to the

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -44,6 +44,7 @@ duplicates = [
         "community/modules/compute/schedmd-slurm-gcp-v6-nodeset/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v6-login/gpu_definition.tf",
+        "community/modules/compute/gke-node-pool/gpu_definition.tf",
     ],
     [
         "community/modules/compute/gke-node-pool/threads_per_core_calc.tf",


### PR DESCRIPTION
## Add known gpu types and their accelerators to gke module

Changes in this PR
* Added a gpu file similar to https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/627b43aa3f238242b6ca98a5575541009ac411df/modules/compute/vm-instance/gpu_definition.tf#L29 which allows GKE module to derive the accelerator type and gpu count from the machine type.
* Additionally added "DEFAULT" driver as the default for each of these machine types for now.
