### PR TITLE
Check string literals for absence of expressions

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -517,35 +517,26 @@ func (s *zeroSuite) TestCheckMovedModules(c *C) {
 	c.Assert(checkMovedModule("./community/modules/scheduler/cloud-batch-job"), NotNil)
 }
 
-func (s *zeroSuite) TestCheckBackend(c *C) {
-	p := Root.Groups.At(173).Backend
+func (s *zeroSuite) TestCheckStringLiteral(c *C) {
+	p := Root.BlueprintName // some path
 
 	{ // OK. Absent
-		c.Check(checkBackend(p, TerraformBackend{}), IsNil)
+		c.Check(checkStringLiteral(p, ""), IsNil)
 	}
-
-	{ // OK. No variables used
-		b := TerraformBackend{
-			Type: "gcs",
-			Configuration: Dict{}.
-				With("bucket", cty.StringVal("trenta")).
-				With("impersonate_service_account", cty.StringVal("who"))}
-		c.Check(checkBackend(p, b), IsNil)
+	{ // OK. No expressions
+		c.Check(checkStringLiteral(p, "who"), IsNil)
 	}
 
 	{ // FAIL. Expression in type
-		b := TerraformBackend{Type: "$(vartype)"}
-		c.Check(checkBackend(p, b), NotNil)
+		c.Check(checkStringLiteral(p, "$(vartype)"), NotNil)
 	}
 
 	{ // FAIL. HCL literal
-		b := TerraformBackend{Type: "((var.zen))"}
-		c.Check(checkBackend(p, b), NotNil)
+		c.Check(checkStringLiteral(p, "((var.zen))"), NotNil)
 	}
 
-	{ // OK. Not a variable
-		b := TerraformBackend{Type: "\\$(vartype)"}
-		c.Check(checkBackend(p, b), IsNil)
+	{ // OK. Not an expression
+		c.Check(checkStringLiteral(p, "\\$(vartype)"), IsNil)
 	}
 }
 


### PR DESCRIPTION
```yaml
...
terraform_backend_defaults:
  type: $(5 * var.watermellons)
  configuration:
    bucket: $(vars.shmucket)

terraform_providers:
  $(vars.alphabet):
    version: 3.5.0
    source: $(vars.well)
    configuration:
      $(vars.cover): sick
...
```

```sh
$ make && ./ghpc create tst.yaml -w
**************** building ghpc ************************
Error: can not use expression here
26:   type: $(5 * var.watermellons)
      ^
Error: can not use expression here
31:   $(vars.alphabet):
      ^
Error: can not use expression here
33:     source: $(vars.well)
        ^
Error: can not use expression here
35:       $(vars.cover): sick
          ^
```