### PR TITLE
Limit `pytest` search space

### DIFF
--- a/.pytest.ini
+++ b/.pytest.ini
@@ -14,3 +14,4 @@
 
 [pytest]
 filterwarnings = ignore::DeprecationWarning
+testpaths = tests community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests


### PR DESCRIPTION
```sh
$ pytest
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.11.8, pytest-7.4.0, pluggy-1.2.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /usr/local/google/home/orlov/wp/hpc-toolkit
configfile: .pytest.ini
testpaths: tests, community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests
plugins: mock-3.14.0, anyio-3.7.1, benchmark-4.0.0, typeguard-2.13.3, xdist-3.3.1
collected 30 items

tests/test_maintenance.py .....                                                                                                                                                         [ 16%]
community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py ..                                                                           [ 23%]
community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_topology.py ..                                                                       [ 30%]
community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py .....................                                                        [100%]

===================================================================================== 30 passed in 1.18s ======================================================================================
$
```