### PR TITLE
Add a new post deploy test for gke cluster

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-job.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-job.yml
@@ -1,0 +1,45 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - cli_deployment_vars.region is defined
+    - custom_vars.project is defined
+
+- name: Get cluster credentials for kubectl
+  delegate_to: localhost
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ cli_deployment_vars.region }} --project {{ custom_vars.project }}
+
+- name: Execute the job
+  delegate_to: localhost
+  ansible.builtin.shell: |
+    array=({{ workspace }}/{{ deployment_name }}/primary/my-job*)
+    kubectl create -f ${array[0]}
+  args:
+    executable: /bin/bash
+  changed_when: False
+
+- name: Wait for job to complete
+  delegate_to: localhost
+  ansible.builtin.command: |
+    kubectl get job --field-selector  status.successful=1
+  register: job_completion
+  until: job_completion.stdout_lines | length > 1
+  retries: 40
+  delay: 15
+
+- name: Print job_completion debug output
+  ansible.builtin.debug:
+    var: job_completion.stdout_lines

--- a/tools/cloud-build/daily-tests/tests/ml-gke.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-gke.yml
@@ -14,9 +14,15 @@
 ---
 test_name: ml-gke
 deployment_name: ml-gke-{{ build }}
+region: asia-southeast1
 zone: asia-southeast1-b  # for remote node
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/ml-gke.yaml"
 network: "{{ deployment_name }}-net"
 remote_node: "{{ deployment_name }}-0"
-post_deploy_tests: []
+cli_deployment_vars:
+  region: "{{ region }}"
+custom_vars:
+  project: "{{ project }}"
+post_deploy_tests:
+- test-validation/test-gke-job.yml

--- a/tools/cloud-build/images/test-runner/Dockerfile
+++ b/tools/cloud-build/images/test-runner/Dockerfile
@@ -36,6 +36,9 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
       | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
     apt-get -y update && apt-get -y install google-cloud-sdk && \
+    apt-get -y install kubectl && \
+    # following is required to execute kubectl commands
+    apt-get -y install google-cloud-cli-gke-gcloud-auth-plugin && \ 
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     # install ansible and python dependencies
     pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
This allows for basic sanity check for the cluster.

* Added kubectl  to the test runner image
* Used kubectl on the localhost to submit sample job and make sure it is successful 