### PR TITLE
Update `topology.conf` during `slurmsync`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -129,7 +129,7 @@ def failed_motd():
 def run_custom_scripts():
     """run custom scripts based on instance_role"""
     custom_dir = dirs.custom_scripts
-    if lkp.instance_role == "controller":
+    if lkp.is_controller:
         # controller has all scripts, but only runs controller.d
         custom_dirs = [custom_dir / "controller.d"]
     elif lkp.instance_role == "compute":

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -99,7 +99,7 @@ def setup_network_storage(log):
     all_mounts = resolve_network_storage()
     ext_mounts, int_mounts = separate_external_internal_mounts(all_mounts)
 
-    if lkp.instance_role == "controller":
+    if lkp.is_controller:
         mounts = ext_mounts
     else:
         mounts = ext_mounts + int_mounts
@@ -192,7 +192,7 @@ def mount_fstab(mounts, log):
 def munge_mount_handler(log):
     if not cfg.munge_mount:
         log.error("Missing munge_mount in cfg")
-    elif lkp.instance_role == "controller":
+    elif lkp.is_controller:
         return
 
     mount = cfg.munge_mount


### PR DESCRIPTION
Naive implementation that always run `reconfigure` if any changes detected to topology.
No drawbacks since no changes are expected yet.