### PR TITLE
Add `pytest` to pre-commit

### DIFF
--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -38,6 +38,10 @@ jobs:
         python-version: '3.10'
         check-latest: true
         cache: 'pip'
+    - run: >
+        pip install
+        -r community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
+        -r community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/requirements.txt
     - uses: actions/setup-go@v5
       with:
         go-version: '1.22'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,12 @@ repos:
     files: 'tools/cloud-build/daily-tests/builds/.*\.yaml'
     pass_filenames: false
     require_serial: true
+  - id: pytest-check
+    name: pytest-check
+    entry: pytest
+    language: system
+    types: [python]
+    pass_filenames: false
 
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
@@ -1,0 +1,17 @@
+addict==2.4.0
+google-api-core==2.19.0
+google-api-python-client==2.93.0
+google-auth==2.22.0
+google-auth-httplib2==0.1.0
+google-cloud-bigquery==3.11.3
+google-cloud-core==2.3.3
+google-cloud-storage==2.10.0
+google-cloud-tpu==1.10.0
+google-resumable-media==2.5.0
+googleapis-common-protos==1.59.1
+grpcio==1.56.0
+grpcio-status==1.56.0
+httplib2==0.22.0
+more-executors==2.11.4
+PyYAML==6.0
+requests==2.31.0

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/requirements.txt
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-mock
+mock


### PR DESCRIPTION
* Add `pytest-check` to pre-commit;
* Add `pip install` to pre-commit GitHub workflow;
* Add `community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/requirements.txt`;
* Add `community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt` based on https://github.com/GoogleCloudPlatform/slurm-gcp/blob/8768099b5b138f03d0489dc4d12b317ac515a0e0/scripts/requirements.txt with following items removed:

```
# backcall==0.2.0
# cachetools==5.3.1
# certifi==2023.7.22
# charset-normalizer==3.2.0
# decorator==5.1.1
# docopt==0.6.2
# google-crc32c==1.5.0
# idna==3.7
# ipython>=8.10
# jedi==0.17.2
# packaging==23.1
# parso==0.7.1
# pexpect==4.8.0
# pickleshare==0.7.5
# pipreqs==0.4.13
# prometheus-client==0.17.1
# prompt-toolkit==3.0.39
# proto-plus==1.22.3
# protobuf==4.23.4
# ptyprocess==0.7.0
# pyasn1==0.5.0
# pyasn1-modules==0.3.0
# Pygments==2.15.1
# pyparsing==3.1.0
# python-dateutil==2.8.2
# rsa==4.9
# six==1.16.0
# traitlets==5.9.0
# uritemplate==4.1.1
# urllib3==1.26.18
# wcwidth==0.2.6
# yarg==0.1.9
```