### PR TITLE
Add parallelstore slurm blueprint and documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,8 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [serverless-batch.yaml](#serverless-batchyaml-) ![core-badge]
   * [serverless-batch-mpi.yaml](#serverless-batch-mpiyaml-) ![core-badge]
   * [pfs-lustre.yaml](#pfs-lustreyaml-) ![core-badge]
+  * [ps-slurm.yaml](#ps-slurmyaml--) ![core-badge] ![experimental-badge]
+  * [pfs-parallelstore.yaml](#pfs-parallelstoreyaml--) ![core-badge] ![experimental-badge]
   * [cae-slurm-v5-legacy.yaml](#cae-slurm-v5-legacyyaml-) ![core-badge]
   * [cae-slurm.yaml](#cae-slurmyaml-) ![core-badge]
   * [hpc-build-slurm-image.yaml](#hpc-build-slurm-imageyaml--) ![community-badge] ![experimental-badge]
@@ -994,6 +996,67 @@ For this example the following is needed in the selected region:
 
 [pfs-lustre.yaml]: ./pfs-lustre.yaml
 
+### [ps-slurm.yaml] ![core-badge] ![experimental-badge]
+
+Creates a Slurm cluster with [Parallelstore] instance mounted.
+
+After cluster is deployed, parallelstore drivers and DAOS client will be installed
+and mount-point will be configured on the VMs. You can SSH to login/ controller
+and verify by running:
+
+```sh
+df -H
+```
+
+This would show `dfuse` file system being attached at `/parallelstore` mount-point.
+
+#### Quota Requirements for ps-slurm.yaml
+
+To get access to a private preview of Parallelstore APIs, your project needs to
+be allowlisted. To set this up, please work with your account representative.
+
+For this example the following is needed in the selected region:
+
+* Cloud Parallelstore API: capacity (GB) per region: 12000 GB
+* Compute Engine API: Persistent Disk SSD (GB): ~100 GB for controller and login node.
+* Compute Engine API: Persistent Disk Standard (GB): 50 GB/node up to 200 GB.
+* Compute Engine API: N2 CPUs: 2 for the login node and 2/node active in the `debug` partition.
+* Compute Engine API: C2 CPUs: 4 for the controller node.
+* Compute Engine API: C2 CPUs: 60/node active in the `debug` partition up to 240.
+
+[ps-slurm.yaml]: ./ps-slurm.yaml
+[Parallelstore]: ../modules/file-system/parallelstore/README.md
+
+### [pfs-parallelstore.yaml] ![core-badge] ![experimental-badge]
+
+This creates 1 compute VM running debian 12 and 1 compute VM running ubuntu 20.04
+and connect with [Parallelstore] instance mounted.
+
+After cluster is deployed, parallelstore drivers and DAOS client will be installed
+and mount-point will be configured on the VMs. You can SSH to compute VM
+and verify by running:
+
+```sh
+df -H
+```
+
+This would show `dfuse` file system being attached at `/parallelstore` mount-point.
+
+#### Quota Requirements for pfs-parallelstore.yaml
+
+To get access to a private preview of Parallelstore APIs, your project needs to
+be allowlisted. To set this up, please work with your account representative.
+
+For this example the following is needed in the selected region:
+
+* Cloud Parallelstore API: capacity (GB) per region: 12000 GB
+* Compute Engine API: Persistent Disk Standard (GB): ~100 GB static.
+* Compute Engine API: N2 CPUs: 112 for the compute VM running debian 12.
+* Compute Engine API: N2 CPUs: 112 for the compute VM running ubuntu 22.04.
+
+[pfs-parallelstore.yaml]: ./pfs-parallelstore.yaml
+[Parallelstore]: ../modules/file-system/parallelstore/README.md
+
 ### [cae-slurm-v5-legacy.yaml] ![core-badge]
 
 The Computer Aided Engineering (CAE) blueprint captures a reference architecture
@@ -1386,9 +1449,9 @@ Toolkit. It includes:
   Note: This blueprint has also been tested with `a2` machines,
   but as capacity is hard to find the example uses `g2` machines which have better obtainability.
   If using with `a2` machines it is recommended to first obtain an automatic reservation.
-  
+
   Example settings for a2 look like:
-  
+
   ```yaml
   source: modules/compute/gke-node-pool
     use: [gke_cluster]

--- a/examples/pfs-parallelstore.yaml
+++ b/examples/pfs-parallelstore.yaml
@@ -1,0 +1,66 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# To get access to a private preview of Parallelstore APIs, your project needs to
+# be allowlisted. To set this up, please work with your account representative.
+
+blueprint_name: parallelstore-vm
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: parallelstore-vm
+  region: us-central1
+  zone: us-central1-a
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+    settings:
+      prefix_length: 24 # recommended to use <=24
+
+  - id: parallelstore
+    source: modules/file-system/parallelstore
+    use: [network, private_service_access]
+
+  # Connect parallelstore instance with Compute VM running debian 12.
+  - id: debian_instance
+    source: modules/compute/vm-instance
+    use: [network, parallelstore]
+    settings:
+      name_prefix: debian
+      instance_count: 1
+      instance_image:
+        family: debian-12
+        project: debian-cloud
+      machine_type: c2d-standard-112
+
+  # Connect parallelstore instance with Compute VM running ubuntu 22.04.
+  - id: ubuntu_instance
+    source: modules/compute/vm-instance
+    use: [network, parallelstore]
+    settings:
+      name_prefix: ubuntu
+      instance_count: 1
+      instance_image:
+        family: ubuntu-2204-lts
+        project: ubuntu-os-cloud
+      machine_type: c2d-standard-112

--- a/examples/ps-slurm.yaml
+++ b/examples/ps-slurm.yaml
@@ -1,0 +1,75 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# To get access to a private preview of Parallelstore APIs, your project needs to
+# be allowlisted. To set this up, please work with your account representative.
+
+blueprint_name: parallelstore-slurm
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: parallelstore-slurm
+  region: us-east4
+  zone: us-east4-b
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+    settings:
+      prefix_length: 24 # recommended to use <=24
+
+  - id: parallelstore
+    source: modules/file-system/parallelstore
+    use: [network, private_service_access]
+
+  - id: debug_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      node_count_dynamic_max: 4
+      machine_type: c2-standard-60
+      enable_placement: false  # the default is: true
+
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [debug_nodeset]
+    settings:
+      partition_name: debug
+      exclusive: false  # allows nodes to stay up after jobs are done.
+      is_default: true
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      machine_type: n2-standard-4
+      enable_login_public_ips: true
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - network
+    - debug_partition
+    - slurm_login
+    - parallelstore  # Connect parallelstore instance with slurm cluster.
+    settings:
+      enable_controller_public_ips: true

--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -60,6 +60,20 @@ filesystem:
 
 Note the use of the MGS NID (Network ID) in the `server_ip` field - in particular, note the `@tcp` suffix.
 
+The following is an example of using `pre-existing-network-storage` with the `daos`
+filesystem. In order to use existing `parallelstore` instance, `fs_type` needs to be
+explicitly mentioned in blueprint. The `remote_mount` option refers to `access_points`
+for `parallelstore` instance.
+
+```yaml
+- id: parallelstorefs
+  source: modules/file-system/pre-existing-network-storage
+  settings:
+    fs_type: daos
+    remote_mount: "[10.246.99.2,10.246.99.3,10.246.99.4]"
+    mount_options: disable-wb-cache,thread-count=16,eq-count=8
+```
+
 ### Mounting
 
 For the `fs_type` listed below, this module will provide `client_install_runner`
@@ -71,6 +85,7 @@ Supported `fs_type`:
 - nfs
 - lustre
 - gcsfuse
+- daos
 
 [scripts/mount.sh](./scripts/mount.sh) is used as the contents of
 `mount_runner`. This script will update `/etc/fstab` and mount the network

--- a/tools/cloud-build/daily-tests/builds/ps-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ps-slurm.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.parallelstore
+- m.vpc
+- m.private-service-access
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- slurm6
+
+timeout: 14400s  # 4hr
+steps:
+- id: ps-slurm
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/ps-slurm.yml"

--- a/tools/cloud-build/daily-tests/tests/ps-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ps-slurm.yml
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+test_name: ps-slurm
+deployment_name: "ps-slurm-{{ build }}"
+region: us-central1
+zone: us-central1-a
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/ps-slurm.yaml"
+network: "{{ deployment_name }}-net"
+slurm_cluster_name: "psslurm{{ build[0:3] }}"
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+# Note: Pattern matching in gcloud only supports 1 wildcard.
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+post_deploy_tests:
+- test-validation/test-partitions.yml
+- test-validation/test-mounts.yml
+custom_vars:
+  mounts:
+  - /parallelstore
+  partitions:
+  - debug


### PR DESCRIPTION
This PR 
* Adds public blueprint to use parallelstore with Slurm cluster and with Client VM running debian 12. 
* Documents parallelstore module, usage, hydration.
* Adds integration test

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
