### PR TITLE
Babysit. Colorize output

### DIFF
--- a/tools/cloud-build/babysit/cli_ui.py
+++ b/tools/cloud-build/babysit/cli_ui.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from typing import Sequence, Dict, Optional
 import time
 from enum import Enum
@@ -27,10 +28,10 @@ class Color(Enum):
     END = "\033[0m"
 
 class CliUI: # implements UIProto
-    def __init__(self, pretty=False) -> None:
+    def __init__(self, no_color=False) -> None:
         self._status: Dict[str, Status] = {}
         self._change = False
-        self._pretty = pretty
+        self._no_color = no_color
 
     def on_init(self, builds: Sequence[Build]) -> None:
         for b in builds:
@@ -68,6 +69,10 @@ class CliUI: # implements UIProto
         for bc in ordered:
             print(self._render_build(bc.build, bc.count))
 
+    def _color(self) -> bool:
+        if self._no_color: return False
+        return hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+    
     def _render_build(self, build: Build, count:int=1) -> str:
         status = self._render_status(build.status)
         cnt = f"[{count}]" if count > 1 else "   "
@@ -76,7 +81,7 @@ class CliUI: # implements UIProto
 
     def _render_status(self, status: Optional[Status]) -> str:
         sn = "NONE" if status is None else status.name
-        if not self._pretty: return sn
+        if not self._color(): return sn
         CM = {
             Status.SUCCESS: Color.GREEN,
             Status.FAILURE: Color.RED,
@@ -91,5 +96,4 @@ class CliUI: # implements UIProto
     
     def _render_link(self, build: Build) -> str:
         name, url = trig_name(build), build.log_url
-        if not self._pretty: return f"{name}\t{url}"
-        return f"\033]8;;{url}\033\\{name}\033]8;;\033\\"
+        return f"{name}\t{url}"

--- a/tools/cloud-build/babysit/runner.py
+++ b/tools/cloud-build/babysit/runner.py
@@ -129,9 +129,9 @@ def run_from_cli():
     parser.add_argument("-r", "--retries", type=int, default=1,
                         help="Number of retries, to disable retries set to 0, default is 1")
     # Non-runner args
-    parser.add_argument("--pretty", action="store_true", help="Render pretty output")
+    parser.add_argument("--nocolor", action="store_true", help="Do not use color in output")
 
     cli_args = vars(parser.parse_args())
-    ui = CliUI(pretty=cli_args.pop("pretty"))
+    ui = CliUI(no_color=cli_args.pop("nocolor"))
 
     run(RunnerArgs(**cli_args), ui)


### PR DESCRIPTION
* Conditionally colorize output (if terminal supports it);
* Add flag `--nocolor`;
* Remove flag `--pretty` as link rendering doesn't work almost always.
