### PR TITLE
Improve `pytest` flow

### DIFF
--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,0 +1,16 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[pytest]
+filterwarnings = ignore::DeprecationWarning

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/README.md
@@ -1,6 +1,0 @@
-# Unit tests
-
-```sh
-# cwd is scripts/tests
-$ pytest -W ignore::DeprecationWarning
-```

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
@@ -1,0 +1,53 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+import sys
+from dataclasses import dataclass, field
+
+SCRIPTS_DIR = "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts"
+if SCRIPTS_DIR not in sys.path:
+    sys.path.append(SCRIPTS_DIR)  # TODO: make this more robust
+
+
+# TODO: use "real" classes once they are defined (instead of NSDict)
+@dataclass
+class TstNodeset:
+    nodeset_name: str
+    node_count_static: int = 0
+    node_count_dynamic_max: int = 0
+
+
+@dataclass
+class TstCfg:
+    slurm_cluster_name: str = "m22"
+    nodeset: dict[str, TstNodeset] = field(default_factory=dict)
+    nodeset_tpu: dict[str, TstNodeset] = field(default_factory=dict)
+    output_dir: Optional[str] = None
+
+
+@dataclass
+class TstTPU:  # to prevent client initialization durint "TPU.__init__"
+    vmcount: int
+
+
+def make_to_hostnames_mock(tbl: Optional[dict[str, list[str]]]):
+    tbl = tbl or {}
+
+    def se(k: str) -> list[str]:
+        if k not in tbl:
+            raise AssertionError(f"to_hostnames mock: unexpected nodelist: '{k}'")
+        return tbl[k]
+
+    return se

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_topology.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_topology.py
@@ -12,50 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 import mock
-import sys
+from common import TstCfg, TstNodeset, TstTPU, make_to_hostnames_mock
 
-if ".." not in sys.path:
-    sys.path.append("..")  # TODO: make this more robust
 import util
 import conf
-
-from dataclasses import dataclass, field
 import tempfile
-
-
-# TODO: use "real" classes once they are defined (instead of NSDict)
-@dataclass
-class TstNodeset:
-    nodeset_name: str
-    node_count_static: int = 0
-    node_count_dynamic_max: int = 0
-
-
-@dataclass
-class TstCfg:
-    slurm_cluster_name: str = "m22"
-    nodeset: dict[str, TstNodeset] = field(default_factory=dict)
-    nodeset_tpu: dict[str, TstNodeset] = field(default_factory=dict)
-    output_dir: Optional[str] = None
-
-
-@dataclass
-class TstTPU:  # to prevent client initialization durint "TPU.__init__"
-    vmcount: int
-
-
-def make_to_hostnames_mock(tbl: Optional[dict[str, list[str]]]):
-    tbl = tbl or {}
-
-    def se(k: str) -> list[str]:
-        if k not in tbl:
-            raise AssertionError(f"to_hostnames mock: unexpected nodelist: '{k}'")
-        return tbl[k]
-
-    return se
-
 
 def test_gen_topology_conf_empty():
     cfg = TstCfg(output_dir=tempfile.mkdtemp())

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import pytest
-
-if ".." not in sys.path:
-    sys.path.append("..")  # TODO: make this more robust
+import common # needed to import util
 import util
 from google.api_core.client_options import ClientOptions  # noqa: E402
 
 # Note: need to install pytest-mock
-
 
 @pytest.mark.parametrize(
     "name,expected",


### PR DESCRIPTION
Invoke `pytest` from root of the repo, without adding flags.
No changes to tests logic.

```sh
$ pwd
/usr/local/google/home/orlov/wp/hpc-toolkit_too
$ pytest
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.11.8, pytest-7.4.0, pluggy-1.2.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /usr/local/google/home/orlov/wp/hpc-toolkit_too
configfile: .pytest.ini
plugins: mock-3.14.0, anyio-3.7.1, benchmark-4.0.0, typeguard-2.13.3, xdist-3.3.1
collected 28 items

community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_topology.py ..                                                                       [  7%]
community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py .....................                                                        [ 82%]
tests/test_maintenance.py .....                                                                                                                                                         [100%]

===================================================================================== 28 passed in 1.60s ======================================================================================
$
```