### PR TITLE
Update A3 mega blueprint to use Slurm-GCP 6.5.12

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
@@ -57,13 +57,17 @@ deployment_groups:
       # if you follow this rule, any module which supports DKMS will be
       # properly configured at the end of image building (gVNIC, NVIDIA, ...)
       - type: shell
-        destination: disable_unattended_upgrades.sh
+        destination: prevent_unintentional_upgrades.sh
         content: |
           #!/bin/bash
           set -e -o pipefail
           systemctl stop unattended-upgrades.service
           systemctl disable unattended-upgrades.service
           systemctl mask unattended-upgrades.service
+          apt-mark hold google-compute-engine
+          apt-mark hold google-compute-engine-oslogin
+          apt-mark hold google-guest-agent
+          apt-mark hold google-osconfig-agent
       - type: ansible-local
         destination: install_headers_archive.yml
         content: |

--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
@@ -104,7 +104,7 @@ deployment_groups:
           apt-get install -y git
           ansible-galaxy role install googlecloudplatform.google_cloud_ops_agents
           ansible-pull \
-              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C 6.5.9 \
+              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C 6.5.12 \
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml


### PR DESCRIPTION
This PR updates the A3 Mega slurm image building solution in 2 ways:

- it will build from the latest tag of [GoogleCloudPlatform/slurm-gcp](https://github.com/GoogleCloudPlatform/slurm-gcp)
- it will "hold" several google custom packages at their version in the base Debian-12 image

The first change aids alignment of Terraform code with the Python autoscaling code added during image building. We previously (#2746) re-enabled `enable_devel: true` which should avoid any problems, but alignment is good.

The second change is critical to address problems introduced by GoogleCloudPlatform/guest-agent#401, which perfectly describes the A3 Mega solution: an ethernet device naming problem stemming from building an image on a Packer VM without local SSD and then provisioning A3 Mega VMs (with local SSD) using the image. The resulting compute nodes that cannot join the network or the cluster.

Before the PR, we observe <10% of nodes joining initially and rarely managing to succeed after every ~1000s retry cycle.  After the PR, we see 100% of nodes joining on the first try.

Future work can be done to update the base debian-12 image (from April 2024) to one that includes the fix to GoogleCloudPlatform/guest-agent#401.


### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
