### PR TITLE
Remove `enable_devel` from examples

### DIFF
--- a/community/examples/hpc-build-slurm-image.yaml
+++ b/community/examples/hpc-build-slurm-image.yaml
@@ -70,6 +70,8 @@ deployment_groups:
           }
       - type: shell
         destination: install_slurm.sh
+        # Note: changes to slurm-gcp `/scripts` folder in the built image will not reflect in the deployed cluster.
+        # Instead the scripts referenced in `schedmd-slurm-gcp-v6-controller/slurm_files` will be used.
         content: |
           #!/bin/bash
           set -e -o pipefail
@@ -117,5 +119,3 @@ deployment_groups:
     settings:
       machine_type: n2d-standard-4
       instance_image: $(vars.built_instance_image)
-      # Will cause Slurm auto-scaling scripts to be sourced from built image
-      enable_devel: false

--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
@@ -241,7 +241,6 @@ deployment_groups:
       machine_type: c2-standard-8
       enable_cleanup_compute: true
       enable_external_prolog_epilog: true
-      enable_devel: false
       slurm_conf_tpl: modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl
       enable_controller_public_ips: false
       controller_startup_script: $(controller_startup.startup_script)


### PR DESCRIPTION
`enable_devel: false` is currently not working due to incompatibility between scripts in image and scripts on slurm repo head.