### PR TITLE
Move GCESysPrep to provisioner in Windows scripts

### DIFF
--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -52,7 +52,6 @@ locals {
     sysprep-specialize-script-cmd = "winrm quickconfig -quiet & net user /add ${local.windows_packer_user} & net localgroup administrators ${local.windows_packer_user} /add & winrm set winrm/config/service/auth @{Basic=\\\"true\\\"}"
     windows-shutdown-script-cmd   = <<-EOT
       net user /delete ${local.windows_packer_user}
-      GCESysprep -no_shutdown
       EOT
   }
   user_metadata = local.communicator == "winrm" ? local.windows_user_metadata : local.linux_user_metadata
@@ -156,6 +155,14 @@ build {
     for_each = var.windows_startup_ps1
     content {
       inline = split("\n", provisioner.value)
+    }
+  }
+
+  dynamic "provisioner" {
+    labels   = ["powershell"]
+    for_each = length(var.windows_startup_ps1) == 0 ? [1] : []
+    content {
+      inline = "GCESysprep -no_shutdown"
     }
   }
 

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -52,7 +52,6 @@ locals {
     sysprep-specialize-script-cmd = "winrm quickconfig -quiet & net user /add ${local.windows_packer_user} & net localgroup administrators ${local.windows_packer_user} /add & winrm set winrm/config/service/auth @{Basic=\\\"true\\\"}"
     windows-shutdown-script-cmd   = <<-EOT
       net user /delete ${local.windows_packer_user}
-      GCESysprep -no_shutdown
       EOT
   }
   user_metadata = local.communicator == "winrm" ? local.windows_user_metadata : local.linux_user_metadata
@@ -156,6 +155,14 @@ build {
     for_each = var.windows_startup_ps1
     content {
       inline = split("\n", provisioner.value)
+    }
+  }
+
+  dynamic "provisioner" {
+    labels   = ["powershell"]
+    for_each = length(var.windows_startup_ps1) == 0 ? [1] : []
+    content {
+      inline = "GCESysprep -no_shutdown"
     }
   }
 

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -52,7 +52,6 @@ locals {
     sysprep-specialize-script-cmd = "winrm quickconfig -quiet & net user /add ${local.windows_packer_user} & net localgroup administrators ${local.windows_packer_user} /add & winrm set winrm/config/service/auth @{Basic=\\\"true\\\"}"
     windows-shutdown-script-cmd   = <<-EOT
       net user /delete ${local.windows_packer_user}
-      GCESysprep -no_shutdown
       EOT
   }
   user_metadata = local.communicator == "winrm" ? local.windows_user_metadata : local.linux_user_metadata
@@ -156,6 +155,14 @@ build {
     for_each = var.windows_startup_ps1
     content {
       inline = split("\n", provisioner.value)
+    }
+  }
+
+  dynamic "provisioner" {
+    labels   = ["powershell"]
+    for_each = length(var.windows_startup_ps1) == 0 ? [1] : []
+    content {
+      inline = "GCESysprep -no_shutdown"
     }
   }
 


### PR DESCRIPTION
We have observed that GCESysPrep is not always given enough time to run at shutdown when run from the shutdown script metadata. This moves the command to a PowerShell provisioner and continues to use to the -no_shutdown argument to ensure that GCESysPrep itself does not power down the Packer VM.

The purpose of GCESysPrep is to "prepare" a live VM's boot disk to become a clean golden image for future VMs to boot with.

This has been tested in customer environment and shown to properly/fully reset the Packer disk into a clean, bootable VM image.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
