### PR TITLE
Stop using `DEFAULT` node definition

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -129,27 +129,24 @@ def nodeset_lines(nodeset, lkp: util.Lookup) -> str:
 
     # follow https://slurm.schedmd.com/slurm.conf.html#OPT_Boards
     # by setting Boards, SocketsPerBoard, CoresPerSocket, and ThreadsPerCore
-    node_def = {
-        "NodeName": "DEFAULT",
-        "State": "UNKNOWN",
+    gres = f"gpu:{template_info.gpu_count}" if template_info.gpu_count else None
+    node_conf = {
         "RealMemory": machine_conf.memory,
         "Boards": machine_conf.boards,
         "SocketsPerBoard": machine_conf.sockets_per_board,
         "CoresPerSocket": machine_conf.cores_per_socket,
         "ThreadsPerCore": machine_conf.threads_per_core,
         "CPUs": machine_conf.cpus,
+        "Gres": gres,
         **nodeset.node_conf,
     }
-
-    gres = f"gpu:{template_info.gpu_count}" if template_info.gpu_count else None
     nodelist = lkp.nodelist(nodeset)
 
     return "\n".join(
         map(
             dict_to_conf,
             [
-                node_def,
-                {"NodeName": nodelist, "State": "CLOUD", "Gres": gres},
+                {"NodeName": nodelist, "State": "CLOUD", **node_conf},
                 {"NodeSet": nodeset.nodeset_name, "Nodes": nodelist},
             ],
         )
@@ -157,19 +154,12 @@ def nodeset_lines(nodeset, lkp: util.Lookup) -> str:
 
 
 def nodeset_tpu_lines(nodeset, lkp: util.Lookup) -> str:
-    node_def = {
-        "NodeName": "DEFAULT",
-        "State": "UNKNOWN",
-        **nodeset.node_conf,
-    }
     nodelist = lkp.nodelist(nodeset)
-
     return "\n".join(
         map(
             dict_to_conf,
             [
-                node_def,
-                {"NodeName": nodelist, "State": "CLOUD"},
+                {"NodeName": nodelist, "State": "CLOUD", **nodeset.node_conf},
                 {"NodeSet": nodeset.nodeset_name, "Nodes": nodelist},
             ],
         )

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Any
 import sys
 from dataclasses import dataclass, field
 
@@ -27,7 +27,8 @@ class TstNodeset:
     nodeset_name: str
     node_count_static: int = 0
     node_count_dynamic_max: int = 0
-
+    node_conf: dict[str, Any] = field(default_factory=dict)
+    instance_template: Optional[str] = None
 
 @dataclass
 class TstCfg:
@@ -41,6 +42,20 @@ class TstCfg:
 class TstTPU:  # to prevent client initialization durint "TPU.__init__"
     vmcount: int
 
+@dataclass
+class TstMachineConf:
+    cpus: int
+    memory: int
+    sockets: int
+    sockets_per_board: int
+    cores_per_socket: int
+    boards: int
+    threads_per_core: int
+
+
+@dataclass
+class TstTemplateInfo:
+    gpu_count: int = 0
 
 def make_to_hostnames_mock(tbl: Optional[dict[str, list[str]]]):
     tbl = tbl or {}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py
@@ -1,0 +1,62 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from mock import Mock
+from common import TstNodeset, TstCfg, TstMachineConf, TstTemplateInfo
+
+import conf
+import util
+
+
+def test_nodeset_tpu_lines():
+    nodeset = TstNodeset(
+        "turbo",
+        node_count_static=2,
+        node_count_dynamic_max=3,
+        node_conf={"red": "velvet"},
+    )
+    assert conf.nodeset_tpu_lines(nodeset, util.Lookup(TstCfg())) == "\n".join(
+        [
+            "NodeName=m22-turbo-[0-4] State=CLOUD red=velvet",
+            "NodeSet=turbo Nodes=m22-turbo-[0-4]",
+        ]
+    )
+
+
+def test_nodeset_lines():
+    nodeset = TstNodeset(
+        "turbo",
+        node_count_static=2,
+        node_count_dynamic_max=3,
+        node_conf={"red": "velvet", "CPUs": 55},
+    )
+    lkp = util.Lookup(TstCfg())
+    lkp.template_info = Mock(return_value=TstTemplateInfo(gpu_count=33))
+    mc = TstMachineConf(
+        cpus=5,
+        memory=6,
+        sockets=7,
+        sockets_per_board=8,
+        boards=9,
+        threads_per_core=10,
+        cores_per_socket=11,
+    )
+    lkp.template_machine_conf = Mock(return_value=mc)
+    assert conf.nodeset_lines(nodeset, lkp) == "\n".join(
+        [
+            "NodeName=m22-turbo-[0-4] State=CLOUD RealMemory=6 Boards=9 SocketsPerBoard=8 CoresPerSocket=11 ThreadsPerCore=10 CPUs=55 Gres=gpu:33 red=velvet",
+            "NodeSet=turbo Nodes=m22-turbo-[0-4]",
+        ]
+    )


### PR DESCRIPTION
**NOTE:** Port of approved PR https://github.com/GoogleCloudPlatform/slurm-gcp/pull/170

```yaml
# BEFORE
NodeName=DEFAULT State=UNKNOWN RealMemory=1351440 Boards=1 SocketsPerBoard=1 CoresPerSocket=48 ThreadsPerCore=1 CPUs=48
NodeName=cluster-ns-[0-3] State=CLOUD Gres=gpu:8
NodeSet=ns Nodes=cluster-ns-[0-3]
# AFTER
NodeName=cluster-ns-[0-3] State=CLOUD Gres=gpu:8 RealMemory=1351440 Boards=1 SocketsPerBoard=1 CoresPerSocket=48 ThreadsPerCore=1 CPUs=48
NodeSet=ns Nodes=cluster-ns-[0-3]
```

**Also:**
* Add license to test files;
* Move "common" test utils in one file;
* Add test coverage to touched code.