### PR TITLE
Add `schedmd-slurm-gcp-v6-nodeset-dynamic` module

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
@@ -1,0 +1,134 @@
+## Description
+
+This module creates an instance template to be used by dynamic nodes,
+also it creates a nodeset data structure intended to be input to the
+[schedmd-slurm-gcp-v6-partition](../schedmd-slurm-gcp-v6-partition/) module.
+
+### Example
+
+The following code snippet creates an instance template to be used by MIG.
+
+```yaml
+  - id: dynamic_ns
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic
+    use: [network, controller]
+    settings:
+      machine_type: n2-standard-2
+
+  - id: dynamic_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [dynamic_ns]
+    settings:
+      partition_name: mp
+      is_default: true
+  
+  - id: controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use: [network, dynamic_partition]  
+
+  - id: mig
+    source: community/modules/compute/mig
+    settings:
+      versions:
+      - name: highlander # there can be only one
+        instance_template: $(dynamic_ns.instance_template_self_link)
+      base_instance_name: $(dynamic_ns.node_name_prefix)
+```
+
+## Custom Images
+
+For more information on creating valid custom images for the node group VM
+instances or for custom instance templates, see our [vm-images.md] documentation
+page.
+
+[vm-images.md]: ../../../../docs/vm-images.md#slurm-on-gcp-custom-images
+
+## GPU Support
+
+More information on GPU support in Slurm on GCP and other HPC Toolkit modules
+can be found at [docs/gpu-support.md](../../../../docs/gpu-support.md)
+
+## Support
+The HPC Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
+modules. For support with the underlying modules, see the instructions in the
+[slurm-gcp README][slurm-gcp-readme].
+
+[slurm-on-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp
+[slurm-gcp-readme]: https://github.com/GoogleCloudPlatform/slurm-gcp#slurm-on-google-cloud-platform
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.11 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_slurm_nodeset_template"></a> [slurm\_nodeset\_template](#module\_slurm\_nodeset\_template) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template | 6.5.8 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+| [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_config"></a> [access\_config](#input\_access\_config) | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
+| <a name="input_additional_disks"></a> [additional\_disks](#input\_additional\_disks) | Configurations of additional disks to be included on the partition nodes. (do not use "disk\_type: local-ssd"; known issue being addressed) | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    disk_size_gb = number<br>    disk_type    = string<br>    disk_labels  = map(string)<br>    auto_delete  = bool<br>    boot         = bool<br>  }))</pre> | `[]` | no |
+| <a name="input_additional_networks"></a> [additional\_networks](#input\_additional\_networks) | Additional network interface details for GCE, if any. | <pre>list(object({<br>    network            = string<br>    subnetwork         = string<br>    subnetwork_project = string<br>    network_ip         = string<br>    nic_type           = string<br>    stack_type         = string<br>    queue_count        = number<br>    access_config = list(object({<br>      nat_ip       = string<br>      network_tier = string<br>    }))<br>    ipv6_access_config = list(object({<br>      network_tier = string<br>    }))<br>    alias_ip_range = list(object({<br>      ip_cidr_range         = string<br>      subnetwork_range_name = string<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Configures the network interface card and the maximum egress bandwidth for VMs.<br>  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.<br>  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.<br>  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).<br>  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.<br>  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.<br>  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details. | `string` | `"platform_default"` | no |
+| <a name="input_can_ip_forward"></a> [can\_ip\_forward](#input\_can\_ip\_forward) | Enable IP forwarding, for NAT instances for example. | `bool` | `false` | no |
+| <a name="input_disk_auto_delete"></a> [disk\_auto\_delete](#input\_disk\_auto\_delete) | Whether or not the boot disk should be auto-deleted. | `bool` | `true` | no |
+| <a name="input_disk_labels"></a> [disk\_labels](#input\_disk\_labels) | Labels specific to the boot disk. These will be merged with var.labels. | `map(string)` | `{}` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of boot disk to create for the partition compute nodes. | `number` | `50` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Boot disk type, can be either hyperdisk-balanced, hyperdisk-extreme, pd-ssd, pd-standard, pd-balanced, or pd-extreme. | `string` | `"pd-standard"` | no |
+| <a name="input_enable_confidential_vm"></a> [enable\_confidential\_vm](#input\_enable\_confidential\_vm) | Enable the Confidential VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables Google Cloud os-login for user login and authentication for VMs.<br>See https://cloud.google.com/compute/docs/oslogin | `bool` | `true` | no |
+| <a name="input_enable_public_ips"></a> [enable\_public\_ips](#input\_enable\_public\_ips) | If set to true. The node group VMs will have a random public IP assigned to it. Ignored if access\_config is set. | `bool` | `false` | no |
+| <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration. Note: the instance image must support option. | `bool` | `false` | no |
+| <a name="input_enable_smt"></a> [enable\_smt](#input\_enable\_smt) | Enables Simultaneous Multi-Threading (SMT) on instance. | `bool` | `false` | no |
+| <a name="input_enable_spot_vm"></a> [enable\_spot\_vm](#input\_enable\_spot\_vm) | Enable the partition to use spot VMs (https://cloud.google.com/spot-vms). | `bool` | `false` | no |
+| <a name="input_feature"></a> [feature](#input\_feature) | The node feature, used to bind nodes to the nodeset. If not set, the nodeset name will be used. | `string` | `null` | no |
+| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br>    type  = string,<br>    count = number<br>  }))</pre> | `[]` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Defines the image that will be used in the Slurm node group VM instances.<br><br>Expected Fields:<br>name: The name of the image. Mutually exclusive with family.<br>family: The image family to use. Mutually exclusive with name.<br>project: The project where the image is hosted.<br><br>For more information on creating custom images that comply with Slurm on GCP<br>see the "Slurm on GCP Custom Images" section in docs/vm-images.md. | `map(string)` | <pre>{<br>  "family": "slurm-gcp-6-5-hpc-rocky-linux-8",<br>  "project": "schedmd-slurm-public"<br>}</pre> | no |
+| <a name="input_instance_image_custom"></a> [instance\_image\_custom](#input\_instance\_image\_custom) | A flag that designates that the user is aware that they are requesting<br>to use a custom and potentially incompatible image for this Slurm on<br>GCP module.<br><br>If the field is set to false, only the compatible families and project<br>names will be accepted.  The deployment will fail with any other image<br>family or name.  If set to true, no checks will be done.<br><br>See: https://goo.gle/hpc-slurm-images | `bool` | `false` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to partition compute instances. Key-value pairs. | `map(string)` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes. | `string` | `"c2-standard-60"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | The name of the minimum CPU platform that you want the instance to use. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the nodeset. Automatically populated by the module id if not set.<br>If setting manually, ensure a unique value across all nodesets. | `string` | n/a | yes |
+| <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Instance availability Policy.<br><br>Note: Placement groups are not supported when on\_host\_maintenance is set to<br>"MIGRATE" and will be deactivated regardless of the value of<br>enable\_placement. To support enable\_placement, ensure on\_host\_maintenance is<br>set to "TERMINATE". | `string` | `"TERMINATE"` | no |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Should use preemptibles to burst. | `bool` | `false` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The default region for Cloud resources. | `string` | n/a | yes |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Service account e-mail address to attach to the compute instances. | `string` | `null` | no |
+| <a name="input_service_account_scopes"></a> [service\_account\_scopes](#input\_service\_account\_scopes) | Scopes to attach to the compute instances. | `set(string)` | <pre>[<br>  "https://www.googleapis.com/auth/cloud-platform"<br>]</pre> | no |
+| <a name="input_shielded_instance_config"></a> [shielded\_instance\_config](#input\_shielded\_instance\_config) | Shielded VM configuration for the instance. Note: not used unless<br>enable\_shielded\_vm is 'true'.<br>- enable\_integrity\_monitoring : Compare the most recent boot measurements to the<br>  integrity policy baseline and return a pair of pass/fail results depending on<br>  whether they match or not.<br>- enable\_secure\_boot : Verify the digital signature of all boot components, and<br>  halt the boot process if signature verification fails.<br>- enable\_vtpm : Use a virtualized trusted platform module, which is a<br>  specialized computer chip you can use to encrypt objects like keys and<br>  certificates. | <pre>object({<br>    enable_integrity_monitoring = bool<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
+| <a name="input_slurm_bucket_path"></a> [slurm\_bucket\_path](#input\_slurm\_bucket\_path) | Path to the Slurm bucket. | `string` | n/a | yes |
+| <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Name of the Slurm cluster. | `string` | n/a | yes |
+| <a name="input_spot_instance_config"></a> [spot\_instance\_config](#input\_spot\_instance\_config) | Configuration for spot VMs. | <pre>object({<br>    termination_action = string<br>  })</pre> | `null` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Network tag list. | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_template_self_link"></a> [instance\_template\_self\_link](#output\_instance\_template\_self\_link) | The URI of the template. |
+| <a name="output_node_name_prefix"></a> [node\_name\_prefix](#output\_node\_name\_prefix) | The prefix to be used for the node names. <br><br>Make sure that nodes are named `<node_name_prefix>-<any_suffix>`<br>This temporary required for proper functioning of the nodes.<br>While Slurm scheduler uses "features" to bind node and nodeset,<br>the SlurmGCP relies on node names for this (to be switched to features as well). |
+| <a name="output_nodeset_dyn"></a> [nodeset\_dyn](#output\_nodeset\_dyn) | Details of the nodeset. Typically used as input to `schedmd-slurm-gcp-v6-partition`. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/gpu_definition.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/gpu_definition.tf
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+## Required variables:
+#  guest_accelerator
+#  machine_type
+
+locals {
+  # example state; terraform will ignore diffs if last element of URL matches
+  # guest_accelerator = [
+  #   {
+  #     count = 1
+  #     type  = "https://www.googleapis.com/compute/beta/projects/PROJECT/zones/ZONE/acceleratorTypes/nvidia-tesla-a100"
+  #   },
+  # ]
+  accelerator_machines = {
+    "a2-highgpu-1g"  = { type = "nvidia-tesla-a100", count = 1 },
+    "a2-highgpu-2g"  = { type = "nvidia-tesla-a100", count = 2 },
+    "a2-highgpu-4g"  = { type = "nvidia-tesla-a100", count = 4 },
+    "a2-highgpu-8g"  = { type = "nvidia-tesla-a100", count = 8 },
+    "a2-megagpu-16g" = { type = "nvidia-tesla-a100", count = 16 },
+    "a2-ultragpu-1g" = { type = "nvidia-a100-80gb", count = 1 },
+    "a2-ultragpu-2g" = { type = "nvidia-a100-80gb", count = 2 },
+    "a2-ultragpu-4g" = { type = "nvidia-a100-80gb", count = 4 },
+    "a2-ultragpu-8g" = { type = "nvidia-a100-80gb", count = 8 },
+    "a3-highgpu-8g"  = { type = "nvidia-h100-80gb", count = 8 },
+    "g2-standard-4"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-8"  = { type = "nvidia-l4", count = 1 },
+    "g2-standard-12" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-16" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-24" = { type = "nvidia-l4", count = 2 },
+    "g2-standard-32" = { type = "nvidia-l4", count = 1 },
+    "g2-standard-48" = { type = "nvidia-l4", count = 4 },
+    "g2-standard-96" = { type = "nvidia-l4", count = 8 },
+  }
+  generated_guest_accelerator = try([local.accelerator_machines[var.machine_type]], [])
+
+  # Select in priority order:
+  # (1) var.guest_accelerator if not empty
+  # (2) local.generated_guest_accelerator if not empty
+  # (3) default to empty list if both are empty
+  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/main.tf
@@ -1,0 +1,100 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v6-nodeset-dynamic", ghpc_role = "compute" })
+}
+
+locals {
+  nodeset_name = substr(replace(var.name, "/[^a-z0-9]/", ""), 0, 14)
+  feature      = coalesce(var.feature, local.nodeset_name)
+  metadata     = merge(var.metadata, { slurmd_feature = local.feature })
+
+  nodeset = {
+    nodeset_name = local.nodeset_name
+    nodeset_feature : local.feature
+  }
+
+  additional_disks = [
+    for ad in var.additional_disks : {
+      disk_name    = ad.disk_name
+      device_name  = ad.device_name
+      disk_type    = ad.disk_type
+      disk_size_gb = ad.disk_size_gb
+      disk_labels  = merge(ad.disk_labels, local.labels)
+      auto_delete  = ad.auto_delete
+      boot         = ad.boot
+    }
+  ]
+
+  public_access_config = var.enable_public_ips ? [{ nat_ip = null, network_tier = null }] : []
+  access_config        = length(var.access_config) == 0 ? local.public_access_config : var.access_config
+
+  service_account = {
+    email  = coalesce(var.service_account_email, data.google_compute_default_service_account.default.email)
+    scopes = var.service_account_scopes
+  }
+}
+
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}
+
+
+module "slurm_nodeset_template" {
+  source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=6.5.8"
+
+  project_id          = var.project_id
+  region              = var.region
+  name_prefix         = local.nodeset_name
+  slurm_cluster_name  = var.slurm_cluster_name
+  slurm_instance_role = "compute"
+  slurm_bucket_path   = var.slurm_bucket_path
+  metadata            = local.metadata
+
+  additional_disks = local.additional_disks
+  disk_auto_delete = var.disk_auto_delete
+  disk_labels      = merge(local.labels, var.disk_labels)
+  disk_size_gb     = var.disk_size_gb
+  disk_type        = var.disk_type
+
+  bandwidth_tier = var.bandwidth_tier
+  can_ip_forward = var.can_ip_forward
+
+  disable_smt              = !var.enable_smt
+  enable_confidential_vm   = var.enable_confidential_vm
+  enable_oslogin           = var.enable_oslogin
+  enable_shielded_vm       = var.enable_shielded_vm
+  shielded_instance_config = var.shielded_instance_config
+
+  labels       = local.labels
+  machine_type = var.machine_type
+
+  min_cpu_platform     = var.min_cpu_platform
+  on_host_maintenance  = var.on_host_maintenance
+  termination_action   = try(var.spot_instance_config.termination_action, null)
+  preemptible          = var.preemptible
+  spot                 = var.enable_spot_vm
+  service_account      = local.service_account
+  gpu                  = one(local.guest_accelerator)          # requires gpu_definition.tf
+  source_image_family  = local.source_image_family             # requires source_image_logic.tf
+  source_image_project = local.source_image_project_normalized # requires source_image_logic.tf
+  source_image         = local.source_image                    # requires source_image_logic.tf
+
+  subnetwork          = var.subnetwork_self_link
+  additional_networks = var.additional_networks
+  access_config       = local.access_config
+  tags                = concat([var.slurm_cluster_name], var.tags)
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/metadata.yaml
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services: [compute.googleapis.com]
+ghpc:
+  inject_module_id: name

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/outputs.tf
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "nodeset_dyn" {
+  description = "Details of the nodeset. Typically used as input to `schedmd-slurm-gcp-v6-partition`."
+  value       = local.nodeset
+}
+
+output "instance_template_self_link" {
+  description = "The URI of the template."
+  value       = module.slurm_nodeset_template.self_link
+}
+
+output "node_name_prefix" {
+  description = <<-EOD
+  The prefix to be used for the node names. 
+  
+  Make sure that nodes are named `<node_name_prefix>-<any_suffix>`
+  This temporary required for proper functioning of the nodes.
+  While Slurm scheduler uses "features" to bind node and nodeset,
+  the SlurmGCP relies on node names for this (to be switched to features as well).
+  EOD
+  value       = "${var.slurm_cluster_name}-${local.nodeset_name}"
+
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/source_image_logic.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/source_image_logic.tf
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # Currently supported images and projects
+  known_project_families = {
+    schedmd-slurm-public = [
+      "slurm-gcp-6-5-debian-11",
+      "slurm-gcp-6-5-hpc-rocky-linux-8",
+      "slurm-gcp-6-5-ubuntu-2004-lts",
+      "slurm-gcp-6-5-ubuntu-2204-lts-arm64",
+      "slurm-gcp-6-5-hpc-centos-7"
+    ]
+  }
+
+  # This approach to "hacking" the project name allows a chain of Terraform
+  # calls to set the instance source_image (boot disk) with a "relative
+  # resource name" that passes muster with VPC Service Control rules
+  #
+  # https://github.com/terraform-google-modules/terraform-google-vm/blob/735bd415fc5f034d46aa0de7922e8fada2327c0c/modules/instance_template/main.tf#L28
+  # https://cloud.google.com/apis/design/resource_names#relative_resource_name
+  source_image_project_normalized = (can(var.instance_image.family) ?
+    "projects/${data.google_compute_image.slurm.project}/global/images/family" :
+    "projects/${data.google_compute_image.slurm.project}/global/images"
+  )
+  source_image_family = can(var.instance_image.family) ? data.google_compute_image.slurm.family : ""
+  source_image        = can(var.instance_image.name) ? data.google_compute_image.slurm.name : ""
+}
+
+data "google_compute_image" "slurm" {
+  family  = try(var.instance_image.family, null)
+  name    = try(var.instance_image.name, null)
+  project = var.instance_image.project
+
+  lifecycle {
+    precondition {
+      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+    }
+
+    postcondition {
+      condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
+      error_message = <<-EOD
+      Images in project ${self.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
+      EOD
+    }
+    postcondition {
+      condition     = !contains(keys(local.known_project_families), self.project) || try(contains(local.known_project_families[self.project], self.family), false)
+      error_message = <<-EOD
+      Image family ${self.family} published by SchedMD in project ${self.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
+      ${join("\n", [for p in try(local.known_project_families[self.project], []) : "\t\"${p}\""])}
+      EOD
+    }
+    postcondition {
+      condition     = var.disk_size_gb >= self.disk_size_gb
+      error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${self.disk_size_gb}GB), please increase the blueprint disk size"
+    }
+  }
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/variables.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/variables.tf
@@ -1,0 +1,345 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "name" {
+  description = <<-EOD
+    Name of the nodeset. Automatically populated by the module id if not set.
+    If setting manually, ensure a unique value across all nodesets.
+    EOD
+  type        = string
+}
+
+variable "feature" {
+  type        = string
+  description = "The node feature, used to bind nodes to the nodeset. If not set, the nodeset name will be used."
+  default     = null
+}
+
+variable "project_id" {
+  type        = string
+  description = "Project ID to create resources in."
+}
+
+variable "slurm_cluster_name" {
+  description = "Name of the Slurm cluster."
+  type        = string
+}
+
+variable "slurm_bucket_path" {
+  description = "Path to the Slurm bucket."
+  type        = string
+}
+
+
+variable "machine_type" {
+  description = "Compute Platform machine type to use for this partition compute nodes."
+  type        = string
+  default     = "c2-standard-60"
+}
+
+variable "metadata" {
+  type        = map(string)
+  description = "Metadata, provided as a map."
+  default     = {}
+}
+
+variable "instance_image" {
+  description = <<-EOD
+    Defines the image that will be used in the Slurm node group VM instances.
+
+    Expected Fields:
+    name: The name of the image. Mutually exclusive with family.
+    family: The image family to use. Mutually exclusive with name.
+    project: The project where the image is hosted.
+
+    For more information on creating custom images that comply with Slurm on GCP
+    see the "Slurm on GCP Custom Images" section in docs/vm-images.md.
+    EOD
+  type        = map(string)
+  default = {
+    family  = "slurm-gcp-6-5-hpc-rocky-linux-8"
+    project = "schedmd-slurm-public"
+  }
+
+  validation {
+    condition     = can(coalesce(var.instance_image.project))
+    error_message = "In var.instance_image, the \"project\" field must be a string set to the Cloud project ID."
+  }
+
+  validation {
+    condition     = can(coalesce(var.instance_image.name)) != can(coalesce(var.instance_image.family))
+    error_message = "In var.instance_image, exactly one of \"family\" or \"name\" fields must be set to desired image family or name."
+  }
+}
+
+variable "instance_image_custom" {
+  description = <<-EOD
+    A flag that designates that the user is aware that they are requesting
+    to use a custom and potentially incompatible image for this Slurm on
+    GCP module.
+
+    If the field is set to false, only the compatible families and project
+    names will be accepted.  The deployment will fail with any other image
+    family or name.  If set to true, no checks will be done.
+
+    See: https://goo.gle/hpc-slurm-images
+    EOD
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "Network tag list."
+  default     = []
+}
+
+variable "disk_type" {
+  description = "Boot disk type, can be either hyperdisk-balanced, hyperdisk-extreme, pd-ssd, pd-standard, pd-balanced, or pd-extreme."
+  type        = string
+  default     = "pd-standard"
+}
+
+variable "disk_size_gb" {
+  description = "Size of boot disk to create for the partition compute nodes."
+  type        = number
+  default     = 50
+}
+
+variable "disk_auto_delete" {
+  type        = bool
+  description = "Whether or not the boot disk should be auto-deleted."
+  default     = true
+}
+
+variable "disk_labels" {
+  description = "Labels specific to the boot disk. These will be merged with var.labels."
+  type        = map(string)
+  default     = {}
+}
+
+variable "additional_disks" {
+  description = "Configurations of additional disks to be included on the partition nodes. (do not use \"disk_type: local-ssd\"; known issue being addressed)"
+  type = list(object({
+    disk_name    = string
+    device_name  = string
+    disk_size_gb = number
+    disk_type    = string
+    disk_labels  = map(string)
+    auto_delete  = bool
+    boot         = bool
+  }))
+  default = []
+}
+
+variable "enable_confidential_vm" {
+  type        = bool
+  description = "Enable the Confidential VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "enable_shielded_vm" {
+  type        = bool
+  description = "Enable the Shielded VM configuration. Note: the instance image must support option."
+  default     = false
+}
+
+variable "shielded_instance_config" {
+  type = object({
+    enable_integrity_monitoring = bool
+    enable_secure_boot          = bool
+    enable_vtpm                 = bool
+  })
+  description = <<-EOD
+    Shielded VM configuration for the instance. Note: not used unless
+    enable_shielded_vm is 'true'.
+    - enable_integrity_monitoring : Compare the most recent boot measurements to the
+      integrity policy baseline and return a pair of pass/fail results depending on
+      whether they match or not.
+    - enable_secure_boot : Verify the digital signature of all boot components, and
+      halt the boot process if signature verification fails.
+    - enable_vtpm : Use a virtualized trusted platform module, which is a
+      specialized computer chip you can use to encrypt objects like keys and
+      certificates.
+    EOD
+  default = {
+    enable_integrity_monitoring = true
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+  }
+}
+
+
+variable "enable_oslogin" {
+  type        = bool
+  description = <<-EOD
+    Enables Google Cloud os-login for user login and authentication for VMs.
+    See https://cloud.google.com/compute/docs/oslogin
+    EOD
+  default     = true
+}
+
+variable "can_ip_forward" {
+  description = "Enable IP forwarding, for NAT instances for example."
+  type        = bool
+  default     = false
+}
+
+variable "enable_smt" {
+  type        = bool
+  description = "Enables Simultaneous Multi-Threading (SMT) on instance."
+  default     = false
+}
+
+variable "labels" {
+  description = "Labels to add to partition compute instances. Key-value pairs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "min_cpu_platform" {
+  description = "The name of the minimum CPU platform that you want the instance to use."
+  type        = string
+  default     = null
+}
+
+variable "on_host_maintenance" {
+  type        = string
+  description = <<-EOD
+    Instance availability Policy.
+
+    Note: Placement groups are not supported when on_host_maintenance is set to
+    "MIGRATE" and will be deactivated regardless of the value of
+    enable_placement. To support enable_placement, ensure on_host_maintenance is
+    set to "TERMINATE".
+    EOD
+  default     = "TERMINATE"
+}
+
+variable "guest_accelerator" {
+  description = "List of the type and count of accelerator cards attached to the instance."
+  type = list(object({
+    type  = string,
+    count = number
+  }))
+  default  = []
+  nullable = false
+
+  validation {
+    condition     = length(var.guest_accelerator) <= 1
+    error_message = "The Slurm modules supports 0 or 1 models of accelerator card on each node."
+  }
+}
+
+variable "preemptible" {
+  description = "Should use preemptibles to burst."
+  type        = bool
+  default     = false
+}
+
+
+variable "service_account_email" {
+  description = "Service account e-mail address to attach to the compute instances."
+  type        = string
+  default     = null
+}
+
+variable "service_account_scopes" {
+  description = "Scopes to attach to the compute instances."
+  type        = set(string)
+  default     = ["https://www.googleapis.com/auth/cloud-platform"]
+}
+
+variable "enable_spot_vm" {
+  description = "Enable the partition to use spot VMs (https://cloud.google.com/spot-vms)."
+  type        = bool
+  default     = false
+}
+
+variable "spot_instance_config" {
+  description = "Configuration for spot VMs."
+  type = object({
+    termination_action = string
+  })
+  default = null
+}
+
+variable "bandwidth_tier" {
+  description = <<EOT
+  Configures the network interface card and the maximum egress bandwidth for VMs.
+  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.
+  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.
+  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).
+  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.
+  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.
+  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details.
+  EOT
+  type        = string
+  default     = "platform_default"
+
+  validation {
+    condition     = contains(["platform_default", "virtio_enabled", "gvnic_enabled", "tier_1_enabled"], var.bandwidth_tier)
+    error_message = "Allowed values for bandwidth_tier are 'platform_default', 'virtio_enabled', 'gvnic_enabled', or 'tier_1_enabled'."
+  }
+}
+
+variable "enable_public_ips" {
+  description = "If set to true. The node group VMs will have a random public IP assigned to it. Ignored if access_config is set."
+  type        = bool
+  default     = false
+}
+
+variable "region" {
+  description = "The default region for Cloud resources."
+  type        = string
+}
+
+variable "subnetwork_self_link" {
+  type        = string
+  description = "Subnet to deploy to."
+}
+
+variable "additional_networks" {
+  description = "Additional network interface details for GCE, if any."
+  default     = []
+  type = list(object({
+    network            = string
+    subnetwork         = string
+    subnetwork_project = string
+    network_ip         = string
+    nic_type           = string
+    stack_type         = string
+    queue_count        = number
+    access_config = list(object({
+      nat_ip       = string
+      network_tier = string
+    }))
+    ipv6_access_config = list(object({
+      network_tier = string
+    }))
+    alias_ip_range = list(object({
+      ip_cidr_range         = string
+      subnetwork_range_name = string
+    }))
+  }))
+}
+
+variable "access_config" {
+  description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
+  type = list(object({
+    nat_ip       = string
+    network_tier = string
+  }))
+  default = []
+}

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.11"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-dynamic/v1.35.1"
+  }
+}

--- a/modules/README.md
+++ b/modules/README.md
@@ -45,6 +45,8 @@ Modules that are still in development and less stable are labeled with the
   Creates a nodeset to be used by the [schedmd-slurm-gcp-v6-partition] module.
 * **[schedmd-slurm-gcp-v6-nodeset-tpu]** ![community-badge] ![experimental-badge]:
   Creates a TPU nodeset to be used by the [schedmd-slurm-gcp-v6-partition] module.
+* **[schedmd-slurm-gcp-v6-nodeset-dynamic]** ![community-badge] ![experimental-badge]:
+  Creates a dynamic nodeset to be used by the [schedmd-slurm-gcp-v6-partition] module and instance template.
 * **[gke-node-pool]** ![community-badge] ![experimental-badge] : Creates a
   Kubernetes node pool using GKE.
 * **[gke-job-template]** ![community-badge] ![experimental-badge] : Creates a
@@ -66,6 +68,7 @@ Modules that are still in development and less stable are labeled with the
 [schedmd-slurm-gcp-v6-partition]: ../community/modules/compute/schedmd-slurm-gcp-v6-partition/README.md
 [schedmd-slurm-gcp-v6-nodeset]: ../community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
 [schedmd-slurm-gcp-v6-nodeset-tpu]: ../community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
+[schedmd-slurm-gcp-v6-nodeset-dynamic]: ../community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
 [htcondor-execute-point]: ../community/modules/compute/htcondor-execute-point/README.md
 [pbspro-execution]: ../community/modules/compute/pbspro-execution/README.md
 [mig]: ../community/modules/compute/mig/README.md

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -42,6 +42,7 @@ duplicates = [
         "community/modules/scheduler/schedmd-slurm-gcp-v5-login/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v5-controller/gpu_definition.tf",
         "community/modules/compute/schedmd-slurm-gcp-v6-nodeset/gpu_definition.tf",
+        "community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/gpu_definition.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v6-login/gpu_definition.tf",
         "community/modules/compute/gke-node-pool/gpu_definition.tf",
@@ -59,6 +60,7 @@ duplicates = [
         "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/source_image_logic.tf",
         "community/modules/scheduler/schedmd-slurm-gcp-v6-login/source_image_logic.tf",
         "community/modules/compute/schedmd-slurm-gcp-v6-nodeset/source_image_logic.tf",
+        "community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/source_image_logic.tf",
     ],
     [
         "community/modules/scripts/ramble-execute/templates/ramble_execute.yml.tpl",


### PR DESCRIPTION
#### Motivation:

To simplify usage of "dynamic" instances

#### Usage:

```yaml
  - id: dynamic_ns
    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic
    use: [network, controller]
    settings:
      machine_type: n2-standard-2

  - id: dynamic_partition
    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
    use: [dynamic_ns]
    settings:
      partition_name: mp
      is_default: true

  - id: controller
    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
    use: [network, dynamic_partition]  

  - id: mig
    source: community/modules/compute/mig
    settings:
      versions:
      - name: highlander # there can be only one
        instance_template: $(dynamic_ns.instance_template_self_link)
      base_instance_name: $(dynamic_ns.node_name_prefix)```