### PR TITLE
Create 'pre-existing-gke-cluster' module

### DIFF
--- a/community/modules/scheduler/gke-cluster/README.md
+++ b/community/modules/scheduler/gke-cluster/README.md
@@ -155,7 +155,7 @@ limitations under the License.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | An identifier for the resource with format projects/<project\_id>/locations/<region>/clusters/<name>. |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | An identifier for the resource with format projects/{{project\_id}}/locations/{{region}}/clusters/{{name}}. |
 | <a name="output_gke_cluster_exists"></a> [gke\_cluster\_exists](#output\_gke\_cluster\_exists) | A static flag that signals to downstream modules that a cluster has been created. Needed by community/modules/scripts/kubernetes-operations. |
 | <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions on how to connect to the created cluster. |
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Name of k8s service account. |

--- a/community/modules/scheduler/gke-cluster/outputs.tf
+++ b/community/modules/scheduler/gke-cluster/outputs.tf
@@ -15,7 +15,7 @@
   */
 
 output "cluster_id" {
-  description = "An identifier for the resource with format projects/<project_id>/locations/<region>/clusters/<name>."
+  description = "An identifier for the resource with format projects/{{project_id}}/locations/{{region}}/clusters/{{name}}."
   value       = google_container_cluster.gke_cluster.id
 }
 

--- a/community/modules/scheduler/pre-existing-gke-cluster/README.md
+++ b/community/modules/scheduler/pre-existing-gke-cluster/README.md
@@ -52,7 +52,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
 
 ## Providers

--- a/community/modules/scheduler/pre-existing-gke-cluster/README.md
+++ b/community/modules/scheduler/pre-existing-gke-cluster/README.md
@@ -1,0 +1,88 @@
+## Description
+
+This module discovers a Google Kubernetes Engine ([GKE](https://cloud.google.com/kubernetes-engine)) cluster that already exists in Google Cloud and
+outputs cluster attributes that uniquely identify it for use by other modules.
+The module outputs are aligned with the [gke-cluster module][gke-cluster] so that it can be used
+as a drop-in substitute when a GKE cluster already exists.
+
+The below sample blueprint discovers the existing GKE cluster named "my-gke-cluster" in "us-central1" region. With the `use` keyword, the
+[gke-node-pool] module accepts the `cluser_id`
+input variable that uniquely identifies the existing GKE cluster in which the
+GKE node pool will be created.
+
+[gke-cluster]: ../gke-cluster/README.md
+[gke-node-pool]: ../../compute/gke-node-pool/README.md
+
+### Example
+
+```yaml
+- id: existing-gke-cluster
+  source: community/modules/scheduler/pre-existing-gke-cluster
+  settings:
+    project_id: $(vars.project_id)
+    cluster_name: my-gke-cluster
+    region: us-central1
+
+- id: compute_pool
+  source: community/modules/compute/gke-node-pool
+  use: [existing-gke-cluster]
+```
+
+> **_NOTE:_** The `project_id` and `region` settings would be inferred from the
+> deployment variables of the same name, but they are included here for clarity.
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | > 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_container_cluster.existing_gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the existing cluster | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project that hosts the existing cluster | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region in which to search for the cluster | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | An identifier for the gke cluster with format projects/<project\_id>/locations/<region>/clusters/<name>. |
+| <a name="output_gke_cluster_exists"></a> [gke\_cluster\_exists](#output\_gke\_cluster\_exists) | A static flag that signals to downstream modules that a cluster exists. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/pre-existing-gke-cluster/README.md
+++ b/community/modules/scheduler/pre-existing-gke-cluster/README.md
@@ -83,6 +83,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | An identifier for the gke cluster with format projects/<project\_id>/locations/<region>/clusters/<name>. |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | An identifier for the gke cluster with format projects/{{project\_id}}/locations/{{region}}/clusters/{{name}}. |
 | <a name="output_gke_cluster_exists"></a> [gke\_cluster\_exists](#output\_gke\_cluster\_exists) | A static flag that signals to downstream modules that a cluster exists. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/pre-existing-gke-cluster/main.tf
+++ b/community/modules/scheduler/pre-existing-gke-cluster/main.tf
@@ -1,0 +1,21 @@
+/**
+  * Copyright 2024 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+data "google_container_cluster" "existing_gke_cluster" {
+  name     = var.cluster_name
+  project  = var.project_id
+  location = var.region
+}

--- a/community/modules/scheduler/pre-existing-gke-cluster/metadata.yaml
+++ b/community/modules/scheduler/pre-existing-gke-cluster/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - container.googleapis.com

--- a/community/modules/scheduler/pre-existing-gke-cluster/outputs.tf
+++ b/community/modules/scheduler/pre-existing-gke-cluster/outputs.tf
@@ -15,7 +15,7 @@
   */
 
 output "cluster_id" {
-  description = "An identifier for the gke cluster with format projects/<project_id>/locations/<region>/clusters/<name>."
+  description = "An identifier for the gke cluster with format projects/{{project_id}}/locations/{{region}}/clusters/{{name}}."
   value       = data.google_container_cluster.existing_gke_cluster.id
 }
 

--- a/community/modules/scheduler/pre-existing-gke-cluster/outputs.tf
+++ b/community/modules/scheduler/pre-existing-gke-cluster/outputs.tf
@@ -1,0 +1,28 @@
+/**
+  * Copyright 2024 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+output "cluster_id" {
+  description = "An identifier for the gke cluster with format projects/<project_id>/locations/<region>/clusters/<name>."
+  value       = data.google_container_cluster.existing_gke_cluster.id
+}
+
+output "gke_cluster_exists" {
+  description = "A static flag that signals to downstream modules that a cluster exists."
+  value       = true
+  depends_on = [
+    data.google_container_cluster.existing_gke_cluster
+  ]
+}

--- a/community/modules/scheduler/pre-existing-gke-cluster/variables.tf
+++ b/community/modules/scheduler/pre-existing-gke-cluster/variables.tf
@@ -1,0 +1,30 @@
+/**
+  * Copyright 2024 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+variable "project_id" {
+  description = "Project that hosts the existing cluster"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the existing cluster"
+  type        = string
+}
+
+variable "region" {
+  description = "Region in which to search for the cluster"
+  type        = string
+}

--- a/community/modules/scheduler/pre-existing-gke-cluster/versions.tf
+++ b/community/modules/scheduler/pre-existing-gke-cluster/versions.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "> 5.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-gke-cluster/v1.35.0"
+  }
+
+  required_version = ">= 0.14.0"
+}

--- a/community/modules/scheduler/pre-existing-gke-cluster/versions.tf
+++ b/community/modules/scheduler/pre-existing-gke-cluster/versions.tf
@@ -26,5 +26,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:pre-existing-gke-cluster/v1.35.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = ">= 1.0.0"
 }

--- a/modules/README.md
+++ b/modules/README.md
@@ -184,6 +184,8 @@ Pub/Sub subscription. Primarily used for [FSI - MonteCarlo Tutorial][fsi-monteca
   submission of Google Cloud Batch jobs.
 * **[gke-cluster]** ![community-badge] ![experimental-badge] : Creates a
   Kubernetes cluster using GKE.
+* **[pre-existing-gke-cluster]** ![community-badge] ![experimental-badge] : Retrieves an existing
+  GKE cluster's attributes to be used in other modules as a substitute for creating a new cluster ([gke-cluster]).
 * **[schedmd-slurm-gcp-v5-controller]** ![community-badge] :
   Creates a Slurm controller node using [slurm-gcp-version-5].
 * **[schedmd-slurm-gcp-v5-login]** ![community-badge] :
@@ -210,6 +212,7 @@ Pub/Sub subscription. Primarily used for [FSI - MonteCarlo Tutorial][fsi-monteca
 [batch-job-template]: ../modules/scheduler/batch-job-template/README.md
 [batch-login-node]: ../modules/scheduler/batch-login-node/README.md
 [gke-cluster]: ../community/modules/scheduler/gke-cluster/README.md
+[pre-existing-gke-cluster]: ../community/modules/scheduler/pre-existing-gke-cluster/README.md
 [htcondor-setup]: ../community/modules/scheduler/htcondor-setup/README.md
 [htcondor-pool-secrets]: ../community/modules/scheduler/htcondor-pool-secrets/README.md
 [htcondor-access-point]: ../community/modules/scheduler/htcondor-access-point/README.md

--- a/modules/README.md
+++ b/modules/README.md
@@ -184,8 +184,7 @@ Pub/Sub subscription. Primarily used for [FSI - MonteCarlo Tutorial][fsi-monteca
   submission of Google Cloud Batch jobs.
 * **[gke-cluster]** ![community-badge] ![experimental-badge] : Creates a
   Kubernetes cluster using GKE.
-* **[pre-existing-gke-cluster]** ![community-badge] ![experimental-badge] : Retrieves an existing
-  GKE cluster's attributes to be used in other modules as a substitute for creating a new cluster ([gke-cluster]).
+* **[pre-existing-gke-cluster]** ![community-badge] ![experimental-badge] : Retrieves an existing GKE cluster. Substitute for ([gke-cluster]) module.
 * **[schedmd-slurm-gcp-v5-controller]** ![community-badge] :
   Creates a Slurm controller node using [slurm-gcp-version-5].
 * **[schedmd-slurm-gcp-v5-login]** ![community-badge] :


### PR DESCRIPTION
This PR introduces the pre-existing-gke-cluster module, allowing blueprints to leverage existing Google Kubernetes Engine (GKE) clusters.

### Key Changes:

#### New Module:
**Purpose**: Facilitates the usage of a pre-existing GKE cluster in HPC Toolkit blueprints.
**Location**: community/modules/scheduler/pre-existing-gke-cluster
**Inputs**:
- cluster_name (required): Name of the existing GKE cluster.
- project_id (required): Project that hosts the existing cluster.
- region (required): Region in which to search for the cluster

### Manual testing:

1. Created a new GKE cluster.
2. Deployed the provided sample blueprint (hpc-existing-gke).
3. Verified the successful creation of a new node pool in the GKE cluster through Pantheon.

#### Sample Blueprint:

```yaml
blueprint_name: hpc-existing-gke

vars:

 project_id: ## Set GCP Project ID Here ##

 deployment_name: existing-cluster-01

 region: us-central1



deployment_groups:

- group: primary

 modules:

 - id: existing_cluster

  source: community/modules/scheduler/pre-existing-gke-cluster

  settings:

   cluster_name: "cluster-01"



 - id: compute_pool

  source: community/modules/compute/gke-node-pool

  use: [existing_cluster]



 - id: job-template

  source: community/modules/compute/gke-job-template

  use: [compute_pool]

  settings:

   image: busybox

   command:

   - echo

   - Hello World

   node_count: 3

  outputs: [instructions]
```

### Additional Notes:

- Made changes to relevant documentation.