### PR TITLE
Revert "Remove installation of enroot and pyxis from a3-highgpu-8g blueprint"

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
@@ -127,12 +127,34 @@ deployment_groups:
 
           [Install]
           WantedBy=multi-user.target
-      - type: data
-        destination: /etc/enroot/enroot.conf
+      - type: shell
+        destination: install_enroot_pyxis.sh
         content: |
+          #!/bin/bash
+          set -e -o pipefail
+          ### Setting up Enroot
+          if ! dpkg -l enroot &>/dev/null; then
+              arch=\$(dpkg --print-architecture)
+              curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot_3.4.1-1_${arch}.deb
+              curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot+caps_3.4.1-1_${arch}.deb # optional
+              apt-get update
+              apt-get install --assume-yes ./*.deb
+              rm enroot*.deb
+          fi
+          # configure enroot
+          # use single quotes around EOT to avoid shell interpolation
+          cat <<'EOT' > /etc/enroot/enroot.conf
           ENROOT_RUNTIME_PATH    /mnt/localssd/${UID}/enroot/runtime
           ENROOT_CACHE_PATH      /mnt/localssd/${UID}/enroot/cache
           ENROOT_DATA_PATH       /mnt/localssd/${UID}/enroot/data
+          EOT
+          ### Install Pyxis
+          if [ ! -f "/usr/local/lib/slurm/spank_pyxis.so" ]; then
+              git clone --depth 1 https://github.com/NVIDIA/pyxis.git
+              cd pyxis && make install && cd -
+              rm -rf pyxis
+              echo "required /usr/local/lib/slurm/spank_pyxis.so" > /etc/slurm/plugstack.conf
+          fi
       - type: shell
         destination: install_mdadm.sh
         content: |


### PR DESCRIPTION
This reverts commit c4f87dd2e59a6303e572cb203000f9e1960b257a, because slurm-v5 does not yet have pyxis built into the slurm install.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
