### PR TITLE
Gke optional accelerator

### DIFF
--- a/community/modules/compute/gke-node-pool/main.tf
+++ b/community/modules/compute/gke-node-pool/main.tf
@@ -87,11 +87,11 @@ resource "google_container_node_pool" "node_pool" {
     dynamic "guest_accelerator" {
       for_each = local.guest_accelerator
       content {
-        type                           = guest_accelerator.value.type
-        count                          = guest_accelerator.value.count
-        gpu_driver_installation_config = try(guest_accelerator.value.gpu_driver_installation_config, [{ gpu_driver_version = "DEFAULT" }])
-        gpu_partition_size             = try(guest_accelerator.value.gpu_partition_size, null)
-        gpu_sharing_config             = try(guest_accelerator.value.gpu_sharing_config, null)
+        type                           = coalesce(guest_accelerator.value.type, try(local.generated_guest_accelerator[0].type, ""))
+        count                          = coalesce(try(guest_accelerator.value.count, 0) > 0 ? guest_accelerator.value.count : try(local.generated_guest_accelerator[0].count, "0"))
+        gpu_driver_installation_config = coalescelist(try(guest_accelerator.value.gpu_driver_installation_config, []), [{ gpu_driver_version = "DEFAULT" }])
+        gpu_partition_size             = try(guest_accelerator.value.gpu_partition_size, "")
+        gpu_sharing_config             = try(guest_accelerator.value.gpu_sharing_config, [])
       }
     }
 

--- a/community/modules/compute/gke-node-pool/variables.tf
+++ b/community/modules/compute/gke-node-pool/variables.tf
@@ -69,16 +69,16 @@ variable "enable_secure_boot" {
 variable "guest_accelerator" {
   description = "List of the type and count of accelerator cards attached to the instance."
   type = list(object({
-    type  = string
-    count = number
-    gpu_driver_installation_config = list(object({
+    type  = optional(string)
+    count = optional(number, 0)
+    gpu_driver_installation_config = optional(list(object({
       gpu_driver_version = string
-    }))
-    gpu_partition_size = string
-    gpu_sharing_config = list(object({
-      gpu_sharing_strategy       = string
-      max_shared_clients_per_gpu = number
-    }))
+    })))
+    gpu_partition_size = optional(string)
+    gpu_sharing_config = optional(list(object({
+      gpu_sharing_strategy       = optional(string)
+      max_shared_clients_per_gpu = optional(number)
+    })))
   }))
   default = null
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1399,32 +1399,26 @@ Toolkit. It includes:
 
   Users only need to provide machine type for standard ["a2", "a3" and "g2"] machine families,
   while the other settings like `type`, `count` , `gpu_driver_installation_config` will default to
-  machine family specific values.
-  However, for other standard or custom machine families users will need to provide
-  the entire configuration as follows:
+  machine family specific values. More on this [gke-node-pool](../community/modules/compute/gke-node-pool/README.md#gpus-examples)
 
 ```yaml
 machine_type: n1-standard-1
 guest_accelerator:
 - type: nvidia-tesla-t4
   count: 1
-  gpu_partition_size: null
-  gpu_sharing_config: null
-  gpu_driver_installation_config:
-  - gpu_driver_version: "DEFAULT"
 ```
 
-Custom g2 pool
+Custom g2 pool with custom `guest_accelerator` config
 
 ```yaml
 machine_type: g2-custom-16-55296
+disk_type: pd-balanced
 guest_accelerator:
 - type: nvidia-l4
   count: 1
-  gpu_partition_size: null
   gpu_sharing_config:
-  -  max_shared_clients_per_gpu: 2
-      gpu_sharing_strategy: "TIME_SHARING"
+  - max_shared_clients_per_gpu: 2
+    gpu_sharing_strategy: "TIME_SHARING"
   gpu_driver_installation_config:
   - gpu_driver_version: "LATEST"
 ```
@@ -1434,8 +1428,7 @@ guest_accelerator:
   GPU node pool.
 
 > **Note**: The Kubernetes API server will only allow requests from authorized
-> networks. Nvidia drivers are installed on GPU nodes by a DaemonSet created by
-> the [`kubernetes-operations`] Terraform module. **You must use the
+> networks. **You must use the
 > `authorized_cidr` variable to supply an authorized network which contains the
 > IP address of the machine deploying the blueprint, for example
 > `--vars authorized_cidr=<your-ip-address>/32`.** This will allow Terraform to


### PR DESCRIPTION
# Make GKE guest_accelerator_config truly optional

With this fix following nodepool configuration will be supported, where type/count are picked up from `g2-standard-4` but the driver is picked from configuration 

```
- id: g2_pool
    source: community/modules/compute/gke-node-pool
    use: [gke_cluster]
    settings:
      name: g2-latest-driver
      disk_type: pd-balanced
      machine_type: g2-standard-4
      guest_accelerator:
      - gpu_driver_installation_config:
        - gpu_driver_version: "LATEST"

```

In the below configuration for `n1_pool` where the `gpu_driver_version` is defaulted to `DEFAULT`

```
  - id: n1_pool_defaults
    source: community/modules/compute/gke-node-pool
    use: [gke_cluster]
    settings:
      name: n1-pool-defaults
      disk_type: pd-balanced
      machine_type: n1-standard-1
      guest_accelerator:
      - type: nvidia-tesla-t4
        count: 2
```
