### PR TITLE
Address centos-7 image family deprecation

### DIFF
--- a/tools/cloud-build/daily-tests/blueprints/lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-vm.yaml
@@ -98,7 +98,7 @@ deployment_groups:
       name_prefix: centos
       add_deployment_name_before_prefix: true
       instance_image:
-        family: centos-7
+        name: centos-7-v20240611
         project: centos-cloud
   - id: wait-centos
     source: community/modules/scripts/wait-for-startup

--- a/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
@@ -71,7 +71,7 @@ deployment_groups:
     - homefs
     settings:
       instance_image:
-        family: centos-7
+        name: centos-7-v20240611
         project: centos-cloud
       name_prefix: workstation-centos
       instance_count: 1

--- a/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
@@ -79,7 +79,7 @@ deployment_groups:
       name_prefix: centos
       instance_count: 1
       instance_image:
-        family: centos-7
+        name: centos-7-v20240611
         project: centos-cloud
   - id: wait-centos
     source: community/modules/scripts/wait-for-startup


### PR DESCRIPTION
The centos-7 family has been entirely deprecated. This change uses the final image from the family in integration tests until we elect to remove CentOS 7 testing entirely from the Toolkit.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
