### PR TITLE
Add "pretty" mode to babysitter

### DIFF
--- a/tools/cloud-build/babysit/cli_ui.py
+++ b/tools/cloud-build/babysit/cli_ui.py
@@ -14,14 +14,23 @@
 
 from typing import Sequence, Dict, Optional
 import time
+from enum import Enum
 
 from .core import Status, Build, latest_by_trigger, trig_name
 
 
+class Color(Enum):
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    BLUE = "\033[94m"
+    END = "\033[0m"
+
 class CliUI: # implements UIProto
-    def __init__(self) -> None:
+    def __init__(self, pretty=False) -> None:
         self._status: Dict[str, Status] = {}
         self._change = False
+        self._pretty = pretty
 
     def on_init(self, builds: Sequence[Build]) -> None:
         for b in builds:
@@ -53,15 +62,34 @@ class CliUI: # implements UIProto
         time.sleep(sec)
 
     def _render_summary(self, builds: Sequence[Build]) -> None:
-        for _, bc in sorted(latest_by_trigger(builds).items()):
+        order_fn = lambda bc: (bc.build.status, trig_name(bc.build))
+
+        ordered = sorted(latest_by_trigger(builds).values(), key=order_fn)
+        for bc in ordered:
             print(self._render_build(bc.build, bc.count))
 
-    def _render_build(self, build: Build, count=1) -> str:
-        if count > 1:
-            return f"{self._render_status(build.status)}[{count}]\t{trig_name(build)}\t{build.log_url}"
-        return f"{self._render_status(build.status)}\t{trig_name(build)}\t{build.log_url}"
+    def _render_build(self, build: Build, count:int=1) -> str:
+        status = self._render_status(build.status)
+        cnt = f"[{count}]" if count > 1 else "   "
+        link = self._render_link(build)
+        return f"{status}{cnt} {link}"
 
     def _render_status(self, status: Optional[Status]) -> str:
-        if status is None:
-            return "NONE"
-        return status.name
+        sn = "NONE" if status is None else status.name
+        if not self._pretty: return sn
+        CM = {
+            Status.SUCCESS: Color.GREEN,
+            Status.FAILURE: Color.RED,
+            Status.TIMEOUT: Color.RED,
+            Status.PENDING: Color.END, # default
+            Status.QUEUED: Color.BLUE,
+            Status.WORKING: Color.BLUE,
+        }
+        def_color = Color.YELLOW # render "unusual" states with something bright
+        clr = CM.get(status, def_color).value
+        return f"{clr}{sn}{Color.END.value}"
+    
+    def _render_link(self, build: Build) -> str:
+        name, url = trig_name(build), build.log_url
+        if not self._pretty: return f"{name}\t{url}"
+        return f"\033]8;;{url}\033\\{name}\033]8;;\033\\"

--- a/tools/cloud-build/babysit/runner.py
+++ b/tools/cloud-build/babysit/runner.py
@@ -128,6 +128,10 @@ def run_from_cli():
                         help="Number of tests to run concurrently, default is 1")
     parser.add_argument("-r", "--retries", type=int, default=1,
                         help="Number of retries, to disable retries set to 0, default is 1")
+    # Non-runner args
+    parser.add_argument("--pretty", action="store_true", help="Render pretty output")
 
-    args = RunnerArgs(**vars(parser.parse_args()))
-    run(args, CliUI())
+    cli_args = vars(parser.parse_args())
+    ui = CliUI(pretty=cli_args.pop("pretty"))
+
+    run(RunnerArgs(**cli_args), ui)


### PR DESCRIPTION
Add `--pretty` to CLI args. Off be default.

**Always:**
* Order build by status first (to group);
* Align rendering of builds with and without retries;

**In "pretty" mode:**
* Use color for status;
* Use "OSC 8" to render links.


**Before:**
<img width="1507" alt="Screenshot 2024-07-19 at 11 47 22 PM" src="https://github.com/user-attachments/assets/2e39e374-48ed-49a5-9bc2-ebbcb53ab1f5">

**After:**
<img width="727" alt="Screenshot 2024-07-19 at 11 46 48 PM" src="https://github.com/user-attachments/assets/479f5bed-d20e-423c-808b-57b4b18251ce">


