### PR TITLE
Tidy up Slurm config generation

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -256,7 +256,7 @@ def make_cloud_conf(lkp: util.Lookup) -> str:
 def gen_cloud_conf(lkp: util.Lookup) -> None:
     content = make_cloud_conf(lkp)
 
-    conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "cloud.conf"
+    conf_file = lkp.etc_dir / "cloud.conf"
     conf_file.write_text(content)
     util.chown_slurm(conf_file, mode=0o644)
 
@@ -281,7 +281,7 @@ def install_slurm_conf(lkp: util.Lookup) -> None:
 
     conf = lkp.cfg.slurm_conf_tpl.format(**conf_options)
 
-    conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "slurm.conf"
+    conf_file = lkp.etc_dir / "slurm.conf"
     conf_file.write_text(conf)
     util.chown_slurm(conf_file, mode=0o644)
 
@@ -319,14 +319,14 @@ def install_slurmdbd_conf(lkp: util.Lookup) -> None:
 
     conf = lkp.cfg.slurmdbd_conf_tpl.format(**conf_options)
 
-    conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "slurmdbd.conf"
+    conf_file = lkp.etc_dir / "slurmdbd.conf"
     conf_file.write_text(conf)
     util.chown_slurm(conf_file, 0o600)
 
 
 def install_cgroup_conf(lkp: util.Lookup) -> None:
     """install cgroup.conf"""
-    conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "cgroup.conf"
+    conf_file = lkp.etc_dir / "cgroup.conf"
     conf_file.write_text(lkp.cfg.cgroup_conf_tpl)
     util.chown_slurm(conf_file, mode=0o600)
 
@@ -343,7 +343,7 @@ def install_jobsubmit_lua(lkp: util.Lookup) -> None:
         }
         conf = lkp.cfg.jobsubmit_lua_tpl.format(**conf_options)
 
-        conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "job_submit.lua"
+        conf_file = lkp.etc_dir / "job_submit.lua"
         conf_file.write_text(conf)
         util.chown_slurm(conf_file, 0o600)
 
@@ -372,14 +372,14 @@ def gen_cloud_gres_conf(lkp: util.Lookup) -> None:
     lines.append("\n")
     content = FILE_PREAMBLE + "\n".join(lines)
 
-    conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "cloud_gres.conf"
+    conf_file = lkp.etc_dir / "cloud_gres.conf"
     conf_file.write_text(content)
     util.chown_slurm(conf_file, mode=0o600)
 
 
 def install_gres_conf(lkp: util.Lookup) -> None:
-    conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "cloud_gres.conf"
-    gres_conf = Path(lkp.cfg.output_dir or slurmdirs.etc) / "gres.conf"
+    conf_file = lkp.etc_dir / "cloud_gres.conf"
+    gres_conf = lkp.etc_dir / "gres.conf"
     if not gres_conf.exists():
         gres_conf.symlink_to(conf_file)
     util.chown_slurm(gres_conf, mode=0o600)
@@ -485,7 +485,8 @@ def gen_topology(lkp: util.Lookup) -> TopologyBuilder:
 def gen_topology_conf(lkp: util.Lookup) -> None:
     """generate slurm topology.conf from config.yaml"""
     bldr = gen_topology(lkp).compress()
-    conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "cloud_topology.conf"
+    conf_file = lkp.etc_dir / "cloud_topology.conf"
+
     with open(conf_file, "w") as f:
         f.writelines(FILE_PREAMBLE + "\n")
         for line in bldr.render_conf_lines():
@@ -496,8 +497,21 @@ def gen_topology_conf(lkp: util.Lookup) -> None:
 
 
 def install_topology_conf(lkp: util.Lookup) -> None:
-    conf_file = Path(lkp.cfg.output_dir or slurmdirs.etc) / "cloud_topology.conf"
-    topo_conf = Path(lkp.cfg.output_dir or slurmdirs.etc) / "topology.conf"
+    conf_file = lkp.etc_dir / "cloud_topology.conf"
+    topo_conf = lkp.etc_dir / "topology.conf"
     if not topo_conf.exists():
         topo_conf.symlink_to(conf_file)
     util.chown_slurm(conf_file, mode=0o600)
+
+
+def gen_controller_configs(lkp: util.Lookup) -> None:
+    install_slurm_conf(lkp)
+    install_slurmdbd_conf(lkp)
+    gen_cloud_conf(lkp)
+    gen_cloud_gres_conf(lkp)
+    gen_topology_conf(lkp)
+
+    install_gres_conf(lkp)
+    install_cgroup_conf(lkp)
+    install_topology_conf(lkp)
+    install_jobsubmit_lua(lkp)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -34,19 +34,8 @@ from util import (
     run,
     install_custom_scripts,
 )
+import conf
 
-from conf import (
-    install_slurm_conf,
-    install_slurmdbd_conf,
-    gen_cloud_conf,
-    gen_cloud_gres_conf,
-    gen_topology_conf,
-    install_gres_conf,
-    install_cgroup_conf,
-    install_topology_conf,
-    install_jobsubmit_lua,
-    login_nodeset,
-)
 from slurmsync import sync_slurm
 
 from setup_network_storage import (
@@ -336,18 +325,7 @@ def setup_controller(args):
     log.info("Setting up controller")
     util.chown_slurm(dirs.scripts / "config.yaml", mode=0o600)
     install_custom_scripts()
-
-    install_slurm_conf(lkp)
-    install_slurmdbd_conf(lkp)
-
-    gen_cloud_conf(lkp)
-    gen_cloud_gres_conf(lkp)
-    gen_topology_conf(lkp)
-    install_gres_conf(lkp)
-    install_cgroup_conf(lkp)
-    install_topology_conf(lkp)
-    install_jobsubmit_lua(lkp)
-
+    conf.gen_controller_configs(lkp)
     setup_jwt_key()
     setup_munge_key()
     setup_sudoers()
@@ -412,7 +390,7 @@ def setup_login(args):
         slurmctld_host = f"{lkp.control_host}({lkp.control_addr})"
     slurmd_options = [
         f'--conf-server="{slurmctld_host}:{lkp.control_host_port}"',
-        f'--conf="Feature={login_nodeset}"',
+        f'--conf="Feature={conf.login_nodeset}"',
         "-Z",
     ]
     sysconf = f"""SLURMD_OPTIONS='{" ".join(slurmd_options)}'"""

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -48,16 +48,7 @@ from util import (
 from util import lkp, cfg, CONFIG_FILE
 from suspend import delete_instances
 from resume import start_tpu
-from conf import (
-    gen_cloud_conf,
-    gen_cloud_gres_conf,
-    gen_topology_conf,
-    install_slurm_conf,
-    install_slurmdbd_conf,
-    install_gres_conf,
-    install_cgroup_conf,
-    install_topology_conf,
-)
+import conf
 
 filename = Path(__file__).name
 LOGFILE = (Path(cfg.slurm_log_dir if cfg else ".") / filename).with_suffix(".log")
@@ -478,14 +469,7 @@ def reconfigure_slurm():
         lkp = Lookup(cfg_new)
         util.lkp = lkp
         if lkp.instance_role_safe == "controller":
-            install_slurm_conf(lkp)
-            install_slurmdbd_conf(lkp)
-            gen_cloud_conf(lkp)
-            gen_cloud_gres_conf(lkp)
-            gen_topology_conf(lkp)
-            install_gres_conf(lkp)
-            install_cgroup_conf(lkp)
-            install_topology_conf(lkp)
+            conf.gen_controller_configs(lkp)
             log.info("Restarting slurmctld to make changes take effect.")
             try:
                 run("sudo systemctl restart slurmctld.service", check=False)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -1890,6 +1890,10 @@ class Lookup:
             nodeset_map[self.node_nodeset_name(node)].append(node)
         return nodeset_map
 
+    @property
+    def etc_dir(self) -> Path:
+        return Path(self.cfg.output_dir or slurmdirs.etc)
+
 
 # Define late globals
 lkp = Lookup()


### PR DESCRIPTION
Reduce code duplication.

Fix bug for reconfiguration "Add first TPU nodeset" not working properly due to lack of installed plugin.