### PR TITLE
Add parallelstore module and support for rocky 8, ubuntu 22.04 and     debian 12

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1888,3 +1888,38 @@ To avoid these issues, the `ghpc_stage` function can be used to copy a file (or 
 
 The `ghpc_stage` function will always look first in the path specified in the blueprint. If the file is not found at this path then `ghpc_stage` will look for the staged file in the deployment folder, if a deployment folder exists.
 This means that you can redeploy a blueprint (`ghpc deploy <blueprint> -w`) so long as you have the deployment folder from the original deployment, even if locally referenced files are not available.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_compute_global_address.private_ip_alloc](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_global_address) | resource |
+| [google-beta_google_compute_network.network](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_network) | resource |
+| [google-beta_google_parallelstore_instance.instance](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_parallelstore_instance) | resource |
+| [google-beta_google_service_networking_connection.default](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_service_networking_connection) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_access_points"></a> [access\_points](#output\_access\_points) | Output access points |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/README.md
+++ b/modules/README.md
@@ -91,6 +91,7 @@ Modules that are still in development and less stable are labeled with the
 ### File System
 
 * **[filestore]** ![core-badge] : Creates a [filestore](https://cloud.google.com/filestore) file system.
+* **[parallelstore]** ![core-badge] ![experimental-badge]: Creates a [parallelstore](https://cloud.google.com/parallelstore) file system.
 * **[pre-existing-network-storage]** ![core-badge] : Specifies a
   pre-existing file system that can be mounted on a VM.
 * **[DDN-EXAScaler]** ![community-badge] : Creates
@@ -105,6 +106,7 @@ Modules that are still in development and less stable are labeled with the
   configures an NFS server that can be mounted by other VM.
 
 [filestore]: file-system/filestore/README.md
+[parallelstore]: file-system/parallelstore/README.md
 [pre-existing-network-storage]: file-system/pre-existing-network-storage/README.md
 [ddn-exascaler]: ../community/modules/file-system/DDN-EXAScaler/README.md
 [intel-daos]: ../community/modules/file-system/Intel-DAOS/README.md

--- a/modules/file-system/parallelstore/README.md
+++ b/modules/file-system/parallelstore/README.md
@@ -1,0 +1,68 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 5.25.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 5.25.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_parallelstore_instance.instance](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_parallelstore_instance) | resource |
+| [null_resource.hydration](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment. | `string` | n/a | yes |
+| <a name="input_destination_hydration_parallelstore"></a> [destination\_hydration\_parallelstore](#input\_destination\_hydration\_parallelstore) | The name of local path to import data on parallelstore instance from GCS bucket. | `string` | `"/"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to parallel store instance. | `map(string)` | `{}` | no |
+| <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | The mount point where the contents of the device may be accessed after mounting. | `string` | `"/parallelstore"` | no |
+| <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | Options describing various aspects of the parallelstore instance. | `string` | `"disable-wb-cache,thread-count=16,eq-count=8"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of parallelstore instance. | `string` | `null` | no |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is connected given in the format:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
+| <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
+| <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the parallelstore instance in GB. | `number` | `12000` | no |
+| <a name="input_source_gcs_bucket_uri"></a> [source\_gcs\_bucket\_uri](#input\_source\_gcs\_bucket\_uri) | The name of the GCS bucket to import data from to parallelstore. | `string` | `""` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Location for parallelstore instance. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions to monitor import-data operation from GCS bucket to parallelstore. |
+| <a name="output_network_storage"></a> [network\_storage](#output\_network\_storage) | Describes a parallelstore instance. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/file-system/parallelstore/main.tf
+++ b/modules/file-system/parallelstore/main.tf
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "parallelstore", ghpc_role = "file-system" })
+}
+
+locals {
+  fs_type       = "daos"
+  server_ip     = ""
+  remote_mount  = ""
+  access_points = jsonencode(google_parallelstore_instance.instance.access_points)
+
+  client_install_runner = {
+    "type"        = "shell"
+    "source"      = "${path.module}/scripts/install-daos-client.sh"
+    "args"        = "--access_points=\"${local.access_points}\""
+    "destination" = "install_daos_client.sh"
+  }
+
+  mount_runner = {
+    "type"        = "shell"
+    "source"      = "${path.module}/scripts/mount-daos.sh"
+    "args"        = "--local_mount=\"${var.local_mount}\" --mount_options=\"${var.mount_options}\""
+    "destination" = "mount_daos.sh"
+  }
+}
+
+resource "random_id" "resource_name_suffix" {
+  byte_length = 4
+}
+
+resource "google_parallelstore_instance" "instance" {
+  instance_id  = var.name != null ? var.name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
+  location     = var.zone
+  capacity_gib = var.size_gb
+  network      = var.network_id
+
+  labels = local.labels
+
+  provider   = google-beta
+  depends_on = [var.private_vpc_connection_peering]
+}
+
+resource "null_resource" "hydration" {
+  count = var.source_gcs_bucket_uri != "" ? 1 : 0
+
+  depends_on = [resource.google_parallelstore_instance.instance]
+  provisioner "local-exec" {
+    command = "curl -X POST   -H \"Content-Type: application/json\"   -H \"Authorization: Bearer $(gcloud auth print-access-token)\"   -d '{\"source_gcs_bucket\": {\"uri\":\"${var.source_gcs_bucket_uri}\"}, \"destination_parallelstore\": {\"path\":\"${var.destination_hydration_parallelstore}\"}}'   https://parallelstore.googleapis.com/v1beta/projects/${var.project_id}/locations/${var.zone}/instances/${var.name}:importData"
+  }
+}

--- a/modules/file-system/parallelstore/metadata.yaml
+++ b/modules/file-system/parallelstore/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - parallelstore.googleapis.com

--- a/modules/file-system/parallelstore/outputs.tf
+++ b/modules/file-system/parallelstore/outputs.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  operation_instructions = <<-EOT
+    Data is being imported from GCS bucket to parallelstore instance. It may
+    not be available immediately.
+  EOT
+}
+
+output "network_storage" {
+  description = "Describes a parallelstore instance."
+  value = {
+    server_ip             = local.server_ip
+    remote_mount          = local.remote_mount
+    local_mount           = var.local_mount
+    fs_type               = local.fs_type
+    mount_options         = var.mount_options
+    client_install_runner = local.client_install_runner
+    mount_runner          = local.mount_runner
+  }
+}
+
+output "instructions" {
+  description = "Instructions to monitor import-data operation from GCS bucket to parallelstore."
+  value       = var.source_gcs_bucket_uri != "" ? local.operation_instructions : "Data is not imported from GCS bucket."
+}

--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Parse access_points.
+for arg in "$@"; do
+	if [[ $arg == --access_points=* ]]; then
+		access_points="${arg#*=}"
+	fi
+done
+
+# Install the DAOS client library
+# The following commands should be executed on each client vm.
+## For Rocky linux 8.
+if grep -q "ID=\"rocky\"" /etc/os-release && lsb_release -rs | grep -q "8\.[0-9]"; then
+
+	# 1) Add the Parallelstore package repository
+	tee /etc/yum.repos.d/parallelstore-v2-4-el8.repo <<EOF
+[parallelstore-v2-4-el8]
+name=Parallelstore EL8 v2.4
+baseurl=https://us-central1-yum.pkg.dev/projects/parallelstore-packages/v2-4-el8
+enabled=1
+repo_gpgcheck=0
+gpgcheck=0
+EOF
+	dnf makecache
+
+	# 2) Install daos-client
+	dnf install -y epel-release # needed for capstone
+	dnf install -y daos-client
+
+	# 3) Upgrade libfabric
+	dnf upgrade -y libfabric
+
+# For Ubuntu 22.04 and debian 12,
+elif (grep -q "ID=ubuntu" /etc/os-release && lsb_release -rs | grep -q "22\.04") || (grep -q "ID=debian" /etc/os-release && lsb_release -rs | grep -q "12"); then
+
+	# 1) Add the Parallelstore package repository
+	curl https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg | apt-key add -
+	echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-4-deb main" | tee -a /etc/apt/sources.list.d/artifact-registry.list
+
+	apt update
+
+	# 2) Install daos-client
+	apt install -y daos-client
+
+else
+	echo "Unsupported operating system. This script only supports Rocky Linux 8, Ubuntu 22.04, and Debian 12."
+	exit 1
+fi
+
+# Edit agent config
+daos_config=/etc/daos/daos_agent.yml
+sed -i "s/#.*transport_config/transport_config/g" $daos_config
+sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
+sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
+
+# Start service
+if grep -q "ID=\"rocky\"" /etc/os-release && lsb_release -rs | grep -q "8\.[0-9]"; then
+	systemctl start daos_agent.service
+
+elif (grep -q "ID=ubuntu" /etc/os-release && lsb_release -rs | grep -q "22\.04") || (grep -q "ID=debian" /etc/os-release && lsb_release -rs | grep -q "12"); then
+	mkdir -p /var/run/daos_agent
+	daos_agent -o /etc/daos/daos_agent.yml &
+
+else
+	echo "Unsupported operating system. This script only supports Rocky Linux 8, Ubuntu 22.04, and Debian 12."
+	exit 1
+fi
+
+exit 0

--- a/modules/file-system/parallelstore/scripts/mount-daos.sh
+++ b/modules/file-system/parallelstore/scripts/mount-daos.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Parse local_mount, mount_options from argument.
+# Format mount-options string to be compatible to dfuse mount command.
+# e.g. "disable-wb-cache,eq-count=8" --> --disable-wb-cache --eq-count=8.
+for arg in "$@"; do
+	if [[ $arg == --local_mount=* ]]; then
+		local_mount="${arg#*=}"
+	fi
+	if [[ $arg == --mount_options=* ]]; then
+		mount_options="${arg#*=}"
+		mount_options="--${mount_options//,/ --}"
+	fi
+done
+
+# Mount parallelstore instance to client vm.
+mkdir -p "$local_mount"
+chmod 777 "$local_mount"
+
+# Mount container for multi-user.
+fuse_config=/etc/fuse.conf
+sed -i "s/#.*user_allow_other/user_allow_other/g" $fuse_config
+dfuse -m "$local_mount" --pool default-pool --container default-container --multi-user -o "$mount_options"
+
+exit 0

--- a/modules/file-system/parallelstore/variables.tf
+++ b/modules/file-system/parallelstore/variables.tf
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project in which the HPC deployment will be created."
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "Name of the HPC deployment."
+  type        = string
+}
+
+variable "name" {
+  description = "Name of parallelstore instance."
+  type        = string
+  default     = null
+}
+
+variable "zone" {
+  description = "Location for parallelstore instance."
+  type        = string
+}
+
+variable "size_gb" {
+  description = "Storage size of the parallelstore instance in GB."
+  type        = number
+  default     = 12000
+}
+
+variable "labels" {
+  description = "Labels to add to parallel store instance."
+  type        = map(string)
+  default     = {}
+}
+
+variable "local_mount" {
+  description = "The mount point where the contents of the device may be accessed after mounting."
+  type        = string
+  default     = "/parallelstore"
+}
+
+variable "mount_options" {
+  description = "Options describing various aspects of the parallelstore instance."
+  type        = string
+  default     = "disable-wb-cache,thread-count=16,eq-count=8"
+}
+
+variable "private_vpc_connection_peering" {
+  description = "The name of the VPC Network peering connection."
+  type        = string
+}
+
+variable "network_id" {
+  description = <<-EOT
+    The ID of the GCE VPC network to which the instance is connected given in the format:
+    `projects/<project_id>/global/networks/<network_name>`"
+    EOT
+  type        = string
+  validation {
+    condition     = length(split("/", var.network_id)) == 5
+    error_message = "The network id must be provided in the following format: projects/<project_id>/global/networks/<network_name>."
+  }
+}
+
+variable "source_gcs_bucket_uri" {
+  description = "The name of the GCS bucket to import data from to parallelstore."
+  type        = string
+  default     = ""
+}
+
+variable "destination_hydration_parallelstore" {
+  description = "The name of local path to import data on parallelstore instance from GCS bucket."
+  type        = string
+  default     = "/"
+}

--- a/modules/file-system/parallelstore/versions.tf
+++ b/modules/file-system/parallelstore/versions.tf
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 5.25.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -75,7 +75,15 @@ duplicates = [
     [
         "community/modules/scheduler/schedmd-slurm-gcp-v5-controller/etc/long-prolog-slurm.conf.tpl",
         "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl",
-    ]
+    ],
+    [
+        "modules/file-system/parallelstore/scripts/install-daos-client.sh",
+        "modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh",
+    ],
+    [
+        "modules/file-system/parallelstore/scripts/mount-daos.sh",
+        "modules/file-system/pre-existing-network-storage/scripts/mount-daos.sh",
+    ],
 ]
 
 for group in duplicates:


### PR DESCRIPTION
This PR adds a skeleton code for parallelstore module. 

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
