### PR TITLE
Fix 'spot' and 'termination_action' variable passing in schedmd-slurm-gcp-v6-controller

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
@@ -53,6 +53,8 @@ module "slurm_nodeset_template" {
   name_prefix              = each.value.nodeset_name
   on_host_maintenance      = each.value.on_host_maintenance
   preemptible              = each.value.preemptible
+  spot                     = each.value.spot
+  termination_action       = each.value.termination_action
   service_account          = each.value.service_account
   shielded_instance_config = each.value.shielded_instance_config
   source_image_family      = each.value.source_image_family


### PR DESCRIPTION
This PR fixes the passing of 'spot' and 'termination_action' in schedmd-slurm-gcp-v6-controller when setting up the instance templates. 

The slurm v6 nodeset templates contain spot variables (for example [these](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/ae08b5988ee9b2a67e2b6dee7cce6f36709446be/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/variables.tf#L289-L301)), but without this fix those variables get dropped. 
