### PR TITLE
Disable force_destroy on bucket created in A3 Mega blueprint

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
@@ -46,7 +46,6 @@ deployment_groups:
       local_mount: /gcs
       mount_options: defaults,rw,_netdev,implicit_dirs,allow_other,implicit_dirs,file_mode=777,dir_mode=777
       random_suffix: true
-      force_destroy: true
 
   - id: gpunets
     source: modules/network/multivpc


### PR DESCRIPTION
Prevents unintended deletion of manually created objects. Based on customer feedback. If all objects are managed via Terraform, this will continue to destroy the bucket. It only impacts buckets with manually managed objects.

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#force_destroy

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
