### PR TITLE
Develop and adopt boot-time fix for EOL CentOS 7 repositories

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -185,7 +185,7 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_netstorage_startup_script"></a> [netstorage\_startup\_script](#module\_netstorage\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.35.0&depth=1 |
+| <a name="module_netstorage_startup_script"></a> [netstorage\_startup\_script](#module\_netstorage\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | b83107e0 |
 
 ## Resources
 

--- a/modules/compute/vm-instance/startup_from_network_storage.tf
+++ b/modules/compute/vm-instance/startup_from_network_storage.tf
@@ -55,7 +55,7 @@ locals {
 }
 
 module "netstorage_startup_script" {
-  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=v1.35.0&depth=1"
+  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=b83107e0"
 
   labels          = local.labels
   project_id      = var.project_id

--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -139,7 +139,7 @@ limitations under the License.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_instance_template"></a> [instance\_template](#module\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 10.1.1 |
-| <a name="module_netstorage_startup_script"></a> [netstorage\_startup\_script](#module\_netstorage\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.35.0&depth=1 |
+| <a name="module_netstorage_startup_script"></a> [netstorage\_startup\_script](#module\_netstorage\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | b83107e0 |
 
 ## Resources
 

--- a/modules/scheduler/batch-job-template/startup_from_network_storage.tf
+++ b/modules/scheduler/batch-job-template/startup_from_network_storage.tf
@@ -55,7 +55,7 @@ locals {
 }
 
 module "netstorage_startup_script" {
-  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=v1.35.0&depth=1"
+  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script?ref=b83107e0"
 
   labels          = local.labels
   project_id      = var.project_id

--- a/modules/scripts/startup-script/files/early_run_hotfixes.sh
+++ b/modules/scripts/startup-script/files/early_run_hotfixes.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script applies fixes to VMs that must occur early in boot. For example,
+# when yum or apt repositories are misconfigured, preventing most package
+# operations from completing successfully.
+
+source /etc/os-release
+
+if [[ "$PRETTY_NAME" == "CentOS Linux 7 (Core)" ]]; then
+	echo "Applying hotfixes for CentOS 7"
+	if grep -q '^mirrorlist' /etc/yum.repos.d/CentOS-Base.repo; then
+		echo "Removing mirrorlist from default CentOS 7 repositories"
+		sed -i '/^mirrorlist/d' /etc/yum.repos.d/CentOS-Base.repo
+	fi
+	if grep -q '^#baseurl=http://mirror.centos.org' /etc/yum.repos.d/CentOS-Base.repo; then
+		echo "Reconfiguring default CentOS 7 repositories to use CentOS Vault"
+		sed -i 's,^#baseurl=http://mirror.centos.org/,baseurl=http://vault.centos.org/,' /etc/yum.repos.d/CentOS-Base.repo
+	fi
+fi

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -108,8 +108,15 @@ locals {
     args        = var.ansible_virtualenv_path
   }] : []
 
+  hotfix_runner = [{
+    type        = "shell"
+    source      = "${path.module}/files/early_run_hotfixes.sh"
+    destination = "early_run_hotfixes.sh"
+  }]
+
   runners = concat(
     local.warnings,
+    local.hotfix_runner,
     local.proxy_runner,
     local.monitoring_agent_installer,
     local.ansible_installer,

--- a/tools/cloud-build/daily-tests/blueprints/lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-vm.yaml
@@ -98,7 +98,7 @@ deployment_groups:
       name_prefix: centos
       add_deployment_name_before_prefix: true
       instance_image:
-        family: centos-7
+        name: centos-7-v20240611
         project: centos-cloud
   - id: wait-centos
     source: community/modules/scripts/wait-for-startup

--- a/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
@@ -71,7 +71,7 @@ deployment_groups:
     - homefs
     settings:
       instance_image:
-        family: centos-7
+        name: centos-7-v20240611
         project: centos-cloud
       name_prefix: workstation-centos
       instance_count: 1

--- a/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
@@ -79,7 +79,7 @@ deployment_groups:
       name_prefix: centos
       instance_count: 1
       instance_image:
-        family: centos-7
+        name: centos-7-v20240611
         project: centos-cloud
   - id: wait-centos
     source: community/modules/scripts/wait-for-startup


### PR DESCRIPTION
This PR introduces a new runner intended to apply early-boot hotfixes on VMs that use our startup-script module. It is chained as 3 commits:

1. The early boot hotfix itself
2. Adoption of the hotfix in the vm-instance module's use of startup-script
3. Un an integration test that will make use of 1+2, swap the centos-7 VM family name for image ID because all images in the family are now deprecated (i.e. you can't use the family name to get latest non-deprecated image)

Observed in logs:

```
Jul  2 22:31:09 testfix-0 startup-script-stdlib[1236]: === start executing runner: early_run_hotfixes.sh-b383 ===
Jul  2 22:31:09 testfix-0 google_metadata_script_runner: startup-script: Tue Jul 02 22:31:09 +0000 2024 Info [1236]: === start executing runner: early
_run_hotfixes.sh-b383 ===
Jul  2 22:31:09 testfix-0 google_metadata_script_runner: startup-script: Applying hotfixes for CentOS 7
Jul  2 22:31:09 testfix-0 google_metadata_script_runner: startup-script: Removing mirrorlist from default CentOS 7 repositories
Jul  2 22:31:09 testfix-0 google_metadata_script_runner: startup-script: Reconfiguring default CentOS 7 repositories to use CentOS Vault
Jul  2 22:31:09 testfix-0 startup-script-stdlib[1236]: === early_run_hotfixes.sh-b383 finished with exit_code=0 ===
```

On a repeated run, you (correctly) only observe the first message:

```
Jul  2 22:32:51 testfix-0 startup-script-stdlib[1811]: === start executing runner: early_run_hotfixes.sh-b383 ===
Jul  2 22:32:51 testfix-0 google_metadata_script_runner: startup-script: Tue Jul 02 22:32:51 +0000 2024 Info [1811]: === start executing runner: early_run_hotfixes.sh-b383 ===
Jul  2 22:32:51 testfix-0 google_metadata_script_runner: startup-script: Applying hotfixes for CentOS 7
```

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
