### PR TITLE
Remove global `cfg`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/load_bq.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/load_bq.py
@@ -29,7 +29,6 @@ from google.api_core import retry, exceptions
 
 import util
 from util import run
-from util import cfg
 
 
 SACCT = "sacct"
@@ -176,14 +175,14 @@ job_schema = {field.name: field for field in schema_fields}
 Job = namedtuple("Job", job_schema.keys())
 
 client = bq.Client(
-    project=cfg.project,
+    project=util.lkp.project,
     credentials=util.default_credentials(),
     client_options=util.create_client_options(util.ApiEndpoint.BQ),
 )
-dataset_id = f"{cfg.slurm_cluster_name}_job_data"
-dataset = bq.DatasetReference(project=cfg.project, dataset_id=dataset_id)
+dataset_id = f"{util.lkp.cfg.slurm_cluster_name}_job_data"
+dataset = bq.DatasetReference(project=util.lkp.project, dataset_id=dataset_id)
 table = bq.Table(
-    bq.TableReference(dataset, f"jobs_{cfg.slurm_cluster_name}"), schema_fields
+    bq.TableReference(dataset, f"jobs_{util.lkp.cfg.slurm_cluster_name}"), schema_fields
 )
 
 
@@ -198,8 +197,8 @@ def make_job_row(job):
         if field_name in job
     }
     job_row["entry_uuid"] = uuid.uuid4().hex
-    job_row["cluster_id"] = cfg.cluster_id
-    job_row["cluster_name"] = cfg.slurm_cluster_name
+    job_row["cluster_id"] = util.lkp.cfg.cluster_id
+    job_row["cluster_name"] = util.lkp.cfg.slurm_cluster_name
     return job_row
 
 
@@ -310,7 +309,7 @@ def update_job_idx_cache(jobs, timestamp):
 
 
 def main():
-    if not cfg.enable_bigquery_load:
+    if not util.lkp.cfg.enable_bigquery_load:
         print("bigquery load is not currently enabled")
         exit(0)
     init_table()

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -26,7 +26,7 @@ from concurrent.futures import as_completed
 from addict import Dict as NSDict
 
 import util
-from util import lkp, run, cfg, dirs, separate
+from util import lkp, run, dirs, separate
 from more_executors import Executors, ExceptionRetryPolicy
 
 
@@ -46,7 +46,7 @@ def resolve_network_storage(nodeset=None):
             nodeset = None
 
     # seed mounts with the default controller mounts
-    if cfg.disable_default_mounts:
+    if lkp.cfg.disable_default_mounts:
         default_mounts = []
     else:
         default_mounts = [
@@ -70,9 +70,9 @@ def resolve_network_storage(nodeset=None):
 
     # On non-controller instances, entries in network_storage could overwrite
     # default exports from the controller. Be careful, of course
-    mounts.update(mounts_by_local(cfg.network_storage))
+    mounts.update(mounts_by_local(lkp.cfg.network_storage))
     if lkp.instance_role in ("login", "controller"):
-        mounts.update(mounts_by_local(cfg.login_network_storage))
+        mounts.update(mounts_by_local(lkp.cfg.login_network_storage))
 
     if nodeset is not None:
         mounts.update(mounts_by_local(nodeset.network_storage))
@@ -190,16 +190,16 @@ def mount_fstab(mounts, log):
 
 
 def munge_mount_handler(log):
-    if not cfg.munge_mount:
+    if not lkp.cfg.munge_mount:
         log.error("Missing munge_mount in cfg")
     elif lkp.is_controller:
         return
 
-    mount = cfg.munge_mount
+    mount = lkp.cfg.munge_mount
     server_ip = (
         mount.server_ip
         if mount.server_ip
-        else (cfg.slurm_control_addr or cfg.slurm_control_host)
+        else (lkp.cfg.slurm_control_addr or lkp.cfg.slurm_control_host)
     )
     remote_mount = mount.remote_mount
     local_mount = Path("/mnt/munge")
@@ -273,18 +273,18 @@ def setup_nfs_exports():
     mounts.append(
         NSDict(
             {
-                "server_ip": cfg.munge_mount.server_ip,
-                "remote_mount": cfg.munge_mount.remote_mount,
+                "server_ip": lkp.cfg.munge_mount.server_ip,
+                "remote_mount": lkp.cfg.munge_mount.remote_mount,
                 "local_mount": Path(f"{dirs.munge}_tmp"),
-                "fs_type": cfg.munge_mount.fs_type,
-                "mount_options": cfg.munge_mount.mount_options,
+                "fs_type": lkp.cfg.munge_mount.fs_type,
+                "mount_options": lkp.cfg.munge_mount.mount_options,
             }
         )
     )
     # controller mounts
     _, con_mounts = separate_external_internal_mounts(mounts)
     con_mounts = {m.remote_mount: m for m in con_mounts}
-    for nodeset in cfg.nodeset.values():
+    for nodeset in lkp.cfg.nodeset.values():
         # get internal mounts for each nodeset by calling
         # resolve_network_storage as from a node in each nodeset
         ns_mounts = resolve_network_storage(nodeset=nodeset)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -45,13 +45,13 @@ from util import (
     TPU,
     chunked,
 )
-from util import lkp, cfg, CONFIG_FILE
+from util import lkp, CONFIG_FILE
 from suspend import delete_instances
 from resume import start_tpu
 import conf
 
 filename = Path(__file__).name
-LOGFILE = (Path(cfg.slurm_log_dir if cfg else ".") / filename).with_suffix(".log")
+LOGFILE = (Path(lkp.cfg.slurm_log_dir if lkp.cfg else ".") / filename).with_suffix(".log")
 
 log = logging.getLogger(filename)
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
@@ -31,12 +31,12 @@ from util import (
     separate,
     execute_with_futures,
 )
-from util import lkp, cfg, TPU
+from util import lkp, TPU
 
 import slurm_gcp_plugins
 
 filename = Path(__file__).name
-LOGFILE = (Path(cfg.slurm_log_dir if cfg else ".") / filename).with_suffix(".log")
+LOGFILE = (Path(lkp.cfg.slurm_log_dir if lkp.cfg else ".") / filename).with_suffix(".log")
 log = logging.getLogger(filename)
 
 TOT_REQ_CNT = 1000


### PR DESCRIPTION
Showcase of the problem to fix:

```py
# ut.py
cfg = { "val": "original" }

# a.py
from ut import cfg
def fn():
  print(cfg["val"])
  
# b.py
import ut
import a
ut.cfg = {"val": "changed"}
a.fn()
```

```sh
$ python3 b.py
original
```