### PR TITLE
Only enable gpu taints if guest_acclerator list is not empty

### DIFF
--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -23,7 +23,7 @@ locals {
   sa_email = var.service_account_email != null ? var.service_account_email : data.google_compute_default_service_account.default_sa.email
 
   preattached_gpu_machine_family = contains(["a2", "a3", "g2"], local.machine_family)
-  has_gpu                        = local.guest_accelerator != null || local.preattached_gpu_machine_family
+  has_gpu                        = (local.guest_accelerator != null && length(local.guest_accelerator) > 0) || local.preattached_gpu_machine_family
   gpu_taint = local.has_gpu ? [{
     key    = "nvidia.com/gpu"
     value  = "present"


### PR DESCRIPTION
* Found an issue where the gpu_taint was being added to a node-pool even when the gpu_accelerator list was empty. 
* This could lead to pods not getting scheduled on the nodepool.
