### PR TITLE
add test for gke n2 pool with default driver

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-ml-gke-e2e-validation.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-ml-gke-e2e-validation.yml
@@ -22,6 +22,7 @@
   delegate_to: localhost
   ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ cli_deployment_vars.region }} --project {{ custom_vars.project }}
 
+# JOB 1
 - name: Execute job on g2 latest driver pool
   delegate_to: localhost
   ansible.builtin.shell: |
@@ -31,6 +32,17 @@
     executable: /bin/bash
   changed_when: False
 
+# JOB 2
+- name: Execute job on n1 default pool
+  delegate_to: localhost
+  ansible.builtin.shell: |
+    array=({{ workspace }}/{{ deployment_name }}/primary/job-n1-pool-default*)
+    kubectl create -f ${array[0]}
+  args:
+    executable: /bin/bash
+  changed_when: False
+
+# JOB 3
 - name: Execute job on n1 full spec pool
   delegate_to: localhost
   ansible.builtin.shell: |
@@ -45,7 +57,7 @@
   ansible.builtin.command: |
     kubectl get job --field-selector  status.successful=1
   register: job_completion
-  until: job_completion.stdout_lines | length > 2  # 2 jobs total
+  until: job_completion.stdout_lines | length > 3  # 3 jobs total
   retries: 40
   delay: 15
 

--- a/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
@@ -81,6 +81,34 @@ deployment_groups:
       ]
     outputs: [instructions]
 
+  - id: n1_pool_default
+    source: modules/compute/gke-node-pool
+    use: [gke_cluster]
+    settings:
+      name: n1-pool-default
+      disk_type: pd-balanced
+      machine_type: n1-standard-4
+      guest_accelerator:
+      - type: nvidia-tesla-t4
+        count: 2
+
+  - id: job_template_n1_pool_default
+    source: modules/compute/gke-job-template
+    use: [n1_pool_default]
+    settings:
+      name: job-n1-pool-default
+      image: nvidia/cuda:11.0.3-runtime-ubuntu20.04
+      command:
+      - nvidia-smi
+      node_count: 1
+      node_selectors: [
+        {
+          "key": "cloud.google.com/gke-nodepool",
+          "value": "n1-pool-default"
+        }
+      ]
+    outputs: [instructions]
+
   - id: n1_pool_full_spec
     source: modules/compute/gke-node-pool
     use: [gke_cluster]


### PR DESCRIPTION
add test with nodepool n1_pool_default without specifying driver version, test should pass with using default driver version

cloud build run pass: https://pantheon.corp.google.com/cloud-build/builds/28660e90-bfd1-40fb-ae0f-9aa4c386c3c5?project=hpc-toolkit-dev&mods=monitoring_api_prod