### PR TITLE
Fix slurm script tests

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
@@ -44,7 +44,6 @@ from util import (
 )
 from util import cfg, lkp, NSDict, TPU
 
-# from util import cfg, lkp, NSDict
 import slurm_gcp_plugins
 
 
@@ -214,7 +213,7 @@ def create_instances_request(nodes, partition_name, placement_group, job_id=None
             request_body=body,
         )
 
-    request = util.compute.regionInstances().bulkInsert(
+    request = lkp.compute.regionInstances().bulkInsert(
         project=cfg.project, region=region, body=body.to_dict()
     )
 
@@ -529,7 +528,7 @@ def create_placement_request(pg_name, region):
         slurm_gcp_plugins.pre_placement_group_insert(
             lkp=lkp, pg_name=pg_name, region=region, request_body=config
         )
-    request = util.compute.resourcePolicies().insert(
+    request = lkp.compute.resourcePolicies().insert(
         project=cfg.project, region=region, body=config
     )
     log_api_request(request)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -45,7 +45,7 @@ from util import (
     TPU,
     chunked,
 )
-from util import lkp, cfg, compute, CONFIG_FILE
+from util import lkp, cfg, CONFIG_FILE
 from suspend import delete_instances
 from resume import start_tpu
 from conf import (
@@ -83,10 +83,9 @@ NodeStatus = Enum(
 )
 
 
-def start_instance_op(inst, project=None):
-    project = project or lkp.project
-    return compute.instances().start(
-        project=project,
+def start_instance_op(inst):
+    return lkp.compute.instances().start(
+        project=lkp.project,
         zone=lkp.instance(inst).zone,
         instance=inst,
     )
@@ -334,7 +333,7 @@ def do_node_update(status, nodes):
 
 def delete_placement_groups(placement_groups):
     def delete_placement_request(pg_name, region):
-        return compute.resourcePolicies().delete(
+        return lkp.compute.resourcePolicies().delete(
             project=lkp.project, region=region, resourcePolicy=pg_name
         )
 
@@ -384,7 +383,7 @@ def sync_placement_groups():
 
     fields = "items.regions.resourcePolicies,nextPageToken"
     flt = f"name={lkp.cfg.slurm_cluster_name}-*"
-    act = compute.resourcePolicies()
+    act = lkp.compute.resourcePolicies()
     op = act.aggregatedList(project=lkp.project, fields=fields, filter=flt)
     placement_groups = {}
     pg_regex = re.compile(

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
@@ -31,7 +31,7 @@ from util import (
     separate,
     execute_with_futures,
 )
-from util import lkp, cfg, compute, TPU
+from util import lkp, cfg, TPU
 
 import slurm_gcp_plugins
 
@@ -52,11 +52,10 @@ def truncate_iter(iterable, max_count):
         yield el
 
 
-def delete_instance_request(instance, project=None, zone=None):
-    project = project or lkp.project
-    request = compute.instances().delete(
-        project=project,
-        zone=(zone or lkp.instance(instance).zone),
+def delete_instance_request(instance):
+    request = lkp.compute.instances().delete(
+        project=lkp.project,
+        zone=lkp.instance(instance).zone,
         instance=instance,
     )
     log_api_request(request)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
@@ -102,43 +102,29 @@ def test_to_hostlist_fast(names, expected):
         (
             util.ApiEndpoint.BQ,
             "v1",
-            ClientOptions(
-                api_endpoint="https://bq.googleapis.com/v1/",
-                universe_domain="googleapis.com",
-            ),
+            ClientOptions(api_endpoint="https://bq.googleapis.com/v1/"),
         ),
         (
             util.ApiEndpoint.COMPUTE,
             "staging_v1",
-            ClientOptions(
-                api_endpoint="https://compute.googleapis.com/staging_v1/",
-                universe_domain="googleapis.com",
-            ),
+            ClientOptions(api_endpoint="https://compute.googleapis.com/staging_v1/"),
         ),
         (
             util.ApiEndpoint.SECRET,
             "v1",
-            ClientOptions(
-                api_endpoint="https://secret_manager.googleapis.com/v1/",
-                universe_domain="googleapis.com",
-            ),
+            ClientOptions(api_endpoint="https://secret_manager.googleapis.com/v1/"),
         ),
         (
             util.ApiEndpoint.STORAGE,
             "beta",
-            ClientOptions(
-                api_endpoint="https://storage.googleapis.com/beta/",
-                universe_domain="googleapis.com",
-            ),
+            ClientOptions(api_endpoint="https://storage.googleapis.com/beta/"),
         ),
         (
             util.ApiEndpoint.TPU,
             "alpha",
-            ClientOptions(
-                api_endpoint="https://tpu.googleapis.com/alpha/",
-                universe_domain="googleapis.com",
-            ),
+            ClientOptions(api_endpoint="https://tpu.googleapis.com/alpha/"),
         ),
+        (None, None, ClientOptions()),
     ],
 )
 def test_create_client_options(
@@ -148,15 +134,4 @@ def test_create_client_options(
     ep_mock = mocker.patch("util.endpoint_version")
     ud_mock.return_value = "googleapis.com"
     ep_mock.return_value = ep_ver
-    co = util.create_client_options(api)
-    assert (
-        co.api_endpoint == expected.api_endpoint
-        and co.universe_domain == expected.universe_domain
-    )
-    ud_mock.return_value = None
-    ep_mock.return_value = None
-    co = util.create_client_options(api)
-    assert (
-        co.api_endpoint != expected.api_endpoint
-        and co.universe_domain != expected.universe_domain
-    )
+    assert util.create_client_options(api).__repr__() == expected.__repr__()


### PR DESCRIPTION
* Remove global `compute` that was slowing down tests;
* Remove unused optional args;
* Fix "NPE" in `create_client_options`;
* Refactor `test_create_client_options`.